### PR TITLE
Fix auth error handling to use error code string instead of message

### DIFF
--- a/lib/libraries/auth/auth_manager_impl.dart
+++ b/lib/libraries/auth/auth_manager_impl.dart
@@ -85,7 +85,7 @@ class AuthManagerImpl implements AuthManager {
 
     if (error is supabase.AuthException) {
       final code = SupabaseAuthErrorCode.fromCode(error.code ?? 'unknown');
-      return AuthResult.failure(code.message, code.toAuthErrorType());
+      return AuthResult.failure(code.toString(), code.toAuthErrorType());
     }
 
     if (error is TimeoutException) {

--- a/lib/libraries/supabase/data/supabase_types.dart
+++ b/lib/libraries/supabase/data/supabase_types.dart
@@ -1,7 +1,7 @@
 // coverage:ignore-file
 
 /// Postgres error codes
-/// 
+///
 /// [uniqueViolation] corresponds to the error code 23505 and is used when a unique constraint is violated
 /// [unableToConnect] corresponds to the error code 08001 and is used when the connection to the server is lost
 /// [connectionFailure] corresponds to the error code 08006 and is used when the connection to the server is lost
@@ -28,9 +28,10 @@ enum PostgresErrorCode {
         return PostgresErrorCode.unknownError;
     }
   }
+
   @override
-  String toString(){
-    switch(this){
+  String toString() {
+    switch (this) {
       case PostgresErrorCode.uniqueViolation:
         return '23505';
       case PostgresErrorCode.unableToConnect:
@@ -61,12 +62,13 @@ enum PostgresErrorCode {
 }
 
 /// Supabase auth error codes, grouped by error type
-/// 
+///
 /// [invalidCredentials] corresponds to the error code invalid_credentials and is used when the credentials are invalid, eg. wrong email and password combination
 /// [emailExists] corresponds to the error code email_exists and is used when the email already exists
 /// [rateLimited] corresponds to the error code over_request_rate_limit and is used when the rate limit is exceeded, eg. when token is requested multiple times in a short period of time
 /// [registrationFailure] corresponds to the error code signup_disabled and is used when user registration fails
 /// [timeout] corresponds to the error code request_timeout and is used when the operation times out
+/// [samePassword] corresponds to a user cedential update that uses the same password as the current one
 /// [unknown] is used when the error is unknown
 enum SupabaseAuthErrorCode {
   invalidCredentials,
@@ -74,6 +76,7 @@ enum SupabaseAuthErrorCode {
   rateLimited,
   registrationFailure,
   timeout,
+  samePassword,
   unknown;
 
   static SupabaseAuthErrorCode fromCode(String code) {
@@ -96,6 +99,9 @@ enum SupabaseAuthErrorCode {
       case 'user_already_exists':
         return SupabaseAuthErrorCode.emailExists;
 
+      case 'same_password':
+        return SupabaseAuthErrorCode.samePassword;
+
       case 'over_request_rate_limit':
       case 'over_email_send_rate_limit':
       case 'over_sms_send_rate_limit':
@@ -115,45 +121,24 @@ enum SupabaseAuthErrorCode {
   }
 
   @override
-  String toString(){
-    switch(this){
+  String toString() {
+    switch (this) {
       case SupabaseAuthErrorCode.invalidCredentials:
         return 'invalid_credentials';
       case SupabaseAuthErrorCode.emailExists:
         return 'email_exists';
       case SupabaseAuthErrorCode.rateLimited:
         return 'over_request_rate_limit';
-      case SupabaseAuthErrorCode.registrationFailure:
-        return 'signup_disabled';
       case SupabaseAuthErrorCode.timeout:
         return 'request_timeout';
+      case SupabaseAuthErrorCode.samePassword:
+        return 'same_password';
+      case SupabaseAuthErrorCode.registrationFailure:
+        return 'signup_disabled';
       case SupabaseAuthErrorCode.unknown:
         return 'unknown';
     }
   }
+}
 
-  String get message {
-    switch (this) {
-      case SupabaseAuthErrorCode.invalidCredentials:
-        return 'Invalid email or password';
-      case SupabaseAuthErrorCode.emailExists:
-        return 'Email already exists';
-      case SupabaseAuthErrorCode.rateLimited:
-        return 'Too many attempts. Please try again later.';
-      case SupabaseAuthErrorCode.registrationFailure:
-        return 'Registration is currently disabled';
-      case SupabaseAuthErrorCode.timeout:
-        return 'Request timed out. Please try again.';
-      case SupabaseAuthErrorCode.unknown:
-        return 'An unknown error occurred';
-    }
-  }
-}
-enum SupabaseExceptionType{
-  auth,
-  postgrest,
-  socket,
-  timeout,
-  type,
-  unknown
-}
+enum SupabaseExceptionType { auth, postgrest, socket, timeout, type, unknown }

--- a/lib/libraries/supabase/data/supabase_types.dart
+++ b/lib/libraries/supabase/data/supabase_types.dart
@@ -76,7 +76,6 @@ enum SupabaseAuthErrorCode {
   rateLimited,
   registrationFailure,
   timeout,
-  samePassword,
   unknown;
 
   static SupabaseAuthErrorCode fromCode(String code) {
@@ -98,9 +97,6 @@ enum SupabaseAuthErrorCode {
       case 'email_exists':
       case 'user_already_exists':
         return SupabaseAuthErrorCode.emailExists;
-
-      case 'same_password':
-        return SupabaseAuthErrorCode.samePassword;
 
       case 'over_request_rate_limit':
       case 'over_email_send_rate_limit':
@@ -131,8 +127,6 @@ enum SupabaseAuthErrorCode {
         return 'over_request_rate_limit';
       case SupabaseAuthErrorCode.timeout:
         return 'request_timeout';
-      case SupabaseAuthErrorCode.samePassword:
-        return 'same_password';
       case SupabaseAuthErrorCode.registrationFailure:
         return 'signup_disabled';
       case SupabaseAuthErrorCode.unknown:

--- a/lib/libraries/supabase/data/supabase_types.dart
+++ b/lib/libraries/supabase/data/supabase_types.dart
@@ -135,4 +135,11 @@ enum SupabaseAuthErrorCode {
   }
 }
 
+/// Supabase exception types
+/// [auth] corresponds to the authentication related errors
+/// [postgrest] corresponds to the postgrest error code, specifically database level errors
+/// [socket] corresponds to the socket error code when the connection to the server is lost
+/// [timeout] corresponds to the timeout error code
+/// [type] corresponds to the type error code when there is type mismatch
+/// [unknown] corresponds to the unknown error code
 enum SupabaseExceptionType { auth, postgrest, socket, timeout, type, unknown }

--- a/lib/libraries/supabase/interfaces/supabase_wrapper.dart
+++ b/lib/libraries/supabase/interfaces/supabase_wrapper.dart
@@ -13,14 +13,14 @@ abstract class SupabaseWrapper {
 
   /// Whether the user is authenticated
   bool get isAuthenticated;
-  
+
   /// Initialize the Supabase client
-  /// 
+  ///
   /// throws [ClientException] if the supabase url or anon key is not set
   Future<void> initialize();
 
   /// Sign in a user with email and password
-  /// 
+  ///
   /// [email] The email of the user
   /// [password] The password of the user
   Future<supabase.AuthResponse> signInWithPassword({
@@ -29,16 +29,16 @@ abstract class SupabaseWrapper {
   });
 
   /// Sign up a new user with email and password
-  /// 
+  ///
   /// [email] The email of the user
   /// [password] The password of the user
   Future<supabase.AuthResponse> signUp({
     required String email,
     required String password,
   });
-  
+
   /// Sign in a user with an OTP/Used in this app for the purposes of sending OTPs
-  /// 
+  ///
   /// [email] The email of the user
   /// [phone] The phone number of the user
   /// [shouldCreateUser] Whether to create the user if they don't exist
@@ -47,9 +47,9 @@ abstract class SupabaseWrapper {
     String? phone,
     bool shouldCreateUser = false,
   });
-  
+
   /// Verify an OTP sent to an email or phone
-  /// 
+  ///
   /// [email] The email of the user
   /// [phone] The phone number of the user
   /// [token] The OTP token, in this case a 6 digit number
@@ -60,20 +60,20 @@ abstract class SupabaseWrapper {
     required String token,
     required supabase.OtpType type,
   });
-  
+
   /// Reset a user's password for email
-  /// 
+  ///
   /// [email] The email of the user
-  /// [redirectTo] The URL to redirect to after password reset, 
+  /// [redirectTo] The URL to redirect to after password reset,
   /// this is currently not used in the app
   Future<void> resetPasswordForEmail(String email, {String? redirectTo});
-  
+
   /// Sign out the current user
   Future<void> signOut();
-  
+
   // Database-related methods
   /// Select a single row from a table
-  /// 
+  ///
   /// [table] The table to select from
   /// [columns] The columns to select, defaults to '*'
   /// [filterColumn] The column to filter by
@@ -84,18 +84,32 @@ abstract class SupabaseWrapper {
     required String filterColumn,
     required dynamic filterValue,
   });
-  
+
+  /// Select all rows from a table based on a filter
+  ///
+  /// [table] The table to select from
+  /// [filterColumn] The column to filter by
+  /// [filterValue] The value to filter by
+  /// [orderByColumn] The column to order by
+  /// [orderByDirection] The direction to order by, defaults to 'asc'
+  Future<List<Map<String, dynamic>>> selectAll(
+    String table, {
+    String columns,
+    String orderByColumn,
+    String orderByDirection,
+  });
+
   /// Insert a row into a table
-  /// 
+  ///
   /// [table] The table to insert into
   /// [data] The data to insert, [Map]
   Future<Map<String, dynamic>> insert({
     required String table,
     required Map<String, dynamic> data,
   });
-  
+
   /// Update a row in a table
-  /// 
+  ///
   /// [table] The table to update
   /// [data] The data to update, [Map]
   /// [filterColumn] The column to filter by
@@ -106,4 +120,11 @@ abstract class SupabaseWrapper {
     required String filterColumn,
     required dynamic filterValue,
   });
-} 
+
+  /// Update supabase user,can be used to update the user's email as well as password.
+  ///
+  /// [userAttributes] The user details to update, this is the [supabase.UserAttributes] object from the supabase client
+  Future<supabase.UserResponse> updateUser(
+    supabase.UserAttributes userAttributes,
+  );
+}

--- a/lib/libraries/supabase/interfaces/supabase_wrapper.dart
+++ b/lib/libraries/supabase/interfaces/supabase_wrapper.dart
@@ -85,20 +85,6 @@ abstract class SupabaseWrapper {
     required dynamic filterValue,
   });
 
-  /// Select all rows from a table based on a filter
-  ///
-  /// [table] The table to select from
-  /// [filterColumn] The column to filter by
-  /// [filterValue] The value to filter by
-  /// [orderByColumn] The column to order by
-  /// [orderByDirection] The direction to order by, defaults to 'asc'
-  Future<List<Map<String, dynamic>>> selectAll(
-    String table, {
-    String columns,
-    String orderByColumn,
-    String orderByDirection,
-  });
-
   /// Insert a row into a table
   ///
   /// [table] The table to insert into
@@ -120,11 +106,4 @@ abstract class SupabaseWrapper {
     required String filterColumn,
     required dynamic filterValue,
   });
-
-  /// Update supabase user,can be used to update the user's email as well as password.
-  ///
-  /// [userAttributes] The user details to update, this is the [supabase.UserAttributes] object from the supabase client
-  Future<supabase.UserResponse> updateUser(
-    supabase.UserAttributes userAttributes,
-  );
 }

--- a/lib/libraries/supabase/supabase_module.dart
+++ b/lib/libraries/supabase/supabase_module.dart
@@ -1,15 +1,13 @@
 import 'package:construculator/libraries/config/config_module.dart';
-import 'package:construculator/app/module_param.dart';
 import 'package:construculator/libraries/supabase/interfaces/supabase_wrapper.dart';
+import 'package:construculator/libraries/supabase/supabase_wrapper_impl.dart';
 import 'package:flutter_modular/flutter_modular.dart';
 
 class SupabaseModule extends Module {
-  final ModuleParam moduleParam;
-  SupabaseModule(this.moduleParam);
   @override
-  List<Module> get imports => [ConfigModule(moduleParam)];
+  List<Module> get imports => [ConfigModule()];
   @override
   void exportedBinds(Injector i) {
-    i.addLazySingleton<SupabaseWrapper>(() => moduleParam.supabaseWrapper);
+    i.addLazySingleton<SupabaseWrapper>(() => SupabaseWrapperImpl(envLoader: i()));
   }
 }

--- a/lib/libraries/supabase/supabase_module.dart
+++ b/lib/libraries/supabase/supabase_module.dart
@@ -1,19 +1,15 @@
 import 'package:construculator/libraries/config/config_module.dart';
-import 'package:construculator/libraries/supabase/supabase_wrapper_impl.dart';
+import 'package:construculator/app/module_param.dart';
 import 'package:construculator/libraries/supabase/interfaces/supabase_wrapper.dart';
 import 'package:flutter_modular/flutter_modular.dart';
 
 class SupabaseModule extends Module {
+  final ModuleParam moduleParam;
+  SupabaseModule(this.moduleParam);
   @override
-  List<Module> get imports => [
-    ConfigModule(),
-  ];
+  List<Module> get imports => [ConfigModule(moduleParam)];
   @override
-  void exportedBinds(Injector i) async{
-    final wrapperImpl = SupabaseWrapperImpl(envLoader: i());
-    await wrapperImpl.initialize();
-    i.addLazySingleton<SupabaseWrapper>(
-      () => wrapperImpl,
-    );
+  void exportedBinds(Injector i) {
+    i.addLazySingleton<SupabaseWrapper>(() => moduleParam.supabaseWrapper);
   }
 }

--- a/lib/libraries/supabase/supabase_wrapper_impl.dart
+++ b/lib/libraries/supabase/supabase_wrapper_impl.dart
@@ -23,8 +23,12 @@ class SupabaseWrapperImpl implements SupabaseWrapper {
         debug: _envLoader.get('DEBUG_MODE') == 'true',
       );
       _supabaseClient = supabase.Supabase.instance.client;
+      return;
     }
-    throw ClientException(Trace.current(), 'SUPABASE_URL and SUPABASE_ANON_KEY variables are required');
+    throw ClientException(
+      Trace.current(),
+      'SUPABASE_URL and SUPABASE_ANON_KEY variables are required',
+    );
   }
 
   @override
@@ -112,6 +116,18 @@ class SupabaseWrapperImpl implements SupabaseWrapper {
   }
 
   @override
+  Future<List<Map<String, dynamic>>> selectAll(String table,{
+    String columns = '*', 
+    String orderByColumn = 'id',
+    String orderByDirection = 'asc',
+  }) async {
+    return await _supabaseClient
+        .from(table)
+        .select(columns)
+        .order(orderByColumn, ascending: orderByDirection == 'asc');
+  }
+
+  @override
   Future<Map<String, dynamic>> insert({
     required String table,
     required Map<String, dynamic> data,
@@ -132,5 +148,12 @@ class SupabaseWrapperImpl implements SupabaseWrapper {
         .eq(filterColumn, filterValue)
         .select()
         .single();
+  }
+
+  @override
+  Future<supabase.UserResponse> updateUser(
+    supabase.UserAttributes userAttributes,
+  ) async {
+    return await _supabaseClient.auth.updateUser(userAttributes);
   }
 }

--- a/lib/libraries/supabase/supabase_wrapper_impl.dart
+++ b/lib/libraries/supabase/supabase_wrapper_impl.dart
@@ -116,18 +116,6 @@ class SupabaseWrapperImpl implements SupabaseWrapper {
   }
 
   @override
-  Future<List<Map<String, dynamic>>> selectAll(String table,{
-    String columns = '*', 
-    String orderByColumn = 'id',
-    String orderByDirection = 'asc',
-  }) async {
-    return await _supabaseClient
-        .from(table)
-        .select(columns)
-        .order(orderByColumn, ascending: orderByDirection == 'asc');
-  }
-
-  @override
   Future<Map<String, dynamic>> insert({
     required String table,
     required Map<String, dynamic> data,
@@ -148,12 +136,5 @@ class SupabaseWrapperImpl implements SupabaseWrapper {
         .eq(filterColumn, filterValue)
         .select()
         .single();
-  }
-
-  @override
-  Future<supabase.UserResponse> updateUser(
-    supabase.UserAttributes userAttributes,
-  ) async {
-    return await _supabaseClient.auth.updateUser(userAttributes);
   }
 }

--- a/lib/libraries/supabase/testing/fake_supabase_auth_response.dart
+++ b/lib/libraries/supabase/testing/fake_supabase_auth_response.dart
@@ -22,10 +22,18 @@ class FakeAuthResponse implements supabase.AuthResponse {
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }
 
+/// A fake implementation of [supabase.UserResponse] for testing purposes
+@dataModel
 class FakeUserResponse implements supabase.UserResponse {
+
+  /// The supabase user
   @override
   final supabase.User? user;
+
+  /// Creates a new [FakeUserResponse]
   FakeUserResponse({this.user});
+
+  /// Creates a new [FakeUserResponse]
   @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }

--- a/lib/libraries/supabase/testing/fake_supabase_auth_response.dart
+++ b/lib/libraries/supabase/testing/fake_supabase_auth_response.dart
@@ -21,3 +21,11 @@ class FakeAuthResponse implements supabase.AuthResponse {
   @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }
+
+class FakeUserResponse implements supabase.UserResponse {
+  @override
+  final supabase.User? user;
+  FakeUserResponse({this.user});
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}

--- a/lib/libraries/supabase/testing/fake_supabase_user.dart
+++ b/lib/libraries/supabase/testing/fake_supabase_user.dart
@@ -35,6 +35,22 @@ class FakeUser implements supabase.User {
     this.userMetadata,
   });
 
+  FakeUser copyWith({
+    String? id,
+    String? email,
+    String? createdAt,
+    Map<String, dynamic>? appMetadata,
+    Map<String, dynamic>? userMetadata,
+  }) {
+    return FakeUser(
+      id: id ?? this.id,
+      email: email ?? this.email,
+      createdAt: createdAt ?? this.createdAt,
+      appMetadata: appMetadata ?? this.appMetadata,
+      userMetadata: userMetadata ?? this.userMetadata,
+    );
+  }
+  
   @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }

--- a/lib/libraries/supabase/testing/fake_supabase_user.dart
+++ b/lib/libraries/supabase/testing/fake_supabase_user.dart
@@ -35,6 +35,7 @@ class FakeUser implements supabase.User {
     this.userMetadata,
   });
 
+  /// Creates a new [FakeUser] with the given properties
   FakeUser copyWith({
     String? id,
     String? email,


### PR DESCRIPTION
# Fix Supabase Auth Error Handling and Improve Module Initialization

This PR fixes an issue with Supabase authentication error handling by using the error code string directly instead of a custom message. It also:

- Improves the initialization of the Supabase module by making it lazy-loaded
- Adds proper error handling in the Supabase wrapper implementation
- Enhances the fake testing classes with a new `FakeUserResponse` and a `copyWith` method for `FakeUser`
- Cleans up code formatting and documentation
- Removes the unused `message` getter from `SupabaseAuthErrorCode` enum

The main fix is changing `code.message` to `code.toString()` in the auth manager implementation to ensure proper error code propagation.