### PR TITLE
CA-35 - Add EnterPasswordBloc for user authentication

### DIFF
--- a/lib/features/auth/presentation/bloc/enter_password_bloc/enter_password_bloc.dart
+++ b/lib/features/auth/presentation/bloc/enter_password_bloc/enter_password_bloc.dart
@@ -1,0 +1,29 @@
+import 'package:construculator/libraries/errors/failures.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:equatable/equatable.dart';
+import 'package:construculator/features/auth/domain/usecases/login_usecase.dart';
+
+part 'enter_password_event.dart';
+part 'enter_password_state.dart';
+
+class EnterPasswordBloc extends Bloc<EnterPasswordEvent, EnterPasswordState> {
+  final LoginUseCase _loginUseCase;
+
+  EnterPasswordBloc({required LoginUseCase loginUseCase}) 
+      : _loginUseCase = loginUseCase,
+        super(EnterPasswordInitial()) {
+    on<EnterPasswordSubmitted>(_onSubmitted);
+  }
+
+  Future<void> _onSubmitted(
+    EnterPasswordSubmitted event,
+    Emitter<EnterPasswordState> emit,
+  ) async {
+    emit(EnterPasswordSubmitLoading());
+    final result = await _loginUseCase(event.email, event.password);
+    result.fold(
+      (failure) => emit(EnterPasswordSubmitFailure(failure: failure)),
+      (credential) => emit(EnterPasswordSubmitSuccess()),
+    );
+  }
+} 

--- a/lib/features/auth/presentation/bloc/enter_password_bloc/enter_password_event.dart
+++ b/lib/features/auth/presentation/bloc/enter_password_bloc/enter_password_event.dart
@@ -1,0 +1,12 @@
+// coverage:ignore-file
+part of 'enter_password_bloc.dart';
+
+abstract class EnterPasswordEvent extends Equatable {}
+
+class EnterPasswordSubmitted extends EnterPasswordEvent {
+  final String email;
+  final String password;
+  EnterPasswordSubmitted({required this.email, required this.password});
+  @override
+  List<Object> get props => [email, password];
+}

--- a/lib/features/auth/presentation/bloc/enter_password_bloc/enter_password_event.dart
+++ b/lib/features/auth/presentation/bloc/enter_password_bloc/enter_password_event.dart
@@ -1,12 +1,25 @@
 // coverage:ignore-file
 part of 'enter_password_bloc.dart';
 
-abstract class EnterPasswordEvent extends Equatable {}
+/// Abstract class for enter password events
+abstract class EnterPasswordEvent extends Equatable {
+  /// Constructor for enter password events
+  const EnterPasswordEvent();
 
+  /// List of properties that will be used to compare events
+  @override
+  List<Object> get props => [];
+}
+
+/// Event triggered when the user submits the password
 class EnterPasswordSubmitted extends EnterPasswordEvent {
+  /// The email of the user
   final String email;
+  /// The password entered by the user
   final String password;
-  EnterPasswordSubmitted({required this.email, required this.password});
+
+  const EnterPasswordSubmitted({required this.email, required this.password});
+
   @override
   List<Object> get props => [email, password];
 }

--- a/lib/features/auth/presentation/bloc/enter_password_bloc/enter_password_state.dart
+++ b/lib/features/auth/presentation/bloc/enter_password_bloc/enter_password_state.dart
@@ -1,26 +1,40 @@
 // coverage:ignore-file
 part of 'enter_password_bloc.dart';
 
-abstract class EnterPasswordState extends Equatable {}
+/// Abstract class for enter password states
+abstract class EnterPasswordState extends Equatable {
+  /// Constructor for enter password states
+  const EnterPasswordState();
 
+  /// List of properties that will be used to compare states
+  @override
+  List<Object?> get props => [];
+}
+
+/// The initial bloc state, typically when the enter_password page loads.
 class EnterPasswordInitial extends EnterPasswordState {
   @override
   List<Object?> get props => [];
 }
 
+/// State when the password is being submitted
 class EnterPasswordSubmitLoading extends EnterPasswordState {
   @override
   List<Object?> get props => [];
 }
 
+/// State when the password is submitted successfully
 class EnterPasswordSubmitSuccess extends EnterPasswordState {
   @override
   List<Object?> get props => [];
 }
 
+/// State when the password submission fails
 class EnterPasswordSubmitFailure extends EnterPasswordState { 
+  /// The failure that occurred during the password submission
   final Failure failure;
-  EnterPasswordSubmitFailure({required this.failure});
+  const EnterPasswordSubmitFailure({required this.failure});
+
   @override
   List<Object?> get props => [failure];
 }

--- a/lib/features/auth/presentation/bloc/enter_password_bloc/enter_password_state.dart
+++ b/lib/features/auth/presentation/bloc/enter_password_bloc/enter_password_state.dart
@@ -1,0 +1,26 @@
+// coverage:ignore-file
+part of 'enter_password_bloc.dart';
+
+abstract class EnterPasswordState extends Equatable {}
+
+class EnterPasswordInitial extends EnterPasswordState {
+  @override
+  List<Object?> get props => [];
+}
+
+class EnterPasswordSubmitLoading extends EnterPasswordState {
+  @override
+  List<Object?> get props => [];
+}
+
+class EnterPasswordSubmitSuccess extends EnterPasswordState {
+  @override
+  List<Object?> get props => [];
+}
+
+class EnterPasswordSubmitFailure extends EnterPasswordState { 
+  final Failure failure;
+  EnterPasswordSubmitFailure({required this.failure});
+  @override
+  List<Object?> get props => [failure];
+}

--- a/lib/features/auth/testing/auth_test_module.dart
+++ b/lib/features/auth/testing/auth_test_module.dart
@@ -9,6 +9,7 @@ import 'package:construculator/features/auth/domain/usecases/verify_otp_usecase.
 import 'package:construculator/features/auth/domain/usecases/login_usecase.dart';
 import 'package:construculator/features/auth/domain/usecases/set_new_password_usecase.dart';
 import 'package:construculator/features/auth/presentation/bloc/create_account_bloc/create_account_bloc.dart';
+import 'package:construculator/features/auth/presentation/bloc/enter_password_bloc/enter_password_bloc.dart';
 import 'package:construculator/features/auth/presentation/bloc/login_with_email_bloc/login_with_email_bloc.dart';
 import 'package:construculator/features/auth/presentation/bloc/otp_verification_bloc/otp_verification_bloc.dart';
 import 'package:construculator/features/auth/presentation/bloc/register_with_email_bloc/register_with_email_bloc.dart';
@@ -62,6 +63,9 @@ class AuthTestModule extends Module {
     );
     i.add<LoginWithEmailBloc>(
       () => LoginWithEmailBloc(checkEmailAvailabilityUseCase: i()),
+    );
+    i.add<EnterPasswordBloc>(
+      () => EnterPasswordBloc(loginUseCase: i()),
     );
   }
 }

--- a/test/mutations/libraries/auth/enter_password_bloc.xml
+++ b/test/mutations/libraries/auth/enter_password_bloc.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mutations version="1.0">
+    <files>
+        <file>lib/features/auth/presentation/bloc/enter_password_bloc/enter_password_bloc.dart</file>
+    </files>
+
+    <rules>
+        <literal text="&amp;&amp;" id="and-to-or">
+            <mutation text="||"/>
+        </literal>
+        <literal text="||" id="or-to-and">
+            <mutation text="&amp;&amp;"/>
+        </literal>
+        <literal text="==" id="equals">
+            <mutation text="!="/>
+        </literal>
+        <literal text="!=" id="not-equals">
+            <mutation text="=="/>
+        </literal>
+        
+        <!-- Null safety for fake implementations -->
+        <literal text="??" id="null-coalescing">
+            <mutation text=""/>
+        </literal>
+        
+        <!-- Conditional logic in fake implementations -->
+        <regex pattern="[\s]if[\s]*\((.*?)\)[\s]*{" dotAll="true" id="if-negation">
+            <mutation text=" if (!($1)) {"/>
+        </regex>
+    </rules>
+
+    <commands>
+       <command group="fake-enter-password-bloc" expected-return="0">flutter test test/units/bloc/auth/enter_password_bloc_test.dart</command>
+    </commands>
+
+    <threshold failure="85">
+        <rating over="85" name="A"/>
+        <rating over="75" name="B"/>
+        <rating over="65" name="C"/>
+        <rating over="55" name="D"/>
+        <rating over="35" name="E"/>
+        <rating over="0" name="F"/>
+    </threshold>
+</mutations> 

--- a/test/units/bloc/auth/enter_password_bloc_test.dart
+++ b/test/units/bloc/auth/enter_password_bloc_test.dart
@@ -1,0 +1,151 @@
+import 'package:bloc_test/bloc_test.dart';
+import 'package:construculator/libraries/supabase/testing/fake_supabase_user.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:construculator/features/auth/presentation/bloc/enter_password_bloc/enter_password_bloc.dart';
+import 'package:construculator/libraries/supabase/testing/fake_supabase_wrapper.dart';
+import 'package:flutter_modular/flutter_modular.dart';
+import 'package:construculator/features/auth/testing/auth_test_module.dart';
+import 'package:construculator/libraries/supabase/interfaces/supabase_wrapper.dart';
+
+void main() {
+  late FakeSupabaseWrapper fakeSupabase;
+  late EnterPasswordBloc bloc;
+
+  FakeUser createFakeUser(String email) {
+    return FakeUser(
+      id: 'fake-user-${email.hashCode}',
+      email: email,
+      createdAt: DateTime.now().toIso8601String(),
+    );
+  }
+
+  setUp(() {
+    Modular.init(AuthTestModule());
+    fakeSupabase = Modular.get<SupabaseWrapper>() as FakeSupabaseWrapper;
+    bloc = EnterPasswordBloc(loginUseCase: Modular.get());
+  });
+
+  tearDown(() {
+    fakeSupabase.reset();
+    bloc.close();
+    Modular.destroy();
+  });
+
+  group('EnterPasswordBloc Tests', () {
+    group('EnterPasswordSubmitted', () {
+      blocTest<EnterPasswordBloc, EnterPasswordState>(
+        'emits [EnterPasswordSubmitLoading, EnterPasswordSubmitSuccess] when login succeeds',
+        build: () {
+          fakeSupabase.setCurrentUser(createFakeUser('test@example.com'));
+          return bloc;
+        },
+        act:
+            (bloc) => bloc.add(
+              EnterPasswordSubmitted(
+                email: 'test@example.com',
+                password: '@Password123!',
+              ),
+            ),
+        expect:
+            () => [EnterPasswordSubmitLoading(), EnterPasswordSubmitSuccess()],
+      );
+
+      blocTest<EnterPasswordBloc, EnterPasswordState>(
+        'emits [EnterPasswordSubmitLoading, EnterPasswordSubmitFailure] when invalid credentials',
+        build: () {
+          fakeSupabase.shouldThrowOnSignIn = true;
+          return bloc;
+        },
+        act:
+            (bloc) => bloc.add(
+              EnterPasswordSubmitted(
+                email: 'test@example.com',
+                password: 'wrongpassword',
+              ),
+            ),
+        expect:
+            () => [
+              EnterPasswordSubmitLoading(),
+              isA<EnterPasswordSubmitFailure>(),
+            ],
+      );
+    });
+    group('Multiple Login Attempts', () {
+      blocTest<EnterPasswordBloc, EnterPasswordState>(
+        'handles multiple consecutive login attempts',
+        build: () {
+          fakeSupabase.addTableData('users', [
+            {
+              'id': '1',
+              'email': 'test@example.com',
+              'created_at': DateTime.now().toIso8601String(),
+            },
+          ]);
+          fakeSupabase.shouldThrowOnSignIn = false;
+          return bloc;
+        },
+        act: (bloc) {
+          bloc.add(
+            EnterPasswordSubmitted(
+              email: 'test@example.com',
+              password: '@Password123!',
+            ),
+          );
+          bloc.add(
+            EnterPasswordSubmitted(
+              email: 'test@example.com',
+              password: '@Password123!',
+            ),
+          );
+        },
+        expect:
+            () => [
+              EnterPasswordSubmitLoading(),
+              EnterPasswordSubmitSuccess(),
+              EnterPasswordSubmitLoading(),
+              EnterPasswordSubmitSuccess(),
+            ],
+      );
+
+      blocTest<EnterPasswordBloc, EnterPasswordState>(
+        'handles failed attempts followed by success',
+        build: () {
+          fakeSupabase.addTableData('users', [
+            {
+              'id': '1',
+              'email': 'test@example.com',
+              'created_at': DateTime.now().toIso8601String(),
+            },
+          ]);
+          // First call fails, second succeeds
+          fakeSupabase.shouldThrowOnSignIn = true;
+          fakeSupabase.signInErrorMessage = 'Invalid credentials';
+          return bloc;
+        },
+        act: (bloc) {
+          bloc.add(
+            EnterPasswordSubmitted(
+              email: 'test@example.com',
+              password: 'wrongpassword',
+            ),
+          );
+          // Reset for second attempt
+          fakeSupabase.shouldThrowOnSignIn = false;
+          bloc.add(
+            EnterPasswordSubmitted(
+              email: 'test@example.com',
+              password: '@Password123!',
+            ),
+          );
+        },
+        expect:
+            () => [
+              EnterPasswordSubmitLoading(),
+              isA<EnterPasswordSubmitFailure>(),
+              EnterPasswordSubmitLoading(),
+              EnterPasswordSubmitSuccess(),
+            ],
+      );
+    });
+  });
+}

--- a/test/units/bloc/auth/enter_password_bloc_test.dart
+++ b/test/units/bloc/auth/enter_password_bloc_test.dart
@@ -22,12 +22,11 @@ void main() {
   setUp(() {
     Modular.init(AuthTestModule());
     fakeSupabase = Modular.get<SupabaseWrapper>() as FakeSupabaseWrapper;
-    bloc = EnterPasswordBloc(loginUseCase: Modular.get());
+    bloc = Modular.get<EnterPasswordBloc>();
   });
 
   tearDown(() {
     fakeSupabase.reset();
-    bloc.close();
     Modular.destroy();
   });
 


### PR DESCRIPTION
# Add EnterPasswordBloc for User Authentication

This PR implements the EnterPasswordBloc to handle user login functionality. The bloc manages the password submission process with proper state management for loading, success, and failure scenarios.

Key additions:
- Created EnterPasswordBloc with events and states to handle password submission
- Implemented login logic using the LoginUseCase
- Added the bloc to the auth test module for dependency injection
- Created comprehensive unit tests covering:
  - Successful login attempts
  - Failed login with invalid credentials
  - Multiple consecutive login attempts
  - Recovery from failed attempts

The implementation follows the clean architecture pattern and uses the BLoC pattern for state management, with proper error handling for authentication failures.