### PR TITLE
CA-50 - Add forgot password and set new password routes to AuthModule

### DIFF
--- a/lib/features/auth/auth_module.dart
+++ b/lib/features/auth/auth_module.dart
@@ -46,7 +46,7 @@ class AuthModule extends Module {
   @override
   void binds(Injector i) => _registerDependencies(i);
 }
-
+// extract
 void _registerRoutes(RouteManager r) {
   r.child(
     registerWithEmailRoute,


### PR DESCRIPTION
# Added Forgot Password and Set New Password Routes to Auth Module

This PR adds two new routes to the Auth Module:

1. **Forgot Password Route**:
   - Protected by NoAuthGuard
   - Provides ForgotPasswordBloc and OtpVerificationBloc to the ForgotPasswordPage
   - Uses ResetPasswordUseCase, VerifyOtpUseCase, and SendOtpUseCase

2. **Set New Password Route**:
   - Protected by AuthGuard
   - Provides SetNewPasswordBloc to the SetNewPasswordPage
   - Passes email from route arguments to the page
   - Uses SetNewPasswordUseCase

Additionally, the PR updates module imports:
- Added ToastModule and RouterModule
- Removed SupabaseModule
- Fixed import path for NoAuthGuard