### PR TITLE
CA-141 - Add LocalizationMixin to simplify AppLocalizations handling

### DIFF
--- a/lib/features/auth/presentation/pages/create_account_page.dart
+++ b/lib/features/auth/presentation/pages/create_account_page.dart
@@ -5,6 +5,7 @@ import 'package:construculator/libraries/auth/data/models/professional_role.dart
 import 'package:construculator/libraries/auth/data/types/auth_types.dart';
 
 import 'package:construculator/libraries/errors/failures.dart';
+import 'package:construculator/libraries/mixins/localization_mixin.dart';
 import 'package:construculator/libraries/router/interfaces/app_router.dart';
 import 'package:construculator/libraries/router/routes/dashboard_routes.dart';
 import 'package:flutter/material.dart';
@@ -25,7 +26,7 @@ class CreateAccountPage extends StatefulWidget {
   State<CreateAccountPage> createState() => _CreateAccountPageState();
 }
 
-class _CreateAccountPageState extends State<CreateAccountPage> {
+class _CreateAccountPageState extends State<CreateAccountPage> with LocalizationMixin{
   final _firstNameController = TextEditingController();
   final _lastNameController = TextEditingController();
   final _mobileNumberController = TextEditingController();
@@ -52,8 +53,6 @@ class _CreateAccountPageState extends State<CreateAccountPage> {
   bool _canPressContinue = false;
   bool _isPasswordVisible = false;
   bool _isConfirmPasswordVisible = false;
-
-  AppLocalizations? l10n;
   final AppRouter _router = Modular.get<AppRouter>();
 
   bool get isEmailRegistration {
@@ -312,12 +311,6 @@ class _CreateAccountPageState extends State<CreateAccountPage> {
     });
 
     super.initState();
-  }
-
-  @override
-  void didChangeDependencies() {
-    l10n = AppLocalizations.of(context);
-    super.didChangeDependencies();
   }
 
   @override

--- a/lib/features/auth/presentation/pages/enter_password_page.dart
+++ b/lib/features/auth/presentation/pages/enter_password_page.dart
@@ -1,7 +1,7 @@
 import 'package:construculator/features/auth/presentation/widgets/auth_header.dart';
-import 'package:construculator/l10n/generated/app_localizations.dart';
 import 'package:construculator/libraries/auth/data/types/auth_types.dart';
 import 'package:construculator/libraries/errors/failures.dart';
+import 'package:construculator/libraries/mixins/localization_mixin.dart';
 import 'package:construculator/libraries/router/interfaces/app_router.dart';
 import 'package:construculator/libraries/router/routes/auth_routes.dart';
 import 'package:construculator/libraries/router/routes/dashboard_routes.dart';
@@ -20,12 +20,11 @@ class EnterPasswordPage extends StatefulWidget {
   State<EnterPasswordPage> createState() => _EnterPasswordPageState();
 }
 
-class _EnterPasswordPageState extends State<EnterPasswordPage> {
+class _EnterPasswordPageState extends State<EnterPasswordPage> with LocalizationMixin{
   final TextEditingController _passwordController = TextEditingController();
   bool _isPasswordVisible = false;
   bool _canPressContinue = false;
   List<String>? _passwordErrorList;
-  AppLocalizations? l10n;
   final AppRouter _router = Modular.get<AppRouter>();
 
   void _togglePasswordVisibility() {
@@ -46,12 +45,6 @@ class _EnterPasswordPageState extends State<EnterPasswordPage> {
       });
     });
     super.initState();
-  }
-
-  @override
-  void didChangeDependencies() {
-    l10n = AppLocalizations.of(context);
-    super.didChangeDependencies();
   }
 
   @override

--- a/lib/features/auth/presentation/pages/login_with_email_page.dart
+++ b/lib/features/auth/presentation/pages/login_with_email_page.dart
@@ -3,9 +3,9 @@ import 'package:construculator/features/auth/presentation/widgets/auth_footer.da
 import 'package:construculator/features/auth/presentation/widgets/auth_header.dart';
 import 'package:construculator/features/auth/presentation/widgets/auth_provider_buttons.dart';
 import 'package:construculator/features/auth/presentation/widgets/error_widget_builder.dart';
-import 'package:construculator/l10n/generated/app_localizations.dart';
 import 'package:construculator/libraries/auth/data/types/auth_types.dart';
 import 'package:construculator/libraries/errors/failures.dart';
+import 'package:construculator/libraries/mixins/localization_mixin.dart';
 import 'package:construculator/libraries/router/interfaces/app_router.dart';
 import 'package:construculator/libraries/router/routes/auth_routes.dart';
 import 'package:core_ui/core_ui.dart';
@@ -21,12 +21,11 @@ class LoginWithEmailPage extends StatefulWidget {
   State<LoginWithEmailPage> createState() => _LoginWithEmailPageState();
 }
 
-class _LoginWithEmailPageState extends State<LoginWithEmailPage> {
+class _LoginWithEmailPageState extends State<LoginWithEmailPage> with LocalizationMixin{
   final TextEditingController _emailController = TextEditingController();
   bool _canPressContinue = false;
   List<String>? _emailErrorList;
   List<Widget>? _emailErrorWidgetList;
-  AppLocalizations? l10n;
   final AppRouter _router = Modular.get<AppRouter>();
 
   _getContinueButtonText(LoginWithEmailState state) {
@@ -103,12 +102,6 @@ class _LoginWithEmailPageState extends State<LoginWithEmailPage> {
     });
 
     super.initState();
-  }
-
-  @override
-  void didChangeDependencies() {
-    l10n = AppLocalizations.of(context);
-    super.didChangeDependencies();
   }
 
   @override

--- a/lib/features/auth/presentation/pages/register_with_email_page.dart
+++ b/lib/features/auth/presentation/pages/register_with_email_page.dart
@@ -4,9 +4,9 @@ import 'package:construculator/features/auth/presentation/widgets/auth_header.da
 import 'package:construculator/features/auth/presentation/widgets/auth_provider_buttons.dart';
 import 'package:construculator/features/auth/presentation/widgets/error_widget_builder.dart';
 import 'package:construculator/features/auth/presentation/widgets/otp_quick_sheet/otp_verification_sheet.dart';
-import 'package:construculator/l10n/generated/app_localizations.dart';
 import 'package:construculator/libraries/auth/data/types/auth_types.dart';
 import 'package:construculator/libraries/errors/failures.dart';
+import 'package:construculator/libraries/mixins/localization_mixin.dart';
 import 'package:construculator/libraries/router/interfaces/app_router.dart';
 import 'package:construculator/libraries/router/routes/auth_routes.dart';
 import 'package:core_ui/core_ui.dart';
@@ -23,7 +23,7 @@ class RegisterWithEmailPage extends StatefulWidget {
   State<RegisterWithEmailPage> createState() => _RegisterWithEmailPageState();
 }
 
-class _RegisterWithEmailPageState extends State<RegisterWithEmailPage> {
+class _RegisterWithEmailPageState extends State<RegisterWithEmailPage> with LocalizationMixin{
   final _emailController = TextEditingController();
   final _emailTextFieldFocusNode = FocusNode();
 
@@ -31,7 +31,6 @@ class _RegisterWithEmailPageState extends State<RegisterWithEmailPage> {
   List<String>? _emailErrorTextList;
 
   bool _canPressContinue = false;
-  AppLocalizations? l10n;
   final AppRouter _router = Modular.get<AppRouter>();
 
   void _handleFailure(Failure failure) {
@@ -184,12 +183,6 @@ class _RegisterWithEmailPageState extends State<RegisterWithEmailPage> {
     });
 
     super.initState();
-  }
-
-  @override
-  void didChangeDependencies() {
-    l10n = AppLocalizations.of(context);
-    super.didChangeDependencies();
   }
 
   @override

--- a/lib/libraries/mixins/localization_mixin.dart
+++ b/lib/libraries/mixins/localization_mixin.dart
@@ -1,0 +1,35 @@
+import 'package:construculator/l10n/generated/app_localizations.dart';
+import 'package:flutter/material.dart';
+
+/// A mixin to automatically handle `AppLocalizations` lookup in `StatefulWidgets`.
+///
+/// This mixin:
+/// - Defines a nullable `l10n` property containing `AppLocalizations`.
+/// - Automatically updates `l10n` in `didChangeDependencies()`.
+///
+/// Usage:
+/// ```dart
+/// class MyPage extends StatefulWidget {
+///   @override
+///   _MyPageState createState() => _MyPageState();
+/// }
+///
+/// class _MyPageState extends State<MyPage> with LocalizationMixin {
+///   @override
+///   Widget build(BuildContext context) {
+///     return Text(l10n?.helloWorld ?? "Hello");
+///   }
+/// }
+/// ```
+mixin LocalizationMixin<T extends StatefulWidget> on State<T> {
+  /// Holds the current localization instance for the widget.
+  ///
+  /// This is updated automatically in `didChangeDependencies`.
+  AppLocalizations? l10n;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    l10n = AppLocalizations.of(context);
+  }
+}


### PR DESCRIPTION
# Add LocalizationMixin for Simplified Localization Access

Created a new `LocalizationMixin` to standardize how localization is handled across StatefulWidgets. This mixin automatically manages the `AppLocalizations` instance in the `didChangeDependencies()` lifecycle method, eliminating repetitive code.

The implementation:
- Adds a new `LocalizationMixin` class in `lib/libraries/mixins/localization_mixin.dart`
- Includes comprehensive documentation and usage examples
- Refactors four auth-related pages to use the mixin:
  - `CreateAccountPage`
  - `EnterPasswordPage`
  - `LoginWithEmailPage`
  - `RegisterWithEmailPage`

This change removes duplicate localization setup code and provides a more consistent pattern for accessing localized strings throughout the app.