### PR TITLE
Make User.id optional in JSON and update generated files


### DIFF
--- a/lib/libraries/auth/data/models/auth_state.freezed.dart
+++ b/lib/libraries/auth/data/models/auth_state.freezed.dart
@@ -17,13 +17,13 @@ T _$identity<T>(T value) => value;
 mixin _$AuthState {
 
 /// The current authentication status indicating the state of the user.
-/// 
+///
 /// This can be one of the following values:
 /// - [AuthStatus.authenticated]: User is successfully logged in
 /// - [AuthStatus.unauthenticated]: User is not logged in
 /// - [AuthStatus.connectionError]: Authentication process is in progress
  AuthStatus get status;/// The user credential information if the user is authenticated.
-/// 
+///
 /// This contains user details such as email, user ID, and other
 /// authentication-related information. Will be null when the user
 /// is not authenticated or during loading states.
@@ -108,14 +108,14 @@ class _AuthState extends AuthState {
   factory _AuthState.fromJson(Map<String, dynamic> json) => _$AuthStateFromJson(json);
 
 /// The current authentication status indicating the state of the user.
-/// 
+///
 /// This can be one of the following values:
 /// - [AuthStatus.authenticated]: User is successfully logged in
 /// - [AuthStatus.unauthenticated]: User is not logged in
 /// - [AuthStatus.connectionError]: Authentication process is in progress
 @override final  AuthStatus status;
 /// The user credential information if the user is authenticated.
-/// 
+///
 /// This contains user details such as email, user ID, and other
 /// authentication-related information. Will be null when the user
 /// is not authenticated or during loading states.

--- a/lib/libraries/auth/data/models/auth_user.dart
+++ b/lib/libraries/auth/data/models/auth_user.dart
@@ -27,7 +27,7 @@ sealed class User with _$User {
   /// - [userStatus]: The status of the user
   /// - [userPreferences]: A map of user preferences
   const factory User({
-    String? id,
+    @JsonKey(includeIfNull: false) String? id,
     String? credentialId,
     required String email,
     String? phone,

--- a/lib/libraries/auth/data/models/auth_user.freezed.dart
+++ b/lib/libraries/auth/data/models/auth_user.freezed.dart
@@ -16,7 +16,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$User {
 
- String? get id; String? get credentialId; String get email; String? get phone; String? get countryCode; String get firstName; String get lastName; String get professionalRole; String? get profilePhotoUrl; DateTime get createdAt; DateTime get updatedAt; UserProfileStatus get userStatus; Map<String, dynamic> get userPreferences;
+@JsonKey(includeIfNull: false) String? get id; String? get credentialId; String get email; String? get phone; String? get countryCode; String get firstName; String get lastName; String get professionalRole; String? get profilePhotoUrl; DateTime get createdAt; DateTime get updatedAt; UserProfileStatus get userStatus; Map<String, dynamic> get userPreferences;
 /// Create a copy of User
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -49,7 +49,7 @@ abstract mixin class $UserCopyWith<$Res>  {
   factory $UserCopyWith(User value, $Res Function(User) _then) = _$UserCopyWithImpl;
 @useResult
 $Res call({
- String? id, String? credentialId, String email, String? phone, String? countryCode, String firstName, String lastName, String professionalRole, String? profilePhotoUrl, DateTime createdAt, DateTime updatedAt, UserProfileStatus userStatus, Map<String, dynamic> userPreferences
+@JsonKey(includeIfNull: false) String? id, String? credentialId, String email, String? phone, String? countryCode, String firstName, String lastName, String professionalRole, String? profilePhotoUrl, DateTime createdAt, DateTime updatedAt, UserProfileStatus userStatus, Map<String, dynamic> userPreferences
 });
 
 
@@ -92,10 +92,10 @@ as Map<String, dynamic>,
 @JsonSerializable()
 
 class _User extends User {
-  const _User({this.id, this.credentialId, required this.email, this.phone, this.countryCode, required this.firstName, required this.lastName, required this.professionalRole, this.profilePhotoUrl, required this.createdAt, required this.updatedAt, required this.userStatus, required final  Map<String, dynamic> userPreferences}): _userPreferences = userPreferences,super._();
+  const _User({@JsonKey(includeIfNull: false) this.id, this.credentialId, required this.email, this.phone, this.countryCode, required this.firstName, required this.lastName, required this.professionalRole, this.profilePhotoUrl, required this.createdAt, required this.updatedAt, required this.userStatus, required final  Map<String, dynamic> userPreferences}): _userPreferences = userPreferences,super._();
   factory _User.fromJson(Map<String, dynamic> json) => _$UserFromJson(json);
 
-@override final  String? id;
+@override@JsonKey(includeIfNull: false) final  String? id;
 @override final  String? credentialId;
 @override final  String email;
 @override final  String? phone;
@@ -148,7 +148,7 @@ abstract mixin class _$UserCopyWith<$Res> implements $UserCopyWith<$Res> {
   factory _$UserCopyWith(_User value, $Res Function(_User) _then) = __$UserCopyWithImpl;
 @override @useResult
 $Res call({
- String? id, String? credentialId, String email, String? phone, String? countryCode, String firstName, String lastName, String professionalRole, String? profilePhotoUrl, DateTime createdAt, DateTime updatedAt, UserProfileStatus userStatus, Map<String, dynamic> userPreferences
+@JsonKey(includeIfNull: false) String? id, String? credentialId, String email, String? phone, String? countryCode, String firstName, String lastName, String professionalRole, String? profilePhotoUrl, DateTime createdAt, DateTime updatedAt, UserProfileStatus userStatus, Map<String, dynamic> userPreferences
 });
 
 


### PR DESCRIPTION
This PR updates the `User` model (`auth_user.dart`) by adding `@JsonKey(includeIfNull: false)` to the `id` field.  

- The `id` field will now be omitted from JSON when it is null.
- Regenerated Freezed and JSON files (`auth_user.freezed.dart` and `auth_user.g.dart`) to reflect this change.
- No functional changes; only JSON serialization behavior is affected.
- Helps reduce unnecessary null fields in API payloads and keeps the code consistent.
