### PR TITLE
Refactor(Login-page): Improve State Handling and Validation Logic on Login Page


### DIFF
--- a/lib/features/auth/presentation/pages/login_with_email_page.dart
+++ b/lib/features/auth/presentation/pages/login_with_email_page.dart
@@ -56,24 +56,20 @@ class _LoginWithEmailPageState extends State<LoginWithEmailPage>
   }
 
   void _handleFieldValidation(LoginWithEmailFormFieldValidated state) {
+    List<String>? errorList;
+    if (!state.isValid && state.validator != null) {
+      final errorMessage = state.validator?.localizedMessage(context);
+      errorList = errorMessage != null ? [errorMessage] : null;
+    }
     setState(() {
-      List<String>? errorList;
-
-      if (!state.isValid) {
-        if (state.validator != null) {
-          final errorMessage = state.validator?.localizedMessage(context);
-          errorList = errorMessage != null ? [errorMessage] : null;
-        }
-      } else {
-        errorList = null;
-      }
       switch (state.field) {
         case LoginWithEmailFormField.email:
           _emailErrorList = errorList;
+          _emailErrorWidgetList = null;
           break;
       }
-      _validateForm();
     });
+    _validateForm();
   }
 
   void _validateForm() {
@@ -91,8 +87,6 @@ class _LoginWithEmailPageState extends State<LoginWithEmailPage>
 
   @override
   void initState() {
-    _emailController.text = widget.email;
-
     _emailController.addListener(() {
       BlocProvider.of<LoginWithEmailBloc>(context).add(
         LoginWithEmailFormFieldChanged(
@@ -101,7 +95,7 @@ class _LoginWithEmailPageState extends State<LoginWithEmailPage>
         ),
       );
     });
-
+    _emailController.text = widget.email;
     super.initState();
   }
 

--- a/test/widgets/auth/pages/login_with_email_page_test.dart
+++ b/test/widgets/auth/pages/login_with_email_page_test.dart
@@ -110,6 +110,24 @@ void main() {
     });
 
     testWidgets(
+      'shows validation error immediately for initially invalid email',
+      (WidgetTester tester) async {
+        await tester.pumpWidget(
+          makeTestableWidget(
+            child: const LoginWithEmailPage(email: 'invalid-email'),
+          ),
+        );
+        await tester.pump();
+        expect(
+          find.textContaining(
+            AppLocalizations.of(buildContext!)!.invalidEmailError,
+          ),
+          findsOneWidget,
+        );
+      },
+    );
+
+    testWidgets(
       'valid, registered email enables button and navigates to enter password',
       (WidgetTester tester) async {
         fakeSupabase.addTableData('users', [


### PR DESCRIPTION
This pull request refactors the `LoginWithEmailPage` to improve its robustness, fix subtle bugs in state management, and enhance code clarity. The changes address issues in the widget lifecycle, validation logic, and the handling of simultaneous error messages.

### Key Changes

*   **Corrected `initState` Lifecycle:**
    *   The `_emailController` listener is now added *before* the initial text is set. This is a crucial change that ensures the initial email value passed to the widget is immediately validated when the page loads, providing instant feedback to the user.

*   **Simplified and Refactored Validation Logic:**
    *   In `_handleFieldValidation`, the logic for determining the `errorList` has been refactored. The previous nested `if/else` block has been simplified into a single, more concise `if` statement.
    *   This validation logic has also been moved *outside* of the `setState` call. This is a best practice that cleanly separates the business logic (calculating the error) from the UI update logic (telling Flutter to rebuild), making the code easier to read and maintain.

*   **Prevents Conflicting Error Messages:**
    *   The `_handleFieldValidation` method now explicitly sets `_emailErrorWidgetList` to `null`. This fixes a bug where a standard validation error (e.g., "Invalid email format") could appear at the same time as a custom error widget (e.g., "Email not registered. Register here?"). This change ensures only one clear error message is shown at a time.

*   **Corrected State Update Order:**
    *   The `_validateForm()` method is now called *after* `setState` has completed. This ensures that it correctly evaluates the newly updated `_emailErrorList` to determine if the "Continue" button should be enabled, making the UI more predictable.

These changes result in a more robust and maintainable component that correctly handles the user input lifecycle and provides a more accurate and responsive validation experience.