### PR TITLE
Refactor(Register-page): Improve State Management and UX on Registration Page

### DIFF
--- a/test/widgets/auth/pages/register_with_email_page_test.dart
+++ b/test/widgets/auth/pages/register_with_email_page_test.dart
@@ -246,6 +246,27 @@ void main() {
       },
     );
 
+    testWidgets(
+      'enables continue button on page load when valid email is pre-filled',
+      (WidgetTester tester) async {
+        fakeSupabase.clearTableData('users');
+
+        await tester.pumpWidget(
+          makeTestableWidget(
+            child: const RegisterWithEmailPage(email: 'newuser@example.com'),
+          ),
+        );
+        await tester.pump(const Duration(milliseconds: 300));
+        await tester.pumpAndSettle();
+
+        final continueButton = find.widgetWithText(
+          CoreButton,
+          AppLocalizations.of(buildContext!)!.continueButton,
+        );
+        expect(tester.widget<CoreButton>(continueButton).isDisabled, isFalse);
+      },
+    );
+
     testWidgets('disables continue button when email is submited', (
       WidgetTester tester,
     ) async {


### PR DESCRIPTION
The core of this refactoring was to make the `_buildOtpVerificationBottomSheet` widget stateless by removing its local state variables (`otp`, `otpInvalid`). Instead of managing the OTP and its validity inside the widget, it now relies entirely on the `OtpVerificationBloc` as the single source of truth. This makes the UI more robust and less prone to state-related bugs.

### Detailed Changes

#### OTP Bottom Sheet Refactoring

*   **Removed Local State:** The local variables `String otp = '';` and `bool otpInvalid = true;` were removed from the `_buildOtpVerificationBottomSheet` method. The widget no longer manages its own state.

*   **State-Driven UI:**
    *   **Verify Button Logic:** The logic for `verifyButtonDisabled` was updated to derive its value directly from the BLoC's state. The button is now disabled if the state is `OtpVerificationInitial`, if the OTP is invalid (`OtpVerificationOtpChangeSuccess && state.otpInvalid`), or if any loading process is active.
    *   **onVerify Callback:** The `onVerify` callback no longer uses a local `otp` variable. It now retrieves the current OTP directly from the `OtpVerificationOtpChangeSuccess` state when the button is pressed.

*   **Simplified BlocConsumer:** The listener no longer needs to update local variables when the OTP changes (`OtpVerificationOtpChangeSuccess`), so that part of the listener was removed.

*   **Context Renaming for Clarity:**
    *   In `_buildOtpVerificationBottomSheet`, the `BuildContext` parameter was renamed from `context` to `callingContext`.
    *   This change was propagated through all the callbacks (`onResend`, `onEdit`, `onVerify`, `onChanged`) to use `callingContext` when accessing the BLoC. This avoids confusion with the widget's own `context` and makes it clear which context is being used.

#### `initState` Refactoring

*   **Reordered Controller Logic:** The line `_emailController.text = widget.email;` was moved to be after `_emailController.addListener(...)`. This has the important effect of triggering the listener immediately upon page load with the initial email value, ensuring the form is validated right away.