### PR TITLE
Ca 227 feat/global search supabse

### DIFF
--- a/lib/features/dashboard/dashboard_module.dart
+++ b/lib/features/dashboard/dashboard_module.dart
@@ -1,6 +1,7 @@
 import 'package:construculator/app/app_bootstrap.dart';
 import 'package:construculator/features/dashboard/presentation/bloc/project_dropdown_bloc/project_dropdown_bloc.dart';
 import 'package:construculator/features/dashboard/presentation/pages/dashboard_page.dart';
+import 'package:construculator/features/global_search/global_search_module.dart';
 import 'package:construculator/libraries/auth/auth_library_module.dart';
 import 'package:construculator/libraries/project/project_library_module.dart';
 import 'package:construculator/libraries/router/guards/auth_guard.dart';
@@ -14,6 +15,7 @@ class DashboardModule extends Module {
   @override
   List<Module> get imports => [
     AuthLibraryModule(appBootstrap),
+    GlobalSearchModule(appBootstrap),
     ProjectLibraryModule(appBootstrap),
     RouterModule(),
   ];

--- a/lib/features/global_search/data/data_source/interfaces/global_search_data_source.dart
+++ b/lib/features/global_search/data/data_source/interfaces/global_search_data_source.dart
@@ -1,0 +1,55 @@
+import 'package:construculator/features/global_search/data/models/search_params_dto.dart';
+import 'package:construculator/features/global_search/data/models/search_results_dto.dart';
+import 'package:construculator/features/global_search/data/models/search_scope.dart';
+
+/// Interface that abstracts global search data source operations.
+///
+/// This allows the global search feature to work with any backend implementation.
+abstract class GlobalSearchDataSource {
+  /// Performs a global search across projects, estimations, and members.
+  ///
+  /// [params] The search parameters including query, filters, and pagination.
+  /// Returns [SearchResultsDto] with matching projects, estimations, and members.
+  ///
+  /// Unlike history methods, this does not guard on authentication client-side.
+  /// Throws when the user is not authenticated — access is enforced by RLS at
+  /// the database level rather than guarded client-side.
+  Future<SearchResultsDto> search(SearchParamsDto params);
+
+  /// Fetches recent search terms for the given [scope].
+  ///
+  /// Returns all terms the user has searched in this scope, ordered by most
+  /// recent first — including terms that returned zero results. Callers that
+  /// need suggestion-quality terms (has_results = true only) should use
+  /// [getSearchSuggestions] instead.
+  /// Returns an empty list when the user is not authenticated.
+  Future<List<String>> getRecentSearches(SearchScopeDto scope);
+
+  /// Saves a [searchTerm] for the given [scope] to recent searches.
+  ///
+  /// Normalizes the term to lowercase and trims whitespace.
+  /// [projectId] is the project context in which the search was performed.
+  /// It is nullable for searches not scoped to a specific project (e.g. dashboard).
+  /// [hasResults] should be true only when the search returned at least one result.
+  /// Terms with [hasResults] = false are saved to history but excluded from suggestions.
+  /// Does nothing when the user is not authenticated or the term is empty.
+  Future<void> saveRecentSearch(
+    String searchTerm,
+    SearchScopeDto scope, {
+    String? projectId,
+    bool hasResults = false,
+  });
+
+  /// Removes a [searchTerm] from recent searches for the given [scope].
+  ///
+  /// Does NOT affect search_analytics — global suggestion counts are preserved.
+  /// Does nothing when the user is not authenticated or the term is empty.
+  Future<void> deleteRecentSearch(String searchTerm, SearchScopeDto scope);
+
+  /// Fetches personalized search suggestions for the authenticated user.
+  ///
+  /// Priority 1: user's own search history (has_results = true), sorted by frequency.
+  /// Priority 2: searches by teammates within shared projects (has_results = true).
+  /// Returns an empty list when no suggestions are found or the user is not authenticated.
+  Future<List<String>> getSearchSuggestions();
+}

--- a/lib/features/global_search/data/data_source/remote_global_search_data_source.dart
+++ b/lib/features/global_search/data/data_source/remote_global_search_data_source.dart
@@ -1,0 +1,220 @@
+import 'package:construculator/features/estimation/data/models/cost_estimate_dto.dart';
+import 'package:construculator/features/global_search/data/data_source/interfaces/global_search_data_source.dart';
+import 'package:construculator/features/global_search/data/models/search_params_dto.dart';
+import 'package:construculator/features/global_search/data/models/search_results_dto.dart';
+import 'package:construculator/features/global_search/data/models/search_scope.dart';
+import 'package:construculator/libraries/auth/data/models/user_profile_dto.dart';
+import 'package:construculator/libraries/logging/app_logger.dart';
+import 'package:construculator/libraries/project/data/models/project_dto.dart';
+import 'package:construculator/libraries/supabase/database_constants.dart';
+import 'package:construculator/libraries/supabase/interfaces/supabase_wrapper.dart';
+
+/// Remote implementation of [GlobalSearchDataSource] using Supabase.
+///
+/// Executes full-text search via the `global_search` RPC and manages per-user
+/// search history in the `search_history` table. All history operations fail
+/// silently when no user is authenticated.
+class RemoteGlobalSearchDataSource implements GlobalSearchDataSource {
+  final SupabaseWrapper _supabaseWrapper;
+  static final _logger = AppLogger().tag('RemoteGlobalSearchDataSource');
+
+  const RemoteGlobalSearchDataSource({required SupabaseWrapper supabaseWrapper})
+    : _supabaseWrapper = supabaseWrapper;
+
+  @override
+  Future<SearchResultsDto> search(SearchParamsDto params) async {
+    try {
+      _logger.debug('Performing global search for query: ${params.query}');
+
+      final rpcParams = _toRpcParams(params);
+      final response = await _supabaseWrapper.rpc<Map<String, dynamic>>(
+        DatabaseConstants.globalSearchRpcFunction,
+        params: rpcParams,
+      );
+
+      return _parseSearchResponse(response);
+    } catch (error, stackTrace) {
+      _logger.error(
+        'Error while performing global search for query: ${params.query}, error: $error',
+        stackTrace.toString(),
+      );
+      rethrow;
+    }
+  }
+
+  @override
+  Future<List<String>> getRecentSearches(SearchScopeDto scope) async {
+    try {
+      final userId = _supabaseWrapper.currentUser?.id;
+      if (userId == null) {
+        _logger.debug('No user logged in, returning empty recent searches');
+        return [];
+      }
+
+      _logger.debug('Getting recent searches for scope: ${scope.name}');
+
+      final rows = await _supabaseWrapper.selectMatch(
+        table: DatabaseConstants.searchHistoryTable,
+        filters: {
+          DatabaseConstants.userIdColumn: userId,
+          DatabaseConstants.scopeColumn: scope.name,
+        },
+        orderBy: DatabaseConstants.createdAtColumn,
+        ascending: false,
+      );
+
+      return rows
+          .map(
+            (row) => row[DatabaseConstants.searchTermColumn]?.toString() ?? '',
+          )
+          .where((term) => term.isNotEmpty)
+          .toList();
+    } catch (error, stackTrace) {
+      _logger.error(
+        'Error while getting recent searches for scope: ${scope.name}, error: $error',
+        stackTrace.toString(),
+      );
+      rethrow;
+    }
+  }
+
+  @override
+  Future<void> saveRecentSearch(
+    String searchTerm,
+    SearchScopeDto scope, {
+    String? projectId,
+    bool hasResults = false,
+  }) async {
+    try {
+      final normalized = searchTerm.toLowerCase().trim();
+      if (normalized.isEmpty) return;
+
+      final userId = _supabaseWrapper.currentUser?.id;
+      if (userId == null) {
+        _logger.debug('No user logged in, skipping save recent search');
+        return;
+      }
+
+      _logger.debug(
+        'Saving recent search: $normalized for scope: ${scope.name}, '
+        'projectId: $projectId, hasResults: $hasResults',
+      );
+
+      await _supabaseWrapper.upsert(
+        table: DatabaseConstants.searchHistoryTable,
+        data: {
+          DatabaseConstants.userIdColumn: userId,
+          DatabaseConstants.searchTermColumn: normalized,
+          DatabaseConstants.scopeColumn: scope.name,
+          DatabaseConstants.projectIdColumn: projectId,
+          DatabaseConstants.hasResultsColumn: hasResults,
+          // search_count intentionally omitted — incremented atomically by DB trigger on conflict.
+          // created_at intentionally omitted — DB DEFAULT handles insert;
+          // trigger preserves OLD.created_at on conflict update.
+        },
+        onConflict: DatabaseConstants.searchHistoryUpsertConflictColumns,
+      );
+    } catch (error, stackTrace) {
+      _logger.error(
+        'Error while saving recent search: $searchTerm, error: $error',
+        stackTrace.toString(),
+      );
+      rethrow;
+    }
+  }
+
+  @override
+  Future<void> deleteRecentSearch(String searchTerm, SearchScopeDto scope) async {
+    try {
+      final normalized = searchTerm.toLowerCase().trim();
+      if (normalized.isEmpty) return;
+
+      final userId = _supabaseWrapper.currentUser?.id;
+      if (userId == null) {
+        _logger.debug('No user logged in, skipping delete recent search');
+        return;
+      }
+
+      _logger.debug(
+        'Deleting recent search: $normalized for scope: ${scope.name}',
+      );
+
+      await _supabaseWrapper.deleteMatch(
+        table: DatabaseConstants.searchHistoryTable,
+        filters: {
+          DatabaseConstants.userIdColumn: userId,
+          DatabaseConstants.scopeColumn: scope.name,
+          DatabaseConstants.searchTermColumn: normalized,
+        },
+      );
+    } catch (error, stackTrace) {
+      _logger.error(
+        'Error while deleting recent search: $searchTerm, error: $error',
+        stackTrace.toString(),
+      );
+      rethrow;
+    }
+  }
+
+  @override
+  Future<List<String>> getSearchSuggestions() async {
+    try {
+      _logger.debug('Fetching search suggestions');
+      final userId = _supabaseWrapper.currentUser?.id;
+      if (userId == null) {
+        _logger.debug('No user logged in, returning empty search suggestions');
+        return [];
+      }
+      final response = await _supabaseWrapper.rpc<List<dynamic>>(
+        DatabaseConstants.searchSuggestionsRpcFunction,
+        params: {DatabaseConstants.userIdColumn: userId},
+      );
+      return response.whereType<String>().toList();
+    } catch (error, stackTrace) {
+      _logger.error(
+        'Error fetching search suggestions, error: $error',
+        stackTrace.toString(),
+      );
+      rethrow;
+    }
+  }
+
+  Map<String, dynamic> _toRpcParams(SearchParamsDto params) {
+    return {
+      'query': params.query,
+      'filter_by_tag': params.filterByTag,
+      'filter_by_date': params.filterByDate?.toIso8601String(),
+      'filter_by_owner': params.filterByOwner,
+      'scope': params.scope?.name,
+      'offset': params.pagination.offset,
+      'limit': params.pagination.limit,
+    };
+  }
+
+  SearchResultsDto _parseSearchResponse(Map<String, dynamic> response) {
+    final projectsRaw = response['projects'] as List<dynamic>? ?? [];
+    final estimationsRaw = response['estimations'] as List<dynamic>? ?? [];
+    final membersRaw = response['members'] as List<dynamic>? ?? [];
+
+    final projects = projectsRaw
+        .whereType<Map<String, dynamic>>()
+        .map(ProjectDto.fromJson)
+        .toList();
+
+    final estimations = estimationsRaw
+        .whereType<Map<String, dynamic>>()
+        .map(CostEstimateDto.fromJson)
+        .toList();
+
+    final members = membersRaw
+        .whereType<Map<String, dynamic>>()
+        .map(UserProfileDto.fromJson)
+        .toList();
+
+    return SearchResultsDto(
+      projects: projects,
+      estimations: estimations,
+      members: members,
+    );
+  }
+}

--- a/lib/features/global_search/data/models/search_results_dto.dart
+++ b/lib/features/global_search/data/models/search_results_dto.dart
@@ -1,4 +1,5 @@
 import 'package:construculator/features/estimation/data/models/cost_estimate_dto.dart';
+import 'package:construculator/features/global_search/domain/entities/search_results.dart';
 import 'package:construculator/libraries/auth/data/models/user_profile_dto.dart';
 import 'package:construculator/libraries/project/data/models/project_dto.dart';
 import 'package:equatable/equatable.dart';
@@ -28,6 +29,15 @@ class SearchResultsDto extends Equatable {
       projects: projects ?? this.projects,
       estimations: estimations ?? this.estimations,
       members: members ?? this.members,
+    );
+  }
+
+  /// Converts this DTO to the [SearchResults] domain entity.
+  SearchResults toDomain() {
+    return SearchResults(
+      projects: projects.map((p) => p.toDomain()).toList(),
+      estimations: estimations.map((e) => e.toDomain()).toList(),
+      members: members.map((m) => m.toDomain()).toList(),
     );
   }
 

--- a/lib/features/global_search/data/repositories/global_search_repository_impl.dart
+++ b/lib/features/global_search/data/repositories/global_search_repository_impl.dart
@@ -1,0 +1,206 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:construculator/features/global_search/data/data_source/interfaces/global_search_data_source.dart';
+import 'package:construculator/features/global_search/data/models/pagination_params_dto.dart';
+import 'package:construculator/features/global_search/data/models/search_params_dto.dart';
+import 'package:construculator/features/global_search/data/models/search_scope.dart';
+import 'package:construculator/features/global_search/domain/entities/search_params_entity.dart';
+import 'package:construculator/features/global_search/domain/entities/search_results.dart';
+import 'package:construculator/features/global_search/domain/entities/search_scope_entity.dart';
+import 'package:construculator/features/global_search/domain/repositories/global_search_repository.dart';
+import 'package:construculator/libraries/either/either.dart';
+import 'package:construculator/libraries/errors/failures.dart';
+import 'package:construculator/libraries/global_search/domain/search_error_type.dart';
+import 'package:construculator/libraries/logging/app_logger.dart';
+import 'package:construculator/libraries/supabase/data/supabase_types.dart';
+import 'package:supabase_flutter/supabase_flutter.dart' as supabase;
+
+/// Supabase-backed implementation of [GlobalSearchRepository].
+///
+/// Delegates all operations to [GlobalSearchDataSource] and maps any thrown
+/// exceptions to typed [Failure] values so callers never have to catch.
+class GlobalSearchRepositoryImpl implements GlobalSearchRepository {
+  final GlobalSearchDataSource _dataSource;
+  static final _logger = AppLogger().tag('GlobalSearchRepositoryImpl');
+
+  GlobalSearchRepositoryImpl({required GlobalSearchDataSource dataSource})
+    : _dataSource = dataSource;
+
+  SearchScopeDto _toDataScope(SearchScope entity) {
+    switch (entity) {
+      case SearchScope.dashboard:
+        return SearchScopeDto.dashboard;
+      case SearchScope.calculation:
+        return SearchScopeDto.calculation;
+      case SearchScope.estimation:
+        return SearchScopeDto.estimation;
+      case SearchScope.member:
+        return SearchScopeDto.member;
+    }
+  }
+
+  SearchParamsDto _toDataParams(SearchParams entity) {
+    final entityScope = entity.scope;
+    return SearchParamsDto(
+      query: entity.query,
+      filterByTag: entity.filterByTag,
+      filterByDate: entity.filterByDate,
+      filterByOwner: entity.filterByOwner,
+      scope: entityScope != null ? _toDataScope(entityScope) : null,
+      pagination: PaginationParamsDto(
+        offset: entity.pagination.offset,
+        limit: entity.pagination.limit,
+      ),
+    );
+  }
+
+  Failure _handleError(Object error, String operation) {
+    if (error is TimeoutException) {
+      _logger.warning(
+        'Timeout error $operation: '
+        'message=${error.message}, duration=${error.duration}',
+      );
+      return SearchFailure(errorType: SearchErrorType.timeoutError);
+    }
+
+    if (error is SocketException) {
+      _logger.warning(
+        'Connection error $operation: '
+        'message=${error.message}, address=${error.address}, '
+        'port=${error.port}, osError=${error.osError}',
+      );
+      return SearchFailure(errorType: SearchErrorType.connectionError);
+    }
+
+    if (error is TypeError) {
+      _logger.error(
+        'Parsing error $operation: ${error.toString()}',
+        'returning parsing failure',
+      );
+      return SearchFailure(errorType: SearchErrorType.parsingError);
+    }
+
+    if (error is supabase.PostgrestException) {
+      final postgresErrorCode = PostgresErrorCode.fromCode(error.code);
+
+      if (postgresErrorCode == PostgresErrorCode.noDataFound) {
+        _logger.warning(
+          'No data found $operation: '
+          'code=${error.code}, message=${error.message}',
+        );
+        return SearchFailure(errorType: SearchErrorType.notFoundError);
+      }
+
+      if (postgresErrorCode == PostgresErrorCode.uniqueViolation) {
+        _logger.warning(
+          'Unique constraint violation $operation: '
+          'code=${error.code}, message=${error.message}',
+        );
+        return SearchFailure(errorType: SearchErrorType.duplicateEntryError);
+      }
+
+      if (postgresErrorCode == PostgresErrorCode.connectionFailure ||
+          postgresErrorCode == PostgresErrorCode.unableToConnect ||
+          postgresErrorCode == PostgresErrorCode.connectionDoesNotExist) {
+        _logger.error(
+          'PostgreSQL connection error $operation: '
+          'code=${error.code}, message=${error.message}, '
+          'details=${error.details}, hint=${error.hint}',
+        );
+        return SearchFailure(errorType: SearchErrorType.connectionError);
+      }
+
+      _logger.error(
+        'Unexpected PostgreSQL error $operation: '
+        'code=${error.code}, message=${error.message}, '
+        'details=${error.details}, hint=${error.hint}',
+      );
+      return SearchFailure(errorType: SearchErrorType.unexpectedDatabaseError);
+    }
+
+    _logger.error('Unexpected error $operation: $error');
+    return UnexpectedFailure();
+  }
+
+  @override
+  Future<Either<Failure, SearchResults>> search(SearchParams params) async {
+    try {
+      _logger.debug('Performing global search for query: ${params.query}');
+      final dto = await _dataSource.search(_toDataParams(params));
+      _logger.debug(
+        'Search completed: ${dto.projects.length} projects, '
+        '${dto.estimations.length} estimations, '
+        '${dto.members.length} members',
+      );
+      return Right(dto.toDomain());
+    } catch (e) {
+      return Left(_handleError(e, 'performing global search'));
+    }
+  }
+
+  @override
+  Future<Either<Failure, List<String>>> getRecentSearches(
+    SearchScope scope,
+  ) async {
+    try {
+      _logger.debug('Getting recent searches for scope: ${scope.name}');
+      final terms = await _dataSource.getRecentSearches(_toDataScope(scope));
+      _logger.debug('Retrieved ${terms.length} recent searches');
+      return Right(terms);
+    } catch (e) {
+      return Left(_handleError(e, 'getting recent searches'));
+    }
+  }
+
+  @override
+  Future<Either<Failure, void>> saveRecentSearch(
+    String searchTerm,
+    SearchScope scope, {
+    String? projectId,
+    bool hasResults = false,
+  }) async {
+    try {
+      _logger.debug(
+        'Saving recent search: $searchTerm for scope: ${scope.name}',
+      );
+      await _dataSource.saveRecentSearch(
+        searchTerm,
+        _toDataScope(scope),
+        projectId: projectId,
+        hasResults: hasResults,
+      );
+      return const Right(null);
+    } catch (e) {
+      return Left(_handleError(e, 'saving recent search'));
+    }
+  }
+
+  @override
+  Future<Either<Failure, void>> deleteRecentSearch(
+    String searchTerm,
+    SearchScope scope,
+  ) async {
+    try {
+      _logger.debug(
+        'Deleting recent search: $searchTerm for scope: ${scope.name}',
+      );
+      await _dataSource.deleteRecentSearch(searchTerm, _toDataScope(scope));
+      return const Right(null);
+    } catch (e) {
+      return Left(_handleError(e, 'deleting recent search'));
+    }
+  }
+
+  @override
+  Future<Either<Failure, List<String>>> getSearchSuggestions() async {
+    try {
+      _logger.debug('Fetching search suggestions');
+      final suggestions = await _dataSource.getSearchSuggestions();
+      _logger.debug('Retrieved ${suggestions.length} search suggestions');
+      return Right(suggestions);
+    } catch (e) {
+      return Left(_handleError(e, 'fetching search suggestions'));
+    }
+  }
+}

--- a/lib/features/global_search/domain/entities/pagination_params.dart
+++ b/lib/features/global_search/domain/entities/pagination_params.dart
@@ -1,0 +1,31 @@
+import 'package:equatable/equatable.dart';
+
+/// Domain value object encapsulating offset/limit pagination for a search operation.
+///
+/// - [offset] is the number of records to skip (default: 0).
+/// - [limit] is the maximum number of records to return per page (default: 20).
+///
+/// Example — fetching the second page of 20 results:
+/// ```dart
+/// const PaginationParams(offset: 20, limit: 20)
+/// ```
+class PaginationParams extends Equatable {
+  final int offset;
+  final int limit;
+
+  const PaginationParams({
+    this.offset = 0,
+    this.limit = 20,
+  });
+
+  /// Returns a copy of this [PaginationParams] with the given fields replaced.
+  PaginationParams copyWith({int? offset, int? limit}) {
+    return PaginationParams(
+      offset: offset ?? this.offset,
+      limit: limit ?? this.limit,
+    );
+  }
+
+  @override
+  List<Object?> get props => [offset, limit];
+}

--- a/lib/features/global_search/domain/entities/search_params_entity.dart
+++ b/lib/features/global_search/domain/entities/search_params_entity.dart
@@ -1,0 +1,66 @@
+import 'package:construculator/features/global_search/domain/entities/pagination_params.dart';
+import 'package:construculator/features/global_search/domain/entities/search_scope_entity.dart';
+import 'package:equatable/equatable.dart';
+
+/// Domain entity representing the parameters for a global search operation.
+///
+/// Mirrors [SearchParamsDto] in the data layer without introducing a data-layer
+/// dependency into the domain. The data layer maps this entity to [SearchParamsDto]
+/// before passing it to the data source.
+///
+/// **Date filtering**: [filterByDate] is sent as an ISO8601 string. If the UI
+/// lets users pick a calendar date (e.g. March 20th), truncate to start of day
+/// (00:00:00) before passing, or ensure the backend RPC treats it as a date range.
+class SearchParams extends Equatable {
+  /// The search query text.
+  final String query;
+
+  /// Optional tag to restrict results to items with this tag.
+  final String? filterByTag;
+
+  /// Date filter. Truncate to start of day (00:00:00) if picking a calendar date
+  /// to avoid exact-timestamp mismatch with backend.
+  final DateTime? filterByDate;
+
+  /// Optional owner identifier to restrict results to items owned by this user.
+  final String? filterByOwner;
+
+  /// Optional scope limiting which areas or entity types are searched.
+  final SearchScope? scope;
+
+  /// Pagination settings for the search request and result pages.
+  final PaginationParams pagination;
+
+  const SearchParams({
+    required this.query,
+    this.filterByTag,
+    this.filterByDate,
+    this.filterByOwner,
+    this.scope,
+    this.pagination = const PaginationParams(),
+  });
+
+  static const Object _absent = Object();
+
+  /// Returns a copy of this [SearchParams] with the given fields replaced.
+  SearchParams copyWith({
+    String? query,
+    Object? filterByTag = _absent,
+    Object? filterByDate = _absent,
+    Object? filterByOwner = _absent,
+    Object? scope = _absent,
+    PaginationParams? pagination,
+  }) {
+    return SearchParams(
+      query: query ?? this.query,
+      filterByTag: filterByTag == _absent ? this.filterByTag : filterByTag as String?,
+      filterByDate: filterByDate == _absent ? this.filterByDate : filterByDate as DateTime?,
+      filterByOwner: filterByOwner == _absent ? this.filterByOwner : filterByOwner as String?,
+      scope: scope == _absent ? this.scope : scope as SearchScope?,
+      pagination: pagination ?? this.pagination,
+    );
+  }
+
+  @override
+  List<Object?> get props => [query, filterByTag, filterByDate, filterByOwner, scope, pagination];
+}

--- a/lib/features/global_search/domain/entities/search_results.dart
+++ b/lib/features/global_search/domain/entities/search_results.dart
@@ -1,0 +1,43 @@
+import 'package:construculator/features/estimation/domain/entities/cost_estimate_entity.dart';
+import 'package:construculator/libraries/auth/domain/entities/user_profile_entity.dart';
+import 'package:construculator/libraries/project/domain/entities/project_entity.dart';
+import 'package:equatable/equatable.dart';
+
+/// Domain entity representing the results of a global search.
+///
+/// Holds the matched [projects], cost [estimations], and [members] returned
+/// after executing a search query against the backend.
+///
+/// All lists default to empty, so callers can always iterate without null checks.
+class SearchResults extends Equatable {
+  /// Projects matching the search query.
+  final List<Project> projects;
+
+  /// Cost estimations matching the search query.
+  final List<CostEstimate> estimations;
+
+  /// Team members matching the search query.
+  final List<UserProfile> members;
+
+  const SearchResults({
+    this.projects = const [],
+    this.estimations = const [],
+    this.members = const [],
+  });
+
+  /// Returns a copy of this [SearchResults] with the given fields replaced.
+  SearchResults copyWith({
+    List<Project>? projects,
+    List<CostEstimate>? estimations,
+    List<UserProfile>? members,
+  }) {
+    return SearchResults(
+      projects: projects ?? this.projects,
+      estimations: estimations ?? this.estimations,
+      members: members ?? this.members,
+    );
+  }
+
+  @override
+  List<Object?> get props => [projects, estimations, members];
+}

--- a/lib/features/global_search/domain/entities/search_scope_entity.dart
+++ b/lib/features/global_search/domain/entities/search_scope_entity.dart
@@ -1,0 +1,6 @@
+/// Domain-level enum identifying which domain(s) the global search operates across.
+///
+/// Mirrors [SearchScope] in the data layer without introducing a data-layer
+/// dependency into the domain. The data layer maps to this type via
+/// [SearchScope.values.byName].
+enum SearchScope { dashboard, calculation, estimation, member }

--- a/lib/features/global_search/domain/repositories/global_search_repository.dart
+++ b/lib/features/global_search/domain/repositories/global_search_repository.dart
@@ -1,0 +1,75 @@
+import 'package:construculator/features/global_search/domain/entities/search_params_entity.dart';
+import 'package:construculator/features/global_search/domain/entities/search_results.dart';
+import 'package:construculator/features/global_search/domain/entities/search_scope_entity.dart';
+import 'package:construculator/libraries/either/interfaces/either.dart';
+import 'package:construculator/libraries/errors/failures.dart';
+
+/// Abstract repository interface for global search operations.
+///
+/// This repository defines the contract for searching across projects,
+/// cost estimations, and members, as well as managing per-user search history
+/// and suggestions. It follows the repository pattern to decouple the domain
+/// layer from the specific data source implementation.
+///
+/// All methods return [Either] so that callers receive a typed [Failure] on
+/// error rather than catching exceptions directly.
+abstract class GlobalSearchRepository {
+  /// Performs a global search using the supplied [params].
+  ///
+  /// Returns a [Future] that completes with an [Either] containing either
+  /// a [Failure] or a [SearchResults] holding matched projects, estimations,
+  /// and members.
+  ///
+  /// Filtering (tag, date, owner, scope) and pagination are driven by [params].
+  Future<Either<Failure, SearchResults>> search(SearchParams params);
+
+  /// Fetches the authenticated user's recent search terms for the given [scope].
+  ///
+  /// Returns a [Future] that completes with an [Either] containing either
+  /// a [Failure] or a [List<String>] ordered by most recent first.
+  /// Returns an empty list when the user is not authenticated.
+  Future<Either<Failure, List<String>>> getRecentSearches(SearchScope scope);
+
+  /// Saves [searchTerm] to the authenticated user's history for [scope].
+  ///
+  /// [projectId] is the project context in which the search was performed.
+  /// It is nullable for searches not scoped to a specific project (e.g. dashboard).
+  /// [hasResults] should be `true` only when the search returned at least one result.
+  /// Terms saved with [hasResults] = false are kept in history but excluded from
+  /// suggestions.
+  ///
+  /// Returns a [Future] that completes with an [Either] containing either
+  /// a [Failure] or void on success.
+  /// Does nothing when the user is not authenticated or the term is empty.
+  Future<Either<Failure, void>> saveRecentSearch(
+    String searchTerm,
+    SearchScope scope, {
+    String? projectId,
+    bool hasResults = false,
+  });
+
+  /// Removes [searchTerm] from the authenticated user's history for [scope].
+  ///
+  /// Does NOT affect global suggestion counts — the term's analytics record is
+  /// preserved.
+  ///
+  /// Returns a [Future] that completes with an [Either] containing either
+  /// a [Failure] or void on success.
+  /// Does nothing when the user is not authenticated or the term is empty.
+  Future<Either<Failure, void>> deleteRecentSearch(
+    String searchTerm,
+    SearchScope scope,
+  );
+
+  /// Fetches personalized search suggestions for the authenticated user.
+  ///
+  /// Priority 1: user's own search history (has_results = true), sorted by
+  /// frequency.
+  /// Priority 2: searches by teammates within shared projects (has_results = true).
+  ///
+  /// Returns a [Future] that completes with an [Either] containing either
+  /// a [Failure] or a [List<String>].
+  /// Returns an empty list when no suggestions are found or the user is not
+  /// authenticated.
+  Future<Either<Failure, List<String>>> getSearchSuggestions();
+}

--- a/lib/features/global_search/global_search_module.dart
+++ b/lib/features/global_search/global_search_module.dart
@@ -1,0 +1,36 @@
+import 'package:construculator/app/app_bootstrap.dart';
+import 'package:construculator/features/global_search/data/data_source/interfaces/global_search_data_source.dart';
+import 'package:construculator/features/global_search/data/data_source/remote_global_search_data_source.dart';
+import 'package:construculator/features/global_search/data/repositories/global_search_repository_impl.dart';
+import 'package:construculator/features/global_search/domain/repositories/global_search_repository.dart';
+import 'package:construculator/features/global_search/presentation/bloc/global_search_bloc/global_search_bloc.dart';
+import 'package:construculator/libraries/supabase/supabase_module.dart';
+import 'package:flutter_modular/flutter_modular.dart';
+
+/// Module for the global search feature.
+///
+/// Provides [GlobalSearchDataSource] and [GlobalSearchRepository] bindings
+/// for dependency injection.
+class GlobalSearchModule extends Module {
+  final AppBootstrap appBootstrap;
+
+  GlobalSearchModule(this.appBootstrap);
+
+  @override
+  List<Module> get imports => [SupabaseModule(appBootstrap)];
+
+  @override
+  void binds(Injector i) {
+    i.addLazySingleton<GlobalSearchDataSource>(
+      () => RemoteGlobalSearchDataSource(
+        supabaseWrapper: appBootstrap.supabaseWrapper,
+      ),
+    );
+    i.addLazySingleton<GlobalSearchRepository>(
+      () => GlobalSearchRepositoryImpl(dataSource: i()),
+    );
+    i.add<GlobalSearchBloc>(
+      () => GlobalSearchBloc(repository: i()),
+    );
+  }
+}

--- a/lib/features/global_search/presentation/bloc/global_search_bloc/global_search_bloc.dart
+++ b/lib/features/global_search/presentation/bloc/global_search_bloc/global_search_bloc.dart
@@ -1,0 +1,193 @@
+import 'dart:async' show unawaited;
+import 'package:construculator/features/global_search/domain/entities/search_params_entity.dart';
+import 'package:construculator/features/global_search/domain/entities/search_results.dart';
+import 'package:construculator/features/global_search/domain/entities/search_scope_entity.dart';
+import 'package:construculator/features/global_search/domain/repositories/global_search_repository.dart';
+import 'package:construculator/libraries/errors/failures.dart';
+import 'package:construculator/libraries/logging/app_logger.dart';
+import 'package:equatable/equatable.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:rxdart/rxdart.dart';
+
+part 'global_search_event.dart';
+part 'global_search_state.dart';
+
+/// Debounce duration applied to [GlobalSearchQueryUpdated] events.
+/// Kept here so the BLoC owns the contract — no UI-side debouncing required.
+const Duration _kQueryDebounceDuration = Duration(milliseconds: 300);
+
+/// Returns an [EventTransformer] that debounces events by [duration] and
+/// switches to the latest mapper stream, cancelling any in-flight processing.
+///
+/// Extracted so any future event that needs the same treatment can reuse it
+/// without duplicating the rxdart pipeline inline.
+EventTransformer<E> _debounce<E>(Duration duration) =>
+    (events, mapper) => events.debounceTime(duration).switchMap(mapper);
+
+/// Bloc for managing global search state across projects, estimations, and members
+class GlobalSearchBloc extends Bloc<GlobalSearchEvent, GlobalSearchState> {
+  static final _logger = AppLogger().tag('GlobalSearchBloc');
+  final GlobalSearchRepository _repository;
+
+  List<String> _recentSearches = const [];
+
+  List<String> _suggestions = const [];
+
+  String _currentQuery = '';
+
+  GlobalSearchBloc({required GlobalSearchRepository repository})
+    : _repository = repository,
+      super(const GlobalSearchInitial()) {
+    on<GlobalSearchStarted>(_onStarted);
+    on<GlobalSearchQueryUpdated>(
+      _onQueryUpdated,
+      // Debounce at the BLoC level so the UI can dispatch on every keystroke
+      // without triggering redundant state emissions.
+      transformer: _debounce(_kQueryDebounceDuration),
+    );
+    on<GlobalSearchPerformed>(_onPerformed);
+    on<GlobalSearchRecentRemoved>(_onRecentRemoved);
+    on<GlobalSearchSuggestionsRequested>(_onSuggestionsRequested);
+  }
+
+  Future<void> _onStarted(
+    GlobalSearchStarted event,
+    Emitter<GlobalSearchState> emit,
+  ) async {
+    final result = await _repository.getRecentSearches(event.scope);
+    result.fold((failure) => emit(GlobalSearchLoadFailure(failure: failure)), (
+      recentSearches,
+    ) {
+      _recentSearches = recentSearches;
+      _suggestions = const [];
+      _currentQuery = '';
+      emit(
+        GlobalSearchReady(
+          recentSearches: recentSearches,
+          query: '',
+          suggestions: const [],
+          suggestionsLoading: false,
+        ),
+      );
+    });
+  }
+
+  void _onQueryUpdated(
+    GlobalSearchQueryUpdated event,
+    Emitter<GlobalSearchState> emit,
+  ) {
+    _currentQuery = event.query;
+    emit(
+      GlobalSearchReady(
+        recentSearches: _recentSearches,
+        query: event.query,
+        suggestions: _suggestions,
+        suggestionsLoading: false,
+      ),
+    );
+  }
+
+  Future<void> _onPerformed(
+    GlobalSearchPerformed event,
+    Emitter<GlobalSearchState> emit,
+  ) async {
+    _currentQuery = event.query;
+    emit(GlobalSearchLoadInProgress(query: event.query));
+
+    final result = await _repository.search(
+      SearchParams(query: event.query, scope: event.scope),
+    );
+
+    result.fold((failure) => emit(GlobalSearchLoadFailure(failure: failure)), (
+      searchResults,
+    ) {
+      final hasResults =
+          searchResults.projects.isNotEmpty ||
+          searchResults.estimations.isNotEmpty ||
+          searchResults.members.isNotEmpty;
+
+      if (hasResults) {
+        emit(GlobalSearchLoadSuccess(results: searchResults));
+      } else {
+        emit(GlobalSearchLoadEmpty(query: event.query));
+      }
+
+      if (!_recentSearches.contains(event.query)) {
+        _recentSearches = [event.query, ..._recentSearches];
+      }
+
+      // Non-blocking: persistence runs after results are shown.
+      // Do NOT call emit() inside this callback — the Emitter is already
+      // closed when _onPerformed returns.
+      unawaited(
+        _repository
+            .saveRecentSearch(event.query, event.scope, hasResults: hasResults)
+            .then(
+              (saveResult) => saveResult.fold(
+                (_) => _logger.warning(
+                  'Recent search save failed silently (non-blocking; search results already shown)',
+                ),
+                (_) {},
+              ),
+            ),
+      );
+    });
+  }
+
+  Future<void> _onRecentRemoved(
+    GlobalSearchRecentRemoved event,
+    Emitter<GlobalSearchState> emit,
+  ) async {
+    final result = await _repository.deleteRecentSearch(
+      event.searchTerm,
+      event.scope,
+    );
+
+    result.fold(
+      (failure) => emit(GlobalSearchRecentDeleteFailure(failure: failure)),
+      (_) {
+        _recentSearches = List<String>.from(_recentSearches)
+          ..removeWhere((term) => term == event.searchTerm);
+        emit(
+          GlobalSearchReady(
+            recentSearches: _recentSearches,
+            query: _currentQuery,
+            suggestions: _suggestions,
+            suggestionsLoading: false,
+          ),
+        );
+      },
+    );
+  }
+
+  Future<void> _onSuggestionsRequested(
+    GlobalSearchSuggestionsRequested event,
+    Emitter<GlobalSearchState> emit,
+  ) async {
+    emit(
+      GlobalSearchReady(
+        recentSearches: _recentSearches,
+        query: _currentQuery,
+        suggestions: _suggestions,
+        suggestionsLoading: true,
+      ),
+    );
+
+    final result = await _repository.getSearchSuggestions();
+
+    result.fold(
+      (failure) => emit(GlobalSearchSuggestionsLoadFailure(failure: failure)),
+      (suggestions) {
+        _suggestions = suggestions;
+        emit(
+          GlobalSearchReady(
+            recentSearches: _recentSearches,
+            query: _currentQuery,
+            suggestions: suggestions,
+            suggestionsLoading: false,
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/features/global_search/presentation/bloc/global_search_bloc/global_search_event.dart
+++ b/lib/features/global_search/presentation/bloc/global_search_bloc/global_search_event.dart
@@ -1,0 +1,74 @@
+// coverage:ignore-file
+part of 'global_search_bloc.dart';
+
+/// Base sealed class for all GlobalSearch events
+sealed class GlobalSearchEvent extends Equatable {
+  const GlobalSearchEvent();
+
+  @override
+  List<Object?> get props => [];
+}
+
+/// Event for initializing the search screen and loading recent search history
+class GlobalSearchStarted extends GlobalSearchEvent {
+  /// The scope to load recent searches for, defaults to [SearchScope.dashboard]
+  final SearchScope scope;
+
+  const GlobalSearchStarted({this.scope = SearchScope.dashboard});
+
+  @override
+  List<Object?> get props => [scope];
+}
+
+/// Event for updating the search query text field.
+///
+/// Can be dispatched on every keystroke — the BLoC applies a debounce
+/// transformer so redundant rapid emissions are coalesced automatically.
+class GlobalSearchQueryUpdated extends GlobalSearchEvent {
+  /// The current value of the search input field
+  final String query;
+
+  const GlobalSearchQueryUpdated({required this.query});
+
+  @override
+  List<Object?> get props => [query];
+}
+
+/// Event for submitting a search query
+class GlobalSearchPerformed extends GlobalSearchEvent {
+  /// The search query entered by the user
+  final String query;
+
+  /// The scope to search within, defaults to [SearchScope.dashboard]
+  final SearchScope scope;
+
+  const GlobalSearchPerformed({
+    required this.query,
+    this.scope = SearchScope.dashboard,
+  });
+
+  @override
+  List<Object?> get props => [query, scope];
+}
+
+/// Event for removing a term from the user's recent search history
+class GlobalSearchRecentRemoved extends GlobalSearchEvent {
+  /// The search term to remove
+  final String searchTerm;
+
+  /// The scope the search term belongs to
+  final SearchScope scope;
+
+  const GlobalSearchRecentRemoved({
+    required this.searchTerm,
+    required this.scope,
+  });
+
+  @override
+  List<Object?> get props => [searchTerm, scope];
+}
+
+/// Event for loading personalized search suggestions
+class GlobalSearchSuggestionsRequested extends GlobalSearchEvent {
+  const GlobalSearchSuggestionsRequested();
+}

--- a/lib/features/global_search/presentation/bloc/global_search_bloc/global_search_state.dart
+++ b/lib/features/global_search/presentation/bloc/global_search_bloc/global_search_state.dart
@@ -1,0 +1,123 @@
+// coverage:ignore-file
+part of 'global_search_bloc.dart';
+
+/// Base sealed class for all GlobalSearch states.
+sealed class GlobalSearchState extends Equatable {
+  const GlobalSearchState();
+
+  @override
+  List<Object?> get props => [];
+}
+
+/// Cold start before [GlobalSearchStarted] has completed (no history loaded yet).
+class GlobalSearchInitial extends GlobalSearchState {
+  const GlobalSearchInitial();
+}
+
+/// Idle / interactive state after history has been loaded at least once.
+///
+/// Emitted after [GlobalSearchStarted], on [GlobalSearchQueryUpdated], while
+/// loading suggestions, and after history or suggestions change.
+class GlobalSearchReady extends GlobalSearchState {
+  /// Recent search terms previously submitted by the user.
+  final List<String> recentSearches;
+
+  /// The current text typed into the search field.
+  final String query;
+
+  /// Personalized search suggestions fetched from the repository.
+  final List<String> suggestions;
+
+  /// Whether a suggestions fetch is currently in flight.
+  final bool suggestionsLoading;
+
+  const GlobalSearchReady({
+    this.recentSearches = const [],
+    this.query = '',
+    this.suggestions = const [],
+    this.suggestionsLoading = false,
+  });
+
+  GlobalSearchReady copyWith({
+    List<String>? recentSearches,
+    String? query,
+    List<String>? suggestions,
+    bool? suggestionsLoading,
+  }) {
+    return GlobalSearchReady(
+      recentSearches: recentSearches ?? this.recentSearches,
+      query: query ?? this.query,
+      suggestions: suggestions ?? this.suggestions,
+      suggestionsLoading: suggestionsLoading ?? this.suggestionsLoading,
+    );
+  }
+
+  @override
+  List<Object?> get props => [recentSearches, query, suggestions, suggestionsLoading];
+}
+
+/// Emitted while a search request is in flight.
+class GlobalSearchLoadInProgress extends GlobalSearchState {
+  /// The search query that triggered this in-progress request.
+  final String query;
+
+  const GlobalSearchLoadInProgress({required this.query});
+
+  @override
+  List<Object?> get props => [query];
+}
+
+/// Emitted when a search returns at least one result.
+class GlobalSearchLoadSuccess extends GlobalSearchState {
+  /// The results returned by a successful search request.
+  final SearchResults results;
+
+  const GlobalSearchLoadSuccess({required this.results});
+
+  @override
+  List<Object?> get props => [results];
+}
+
+/// Emitted when a search completes successfully but returns no results.
+class GlobalSearchLoadEmpty extends GlobalSearchState {
+  /// The search query that produced no results.
+  final String query;
+
+  const GlobalSearchLoadEmpty({required this.query});
+
+  @override
+  List<Object?> get props => [query];
+}
+
+/// Emitted when a search or history fetch fails.
+class GlobalSearchLoadFailure extends GlobalSearchState {
+  /// The failure describing why the search request failed.
+  final Failure failure;
+
+  const GlobalSearchLoadFailure({required this.failure});
+
+  @override
+  List<Object?> get props => [failure];
+}
+
+/// Emitted when loading personalized suggestions fails.
+class GlobalSearchSuggestionsLoadFailure extends GlobalSearchState {
+  /// The failure describing why the suggestions fetch failed.
+  final Failure failure;
+
+  const GlobalSearchSuggestionsLoadFailure({required this.failure});
+
+  @override
+  List<Object?> get props => [failure];
+}
+
+/// Emitted when removing a recent search term from history fails.
+class GlobalSearchRecentDeleteFailure extends GlobalSearchState {
+  /// The failure describing why the recent search deletion failed.
+  final Failure failure;
+
+  const GlobalSearchRecentDeleteFailure({required this.failure});
+
+  @override
+  List<Object?> get props => [failure];
+}

--- a/lib/libraries/auth/data/models/user_profile_dto.dart
+++ b/lib/libraries/auth/data/models/user_profile_dto.dart
@@ -1,4 +1,5 @@
 import 'package:construculator/libraries/auth/domain/entities/user_profile_entity.dart';
+import 'package:construculator/libraries/supabase/database_constants.dart';
 import 'package:equatable/equatable.dart';
 
 /// Data Transfer Object for UserProfile entity.
@@ -40,12 +41,12 @@ class UserProfileDto extends Equatable {
   /// to the DTO structure, mapping snake_case JSON keys to camelCase Dart properties.
   factory UserProfileDto.fromJson(Map<String, dynamic> json) {
     return UserProfileDto(
-      id: json['id'] as String,
-      credentialId: json['credential_id'] as String?,
-      firstName: json['first_name'] as String,
-      lastName: json['last_name'] as String,
-      professionalRole: json['professional_role'] as String,
-      profilePhotoUrl: json['profile_photo_url'] as String?,
+      id: json[DatabaseConstants.idColumn] as String,
+      credentialId: json[DatabaseConstants.credentialIdColumn] as String?,
+      firstName: json[DatabaseConstants.firstNameColumn] as String,
+      lastName: json[DatabaseConstants.lastNameColumn] as String,
+      professionalRole: json[DatabaseConstants.professionalRoleColumn] as String,
+      profilePhotoUrl: json[DatabaseConstants.profilePhotoUrlColumn] as String?,
     );
   }
 
@@ -58,12 +59,12 @@ class UserProfileDto extends Equatable {
   /// (e.g., `'credential_id': null`). It is intended for read/display
   /// serialization only
   Map<String, dynamic> toJson() => {
-    'id': id,
-    'credential_id': credentialId,
-    'first_name': firstName,
-    'last_name': lastName,
-    'professional_role': professionalRole,
-    'profile_photo_url': profilePhotoUrl,
+    DatabaseConstants.idColumn: id,
+    DatabaseConstants.credentialIdColumn: credentialId,
+    DatabaseConstants.firstNameColumn: firstName,
+    DatabaseConstants.lastNameColumn: lastName,
+    DatabaseConstants.professionalRoleColumn: professionalRole,
+    DatabaseConstants.profilePhotoUrlColumn: profilePhotoUrl,
   };
 
   /// Converts this DTO to a domain [UserProfile] entity.

--- a/lib/libraries/auth/domain/entities/user_profile_entity.dart
+++ b/lib/libraries/auth/domain/entities/user_profile_entity.dart
@@ -15,7 +15,10 @@ class UserProfile extends Equatable {
   /// Unique identifier for the user
   final String id;
 
-  /// The credential ID associated with the user
+  // TODO: [CA-614] credentialId is an internal Supabase Auth identifier (used in
+  // RLS/JWT) with no domain meaning. Strip from UserProfile and UserProfileDto.toDomain()
+  // once all 31 consumers are audited. Do not read or surface this field outside the
+  // auth library. https://ripplearc.youtrack.cloud/issue/CA-614
   final String? credentialId;
 
   /// User's first name

--- a/lib/libraries/errors/failures.dart
+++ b/lib/libraries/errors/failures.dart
@@ -1,5 +1,6 @@
 import 'package:construculator/libraries/auth/domain/types/auth_types.dart';
 import 'package:construculator/libraries/estimation/domain/estimation_error_type.dart';
+import 'package:construculator/libraries/global_search/domain/search_error_type.dart';
 import 'package:equatable/equatable.dart';
 
 /// Failure represents specific, anticipated error conditions or alternative outcomes of an operation (e.g., a use case or repository method).
@@ -58,6 +59,18 @@ class EstimationFailure extends Failure {
   /// The type of estimation error that occurred.
   final EstimationErrorType errorType;
   const EstimationFailure({required this.errorType});
+
+  @override
+  List<Object?> get props => [errorType];
+}
+
+/// Failure thrown when a global search error occurs.
+class SearchFailure extends Failure {
+  /// The type of search error that occurred.
+  final SearchErrorType errorType;
+
+  /// Creates a [SearchFailure] with the given [errorType].
+  const SearchFailure({required this.errorType});
 
   @override
   List<Object?> get props => [errorType];

--- a/lib/libraries/global_search/domain/search_error_type.dart
+++ b/lib/libraries/global_search/domain/search_error_type.dart
@@ -1,0 +1,18 @@
+// coverage:ignore-file
+
+/// Error types for global search operations.
+///
+/// - [connectionError]: network connectivity issue prevented the operation
+/// - [parsingError]: data parsing or mapping from the response failed
+/// - [timeoutError]: the operation timed out before completing
+/// - [unexpectedDatabaseError]: a database query or operation failed unexpectedly
+/// - [notFoundError]: the requested record was not found
+/// - [duplicateEntryError]: a unique constraint was violated (e.g. concurrent upsert)
+enum SearchErrorType {
+  connectionError,
+  parsingError,
+  timeoutError,
+  unexpectedDatabaseError,
+  notFoundError,
+  duplicateEntryError,
+}

--- a/lib/libraries/supabase/database_constants.dart
+++ b/lib/libraries/supabase/database_constants.dart
@@ -15,6 +15,11 @@ class DatabaseConstants {
   static const String costEstimationLogsTable = 'cost_estimate_logs';
   static const String projectsTable = 'projects';
   static const String projectMembersTable = 'project_members';
+  static const String searchHistoryTable = 'search_history';
+
+  // RPC function names
+  static const String globalSearchRpcFunction = 'global_search';
+  static const String searchSuggestionsRpcFunction = 'get_search_suggestions';
 
   // Column names
   static const String idColumn = 'id';
@@ -33,6 +38,24 @@ class DatabaseConstants {
   static const String owningCompanyIdColumn = 'owning_company_id';
   static const String exportFolderLinkColumn = 'export_folder_link';
   static const String exportStorageProviderColumn = 'export_storage_provider';
+
+  // Search history columns
+  static const String searchTermColumn = 'search_term';
+  static const String scopeColumn = 'scope';
+  static const String searchCountColumn = 'search_count';
+  static const String hasResultsColumn = 'has_results';
+
+  /// Unique constraint columns for search_history upsert.
+  /// Used with [SupabaseWrapper.upsert] onConflict parameter.
+  static const String searchHistoryUpsertConflictColumns =
+      '$userIdColumn,$searchTermColumn,$scopeColumn';
+
+  // User profile columns (id field uses the shared idColumn above)
+  static const String credentialIdColumn = 'credential_id';
+  static const String firstNameColumn = 'first_name';
+  static const String lastNameColumn = 'last_name';
+  static const String professionalRoleColumn = 'professional_role';
+  static const String profilePhotoUrlColumn = 'profile_photo_url';
 
   // Cost Estimation Logs columns
   static const String estimateIdColumn = 'estimate_id';

--- a/lib/libraries/supabase/interfaces/supabase_wrapper.dart
+++ b/lib/libraries/supabase/interfaces/supabase_wrapper.dart
@@ -84,6 +84,25 @@ abstract class SupabaseWrapper {
     required dynamic filterValue,
   });
 
+  /// Select rows matching ALL entries in [filters] (multi-column equality).
+  ///
+  /// Equivalent to chaining multiple `.eq()` calls at the database level.
+  /// Prefer this over [select] when filtering by more than one column to
+  /// avoid fetching and filtering rows in memory.
+  ///
+  /// [table] The table to select from
+  /// [columns] The columns to select, defaults to '*'
+  /// [filters] Map of column → value pairs that must all match
+  /// [orderBy] Optional column name to order results by
+  /// [ascending] Sort direction when [orderBy] is provided, defaults to true
+  Future<List<Map<String, dynamic>>> selectMatch({
+    required String table,
+    String columns = '*',
+    required Map<String, dynamic> filters,
+    String? orderBy,
+    bool ascending = true,
+  });
+
   /// Select a set of rows from a table where [filterColumn] value is in [filterValues].
   ///
   /// [table] The table to select from
@@ -123,6 +142,20 @@ abstract class SupabaseWrapper {
     required Map<String, dynamic> data,
   });
 
+  /// Upsert a row into a table.
+  ///
+  /// Inserts the row, or updates it if a conflict occurs on [onConflict] columns.
+  /// Requires a unique constraint on the [onConflict] columns in the database.
+  ///
+  /// [table] The table to upsert into
+  /// [data] The data to insert or update
+  /// [onConflict] Comma-separated column names for conflict detection (e.g. 'user_id,search_term,scope')
+  Future<void> upsert({
+    required String table,
+    required Map<String, dynamic> data,
+    required String onConflict,
+  });
+
   /// Update a row in a table
   ///
   /// [table] The table to update
@@ -152,6 +185,18 @@ abstract class SupabaseWrapper {
     required String table,
     required String filterColumn,
     required dynamic filterValue,
+  });
+
+  /// Delete all rows from a table matching every entry in [filters].
+  ///
+  /// Prefer this over [delete] when deleting by a composite key, as it issues
+  /// a single DELETE … WHERE rather than a select-then-loop approach.
+  ///
+  /// [table] The table to delete from
+  /// [filters] Map of column → value pairs that must all match
+  Future<void> deleteMatch({
+    required String table,
+    required Map<String, dynamic> filters,
   });
 
   /// Select a paginated set of rows from a table, ordered and ranged.

--- a/lib/libraries/supabase/supabase_wrapper_impl.dart
+++ b/lib/libraries/supabase/supabase_wrapper_impl.dart
@@ -115,6 +115,24 @@ class SupabaseWrapperImpl implements SupabaseWrapper {
   }
 
   @override
+  Future<List<Map<String, dynamic>>> selectMatch({
+    required String table,
+    String columns = '*',
+    required Map<String, dynamic> filters,
+    String? orderBy,
+    bool ascending = true,
+  }) async {
+    var query = _supabaseClient
+        .from(table)
+        .select(columns)
+        .match(filters.cast<String, Object>());
+    if (orderBy != null) {
+      return await query.order(orderBy, ascending: ascending);
+    }
+    return await query;
+  }
+
+  @override
   Future<List<Map<String, dynamic>>> selectWhereIn({
     required String table,
     String columns = '*',
@@ -155,6 +173,17 @@ class SupabaseWrapperImpl implements SupabaseWrapper {
   }
 
   @override
+  Future<void> upsert({
+    required String table,
+    required Map<String, dynamic> data,
+    required String onConflict,
+  }) async {
+    await _supabaseClient
+        .from(table)
+        .upsert(data, onConflict: onConflict);
+  }
+
+  @override
   Future<Map<String, dynamic>> update({
     required String table,
     required Map<String, dynamic> data,
@@ -183,6 +212,17 @@ class SupabaseWrapperImpl implements SupabaseWrapper {
     required dynamic filterValue,
   }) async {
     await _supabaseClient.from(table).delete().eq(filterColumn, filterValue);
+  }
+
+  @override
+  Future<void> deleteMatch({
+    required String table,
+    required Map<String, dynamic> filters,
+  }) async {
+    await _supabaseClient
+        .from(table)
+        .delete()
+        .match(filters.cast<String, Object>());
   }
 
   @override

--- a/lib/libraries/supabase/testing/fake_supabase_wrapper.dart
+++ b/lib/libraries/supabase/testing/fake_supabase_wrapper.dart
@@ -67,6 +67,12 @@ class FakeSupabaseWrapper implements SupabaseWrapper {
   /// Controls whether [delete] throws an exception
   bool shouldThrowOnDelete = false;
 
+  /// Controls whether [selectMatch] throws an exception
+  bool shouldThrowOnSelectMatch = false;
+
+  /// Controls whether [upsert] throws an exception
+  bool shouldThrowOnUpsert = false;
+
   /// Controls whether [selectPaginated] throws an exception
   bool shouldThrowOnSelectPaginated = false;
 
@@ -117,6 +123,14 @@ class FakeSupabaseWrapper implements SupabaseWrapper {
   /// Used to specify the error message thrown when [delete] is attempted
   String? deleteErrorMessage;
 
+  /// Error message for selectMatch.
+  /// Used to specify the error message thrown when [selectMatch] is attempted
+  String? selectMatchErrorMessage;
+
+  /// Error message for upsert.
+  /// Used to specify the error message thrown when [upsert] is attempted
+  String? upsertErrorMessage;
+
   /// Error message for selectPaginated.
   /// Used to specify the error message thrown when [selectPaginated] is attempted
   String? selectPaginatedErrorMessage;
@@ -141,6 +155,12 @@ class FakeSupabaseWrapper implements SupabaseWrapper {
   /// Used to specify the type of exception thrown when [delete] is attempted
   SupabaseExceptionType? deleteExceptionType;
 
+  /// Used to specify the type of exception thrown when [selectMatch] is attempted
+  SupabaseExceptionType? selectMatchExceptionType;
+
+  /// Used to specify the type of exception thrown when [upsert] is attempted
+  SupabaseExceptionType? upsertExceptionType;
+
   /// Used to specify the type of exception thrown when [selectPaginated] is attempted
   SupabaseExceptionType? selectPaginatedExceptionType;
 
@@ -158,6 +178,9 @@ class FakeSupabaseWrapper implements SupabaseWrapper {
 
   /// Controls whether [select] returns a null user
   bool shouldReturnNullOnSelectMultiple = false;
+
+  /// Controls whether [selectMatch] returns an empty list
+  bool shouldReturnEmptyOnSelectMatch = false;
 
   /// Controls whether [selectSingle] returns a null user
   bool shouldReturnNullOnSelect = false;
@@ -408,6 +431,62 @@ class FakeSupabaseWrapper implements SupabaseWrapper {
   }
 
   @override
+  Future<List<Map<String, dynamic>>> selectMatch({
+    required String table,
+    String columns = '*',
+    required Map<String, dynamic> filters,
+    String? orderBy,
+    bool ascending = true,
+  }) async {
+    _methodCalls.add({
+      'method': 'selectMatch',
+      'table': table,
+      'columns': columns,
+      'filters': Map<String, dynamic>.from(filters),
+      if (orderBy != null) 'orderBy': orderBy,
+      'ascending': ascending,
+    });
+
+    if (shouldDelayOperations) {
+      await completer?.future;
+    }
+
+    if (shouldThrowOnSelectMatch) {
+      _throwConfiguredException(
+        selectMatchExceptionType,
+        selectMatchErrorMessage ?? 'Select match failed',
+      );
+    }
+
+    if (shouldReturnEmptyOnSelectMatch) {
+      return [];
+    }
+
+    final tableData = _tables[table] ?? [];
+    final results = tableData
+        .where(
+          (row) => filters.entries.every(
+            (entry) => row[entry.key] == entry.value,
+          ),
+        )
+        .toList();
+
+    if (orderBy != null) {
+      results.sort((a, b) {
+        final aVal = a[orderBy];
+        final bVal = b[orderBy];
+        if (aVal == null && bVal == null) return 0;
+        if (aVal == null) return ascending ? -1 : 1;
+        if (bVal == null) return ascending ? 1 : -1;
+        final cmp = aVal.toString().compareTo(bVal.toString());
+        return ascending ? cmp : -cmp;
+      });
+    }
+
+    return results;
+  }
+
+  @override
   Future<List<Map<String, dynamic>>> selectWhereIn({
     required String table,
     String columns = '*',
@@ -615,6 +694,53 @@ class FakeSupabaseWrapper implements SupabaseWrapper {
   }
 
   @override
+  Future<void> upsert({
+    required String table,
+    required Map<String, dynamic> data,
+    required String onConflict,
+  }) async {
+    _methodCalls.add({
+      'method': 'upsert',
+      'table': table,
+      'data': Map<String, dynamic>.from(data),
+      'onConflict': onConflict,
+    });
+
+    if (shouldDelayOperations) {
+      await completer?.future;
+    }
+
+    if (shouldThrowOnUpsert) {
+      _throwConfiguredException(
+        upsertExceptionType,
+        upsertErrorMessage ?? 'Upsert failed',
+      );
+    }
+
+    final conflictColumns =
+        onConflict.split(',').map((c) => c.trim()).where((c) => c.isNotEmpty);
+
+    final tableData = _tables[table] ?? [];
+    final existingIndex = tableData.indexWhere((row) {
+      return conflictColumns.every((col) => row[col] == data[col]);
+    });
+
+    final upsertData = Map<String, dynamic>.from(data);
+    upsertData['updated_at'] = _clock.now().toIso8601String();
+
+    if (existingIndex >= 0) {
+      upsertData['created_at'] = tableData[existingIndex]['created_at'];
+      tableData[existingIndex] = upsertData;
+    } else {
+      upsertData['id'] = (tableData.length + 1).toString();
+      upsertData['created_at'] = _clock.now().toIso8601String();
+      tableData.add(upsertData);
+    }
+    _tables[table] = tableData;
+    _emitTableData(table);
+  }
+
+  @override
   Future<Map<String, dynamic>> update({
     required String table,
     required Map<String, dynamic> data,
@@ -714,6 +840,39 @@ class FakeSupabaseWrapper implements SupabaseWrapper {
         .where((row) => row[filterColumn] != filterValue)
         .toList();
     _tables[table] = filteredData;
+    _emitTableData(table);
+  }
+
+  @override
+  Future<void> deleteMatch({
+    required String table,
+    required Map<String, dynamic> filters,
+  }) async {
+    if (shouldDelayOperations) {
+      await completer?.future;
+    }
+
+    _methodCalls.add({
+      'method': 'deleteMatch',
+      'table': table,
+      'filters': Map<String, dynamic>.from(filters),
+    });
+
+    if (shouldThrowOnDelete) {
+      _throwConfiguredException(
+        deleteExceptionType,
+        deleteErrorMessage ?? 'Delete failed',
+      );
+    }
+
+    final tableData = _tables[table] ?? [];
+    _tables[table] = tableData
+        .where(
+          (row) => !filters.entries.every(
+            (entry) => row[entry.key] == entry.value,
+          ),
+        )
+        .toList();
     _emitTableData(table);
   }
 
@@ -936,8 +1095,10 @@ class FakeSupabaseWrapper implements SupabaseWrapper {
     shouldThrowOnInsert = false;
     shouldThrowOnUpdate = false;
     shouldThrowOnSelectMultiple = false;
+    shouldThrowOnSelectMatch = false;
     shouldThrowOnSelectPaginated = false;
     shouldThrowOnDelete = false;
+    shouldThrowOnUpsert = false;
     shouldThrowOnRpc = false;
 
     signInErrorMessage = null;
@@ -947,23 +1108,28 @@ class FakeSupabaseWrapper implements SupabaseWrapper {
     resetPasswordErrorMessage = null;
     signOutErrorMessage = null;
     selectErrorMessage = null;
+    selectMatchErrorMessage = null;
     selectPaginatedErrorMessage = null;
     insertErrorMessage = null;
     updateErrorMessage = null;
     deleteErrorMessage = null;
+    upsertErrorMessage = null;
     rpcErrorMessage = null;
 
     selectExceptionType = null;
     selectPaginatedExceptionType = null;
     selectMultipleExceptionType = null;
+    selectMatchExceptionType = null;
     insertExceptionType = null;
     updateExceptionType = null;
     deleteExceptionType = null;
+    upsertExceptionType = null;
     rpcExceptionType = null;
     postgrestErrorCode = null;
 
     shouldReturnNullUser = false;
     shouldReturnNullOnSelect = false;
+    shouldReturnEmptyOnSelectMatch = false;
 
     shouldDelayOperations = false;
     completer = null;

--- a/lib/libraries/supabase/testing/fake_supabase_wrapper.dart
+++ b/lib/libraries/supabase/testing/fake_supabase_wrapper.dart
@@ -67,6 +67,9 @@ class FakeSupabaseWrapper implements SupabaseWrapper {
   /// Controls whether [delete] throws an exception
   bool shouldThrowOnDelete = false;
 
+  /// Controls whether [deleteMatch] throws an exception
+  bool shouldThrowOnDeleteMatch = false;
+
   /// Controls whether [selectMatch] throws an exception
   bool shouldThrowOnSelectMatch = false;
 
@@ -123,6 +126,10 @@ class FakeSupabaseWrapper implements SupabaseWrapper {
   /// Used to specify the error message thrown when [delete] is attempted
   String? deleteErrorMessage;
 
+  /// Error message for deleteMatch.
+  /// Used to specify the error message thrown when [deleteMatch] is attempted
+  String? deleteMatchErrorMessage;
+
   /// Error message for selectMatch.
   /// Used to specify the error message thrown when [selectMatch] is attempted
   String? selectMatchErrorMessage;
@@ -154,6 +161,9 @@ class FakeSupabaseWrapper implements SupabaseWrapper {
 
   /// Used to specify the type of exception thrown when [delete] is attempted
   SupabaseExceptionType? deleteExceptionType;
+
+  /// Used to specify the type of exception thrown when [deleteMatch] is attempted
+  SupabaseExceptionType? deleteMatchExceptionType;
 
   /// Used to specify the type of exception thrown when [selectMatch] is attempted
   SupabaseExceptionType? selectMatchExceptionType;
@@ -202,6 +212,9 @@ class FakeSupabaseWrapper implements SupabaseWrapper {
 
   /// The event that occurs when a user signs in
   supabase.AuthChangeEvent signInEvent = supabase.AuthChangeEvent.signedIn;
+
+  /// Auto-incrementing counter for generating unique record IDs
+  int _nextId = 1;
 
   final Clock _clock;
 
@@ -465,9 +478,8 @@ class FakeSupabaseWrapper implements SupabaseWrapper {
     final tableData = _tables[table] ?? [];
     final results = tableData
         .where(
-          (row) => filters.entries.every(
-            (entry) => row[entry.key] == entry.value,
-          ),
+          (row) =>
+              filters.entries.every((entry) => row[entry.key] == entry.value),
         )
         .toList();
 
@@ -478,7 +490,9 @@ class FakeSupabaseWrapper implements SupabaseWrapper {
         if (aVal == null && bVal == null) return 0;
         if (aVal == null) return ascending ? -1 : 1;
         if (bVal == null) return ascending ? 1 : -1;
-        final cmp = aVal.toString().compareTo(bVal.toString());
+        final cmp = (aVal is Comparable && bVal is Comparable)
+            ? (aVal).compareTo(bVal)
+            : aVal.toString().compareTo(bVal.toString());
         return ascending ? cmp : -cmp;
       });
     }
@@ -682,7 +696,7 @@ class FakeSupabaseWrapper implements SupabaseWrapper {
     final tableData = _tables[table] ?? [];
 
     final insertData = Map<String, dynamic>.from(data);
-    insertData['id'] = (tableData.length + 1).toString();
+    insertData['id'] = (_nextId++).toString();
     insertData['created_at'] = _clock.now().toIso8601String();
     insertData['updated_at'] = _clock.now().toIso8601String();
 
@@ -717,8 +731,10 @@ class FakeSupabaseWrapper implements SupabaseWrapper {
       );
     }
 
-    final conflictColumns =
-        onConflict.split(',').map((c) => c.trim()).where((c) => c.isNotEmpty);
+    final conflictColumns = onConflict
+        .split(',')
+        .map((c) => c.trim())
+        .where((c) => c.isNotEmpty);
 
     final tableData = _tables[table] ?? [];
     final existingIndex = tableData.indexWhere((row) {
@@ -732,7 +748,7 @@ class FakeSupabaseWrapper implements SupabaseWrapper {
       upsertData['created_at'] = tableData[existingIndex]['created_at'];
       tableData[existingIndex] = upsertData;
     } else {
-      upsertData['id'] = (tableData.length + 1).toString();
+      upsertData['id'] = (_nextId++).toString();
       upsertData['created_at'] = _clock.now().toIso8601String();
       tableData.add(upsertData);
     }
@@ -858,19 +874,18 @@ class FakeSupabaseWrapper implements SupabaseWrapper {
       'filters': Map<String, dynamic>.from(filters),
     });
 
-    if (shouldThrowOnDelete) {
+    if (shouldThrowOnDeleteMatch) {
       _throwConfiguredException(
-        deleteExceptionType,
-        deleteErrorMessage ?? 'Delete failed',
+        deleteMatchExceptionType,
+        deleteMatchErrorMessage ?? 'Delete match failed',
       );
     }
 
     final tableData = _tables[table] ?? [];
     _tables[table] = tableData
         .where(
-          (row) => !filters.entries.every(
-            (entry) => row[entry.key] == entry.value,
-          ),
+          (row) =>
+              !filters.entries.every((entry) => row[entry.key] == entry.value),
         )
         .toList();
     _emitTableData(table);
@@ -1098,6 +1113,7 @@ class FakeSupabaseWrapper implements SupabaseWrapper {
     shouldThrowOnSelectMatch = false;
     shouldThrowOnSelectPaginated = false;
     shouldThrowOnDelete = false;
+    shouldThrowOnDeleteMatch = false;
     shouldThrowOnUpsert = false;
     shouldThrowOnRpc = false;
 
@@ -1113,6 +1129,7 @@ class FakeSupabaseWrapper implements SupabaseWrapper {
     insertErrorMessage = null;
     updateErrorMessage = null;
     deleteErrorMessage = null;
+    deleteMatchErrorMessage = null;
     upsertErrorMessage = null;
     rpcErrorMessage = null;
 
@@ -1123,6 +1140,7 @@ class FakeSupabaseWrapper implements SupabaseWrapper {
     insertExceptionType = null;
     updateExceptionType = null;
     deleteExceptionType = null;
+    deleteMatchExceptionType = null;
     upsertExceptionType = null;
     rpcExceptionType = null;
     postgrestErrorCode = null;
@@ -1136,6 +1154,7 @@ class FakeSupabaseWrapper implements SupabaseWrapper {
     shouldEmitStreamErrors = false;
     shouldReturnUser = false;
     shouldThrowOnGetUserProfile = false;
+    _nextId = 1;
 
     clearAllData();
     clearMethodCalls();

--- a/lib/libraries/supabase/testing/fake_supabase_wrapper.dart
+++ b/lib/libraries/supabase/testing/fake_supabase_wrapper.dart
@@ -864,15 +864,15 @@ class FakeSupabaseWrapper implements SupabaseWrapper {
     required String table,
     required Map<String, dynamic> filters,
   }) async {
-    if (shouldDelayOperations) {
-      await completer?.future;
-    }
-
     _methodCalls.add({
       'method': 'deleteMatch',
       'table': table,
       'filters': Map<String, dynamic>.from(filters),
     });
+
+    if (shouldDelayOperations) {
+      await completer?.future;
+    }
 
     if (shouldThrowOnDeleteMatch) {
       _throwConfiguredException(

--- a/test/features/global_search/units/blocs/global_search_bloc_test.dart
+++ b/test/features/global_search/units/blocs/global_search_bloc_test.dart
@@ -1,0 +1,711 @@
+import 'package:bloc_test/bloc_test.dart';
+import 'package:construculator/app/app_bootstrap.dart';
+import 'package:construculator/features/global_search/domain/entities/search_scope_entity.dart';
+import 'package:construculator/features/global_search/global_search_module.dart';
+import 'package:construculator/features/global_search/presentation/bloc/global_search_bloc/global_search_bloc.dart';
+import 'package:construculator/libraries/config/testing/fake_app_config.dart';
+import 'package:construculator/libraries/config/testing/fake_env_loader.dart';
+import 'package:construculator/libraries/errors/failures.dart';
+import 'package:construculator/libraries/global_search/domain/search_error_type.dart';
+import 'package:construculator/libraries/supabase/data/supabase_types.dart';
+import 'package:construculator/libraries/supabase/database_constants.dart';
+import 'package:construculator/libraries/supabase/interfaces/supabase_wrapper.dart';
+import 'package:construculator/libraries/supabase/testing/fake_supabase_user.dart';
+import 'package:construculator/libraries/supabase/testing/fake_supabase_wrapper.dart';
+import 'package:construculator/libraries/time/testing/fake_clock_impl.dart';
+import 'package:flutter_modular/flutter_modular.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../../../estimations/helpers/estimation_test_data_map_factory.dart'
+    as estimation_factory;
+
+// ---------------------------------------------------------------------------
+// Test data helpers
+// ---------------------------------------------------------------------------
+
+const String _testUserId = 'user-bloc-test';
+const String _testUserEmail = 'bloc@test.com';
+
+Map<String, dynamic> _fakeMemberData({String? id, String? firstName}) {
+  return <String, dynamic>{
+    DatabaseConstants.idColumn: id ?? 'member-1',
+    DatabaseConstants.credentialIdColumn: null,
+    DatabaseConstants.firstNameColumn: firstName ?? 'John',
+    DatabaseConstants.lastNameColumn: 'Doe',
+    DatabaseConstants.professionalRoleColumn: 'Engineer',
+    DatabaseConstants.profilePhotoUrlColumn: null,
+  };
+}
+
+Map<String, dynamic> _fakeProjectData({String? id, String? projectName}) {
+  return {
+    DatabaseConstants.idColumn: id ?? 'project-1',
+    DatabaseConstants.projectNameColumn: projectName ?? 'Test Project',
+    DatabaseConstants.descriptionColumn: 'Test description',
+    DatabaseConstants.creatorUserIdColumn: _testUserId,
+    DatabaseConstants.owningCompanyIdColumn: null,
+    DatabaseConstants.exportFolderLinkColumn: null,
+    DatabaseConstants.exportStorageProviderColumn: null,
+    DatabaseConstants.createdAtColumn: '2024-01-01T00:00:00.000Z',
+    DatabaseConstants.updatedAtColumn: '2024-01-01T00:00:00.000Z',
+    DatabaseConstants.statusColumn: 'active',
+  };
+}
+
+Map<String, dynamic> _fakeSearchHistoryData({
+  required String userId,
+  required String searchTerm,
+  SearchScope scope = SearchScope.dashboard,
+}) {
+  return {
+    DatabaseConstants.idColumn: '1',
+    DatabaseConstants.userIdColumn: userId,
+    DatabaseConstants.searchTermColumn: searchTerm,
+    DatabaseConstants.scopeColumn: scope.name,
+    DatabaseConstants.searchCountColumn: 1,
+    DatabaseConstants.createdAtColumn: '2024-01-01T00:00:00.000Z',
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+void main() {
+  group('GlobalSearchBloc', () {
+    late FakeSupabaseWrapper fakeSupabase;
+    late FakeClockImpl fakeClock;
+
+    setUpAll(() {
+      fakeClock = FakeClockImpl();
+      Modular.init(
+        GlobalSearchModule(
+          AppBootstrap(
+            supabaseWrapper: FakeSupabaseWrapper(clock: fakeClock),
+            config: FakeAppConfig(),
+            envLoader: FakeEnvLoader(),
+          ),
+        ),
+      );
+      fakeSupabase = Modular.get<SupabaseWrapper>() as FakeSupabaseWrapper;
+    });
+
+    tearDownAll(() {
+      Modular.destroy();
+    });
+
+    setUp(() {
+      fakeSupabase.reset();
+    });
+
+    test('initial state is GlobalSearchInitial (cold start, no history yet)', () {
+      final bloc = Modular.get<GlobalSearchBloc>();
+      expect(bloc.state, const GlobalSearchInitial());
+      expect(bloc.state is GlobalSearchInitial, isTrue);
+      bloc.close();
+    });
+
+    group('GlobalSearchStarted', () {
+      blocTest<GlobalSearchBloc, GlobalSearchState>(
+        'emits GlobalSearchReady with recentSearches when history exists',
+        setUp: () {
+          fakeSupabase.setCurrentUser(
+            FakeUser(
+              id: _testUserId,
+              email: _testUserEmail,
+              createdAt: fakeClock.now().toIso8601String(),
+            ),
+          );
+          fakeSupabase.addTableData(DatabaseConstants.searchHistoryTable, [
+            _fakeSearchHistoryData(userId: _testUserId, searchTerm: 'wall'),
+            _fakeSearchHistoryData(userId: _testUserId, searchTerm: 'concrete'),
+          ]);
+        },
+        build: () => Modular.get<GlobalSearchBloc>(),
+        act: (bloc) => bloc.add(const GlobalSearchStarted()),
+        expect: () => [
+          isA<GlobalSearchReady>().having(
+            (s) => s.recentSearches,
+            'recentSearches',
+            containsAll(['wall', 'concrete']),
+          ),
+        ],
+      );
+
+      blocTest<GlobalSearchBloc, GlobalSearchState>(
+        'emits GlobalSearchReady with empty recentSearches when user is not authenticated',
+        setUp: () {
+          fakeSupabase.setCurrentUser(null);
+        },
+        build: () => Modular.get<GlobalSearchBloc>(),
+        act: (bloc) => bloc.add(const GlobalSearchStarted()),
+        expect: () => [
+          const GlobalSearchReady(),
+        ],
+      );
+
+      blocTest<GlobalSearchBloc, GlobalSearchState>(
+        'emits GlobalSearchLoadFailure when Supabase throws on getRecentSearches',
+        setUp: () {
+          fakeSupabase.setCurrentUser(
+            FakeUser(
+              id: _testUserId,
+              email: _testUserEmail,
+              createdAt: fakeClock.now().toIso8601String(),
+            ),
+          );
+          fakeSupabase.shouldThrowOnSelectMatch = true;
+          fakeSupabase.selectMatchExceptionType = SupabaseExceptionType.timeout;
+        },
+        build: () => Modular.get<GlobalSearchBloc>(),
+        act: (bloc) => bloc.add(const GlobalSearchStarted()),
+        expect: () => [
+          isA<GlobalSearchLoadFailure>().having(
+            (s) => s.failure,
+            'failure',
+            SearchFailure(errorType: SearchErrorType.timeoutError),
+          ),
+        ],
+      );
+
+      blocTest<GlobalSearchBloc, GlobalSearchState>(
+        'uses supplied scope — loads estimation-scoped recents when scope is estimation',
+        setUp: () {
+          fakeSupabase.setCurrentUser(
+            FakeUser(
+              id: _testUserId,
+              email: _testUserEmail,
+              createdAt: fakeClock.now().toIso8601String(),
+            ),
+          );
+          fakeSupabase.addTableData(DatabaseConstants.searchHistoryTable, [
+            _fakeSearchHistoryData(
+              userId: _testUserId,
+              searchTerm: 'estimation-term',
+              scope: SearchScope.estimation,
+            ),
+            _fakeSearchHistoryData(
+              userId: _testUserId,
+              searchTerm: 'dashboard-term',
+            ),
+          ]);
+        },
+        build: () => Modular.get<GlobalSearchBloc>(),
+        act: (bloc) =>
+            bloc.add(const GlobalSearchStarted(scope: SearchScope.estimation)),
+        expect: () => [
+          isA<GlobalSearchReady>()
+              .having(
+                (s) => s.recentSearches,
+                'estimation-scoped recents',
+                contains('estimation-term'),
+              )
+              .having(
+                (s) => s.recentSearches,
+                'no dashboard recents',
+                isNot(contains('dashboard-term')),
+              ),
+        ],
+      );
+
+      blocTest<GlobalSearchBloc, GlobalSearchState>(
+        'resets query to empty when re-opened after a previous search session',
+        setUp: () {
+          fakeSupabase.setCurrentUser(null);
+        },
+        build: () => Modular.get<GlobalSearchBloc>(),
+        act: (bloc) async {
+          bloc.add(const GlobalSearchQueryUpdated(query: 'stale-query'));
+          // Await the debounced GlobalSearchReady emission before re-opening
+          // the screen, so the state sequence is deterministic.
+          await bloc.stream.first;
+          bloc.add(const GlobalSearchStarted());
+        },
+        wait: const Duration(milliseconds: 310),
+        expect: () => [
+          const GlobalSearchReady(recentSearches: [], query: 'stale-query'),
+          isA<GlobalSearchReady>().having(
+            (s) => s.query,
+            'query is reset to empty on fresh start',
+            isEmpty,
+          ),
+        ],
+      );
+    });
+
+    group('GlobalSearchPerformed', () {
+      blocTest<GlobalSearchBloc, GlobalSearchState>(
+        'emits [GlobalSearchLoadInProgress, GlobalSearchLoadSuccess] when search returns results',
+        setUp: () {
+          fakeSupabase.setRpcResponse(
+            DatabaseConstants.globalSearchRpcFunction,
+            {
+              'projects': [_fakeProjectData(projectName: 'Foundation Work')],
+              'estimations': [
+                estimation_factory
+                    .EstimationTestDataMapFactory.createFakeEstimationData(
+                  estimateName: 'Steel Frame',
+                ),
+              ],
+              'members': [],
+            },
+          );
+        },
+        build: () => Modular.get<GlobalSearchBloc>(),
+        act: (bloc) =>
+            bloc.add(const GlobalSearchPerformed(query: 'foundation')),
+        expect: () => [
+          const GlobalSearchLoadInProgress(query: 'foundation'),
+          isA<GlobalSearchLoadSuccess>().having(
+            (s) => s.results.projects,
+            'projects',
+            hasLength(1),
+          ),
+        ],
+      );
+
+      blocTest<GlobalSearchBloc, GlobalSearchState>(
+        'emits [GlobalSearchLoadInProgress, GlobalSearchLoadEmpty] when search returns no results',
+        setUp: () {
+          fakeSupabase.setRpcResponse(
+            DatabaseConstants.globalSearchRpcFunction,
+            {'projects': [], 'estimations': [], 'members': []},
+          );
+        },
+        build: () => Modular.get<GlobalSearchBloc>(),
+        act: (bloc) =>
+            bloc.add(const GlobalSearchPerformed(query: 'nonexistent')),
+        expect: () => [
+          const GlobalSearchLoadInProgress(query: 'nonexistent'),
+          const GlobalSearchLoadEmpty(query: 'nonexistent'),
+        ],
+      );
+
+      blocTest<GlobalSearchBloc, GlobalSearchState>(
+        'emits [GlobalSearchLoadInProgress, GlobalSearchLoadFailure] when Supabase throws on search',
+        setUp: () {
+          fakeSupabase.shouldThrowOnRpc = true;
+          fakeSupabase.rpcExceptionType = SupabaseExceptionType.socket;
+        },
+        build: () => Modular.get<GlobalSearchBloc>(),
+        act: (bloc) => bloc.add(const GlobalSearchPerformed(query: 'test')),
+        expect: () => [
+          const GlobalSearchLoadInProgress(query: 'test'),
+          isA<GlobalSearchLoadFailure>().having(
+            (s) => s.failure,
+            'failure',
+            SearchFailure(errorType: SearchErrorType.connectionError),
+          ),
+        ],
+      );
+
+      blocTest<GlobalSearchBloc, GlobalSearchState>(
+        'emits [GlobalSearchLoadInProgress, GlobalSearchLoadFailure] with timeoutError when RPC times out',
+        setUp: () {
+          fakeSupabase.shouldThrowOnRpc = true;
+          fakeSupabase.rpcExceptionType = SupabaseExceptionType.timeout;
+        },
+        build: () => Modular.get<GlobalSearchBloc>(),
+        act: (bloc) => bloc.add(const GlobalSearchPerformed(query: 'test')),
+        expect: () => [
+          const GlobalSearchLoadInProgress(query: 'test'),
+          isA<GlobalSearchLoadFailure>().having(
+            (s) => s.failure,
+            'failure',
+            SearchFailure(errorType: SearchErrorType.timeoutError),
+          ),
+        ],
+      );
+
+      blocTest<GlobalSearchBloc, GlobalSearchState>(
+        'emits [GlobalSearchLoadInProgress, GlobalSearchLoadFailure] with parsingError on TypeError',
+        setUp: () {
+          fakeSupabase.shouldThrowOnRpc = true;
+          fakeSupabase.rpcExceptionType = SupabaseExceptionType.type;
+        },
+        build: () => Modular.get<GlobalSearchBloc>(),
+        act: (bloc) => bloc.add(const GlobalSearchPerformed(query: 'test')),
+        expect: () => [
+          const GlobalSearchLoadInProgress(query: 'test'),
+          isA<GlobalSearchLoadFailure>(),
+        ],
+      );
+
+      blocTest<GlobalSearchBloc, GlobalSearchState>(
+        'GlobalSearchLoadSuccess carries all three result lists',
+        setUp: () {
+          fakeSupabase.setRpcResponse(
+            DatabaseConstants.globalSearchRpcFunction,
+            {
+              'projects': [_fakeProjectData(id: 'p1')],
+              'estimations': [
+                estimation_factory
+                    .EstimationTestDataMapFactory.createFakeEstimationData(
+                  id: 'e1',
+                ),
+              ],
+              'members': [_fakeMemberData(id: 'm1', firstName: 'Alice')],
+            },
+          );
+        },
+        build: () => Modular.get<GlobalSearchBloc>(),
+        act: (bloc) => bloc.add(const GlobalSearchPerformed(query: 'alice')),
+        verify: (bloc) {
+          final state = bloc.state as GlobalSearchLoadSuccess;
+          expect(state.results.projects, hasLength(1));
+          expect(state.results.estimations, hasLength(1));
+          expect(state.results.members, hasLength(1));
+        },
+      );
+
+      blocTest<GlobalSearchBloc, GlobalSearchState>(
+        'uses supplied scope — emits correct states when scope is estimation',
+        setUp: () {
+          fakeSupabase.setCurrentUser(
+            FakeUser(
+              id: _testUserId,
+              email: _testUserEmail,
+              createdAt: fakeClock.now().toIso8601String(),
+            ),
+          );
+          fakeSupabase.setRpcResponse(
+            DatabaseConstants.globalSearchRpcFunction,
+            {
+              'projects': [_fakeProjectData()],
+              'estimations': [],
+              'members': [],
+            },
+          );
+        },
+        build: () => Modular.get<GlobalSearchBloc>(),
+        act: (bloc) => bloc.add(
+          const GlobalSearchPerformed(
+            query: 'steel',
+            scope: SearchScope.estimation,
+          ),
+        ),
+        expect: () => [
+          const GlobalSearchLoadInProgress(query: 'steel'),
+          isA<GlobalSearchLoadSuccess>(),
+        ],
+        verify: (_) {
+          final rpcCalls = fakeSupabase.getMethodCallsFor('rpc');
+          expect(
+            rpcCalls,
+            isNotEmpty,
+            reason: 'RPC must be called for a search',
+          );
+          final rpcParams = rpcCalls.first['params'] as Map<String, dynamic>?;
+          expect(
+            rpcParams?['scope'],
+            equals(SearchScope.estimation.name),
+            reason: 'scope must be forwarded to the RPC',
+          );
+        },
+      );
+
+      blocTest<GlobalSearchBloc, GlobalSearchState>(
+        'optimistically adds query to recentSearches so GlobalSearchQueryUpdated sees it immediately',
+        setUp: () {
+          fakeSupabase.setCurrentUser(
+            FakeUser(
+              id: _testUserId,
+              email: _testUserEmail,
+              createdAt: fakeClock.now().toIso8601String(),
+            ),
+          );
+          fakeSupabase.setRpcResponse(
+            DatabaseConstants.globalSearchRpcFunction,
+            {
+              'projects': [_fakeProjectData()],
+              'estimations': [],
+              'members': [],
+            },
+          );
+        },
+        build: () => Modular.get<GlobalSearchBloc>(),
+        act: (bloc) async {
+          bloc.add(const GlobalSearchPerformed(query: 'steel'));
+          await bloc.stream.firstWhere((s) => s is GlobalSearchLoadSuccess);
+          bloc.add(const GlobalSearchQueryUpdated(query: ''));
+        },
+        wait: const Duration(milliseconds: 310),
+        expect: () => [
+          const GlobalSearchLoadInProgress(query: 'steel'),
+          isA<GlobalSearchLoadSuccess>(),
+          isA<GlobalSearchReady>().having(
+            (s) => s.recentSearches,
+            'searched term is present without reopening the screen',
+            contains('steel'),
+          ),
+        ],
+      );
+
+      blocTest<GlobalSearchBloc, GlobalSearchState>(
+        'does not duplicate query in recentSearches if already present',
+        setUp: () {
+          fakeSupabase.setCurrentUser(
+            FakeUser(
+              id: _testUserId,
+              email: _testUserEmail,
+              createdAt: fakeClock.now().toIso8601String(),
+            ),
+          );
+          fakeSupabase.addTableData(
+            DatabaseConstants.searchHistoryTable,
+            [_fakeSearchHistoryData(userId: _testUserId, searchTerm: 'steel')],
+          );
+          fakeSupabase.setRpcResponse(
+            DatabaseConstants.globalSearchRpcFunction,
+            {
+              'projects': [_fakeProjectData()],
+              'estimations': [],
+              'members': [],
+            },
+          );
+        },
+        build: () => Modular.get<GlobalSearchBloc>(),
+        act: (bloc) async {
+          bloc.add(const GlobalSearchStarted());
+          await bloc.stream.firstWhere((s) => s is GlobalSearchReady);
+          bloc.add(const GlobalSearchPerformed(query: 'steel'));
+          await bloc.stream.firstWhere((s) => s is GlobalSearchLoadSuccess);
+          bloc.add(const GlobalSearchQueryUpdated(query: ''));
+        },
+        wait: const Duration(milliseconds: 310),
+        verify: (bloc) {
+          final state = bloc.state as GlobalSearchReady;
+          expect(
+            state.recentSearches.where((t) => t == 'steel'),
+            hasLength(1),
+            reason: 'steel must appear exactly once',
+          );
+        },
+      );
+    });
+
+    group('GlobalSearchQueryUpdated', () {
+      blocTest<GlobalSearchBloc, GlobalSearchState>(
+        'emits GlobalSearchReady with updated query and empty recentSearches',
+        build: () => Modular.get<GlobalSearchBloc>(),
+        act: (bloc) =>
+            bloc.add(const GlobalSearchQueryUpdated(query: 'foundation')),
+        wait: const Duration(milliseconds: 310),
+        expect: () => [
+          const GlobalSearchReady(recentSearches: [], query: 'foundation'),
+        ],
+      );
+
+      blocTest<GlobalSearchBloc, GlobalSearchState>(
+        'emits GlobalSearchReady with empty query when query is cleared',
+        build: () => Modular.get<GlobalSearchBloc>(),
+        act: (bloc) => bloc.add(const GlobalSearchQueryUpdated(query: '')),
+        wait: const Duration(milliseconds: 310),
+        expect: () => [
+          const GlobalSearchReady(),
+        ],
+      );
+
+      blocTest<GlobalSearchBloc, GlobalSearchState>(
+        'does not make any Supabase calls when query is updated',
+        build: () => Modular.get<GlobalSearchBloc>(),
+        act: (bloc) =>
+            bloc.add(const GlobalSearchQueryUpdated(query: 'concrete')),
+        wait: const Duration(milliseconds: 310),
+        verify: (_) {
+          expect(fakeSupabase.getMethodCallsFor('rpc'), isEmpty);
+          expect(fakeSupabase.getMethodCallsFor('selectMatch'), isEmpty);
+        },
+      );
+
+      blocTest<GlobalSearchBloc, GlobalSearchState>(
+        'preserves recentSearches loaded by GlobalSearchStarted when query is updated',
+        setUp: () {
+          fakeSupabase.setCurrentUser(
+            FakeUser(
+              id: _testUserId,
+              email: _testUserEmail,
+              createdAt: fakeClock.now().toIso8601String(),
+            ),
+          );
+          fakeSupabase.addTableData(DatabaseConstants.searchHistoryTable, [
+            _fakeSearchHistoryData(userId: _testUserId, searchTerm: 'steel'),
+          ]);
+        },
+        build: () => Modular.get<GlobalSearchBloc>(),
+        act: (bloc) async {
+          bloc.add(const GlobalSearchStarted());
+          await bloc.stream.firstWhere((s) {
+            if (s is! GlobalSearchReady) {
+              return false;
+            }
+            return s.recentSearches.contains('steel');
+          });
+          bloc.add(const GlobalSearchQueryUpdated(query: 'concrete'));
+        },
+        wait: const Duration(milliseconds: 310),
+        expect: () => [
+          isA<GlobalSearchReady>().having(
+            (s) => s.recentSearches,
+            'recentSearches after Started',
+            contains('steel'),
+          ),
+          isA<GlobalSearchReady>()
+              .having((s) => s.query, 'query after QueryUpdated', 'concrete')
+              .having(
+                (s) => s.recentSearches,
+                'recentSearches preserved after QueryUpdated',
+                contains('steel'),
+              ),
+        ],
+      );
+    });
+
+    group('GlobalSearchSuggestionsRequested', () {
+      blocTest<GlobalSearchBloc, GlobalSearchState>(
+        'emits [GlobalSearchReady loading, GlobalSearchReady with suggestions] when RPC succeeds',
+        setUp: () {
+          fakeSupabase.setCurrentUser(
+            FakeUser(
+              id: _testUserId,
+              email: _testUserEmail,
+              createdAt: fakeClock.now().toIso8601String(),
+            ),
+          );
+          fakeSupabase.setRpcResponse(
+            DatabaseConstants.searchSuggestionsRpcFunction,
+            ['foundation', 'concrete mix', 'steel frame'],
+          );
+        },
+        build: () => Modular.get<GlobalSearchBloc>(),
+        act: (bloc) => bloc.add(const GlobalSearchSuggestionsRequested()),
+        expect: () => [
+          isA<GlobalSearchReady>().having(
+            (s) => s.suggestionsLoading,
+            'suggestionsLoading',
+            isTrue,
+          ),
+          isA<GlobalSearchReady>()
+              .having(
+                (s) => s.suggestions,
+                'suggestions',
+                containsAll(['foundation', 'concrete mix', 'steel frame']),
+              )
+              .having(
+                (s) => s.suggestionsLoading,
+                'suggestionsLoading',
+                isFalse,
+              ),
+        ],
+      );
+
+      blocTest<GlobalSearchBloc, GlobalSearchState>(
+        'emits GlobalSearchSuggestionsLoadFailure when RPC throws',
+        setUp: () {
+          fakeSupabase.setCurrentUser(
+            FakeUser(
+              id: _testUserId,
+              email: _testUserEmail,
+              createdAt: fakeClock.now().toIso8601String(),
+            ),
+          );
+          fakeSupabase.shouldThrowOnRpc = true;
+          fakeSupabase.rpcExceptionType = SupabaseExceptionType.timeout;
+        },
+        build: () => Modular.get<GlobalSearchBloc>(),
+        act: (bloc) => bloc.add(const GlobalSearchSuggestionsRequested()),
+        expect: () => [
+          isA<GlobalSearchReady>().having(
+            (s) => s.suggestionsLoading,
+            'suggestionsLoading',
+            isTrue,
+          ),
+          isA<GlobalSearchSuggestionsLoadFailure>().having(
+            (s) => s.failure,
+            'failure',
+            SearchFailure(errorType: SearchErrorType.timeoutError),
+          ),
+        ],
+      );
+    });
+
+    group('GlobalSearchRecentRemoved', () {
+      blocTest<GlobalSearchBloc, GlobalSearchState>(
+        'emits GlobalSearchReady without removed term when delete succeeds',
+        setUp: () {
+          fakeSupabase.setCurrentUser(
+            FakeUser(
+              id: _testUserId,
+              email: _testUserEmail,
+              createdAt: fakeClock.now().toIso8601String(),
+            ),
+          );
+          fakeSupabase.addTableData(DatabaseConstants.searchHistoryTable, [
+            _fakeSearchHistoryData(userId: _testUserId, searchTerm: 'wall'),
+            _fakeSearchHistoryData(userId: _testUserId, searchTerm: 'concrete'),
+          ]);
+        },
+        build: () => Modular.get<GlobalSearchBloc>(),
+        act: (bloc) async {
+          bloc.add(const GlobalSearchStarted());
+          await bloc.stream.firstWhere((s) {
+            if (s is! GlobalSearchReady) {
+              return false;
+            }
+            return s.recentSearches.length == 2;
+          });
+          bloc.add(
+            const GlobalSearchRecentRemoved(
+              searchTerm: 'wall',
+              scope: SearchScope.dashboard,
+            ),
+          );
+        },
+        expect: () => [
+          isA<GlobalSearchReady>().having(
+            (s) => s.recentSearches,
+            'recentSearches after Started',
+            containsAll(['wall', 'concrete']),
+          ),
+          isA<GlobalSearchReady>().having(
+            (s) => s.recentSearches,
+            'recentSearches after Removed',
+            allOf(isNot(contains('wall')), contains('concrete')),
+          ),
+        ],
+      );
+
+      blocTest<GlobalSearchBloc, GlobalSearchState>(
+        'emits GlobalSearchRecentDeleteFailure when delete throws',
+        setUp: () {
+          fakeSupabase.setCurrentUser(
+            FakeUser(
+              id: _testUserId,
+              email: _testUserEmail,
+              createdAt: fakeClock.now().toIso8601String(),
+            ),
+          );
+          fakeSupabase.addTableData(DatabaseConstants.searchHistoryTable, [
+            _fakeSearchHistoryData(userId: _testUserId, searchTerm: 'wall'),
+          ]);
+          fakeSupabase.shouldThrowOnDeleteMatch = true;
+          fakeSupabase.deleteMatchExceptionType = SupabaseExceptionType.socket;
+        },
+        build: () => Modular.get<GlobalSearchBloc>(),
+        act: (bloc) => bloc.add(
+          const GlobalSearchRecentRemoved(
+            searchTerm: 'wall',
+            scope: SearchScope.dashboard,
+          ),
+        ),
+        expect: () => [
+          isA<GlobalSearchRecentDeleteFailure>().having(
+            (s) => s.failure,
+            'failure',
+            SearchFailure(errorType: SearchErrorType.connectionError),
+          ),
+        ],
+      );
+    });
+  });
+}

--- a/test/features/global_search/units/data/data_source/remote_global_search_data_source_test.dart
+++ b/test/features/global_search/units/data/data_source/remote_global_search_data_source_test.dart
@@ -1,0 +1,813 @@
+import 'dart:io';
+
+import 'package:construculator/app/app_bootstrap.dart';
+import 'package:construculator/features/global_search/data/data_source/interfaces/global_search_data_source.dart';
+import 'package:construculator/features/global_search/data/data_source/remote_global_search_data_source.dart';
+import 'package:construculator/features/global_search/data/models/pagination_params_dto.dart';
+import 'package:construculator/features/global_search/data/models/search_params_dto.dart';
+import 'package:construculator/features/global_search/data/models/search_scope.dart';
+import 'package:construculator/features/global_search/global_search_module.dart';
+import 'package:construculator/libraries/config/testing/fake_app_config.dart';
+import 'package:construculator/libraries/config/testing/fake_env_loader.dart';
+import 'package:construculator/libraries/supabase/data/supabase_types.dart';
+import 'package:construculator/libraries/supabase/database_constants.dart';
+import 'package:construculator/libraries/supabase/interfaces/supabase_wrapper.dart';
+import 'package:construculator/libraries/supabase/testing/fake_supabase_user.dart';
+import 'package:construculator/libraries/supabase/testing/fake_supabase_wrapper.dart';
+import 'package:construculator/libraries/time/testing/fake_clock_impl.dart';
+import 'package:flutter_modular/flutter_modular.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:supabase_flutter/supabase_flutter.dart' as supabase;
+
+import '../../../../estimations/helpers/estimation_test_data_map_factory.dart'
+    as estimation_factory;
+
+Map<String, dynamic> _fakeSearchHistoryData({
+  String? id,
+  required String userId,
+  required String searchTerm,
+  required String scope,
+  String? createdAt,
+}) {
+  return {
+    DatabaseConstants.idColumn: id ?? '1',
+    DatabaseConstants.userIdColumn: userId,
+    DatabaseConstants.searchTermColumn: searchTerm,
+    DatabaseConstants.scopeColumn: scope,
+    DatabaseConstants.searchCountColumn: 1,
+    DatabaseConstants.createdAtColumn: createdAt ?? '2024-01-01T00:00:00.000Z',
+  };
+}
+
+Map<String, dynamic> _fakeProjectData({
+  String? id,
+  String? projectName,
+  String? description,
+  String? creatorUserId,
+  String? createdAt,
+  String? updatedAt,
+  String? status,
+}) {
+  return {
+    DatabaseConstants.idColumn: id ?? 'project-1',
+    DatabaseConstants.projectNameColumn: projectName ?? 'Test Project',
+    DatabaseConstants.descriptionColumn: description ?? 'Test description',
+    DatabaseConstants.creatorUserIdColumn: creatorUserId ?? 'user-1',
+    DatabaseConstants.owningCompanyIdColumn: null,
+    DatabaseConstants.exportFolderLinkColumn: null,
+    DatabaseConstants.exportStorageProviderColumn: null,
+    DatabaseConstants.createdAtColumn: createdAt ?? '2024-01-01T00:00:00.000Z',
+    DatabaseConstants.updatedAtColumn: updatedAt ?? '2024-01-01T00:00:00.000Z',
+    DatabaseConstants.statusColumn: status ?? 'active',
+  };
+}
+
+void main() {
+  const String testUserId = 'user-123';
+  const String errorMsgDbConnection = 'Database connection failed';
+  const String errorMsgAuth = 'Authentication failed';
+  const String errorMsgNetwork = 'Network connection failed';
+  const String errorMsgTimeout = 'Request timeout';
+
+  group('RemoteGlobalSearchDataSource', () {
+    late RemoteGlobalSearchDataSource dataSource;
+    late FakeSupabaseWrapper fakeSupabaseWrapper;
+    late FakeClockImpl fakeClock;
+
+    setUpAll(() {
+      fakeClock = FakeClockImpl();
+      Modular.init(
+        GlobalSearchModule(
+          AppBootstrap(
+            config: FakeAppConfig(),
+            envLoader: FakeEnvLoader(),
+            supabaseWrapper: FakeSupabaseWrapper(clock: fakeClock),
+          ),
+        ),
+      );
+      fakeSupabaseWrapper =
+          Modular.get<SupabaseWrapper>() as FakeSupabaseWrapper;
+      dataSource =
+          Modular.get<GlobalSearchDataSource>() as RemoteGlobalSearchDataSource;
+    });
+
+    tearDownAll(() {
+      Modular.destroy();
+    });
+
+    setUp(() {
+      fakeSupabaseWrapper.reset();
+    });
+
+    group('search', () {
+      test(
+        'should return SearchResultsDto when RPC succeeds with projects and estimations',
+        () async {
+          final projectData = _fakeProjectData(
+            id: 'project-1',
+            projectName: 'Test Project',
+          );
+          final estimationData =
+              estimation_factory
+                  .EstimationTestDataMapFactory.createFakeEstimationData(
+                id: 'estimate-1',
+                estimateName: 'Test Estimate',
+              );
+
+          fakeSupabaseWrapper.setRpcResponse(
+            DatabaseConstants.globalSearchRpcFunction,
+            {
+              'projects': [projectData],
+              'estimations': [estimationData],
+              'members': [],
+            },
+          );
+
+          final params = const SearchParamsDto(query: 'test');
+          final result = await dataSource.search(params);
+
+          expect(result.projects, hasLength(1));
+          expect(result.projects.first.projectName, equals('Test Project'));
+          expect(result.estimations, hasLength(1));
+          expect(
+            result.estimations.first.estimateName,
+            equals('Test Estimate'),
+          );
+        },
+      );
+
+      test('should return empty results when RPC returns empty', () async {
+        fakeSupabaseWrapper.setRpcResponse(
+          DatabaseConstants.globalSearchRpcFunction,
+          {'projects': [], 'estimations': [], 'members': []},
+        );
+
+        final params = const SearchParamsDto(query: 'empty');
+        final result = await dataSource.search(params);
+
+        expect(result.projects, isEmpty);
+        expect(result.estimations, isEmpty);
+        expect(result.members, isEmpty);
+      });
+
+      test(
+        'should use default pagination (offset 0, limit 20) when not specified',
+        () async {
+          fakeSupabaseWrapper.setRpcResponse(
+            DatabaseConstants.globalSearchRpcFunction,
+            {'projects': [], 'estimations': [], 'members': []},
+          );
+
+          const params = SearchParamsDto(query: 'test');
+
+          await dataSource.search(params);
+
+          final methodCalls = fakeSupabaseWrapper.getMethodCallsFor('rpc');
+          expect(methodCalls, hasLength(1));
+
+          final paramsMap =
+              methodCalls.first['params'] as Map<String, dynamic>?;
+          expect(paramsMap, isNotNull);
+          expect(paramsMap!['offset'], equals(0));
+          expect(paramsMap['limit'], equals(20));
+        },
+      );
+
+      test(
+        'should call rpc with correct params including serialized DateTime and scope',
+        () async {
+          fakeSupabaseWrapper.setRpcResponse(
+            DatabaseConstants.globalSearchRpcFunction,
+            {'projects': [], 'estimations': [], 'members': []},
+          );
+
+          final filterDate = DateTime(2024, 3, 15);
+          final params = SearchParamsDto(
+            query: 'wall',
+            filterByTag: 'construction',
+            filterByDate: filterDate,
+            filterByOwner: 'owner-1',
+            scope: SearchScopeDto.estimation,
+            pagination: const PaginationParamsDto(offset: 10, limit: 25),
+          );
+
+          await dataSource.search(params);
+
+          final methodCalls = fakeSupabaseWrapper.getMethodCallsFor('rpc');
+          expect(methodCalls, hasLength(1));
+
+          final call = methodCalls.first;
+          expect(
+            call['functionName'],
+            equals(DatabaseConstants.globalSearchRpcFunction),
+          );
+
+          final paramsMap = call['params'] as Map<String, dynamic>?;
+          expect(paramsMap, isNotNull);
+          expect(paramsMap!['query'], equals('wall'));
+          expect(paramsMap['filter_by_tag'], equals('construction'));
+          expect(
+            paramsMap['filter_by_date'],
+            equals(filterDate.toIso8601String()),
+          );
+          expect(paramsMap['filter_by_owner'], equals('owner-1'));
+          expect(paramsMap['scope'], equals('estimation'));
+          expect(paramsMap['offset'], equals(10));
+          expect(paramsMap['limit'], equals(25));
+        },
+      );
+
+      test('should rethrow PostgrestException when RPC throws', () async {
+        fakeSupabaseWrapper.shouldThrowOnRpc = true;
+        fakeSupabaseWrapper.rpcExceptionType = SupabaseExceptionType.postgrest;
+        fakeSupabaseWrapper.rpcErrorMessage = errorMsgDbConnection;
+
+        await expectLater(
+          () => dataSource.search(const SearchParamsDto(query: 'test')),
+          throwsA(isA<supabase.PostgrestException>()),
+        );
+      });
+
+      test('should rethrow AuthException when RPC throws auth error', () async {
+        fakeSupabaseWrapper.shouldThrowOnRpc = true;
+        fakeSupabaseWrapper.rpcExceptionType = SupabaseExceptionType.auth;
+        fakeSupabaseWrapper.rpcErrorMessage = errorMsgAuth;
+
+        await expectLater(
+          () => dataSource.search(const SearchParamsDto(query: 'test')),
+          throwsA(isA<supabase.AuthException>()),
+        );
+      });
+
+      test(
+        'should rethrow socket exception when RPC throws network error',
+        () async {
+          fakeSupabaseWrapper.shouldThrowOnRpc = true;
+          fakeSupabaseWrapper.rpcExceptionType = SupabaseExceptionType.socket;
+          fakeSupabaseWrapper.rpcErrorMessage = errorMsgNetwork;
+
+          await expectLater(
+            () => dataSource.search(const SearchParamsDto(query: 'test')),
+            throwsA(isA<SocketException>()),
+          );
+        },
+      );
+
+      test(
+        'should rethrow timeout exception when RPC throws timeout error',
+        () async {
+          fakeSupabaseWrapper.shouldThrowOnRpc = true;
+          fakeSupabaseWrapper.rpcExceptionType = SupabaseExceptionType.timeout;
+          fakeSupabaseWrapper.rpcErrorMessage = errorMsgTimeout;
+
+          await expectLater(
+            () => dataSource.search(const SearchParamsDto(query: 'test')),
+            throwsA(isA<Exception>()),
+          );
+        },
+      );
+    });
+
+    group('getSearchSuggestions', () {
+      test('should return list of strings when RPC succeeds', () async {
+        fakeSupabaseWrapper.setCurrentUser(
+          FakeUser(
+            id: testUserId,
+            email: 'test@test.com',
+            createdAt: fakeClock.now().toIso8601String(),
+          ),
+        );
+        fakeSupabaseWrapper.setRpcResponse(
+          DatabaseConstants.searchSuggestionsRpcFunction,
+          ['foundation', 'concrete mix', 'steel frame'],
+        );
+
+        final result = await dataSource.getSearchSuggestions();
+
+        expect(result, hasLength(3));
+        expect(
+          result,
+          containsAll(['foundation', 'concrete mix', 'steel frame']),
+        );
+      });
+
+      test('should pass user_id to RPC', () async {
+        fakeSupabaseWrapper.setCurrentUser(
+          FakeUser(
+            id: testUserId,
+            email: 'test@test.com',
+            createdAt: fakeClock.now().toIso8601String(),
+          ),
+        );
+        fakeSupabaseWrapper.setRpcResponse(
+          DatabaseConstants.searchSuggestionsRpcFunction,
+          ['foundation'],
+        );
+
+        await dataSource.getSearchSuggestions();
+
+        final rpcCalls = fakeSupabaseWrapper.getMethodCallsFor('rpc');
+        final suggestionsCall = rpcCalls.lastWhere(
+          (c) =>
+              c['functionName'] ==
+              DatabaseConstants.searchSuggestionsRpcFunction,
+        );
+        final params = suggestionsCall['params'] as Map<String, dynamic>?;
+        expect(params, isNotNull);
+        expect(params![DatabaseConstants.userIdColumn], equals(testUserId));
+      });
+
+      test(
+        'should return empty list without calling RPC when user not authenticated',
+        () async {
+          fakeSupabaseWrapper.setCurrentUser(null);
+
+          final result = await dataSource.getSearchSuggestions();
+
+          expect(result, isEmpty);
+          final rpcCalls = fakeSupabaseWrapper.getMethodCallsFor('rpc');
+          expect(
+            rpcCalls.any(
+              (c) =>
+                  c['functionName'] ==
+                  DatabaseConstants.searchSuggestionsRpcFunction,
+            ),
+            isFalse,
+          );
+        },
+      );
+
+      test('should return empty list when RPC returns empty', () async {
+        fakeSupabaseWrapper.setCurrentUser(
+          FakeUser(
+            id: testUserId,
+            email: 'test@test.com',
+            createdAt: fakeClock.now().toIso8601String(),
+          ),
+        );
+        fakeSupabaseWrapper.setRpcResponse(
+          DatabaseConstants.searchSuggestionsRpcFunction,
+          [],
+        );
+
+        final result = await dataSource.getSearchSuggestions();
+
+        expect(result, isEmpty);
+      });
+
+      test('should rethrow PostgrestException when RPC throws', () async {
+        fakeSupabaseWrapper.setCurrentUser(
+          FakeUser(
+            id: testUserId,
+            email: 'test@test.com',
+            createdAt: fakeClock.now().toIso8601String(),
+          ),
+        );
+        fakeSupabaseWrapper.shouldThrowOnRpc = true;
+        fakeSupabaseWrapper.rpcExceptionType = SupabaseExceptionType.postgrest;
+        fakeSupabaseWrapper.rpcErrorMessage = errorMsgDbConnection;
+
+        await expectLater(
+          () => dataSource.getSearchSuggestions(),
+          throwsA(isA<supabase.PostgrestException>()),
+        );
+      });
+    });
+
+    group('getRecentSearches', () {
+      test('should return recent search terms when data exists', () async {
+        fakeSupabaseWrapper.setCurrentUser(
+          FakeUser(
+            id: testUserId,
+            email: 'test@test.com',
+            createdAt: fakeClock.now().toIso8601String(),
+          ),
+        );
+        fakeSupabaseWrapper.addTableData(DatabaseConstants.searchHistoryTable, [
+          _fakeSearchHistoryData(
+            id: '1',
+            userId: testUserId,
+            searchTerm: 'wall',
+            scope: SearchScopeDto.dashboard.name,
+          ),
+          _fakeSearchHistoryData(
+            id: '2',
+            userId: testUserId,
+            searchTerm: 'concrete',
+            scope: SearchScopeDto.dashboard.name,
+          ),
+        ]);
+
+        final result = await dataSource.getRecentSearches(
+          SearchScopeDto.dashboard,
+        );
+
+        expect(result, hasLength(2));
+        expect(result, containsAll(['wall', 'concrete']));
+      });
+
+      test('should return empty list when no user logged in', () async {
+        fakeSupabaseWrapper.setCurrentUser(null);
+
+        final result = await dataSource.getRecentSearches(
+          SearchScopeDto.dashboard,
+        );
+
+        expect(result, isEmpty);
+      });
+
+      test('should return empty list when no data for scope', () async {
+        fakeSupabaseWrapper.setCurrentUser(
+          FakeUser(
+            id: testUserId,
+            email: 'test@test.com',
+            createdAt: fakeClock.now().toIso8601String(),
+          ),
+        );
+        fakeSupabaseWrapper.addTableData(DatabaseConstants.searchHistoryTable, [
+          _fakeSearchHistoryData(
+            id: '1',
+            userId: testUserId,
+            searchTerm: 'wall',
+            scope: SearchScopeDto.estimation.name,
+          ),
+        ]);
+
+        final result = await dataSource.getRecentSearches(
+          SearchScopeDto.dashboard,
+        );
+
+        expect(result, isEmpty);
+      });
+
+      test(
+        'should delegate sorting to DB via orderBy created_at descending',
+        () async {
+          fakeSupabaseWrapper.setCurrentUser(
+            FakeUser(
+              id: testUserId,
+              email: 'test@test.com',
+              createdAt: fakeClock.now().toIso8601String(),
+            ),
+          );
+          fakeSupabaseWrapper
+              .addTableData(DatabaseConstants.searchHistoryTable, [
+                _fakeSearchHistoryData(
+                  id: '1',
+                  userId: testUserId,
+                  searchTerm: 'oldest',
+                  scope: SearchScopeDto.dashboard.name,
+                  createdAt: '2024-01-01T00:00:00.000Z',
+                ),
+                _fakeSearchHistoryData(
+                  id: '2',
+                  userId: testUserId,
+                  searchTerm: 'newest',
+                  scope: SearchScopeDto.dashboard.name,
+                  createdAt: '2024-03-20T12:00:00.000Z',
+                ),
+                _fakeSearchHistoryData(
+                  id: '3',
+                  userId: testUserId,
+                  searchTerm: 'middle',
+                  scope: SearchScopeDto.dashboard.name,
+                  createdAt: '2024-02-15T00:00:00.000Z',
+                ),
+              ]);
+
+          final result = await dataSource.getRecentSearches(
+            SearchScopeDto.dashboard,
+          );
+
+          final selectCall = fakeSupabaseWrapper
+              .getMethodCallsFor('selectMatch')
+              .last;
+          expect(
+            selectCall['orderBy'],
+            equals(DatabaseConstants.createdAtColumn),
+          );
+          expect(selectCall['ascending'], isFalse);
+
+          expect(result, hasLength(3));
+          expect(result[0], equals('newest'));
+          expect(result[1], equals('middle'));
+          expect(result[2], equals('oldest'));
+        },
+      );
+
+      test('should rethrow when select throws', () async {
+        fakeSupabaseWrapper.setCurrentUser(
+          FakeUser(
+            id: testUserId,
+            email: 'test@test.com',
+            createdAt: fakeClock.now().toIso8601String(),
+          ),
+        );
+        fakeSupabaseWrapper.shouldThrowOnSelectMatch = true;
+        fakeSupabaseWrapper.selectMatchExceptionType =
+            SupabaseExceptionType.postgrest;
+        fakeSupabaseWrapper.selectMatchErrorMessage = errorMsgDbConnection;
+
+        await expectLater(
+          () => dataSource.getRecentSearches(SearchScopeDto.dashboard),
+          throwsA(isA<supabase.PostgrestException>()),
+        );
+      });
+    });
+
+    group('saveRecentSearch', () {
+      test('should normalize search term to lowercase', () async {
+        fakeSupabaseWrapper.setCurrentUser(
+          FakeUser(
+            id: testUserId,
+            email: 'test@test.com',
+            createdAt: fakeClock.now().toIso8601String(),
+          ),
+        );
+
+        await dataSource.saveRecentSearch('WALL', SearchScopeDto.dashboard);
+
+        final upsertCalls = fakeSupabaseWrapper.getMethodCallsFor('upsert');
+        final historyCall = upsertCalls.firstWhere(
+          (c) => c['table'] == DatabaseConstants.searchHistoryTable,
+        );
+        final data = historyCall['data'] as Map<String, dynamic>;
+        expect(data[DatabaseConstants.searchTermColumn], equals('wall'));
+      });
+
+      test(
+        'should return early when search term is empty after trim',
+        () async {
+          fakeSupabaseWrapper.setCurrentUser(
+            FakeUser(
+              id: testUserId,
+              email: 'test@test.com',
+              createdAt: fakeClock.now().toIso8601String(),
+            ),
+          );
+
+          await dataSource.saveRecentSearch('   ', SearchScopeDto.dashboard);
+
+          expect(fakeSupabaseWrapper.getMethodCallsFor('upsert'), isEmpty);
+        },
+      );
+
+      test('should return early when user not logged in', () async {
+        fakeSupabaseWrapper.setCurrentUser(null);
+
+        await dataSource.saveRecentSearch('wall', SearchScopeDto.dashboard);
+
+        expect(fakeSupabaseWrapper.getMethodCallsFor('upsert'), isEmpty);
+      });
+
+      test('should upsert to search_history with correct params', () async {
+        fakeSupabaseWrapper.setCurrentUser(
+          FakeUser(
+            id: testUserId,
+            email: 'test@test.com',
+            createdAt: fakeClock.now().toIso8601String(),
+          ),
+        );
+
+        await dataSource.saveRecentSearch('wall', SearchScopeDto.dashboard);
+
+        final upsertCalls = fakeSupabaseWrapper.getMethodCallsFor('upsert');
+        expect(upsertCalls, hasLength(1));
+        final historyCall = upsertCalls.first;
+        expect(
+          historyCall['table'],
+          equals(DatabaseConstants.searchHistoryTable),
+        );
+        expect(
+          historyCall['onConflict'],
+          equals(DatabaseConstants.searchHistoryUpsertConflictColumns),
+        );
+        final data = historyCall['data'] as Map<String, dynamic>;
+        expect(data[DatabaseConstants.userIdColumn], equals(testUserId));
+        expect(data[DatabaseConstants.searchTermColumn], equals('wall'));
+        expect(data[DatabaseConstants.scopeColumn], equals('dashboard'));
+        expect(data.containsKey(DatabaseConstants.searchCountColumn), isFalse);
+        expect(data[DatabaseConstants.hasResultsColumn], isFalse);
+        expect(data[DatabaseConstants.projectIdColumn], isNull);
+        expect(
+          data.containsKey(DatabaseConstants.createdAtColumn),
+          isFalse,
+          reason: 'created_at must not be sent — DB DEFAULT and trigger own it',
+        );
+      });
+
+      test(
+        'should set has_results true and project_id when provided',
+        () async {
+          fakeSupabaseWrapper.setCurrentUser(
+            FakeUser(
+              id: testUserId,
+              email: 'test@test.com',
+              createdAt: fakeClock.now().toIso8601String(),
+            ),
+          );
+
+          await dataSource.saveRecentSearch(
+            'concrete',
+            SearchScopeDto.dashboard,
+            hasResults: true,
+            projectId: 'project-42',
+          );
+
+          final upsertCalls = fakeSupabaseWrapper.getMethodCallsFor('upsert');
+          expect(upsertCalls, hasLength(1));
+          final data = upsertCalls.first['data'] as Map<String, dynamic>;
+          expect(data[DatabaseConstants.hasResultsColumn], isTrue);
+          expect(data[DatabaseConstants.projectIdColumn], equals('project-42'));
+        },
+      );
+
+      test(
+        'should only upsert to search_history — never to search_analytics',
+        () async {
+          fakeSupabaseWrapper.setCurrentUser(
+            FakeUser(
+              id: testUserId,
+              email: 'test@test.com',
+              createdAt: fakeClock.now().toIso8601String(),
+            ),
+          );
+
+          await dataSource.saveRecentSearch(
+            'steel',
+            SearchScopeDto.dashboard,
+            hasResults: true,
+          );
+
+          final upsertCalls = fakeSupabaseWrapper.getMethodCallsFor('upsert');
+          expect(upsertCalls, hasLength(1));
+          expect(
+            upsertCalls.first['table'],
+            equals(DatabaseConstants.searchHistoryTable),
+          );
+        },
+      );
+
+      test('should rethrow when upsert throws', () async {
+        fakeSupabaseWrapper.setCurrentUser(
+          FakeUser(
+            id: testUserId,
+            email: 'test@test.com',
+            createdAt: fakeClock.now().toIso8601String(),
+          ),
+        );
+        fakeSupabaseWrapper.shouldThrowOnUpsert = true;
+        fakeSupabaseWrapper.upsertExceptionType =
+            SupabaseExceptionType.postgrest;
+        fakeSupabaseWrapper.upsertErrorMessage = errorMsgDbConnection;
+
+        await expectLater(
+          () => dataSource.saveRecentSearch('wall', SearchScopeDto.dashboard),
+          throwsA(isA<supabase.PostgrestException>()),
+        );
+      });
+    });
+
+    group('deleteRecentSearch', () {
+      test('should delete row from search_history when it exists', () async {
+        fakeSupabaseWrapper.setCurrentUser(
+          FakeUser(
+            id: testUserId,
+            email: 'test@test.com',
+            createdAt: fakeClock.now().toIso8601String(),
+          ),
+        );
+        fakeSupabaseWrapper.addTableData(DatabaseConstants.searchHistoryTable, [
+          _fakeSearchHistoryData(
+            id: '1',
+            userId: testUserId,
+            searchTerm: 'wall',
+            scope: SearchScopeDto.dashboard.name,
+          ),
+        ]);
+
+        await dataSource.deleteRecentSearch('wall', SearchScopeDto.dashboard);
+
+        final deleteCalls = fakeSupabaseWrapper.getMethodCallsFor(
+          'deleteMatch',
+        );
+        expect(deleteCalls, hasLength(1));
+        final filters = deleteCalls.first['filters'] as Map<String, dynamic>;
+        expect(
+          deleteCalls.first['table'],
+          equals(DatabaseConstants.searchHistoryTable),
+        );
+        expect(filters[DatabaseConstants.userIdColumn], equals(testUserId));
+        expect(filters[DatabaseConstants.searchTermColumn], equals('wall'));
+        expect(
+          filters[DatabaseConstants.scopeColumn],
+          equals(SearchScopeDto.dashboard.name),
+        );
+      });
+
+      test('should normalize search term when deleting', () async {
+        fakeSupabaseWrapper.setCurrentUser(
+          FakeUser(
+            id: testUserId,
+            email: 'test@test.com',
+            createdAt: fakeClock.now().toIso8601String(),
+          ),
+        );
+        fakeSupabaseWrapper.addTableData(DatabaseConstants.searchHistoryTable, [
+          _fakeSearchHistoryData(
+            id: '1',
+            userId: testUserId,
+            searchTerm: 'wall',
+            scope: SearchScopeDto.dashboard.name,
+          ),
+        ]);
+
+        await dataSource.deleteRecentSearch('WALL', SearchScopeDto.dashboard);
+
+        final deleteCalls = fakeSupabaseWrapper.getMethodCallsFor(
+          'deleteMatch',
+        );
+        expect(deleteCalls, hasLength(1));
+        final filters = deleteCalls.first['filters'] as Map<String, dynamic>;
+        expect(filters[DatabaseConstants.searchTermColumn], equals('wall'));
+      });
+
+      test('should return early when no user logged in', () async {
+        fakeSupabaseWrapper.setCurrentUser(null);
+
+        await dataSource.deleteRecentSearch('wall', SearchScopeDto.dashboard);
+
+        expect(fakeSupabaseWrapper.getMethodCallsFor('deleteMatch'), isEmpty);
+      });
+
+      test(
+        'should return early when search term is empty after trim',
+        () async {
+          fakeSupabaseWrapper.setCurrentUser(
+            FakeUser(
+              id: testUserId,
+              email: 'test@test.com',
+              createdAt: fakeClock.now().toIso8601String(),
+            ),
+          );
+
+          await dataSource.deleteRecentSearch('   ', SearchScopeDto.dashboard);
+
+          expect(fakeSupabaseWrapper.getMethodCallsFor('deleteMatch'), isEmpty);
+        },
+      );
+
+      test(
+        'should only delete from search_history — never from other tables',
+        () async {
+          fakeSupabaseWrapper.setCurrentUser(
+            FakeUser(
+              id: testUserId,
+              email: 'test@test.com',
+              createdAt: fakeClock.now().toIso8601String(),
+            ),
+          );
+          fakeSupabaseWrapper
+              .addTableData(DatabaseConstants.searchHistoryTable, [
+                _fakeSearchHistoryData(
+                  id: '1',
+                  userId: testUserId,
+                  searchTerm: 'wall',
+                  scope: SearchScopeDto.dashboard.name,
+                ),
+              ]);
+
+          await dataSource.deleteRecentSearch('wall', SearchScopeDto.dashboard);
+
+          final deleteCalls = fakeSupabaseWrapper.getMethodCallsFor(
+            'deleteMatch',
+          );
+          expect(deleteCalls, hasLength(1));
+          expect(
+            deleteCalls.first['table'],
+            equals(DatabaseConstants.searchHistoryTable),
+          );
+        },
+      );
+
+      test('should rethrow when deleteMatch throws', () async {
+        fakeSupabaseWrapper.setCurrentUser(
+          FakeUser(
+            id: testUserId,
+            email: 'test@test.com',
+            createdAt: fakeClock.now().toIso8601String(),
+          ),
+        );
+        fakeSupabaseWrapper.shouldThrowOnDeleteMatch = true;
+        fakeSupabaseWrapper.deleteMatchExceptionType =
+            SupabaseExceptionType.postgrest;
+        fakeSupabaseWrapper.deleteMatchErrorMessage = errorMsgDbConnection;
+
+        await expectLater(
+          () => dataSource.deleteRecentSearch('wall', SearchScopeDto.dashboard),
+          throwsA(isA<supabase.PostgrestException>()),
+        );
+      });
+    });
+  });
+}

--- a/test/features/global_search/units/data/models/search_results_dto_test.dart
+++ b/test/features/global_search/units/data/models/search_results_dto_test.dart
@@ -1,8 +1,13 @@
+import 'package:construculator/features/estimation/data/models/cost_estimate_dto.dart';
 import 'package:construculator/features/global_search/data/models/search_results_dto.dart';
+import 'package:construculator/features/global_search/domain/entities/search_results.dart';
 import 'package:construculator/libraries/auth/data/models/user_profile_dto.dart';
 import 'package:construculator/libraries/project/data/models/project_dto.dart';
 import 'package:construculator/libraries/project/domain/entities/enums.dart';
 import 'package:flutter_test/flutter_test.dart';
+
+import '../../../../estimations/helpers/estimation_test_data_map_factory.dart'
+    as estimation_factory;
 
 void main() {
   group('SearchResultsDto', () {
@@ -140,6 +145,127 @@ void main() {
         const empty = SearchResultsDto();
 
         expect(populated, isNot(equals(empty)));
+      });
+    });
+
+    group('toDomain', () {
+      test('returns empty SearchResults when all lists are empty', () {
+        const dto = SearchResultsDto();
+
+        final result = dto.toDomain();
+
+        expect(result, const SearchResults());
+        expect(result.projects, isEmpty);
+        expect(result.estimations, isEmpty);
+        expect(result.members, isEmpty);
+      });
+
+      test('maps projects to Project domain entities', () {
+        final dto = SearchResultsDto(projects: [testProject]);
+
+        final result = dto.toDomain();
+
+        expect(result.projects, hasLength(1));
+        expect(result.projects.first.id, equals(testProject.id));
+        expect(
+          result.projects.first.projectName,
+          equals(testProject.projectName),
+        );
+        expect(
+          result.projects.first.creatorUserId,
+          equals(testProject.creatorUserId),
+        );
+      });
+
+      test('maps members to UserProfile domain entities', () {
+        const dto = SearchResultsDto(members: [testMember]);
+
+        final result = dto.toDomain();
+
+        expect(result.members, hasLength(1));
+        expect(result.members.first.id, equals(testMember.id));
+        expect(result.members.first.firstName, equals(testMember.firstName));
+        expect(result.members.first.lastName, equals(testMember.lastName));
+        expect(
+          result.members.first.professionalRole,
+          equals(testMember.professionalRole),
+        );
+      });
+
+      test('maps estimations to CostEstimate domain entities', () {
+        final estimationDto = CostEstimateDto.fromJson(
+          estimation_factory.EstimationTestDataMapFactory
+              .createFakeEstimationData(),
+        );
+        final dto = SearchResultsDto(estimations: [estimationDto]);
+
+        final result = dto.toDomain();
+
+        expect(result.estimations, hasLength(1));
+        expect(result.estimations.first.id, equals(estimationDto.id));
+        expect(
+          result.estimations.first.estimateName,
+          equals(estimationDto.estimateName),
+        );
+        expect(
+          result.estimations.first.projectId,
+          equals(estimationDto.projectId),
+        );
+      });
+
+      test('lists are independent — items do not bleed across lists', () {
+        final estimationDto = CostEstimateDto.fromJson(
+          estimation_factory.EstimationTestDataMapFactory
+              .createFakeEstimationData(),
+        );
+        final dto = SearchResultsDto(
+          projects: [testProject],
+          estimations: [estimationDto],
+          members: [testMember],
+        );
+
+        final result = dto.toDomain();
+
+        expect(result.projects, hasLength(1));
+        expect(result.projects.first.id, equals(testProject.id));
+        expect(result.estimations, hasLength(1));
+        expect(result.estimations.first.id, equals(estimationDto.id));
+        expect(result.members, hasLength(1));
+        expect(result.members.first.id, equals(testMember.id));
+      });
+
+      test('preserves order of items within each list', () {
+        final projectB = ProjectDto(
+          id: 'project-2',
+          projectName: 'Road Project',
+          creatorUserId: 'user-1',
+          createdAt: DateTime(2025, 3, 1),
+          updatedAt: DateTime(2025, 3, 2),
+          status: ProjectStatus.active,
+        );
+        final dto = SearchResultsDto(projects: [testProject, projectB]);
+
+        final result = dto.toDomain();
+
+        expect(result.projects[0].id, equals(testProject.id));
+        expect(result.projects[1].id, equals(projectB.id));
+      });
+
+      test('result equals manually constructed SearchResults', () {
+        final dto = SearchResultsDto(
+          projects: [testProject],
+          members: [testMember],
+        );
+
+        final result = dto.toDomain();
+
+        expect(
+          result,
+          SearchResults(
+            projects: [testProject.toDomain()],
+            members: [testMember.toDomain()],
+          ),
+        );
       });
     });
   });

--- a/test/features/global_search/units/data/repositories/global_search_repository_impl_test.dart
+++ b/test/features/global_search/units/data/repositories/global_search_repository_impl_test.dart
@@ -1,0 +1,1441 @@
+import 'package:construculator/app/app_bootstrap.dart';
+import 'package:construculator/features/global_search/data/repositories/global_search_repository_impl.dart';
+import 'package:construculator/features/global_search/domain/entities/pagination_params.dart';
+import 'package:construculator/features/global_search/domain/entities/search_params_entity.dart';
+import 'package:construculator/features/global_search/domain/entities/search_results.dart';
+import 'package:construculator/features/global_search/domain/entities/search_scope_entity.dart';
+import 'package:construculator/features/global_search/domain/repositories/global_search_repository.dart';
+import 'package:construculator/features/global_search/global_search_module.dart';
+import 'package:construculator/libraries/config/testing/fake_app_config.dart';
+import 'package:construculator/libraries/config/testing/fake_env_loader.dart';
+import 'package:construculator/libraries/either/either.dart';
+import 'package:construculator/libraries/errors/failures.dart';
+import 'package:construculator/libraries/global_search/domain/search_error_type.dart';
+import 'package:construculator/libraries/supabase/data/supabase_types.dart';
+import 'package:construculator/libraries/supabase/database_constants.dart';
+import 'package:construculator/libraries/supabase/interfaces/supabase_wrapper.dart';
+import 'package:construculator/libraries/supabase/testing/fake_supabase_user.dart';
+import 'package:construculator/libraries/supabase/testing/fake_supabase_wrapper.dart';
+import 'package:construculator/libraries/time/testing/fake_clock_impl.dart';
+import 'package:flutter_modular/flutter_modular.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../../../../estimations/helpers/estimation_test_data_map_factory.dart'
+    as estimation_factory;
+
+// ---------------------------------------------------------------------------
+// Test data helpers
+// ---------------------------------------------------------------------------
+
+Map<String, dynamic> _fakeProjectData({
+  String? id,
+  String? projectName,
+  String? creatorUserId,
+  String? createdAt,
+  String? updatedAt,
+  String? status,
+}) {
+  return {
+    DatabaseConstants.idColumn: id ?? 'project-1',
+    DatabaseConstants.projectNameColumn: projectName ?? 'Test Project',
+    DatabaseConstants.descriptionColumn: 'Test description',
+    DatabaseConstants.creatorUserIdColumn: creatorUserId ?? 'user-1',
+    DatabaseConstants.owningCompanyIdColumn: null,
+    DatabaseConstants.exportFolderLinkColumn: null,
+    DatabaseConstants.exportStorageProviderColumn: null,
+    DatabaseConstants.createdAtColumn: createdAt ?? '2024-01-01T00:00:00.000Z',
+    DatabaseConstants.updatedAtColumn: updatedAt ?? '2024-01-01T00:00:00.000Z',
+    DatabaseConstants.statusColumn: status ?? 'active',
+  };
+}
+
+Map<String, dynamic> _fakeMemberData({String? id, String? firstName}) {
+  return {
+    DatabaseConstants.idColumn: id ?? 'member-1',
+    DatabaseConstants.credentialIdColumn: null,
+    DatabaseConstants.firstNameColumn: firstName ?? 'John',
+    DatabaseConstants.lastNameColumn: 'Doe',
+    DatabaseConstants.professionalRoleColumn: 'Engineer',
+    DatabaseConstants.profilePhotoUrlColumn: null,
+  };
+}
+
+Map<String, dynamic> _fakeSearchHistoryData({
+  required String userId,
+  required String searchTerm,
+  required String scope,
+  String? id,
+  String? createdAt,
+}) {
+  return {
+    DatabaseConstants.idColumn: id ?? '1',
+    DatabaseConstants.userIdColumn: userId,
+    DatabaseConstants.searchTermColumn: searchTerm,
+    DatabaseConstants.scopeColumn: scope,
+    DatabaseConstants.searchCountColumn: 1,
+    DatabaseConstants.createdAtColumn: createdAt ?? '2024-01-01T00:00:00.000Z',
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers shared across groups
+// ---------------------------------------------------------------------------
+
+void expectRight<L, R>(Either<L, R> result, void Function(R value) assertions) {
+  result.fold((_) => fail('Expected Right but got Left'), assertions);
+}
+
+void expectLeft<L, R>(Either<L, R> result, void Function(L error) assertions) {
+  result.fold(assertions, (_) => fail('Expected Left but got Right'));
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+void main() {
+  const String testUserId = 'user-123';
+  const String errorMsgServer = 'Server error occurred';
+  const String errorMsgTimeout = 'Request timed out';
+  const String errorMsgNetwork = 'Network connection failed';
+
+  group('GlobalSearchRepositoryImpl', () {
+    late GlobalSearchRepositoryImpl repository;
+    late FakeSupabaseWrapper fakeSupabaseWrapper;
+    late FakeClockImpl fakeClock;
+
+    setUpAll(() {
+      fakeClock = FakeClockImpl();
+      Modular.init(
+        GlobalSearchModule(
+          AppBootstrap(
+            supabaseWrapper: FakeSupabaseWrapper(clock: fakeClock),
+            config: FakeAppConfig(),
+            envLoader: FakeEnvLoader(),
+          ),
+        ),
+      );
+      fakeSupabaseWrapper =
+          Modular.get<SupabaseWrapper>() as FakeSupabaseWrapper;
+      repository =
+          Modular.get<GlobalSearchRepository>() as GlobalSearchRepositoryImpl;
+    });
+
+    tearDownAll(() {
+      Modular.destroy();
+    });
+
+    setUp(() {
+      fakeSupabaseWrapper.reset();
+    });
+
+    // -----------------------------------------------------------------------
+    // search
+    // -----------------------------------------------------------------------
+
+    group('search', () {
+      test(
+        'should return SearchResults with mapped domain entities on success',
+        () async {
+          final projectData = _fakeProjectData(
+            id: 'project-1',
+            projectName: 'Foundation Work',
+          );
+          final estimationData =
+              estimation_factory
+                  .EstimationTestDataMapFactory.createFakeEstimationData(
+                id: 'estimate-1',
+                estimateName: 'Steel Frame',
+              );
+          final memberData = _fakeMemberData(
+            id: 'member-1',
+            firstName: 'Alice',
+          );
+
+          fakeSupabaseWrapper.setRpcResponse(
+            DatabaseConstants.globalSearchRpcFunction,
+            {
+              'projects': [projectData],
+              'estimations': [estimationData],
+              'members': [memberData],
+            },
+          );
+
+          final result = await repository.search(
+            const SearchParams(query: 'foundation'),
+          );
+
+          expect(result.isRight(), isTrue);
+          expectRight(result, (searchResults) {
+            expect(searchResults, isA<SearchResults>());
+            expect(searchResults.projects, hasLength(1));
+            expect(searchResults.projects.first.projectName, 'Foundation Work');
+            expect(searchResults.estimations, hasLength(1));
+            expect(searchResults.estimations.first.estimateName, 'Steel Frame');
+            expect(searchResults.members, hasLength(1));
+            expect(searchResults.members.first.firstName, 'Alice');
+          });
+        },
+      );
+
+      test(
+        'should return empty SearchResults when RPC returns empty lists',
+        () async {
+          fakeSupabaseWrapper.setRpcResponse(
+            DatabaseConstants.globalSearchRpcFunction,
+            {'projects': [], 'estimations': [], 'members': []},
+          );
+
+          final result = await repository.search(
+            const SearchParams(query: 'nonexistent'),
+          );
+
+          expect(result.isRight(), isTrue);
+          expectRight(result, (searchResults) {
+            expect(searchResults.projects, isEmpty);
+            expect(searchResults.estimations, isEmpty);
+            expect(searchResults.members, isEmpty);
+          });
+        },
+      );
+
+      test(
+        'should pass all filter parameters through to the data source',
+        () async {
+          fakeSupabaseWrapper.setRpcResponse(
+            DatabaseConstants.globalSearchRpcFunction,
+            {'projects': [], 'estimations': [], 'members': []},
+          );
+
+          final filterDate = DateTime(2024, 6, 1);
+          final params = SearchParams(
+            query: 'concrete',
+            filterByTag: 'structural',
+            filterByDate: filterDate,
+            filterByOwner: 'owner-42',
+            scope: SearchScope.estimation,
+            pagination: const PaginationParams(offset: 5, limit: 10),
+          );
+
+          await repository.search(params);
+
+          final rpcCalls = fakeSupabaseWrapper.getMethodCallsFor('rpc');
+          expect(rpcCalls, hasLength(1));
+          final rpcParams = rpcCalls.first['params'] as Map<String, dynamic>?;
+          expect(rpcParams, isNotNull);
+          expect(rpcParams!['query'], equals('concrete'));
+          expect(rpcParams['filter_by_tag'], equals('structural'));
+          expect(
+            rpcParams['filter_by_date'],
+            equals(filterDate.toIso8601String()),
+          );
+          expect(rpcParams['filter_by_owner'], equals('owner-42'));
+          expect(rpcParams['scope'], equals('estimation'));
+          expect(rpcParams['offset'], equals(5));
+          expect(rpcParams['limit'], equals(10));
+        },
+      );
+
+      test(
+        'should return timeoutError failure when data source throws TimeoutException',
+        () async {
+          fakeSupabaseWrapper.shouldThrowOnRpc = true;
+          fakeSupabaseWrapper.rpcExceptionType = SupabaseExceptionType.timeout;
+          fakeSupabaseWrapper.rpcErrorMessage = errorMsgTimeout;
+
+          final result = await repository.search(
+            const SearchParams(query: 'test'),
+          );
+
+          expect(result.isLeft(), isTrue);
+          expectLeft(
+            result,
+            (failure) => expect(
+              failure,
+              SearchFailure(errorType: SearchErrorType.timeoutError),
+            ),
+          );
+        },
+      );
+
+      test(
+        'should return connectionError failure when data source throws SocketException',
+        () async {
+          fakeSupabaseWrapper.shouldThrowOnRpc = true;
+          fakeSupabaseWrapper.rpcExceptionType = SupabaseExceptionType.socket;
+          fakeSupabaseWrapper.rpcErrorMessage = errorMsgNetwork;
+
+          final result = await repository.search(
+            const SearchParams(query: 'test'),
+          );
+
+          expect(result.isLeft(), isTrue);
+          expectLeft(
+            result,
+            (failure) => expect(
+              failure,
+              SearchFailure(errorType: SearchErrorType.connectionError),
+            ),
+          );
+        },
+      );
+
+      test(
+        'should return parsingError failure when data source throws TypeError',
+        () async {
+          fakeSupabaseWrapper.shouldThrowOnRpc = true;
+          fakeSupabaseWrapper.rpcExceptionType = SupabaseExceptionType.type;
+
+          final result = await repository.search(
+            const SearchParams(query: 'test'),
+          );
+
+          expect(result.isLeft(), isTrue);
+          expectLeft(
+            result,
+            (failure) => expect(
+              failure,
+              SearchFailure(errorType: SearchErrorType.parsingError),
+            ),
+          );
+        },
+      );
+
+      test(
+        'should return connectionError failure when data source throws PostgrestException with connection failure code',
+        () async {
+          fakeSupabaseWrapper.shouldThrowOnRpc = true;
+          fakeSupabaseWrapper.rpcExceptionType =
+              SupabaseExceptionType.postgrest;
+          fakeSupabaseWrapper.postgrestErrorCode =
+              PostgresErrorCode.connectionFailure;
+          fakeSupabaseWrapper.rpcErrorMessage = 'Connection lost';
+
+          final result = await repository.search(
+            const SearchParams(query: 'test'),
+          );
+
+          expect(result.isLeft(), isTrue);
+          expectLeft(
+            result,
+            (failure) => expect(
+              failure,
+              SearchFailure(errorType: SearchErrorType.connectionError),
+            ),
+          );
+        },
+      );
+
+      test(
+        'should return notFoundError failure when data source throws PostgrestException with no data found code',
+        () async {
+          fakeSupabaseWrapper.shouldThrowOnRpc = true;
+          fakeSupabaseWrapper.rpcExceptionType =
+              SupabaseExceptionType.postgrest;
+          fakeSupabaseWrapper.postgrestErrorCode =
+              PostgresErrorCode.noDataFound;
+          fakeSupabaseWrapper.rpcErrorMessage = 'No data found';
+
+          final result = await repository.search(
+            const SearchParams(query: 'test'),
+          );
+
+          expect(result.isLeft(), isTrue);
+          expectLeft(
+            result,
+            (failure) => expect(
+              failure,
+              SearchFailure(errorType: SearchErrorType.notFoundError),
+            ),
+          );
+        },
+      );
+
+      test(
+        'should return duplicateEntryError failure when data source throws PostgrestException with unique violation code',
+        () async {
+          fakeSupabaseWrapper.shouldThrowOnRpc = true;
+          fakeSupabaseWrapper.rpcExceptionType =
+              SupabaseExceptionType.postgrest;
+          fakeSupabaseWrapper.postgrestErrorCode =
+              PostgresErrorCode.uniqueViolation;
+          fakeSupabaseWrapper.rpcErrorMessage = 'Unique violation';
+
+          final result = await repository.search(
+            const SearchParams(query: 'test'),
+          );
+
+          expect(result.isLeft(), isTrue);
+          expectLeft(
+            result,
+            (failure) => expect(
+              failure,
+              SearchFailure(errorType: SearchErrorType.duplicateEntryError),
+            ),
+          );
+        },
+      );
+
+      test(
+        'should return UnexpectedFailure when data source throws unknown error',
+        () async {
+          fakeSupabaseWrapper.shouldThrowOnRpc = true;
+          fakeSupabaseWrapper.rpcExceptionType = SupabaseExceptionType.unknown;
+          fakeSupabaseWrapper.rpcErrorMessage = errorMsgServer;
+
+          final result = await repository.search(
+            const SearchParams(query: 'test'),
+          );
+
+          expect(result.isLeft(), isTrue);
+          expectLeft(
+            result,
+            (failure) => expect(failure, isA<UnexpectedFailure>()),
+          );
+        },
+      );
+    });
+
+    // -----------------------------------------------------------------------
+    // getRecentSearches
+    // -----------------------------------------------------------------------
+
+    group('getRecentSearches', () {
+      test('should return list of search terms on success', () async {
+        fakeSupabaseWrapper.setCurrentUser(
+          FakeUser(
+            id: testUserId,
+            email: 'test@test.com',
+            createdAt: fakeClock.now().toIso8601String(),
+          ),
+        );
+        fakeSupabaseWrapper.addTableData(DatabaseConstants.searchHistoryTable, [
+          _fakeSearchHistoryData(
+            userId: testUserId,
+            searchTerm: 'wall',
+            scope: SearchScope.dashboard.name,
+          ),
+          _fakeSearchHistoryData(
+            userId: testUserId,
+            searchTerm: 'concrete',
+            scope: SearchScope.dashboard.name,
+          ),
+        ]);
+
+        final result = await repository.getRecentSearches(
+          SearchScope.dashboard,
+        );
+
+        expect(result.isRight(), isTrue);
+        expectRight(result, (terms) {
+          expect(terms, hasLength(2));
+          expect(terms, containsAll(['wall', 'concrete']));
+        });
+      });
+
+      test('should return empty list when user is not authenticated', () async {
+        fakeSupabaseWrapper.setCurrentUser(null);
+
+        final result = await repository.getRecentSearches(
+          SearchScope.dashboard,
+        );
+
+        expect(result.isRight(), isTrue);
+        expectRight(result, (terms) => expect(terms, isEmpty));
+      });
+
+      test(
+        'should return empty list when no history exists for the given scope',
+        () async {
+          fakeSupabaseWrapper.setCurrentUser(
+            FakeUser(
+              id: testUserId,
+              email: 'test@test.com',
+              createdAt: fakeClock.now().toIso8601String(),
+            ),
+          );
+          fakeSupabaseWrapper
+              .addTableData(DatabaseConstants.searchHistoryTable, [
+                _fakeSearchHistoryData(
+                  userId: testUserId,
+                  searchTerm: 'steel',
+                  scope: SearchScope.estimation.name,
+                ),
+              ]);
+
+          final result = await repository.getRecentSearches(
+            SearchScope.dashboard,
+          );
+
+          expect(result.isRight(), isTrue);
+          expectRight(result, (terms) => expect(terms, isEmpty));
+        },
+      );
+
+      test(
+        'should return timeoutError failure when data source throws TimeoutException',
+        () async {
+          fakeSupabaseWrapper.setCurrentUser(
+            FakeUser(
+              id: testUserId,
+              email: 'test@test.com',
+              createdAt: fakeClock.now().toIso8601String(),
+            ),
+          );
+          fakeSupabaseWrapper.shouldThrowOnSelectMatch = true;
+          fakeSupabaseWrapper.selectMatchExceptionType =
+              SupabaseExceptionType.timeout;
+          fakeSupabaseWrapper.selectMatchErrorMessage = errorMsgTimeout;
+
+          final result = await repository.getRecentSearches(
+            SearchScope.dashboard,
+          );
+
+          expect(result.isLeft(), isTrue);
+          expectLeft(
+            result,
+            (failure) => expect(
+              failure,
+              SearchFailure(errorType: SearchErrorType.timeoutError),
+            ),
+          );
+        },
+      );
+
+      test(
+        'should return connectionError failure when data source throws SocketException',
+        () async {
+          fakeSupabaseWrapper.setCurrentUser(
+            FakeUser(
+              id: testUserId,
+              email: 'test@test.com',
+              createdAt: fakeClock.now().toIso8601String(),
+            ),
+          );
+          fakeSupabaseWrapper.shouldThrowOnSelectMatch = true;
+          fakeSupabaseWrapper.selectMatchExceptionType =
+              SupabaseExceptionType.socket;
+          fakeSupabaseWrapper.selectMatchErrorMessage = errorMsgNetwork;
+
+          final result = await repository.getRecentSearches(
+            SearchScope.dashboard,
+          );
+
+          expect(result.isLeft(), isTrue);
+          expectLeft(
+            result,
+            (failure) => expect(
+              failure,
+              SearchFailure(errorType: SearchErrorType.connectionError),
+            ),
+          );
+        },
+      );
+
+      test(
+        'should return connectionError failure when data source throws PostgrestException with connection failure code',
+        () async {
+          fakeSupabaseWrapper.setCurrentUser(
+            FakeUser(
+              id: testUserId,
+              email: 'test@test.com',
+              createdAt: fakeClock.now().toIso8601String(),
+            ),
+          );
+          fakeSupabaseWrapper.shouldThrowOnSelectMatch = true;
+          fakeSupabaseWrapper.selectMatchExceptionType =
+              SupabaseExceptionType.postgrest;
+          fakeSupabaseWrapper.postgrestErrorCode =
+              PostgresErrorCode.connectionFailure;
+          fakeSupabaseWrapper.selectMatchErrorMessage = 'Connection lost';
+
+          final result = await repository.getRecentSearches(
+            SearchScope.dashboard,
+          );
+
+          expect(result.isLeft(), isTrue);
+          expectLeft(
+            result,
+            (failure) => expect(
+              failure,
+              SearchFailure(errorType: SearchErrorType.connectionError),
+            ),
+          );
+        },
+      );
+
+      test(
+        'should return duplicateEntryError failure when data source throws PostgrestException with unique violation code',
+        () async {
+          fakeSupabaseWrapper.setCurrentUser(
+            FakeUser(
+              id: testUserId,
+              email: 'test@test.com',
+              createdAt: fakeClock.now().toIso8601String(),
+            ),
+          );
+          fakeSupabaseWrapper.shouldThrowOnSelectMatch = true;
+          fakeSupabaseWrapper.selectMatchExceptionType =
+              SupabaseExceptionType.postgrest;
+          fakeSupabaseWrapper.postgrestErrorCode =
+              PostgresErrorCode.uniqueViolation;
+          fakeSupabaseWrapper.selectMatchErrorMessage = 'Unique violation';
+
+          final result = await repository.getRecentSearches(
+            SearchScope.dashboard,
+          );
+
+          expect(result.isLeft(), isTrue);
+          expectLeft(
+            result,
+            (failure) => expect(
+              failure,
+              SearchFailure(errorType: SearchErrorType.duplicateEntryError),
+            ),
+          );
+        },
+      );
+
+      test(
+        'should return notFoundError failure when data source throws PostgrestException with no data found code',
+        () async {
+          fakeSupabaseWrapper.setCurrentUser(
+            FakeUser(
+              id: testUserId,
+              email: 'test@test.com',
+              createdAt: fakeClock.now().toIso8601String(),
+            ),
+          );
+          fakeSupabaseWrapper.shouldThrowOnSelectMatch = true;
+          fakeSupabaseWrapper.selectMatchExceptionType =
+              SupabaseExceptionType.postgrest;
+          fakeSupabaseWrapper.postgrestErrorCode =
+              PostgresErrorCode.noDataFound;
+          fakeSupabaseWrapper.selectMatchErrorMessage = 'No data found';
+
+          final result = await repository.getRecentSearches(
+            SearchScope.dashboard,
+          );
+
+          expect(result.isLeft(), isTrue);
+          expectLeft(
+            result,
+            (failure) => expect(
+              failure,
+              SearchFailure(errorType: SearchErrorType.notFoundError),
+            ),
+          );
+        },
+      );
+
+      test(
+        'should return parsingError failure when data source throws TypeError',
+        () async {
+          fakeSupabaseWrapper.setCurrentUser(
+            FakeUser(
+              id: testUserId,
+              email: 'test@test.com',
+              createdAt: fakeClock.now().toIso8601String(),
+            ),
+          );
+          fakeSupabaseWrapper.shouldThrowOnSelectMatch = true;
+          fakeSupabaseWrapper.selectMatchExceptionType =
+              SupabaseExceptionType.type;
+
+          final result = await repository.getRecentSearches(
+            SearchScope.dashboard,
+          );
+
+          expect(result.isLeft(), isTrue);
+          expectLeft(
+            result,
+            (failure) => expect(
+              failure,
+              SearchFailure(errorType: SearchErrorType.parsingError),
+            ),
+          );
+        },
+      );
+
+      test(
+        'should return UnexpectedFailure when data source throws unknown error',
+        () async {
+          fakeSupabaseWrapper.setCurrentUser(
+            FakeUser(
+              id: testUserId,
+              email: 'test@test.com',
+              createdAt: fakeClock.now().toIso8601String(),
+            ),
+          );
+          fakeSupabaseWrapper.shouldThrowOnSelectMatch = true;
+          fakeSupabaseWrapper.selectMatchExceptionType =
+              SupabaseExceptionType.unknown;
+          fakeSupabaseWrapper.selectMatchErrorMessage = errorMsgServer;
+
+          final result = await repository.getRecentSearches(
+            SearchScope.dashboard,
+          );
+
+          expect(result.isLeft(), isTrue);
+          expectLeft(
+            result,
+            (failure) => expect(failure, isA<UnexpectedFailure>()),
+          );
+        },
+      );
+    });
+
+    // -----------------------------------------------------------------------
+    // saveRecentSearch
+    // -----------------------------------------------------------------------
+
+    group('saveRecentSearch', () {
+      test('should return Right(null) on success', () async {
+        fakeSupabaseWrapper.setCurrentUser(
+          FakeUser(
+            id: testUserId,
+            email: 'test@test.com',
+            createdAt: fakeClock.now().toIso8601String(),
+          ),
+        );
+
+        final result = await repository.saveRecentSearch(
+          'wall',
+          SearchScope.dashboard,
+        );
+
+        expect(result.isRight(), isTrue);
+      });
+
+      test(
+        'should return Right(null) without calling upsert when user is not authenticated',
+        () async {
+          fakeSupabaseWrapper.setCurrentUser(null);
+
+          final result = await repository.saveRecentSearch(
+            'wall',
+            SearchScope.dashboard,
+          );
+
+          expect(result.isRight(), isTrue);
+          expect(fakeSupabaseWrapper.getMethodCallsFor('upsert'), isEmpty);
+        },
+      );
+
+      test(
+        'should return Right(null) without calling upsert when search term is empty after trim',
+        () async {
+          fakeSupabaseWrapper.setCurrentUser(
+            FakeUser(
+              id: testUserId,
+              email: 'test@test.com',
+              createdAt: fakeClock.now().toIso8601String(),
+            ),
+          );
+
+          final result = await repository.saveRecentSearch(
+            '   ',
+            SearchScope.dashboard,
+          );
+
+          expect(result.isRight(), isTrue);
+          expect(fakeSupabaseWrapper.getMethodCallsFor('upsert'), isEmpty);
+        },
+      );
+
+      test('should pass hasResults and projectId to the data source', () async {
+        fakeSupabaseWrapper.setCurrentUser(
+          FakeUser(
+            id: testUserId,
+            email: 'test@test.com',
+            createdAt: fakeClock.now().toIso8601String(),
+          ),
+        );
+
+        await repository.saveRecentSearch(
+          'concrete',
+          SearchScope.dashboard,
+          hasResults: true,
+          projectId: 'project-42',
+        );
+
+        final upsertCalls = fakeSupabaseWrapper.getMethodCallsFor('upsert');
+        expect(upsertCalls, hasLength(1));
+        final data = upsertCalls.first['data'] as Map<String, dynamic>;
+        expect(data[DatabaseConstants.hasResultsColumn], isTrue);
+        expect(data[DatabaseConstants.projectIdColumn], equals('project-42'));
+      });
+
+      test(
+        'should return timeoutError failure when data source throws TimeoutException',
+        () async {
+          fakeSupabaseWrapper.setCurrentUser(
+            FakeUser(
+              id: testUserId,
+              email: 'test@test.com',
+              createdAt: fakeClock.now().toIso8601String(),
+            ),
+          );
+          fakeSupabaseWrapper.shouldThrowOnUpsert = true;
+          fakeSupabaseWrapper.upsertExceptionType =
+              SupabaseExceptionType.timeout;
+          fakeSupabaseWrapper.upsertErrorMessage = errorMsgTimeout;
+
+          final result = await repository.saveRecentSearch(
+            'wall',
+            SearchScope.dashboard,
+          );
+
+          expect(result.isLeft(), isTrue);
+          expectLeft(
+            result,
+            (failure) => expect(
+              failure,
+              SearchFailure(errorType: SearchErrorType.timeoutError),
+            ),
+          );
+        },
+      );
+
+      test(
+        'should return connectionError failure when data source throws SocketException',
+        () async {
+          fakeSupabaseWrapper.setCurrentUser(
+            FakeUser(
+              id: testUserId,
+              email: 'test@test.com',
+              createdAt: fakeClock.now().toIso8601String(),
+            ),
+          );
+          fakeSupabaseWrapper.shouldThrowOnUpsert = true;
+          fakeSupabaseWrapper.upsertExceptionType =
+              SupabaseExceptionType.socket;
+          fakeSupabaseWrapper.upsertErrorMessage = errorMsgNetwork;
+
+          final result = await repository.saveRecentSearch(
+            'wall',
+            SearchScope.dashboard,
+          );
+
+          expect(result.isLeft(), isTrue);
+          expectLeft(
+            result,
+            (failure) => expect(
+              failure,
+              SearchFailure(errorType: SearchErrorType.connectionError),
+            ),
+          );
+        },
+      );
+
+      test(
+        'should return connectionError failure when data source throws PostgrestException with connection failure code',
+        () async {
+          fakeSupabaseWrapper.setCurrentUser(
+            FakeUser(
+              id: testUserId,
+              email: 'test@test.com',
+              createdAt: fakeClock.now().toIso8601String(),
+            ),
+          );
+          fakeSupabaseWrapper.shouldThrowOnUpsert = true;
+          fakeSupabaseWrapper.upsertExceptionType =
+              SupabaseExceptionType.postgrest;
+          fakeSupabaseWrapper.postgrestErrorCode =
+              PostgresErrorCode.connectionFailure;
+          fakeSupabaseWrapper.upsertErrorMessage = 'Connection lost';
+
+          final result = await repository.saveRecentSearch(
+            'wall',
+            SearchScope.dashboard,
+          );
+
+          expect(result.isLeft(), isTrue);
+          expectLeft(
+            result,
+            (failure) => expect(
+              failure,
+              SearchFailure(errorType: SearchErrorType.connectionError),
+            ),
+          );
+        },
+      );
+
+      test(
+        'should return duplicateEntryError failure when data source throws PostgrestException with unique violation code',
+        () async {
+          fakeSupabaseWrapper.setCurrentUser(
+            FakeUser(
+              id: testUserId,
+              email: 'test@test.com',
+              createdAt: fakeClock.now().toIso8601String(),
+            ),
+          );
+          fakeSupabaseWrapper.shouldThrowOnUpsert = true;
+          fakeSupabaseWrapper.upsertExceptionType =
+              SupabaseExceptionType.postgrest;
+          fakeSupabaseWrapper.postgrestErrorCode =
+              PostgresErrorCode.uniqueViolation;
+          fakeSupabaseWrapper.upsertErrorMessage = 'DB error';
+
+          final result = await repository.saveRecentSearch(
+            'wall',
+            SearchScope.dashboard,
+          );
+
+          expect(result.isLeft(), isTrue);
+          expectLeft(
+            result,
+            (failure) => expect(
+              failure,
+              SearchFailure(errorType: SearchErrorType.duplicateEntryError),
+            ),
+          );
+        },
+      );
+
+      test(
+        'should return UnexpectedFailure when data source throws unknown error',
+        () async {
+          fakeSupabaseWrapper.setCurrentUser(
+            FakeUser(
+              id: testUserId,
+              email: 'test@test.com',
+              createdAt: fakeClock.now().toIso8601String(),
+            ),
+          );
+          fakeSupabaseWrapper.shouldThrowOnUpsert = true;
+          fakeSupabaseWrapper.upsertExceptionType =
+              SupabaseExceptionType.unknown;
+          fakeSupabaseWrapper.upsertErrorMessage = errorMsgServer;
+
+          final result = await repository.saveRecentSearch(
+            'wall',
+            SearchScope.dashboard,
+          );
+
+          expect(result.isLeft(), isTrue);
+          expectLeft(
+            result,
+            (failure) => expect(failure, isA<UnexpectedFailure>()),
+          );
+        },
+      );
+    });
+
+    // -----------------------------------------------------------------------
+    // deleteRecentSearch
+    // -----------------------------------------------------------------------
+
+    group('deleteRecentSearch', () {
+      test('should return Right(null) on success', () async {
+        fakeSupabaseWrapper.setCurrentUser(
+          FakeUser(
+            id: testUserId,
+            email: 'test@test.com',
+            createdAt: fakeClock.now().toIso8601String(),
+          ),
+        );
+        fakeSupabaseWrapper.addTableData(DatabaseConstants.searchHistoryTable, [
+          _fakeSearchHistoryData(
+            userId: testUserId,
+            searchTerm: 'wall',
+            scope: SearchScope.dashboard.name,
+          ),
+        ]);
+
+        final result = await repository.deleteRecentSearch(
+          'wall',
+          SearchScope.dashboard,
+        );
+
+        expect(result.isRight(), isTrue);
+      });
+
+      test(
+        'should return Right(null) without calling deleteMatch when user is not authenticated',
+        () async {
+          fakeSupabaseWrapper.setCurrentUser(null);
+
+          final result = await repository.deleteRecentSearch(
+            'wall',
+            SearchScope.dashboard,
+          );
+
+          expect(result.isRight(), isTrue);
+          expect(fakeSupabaseWrapper.getMethodCallsFor('deleteMatch'), isEmpty);
+        },
+      );
+
+      test(
+        'should return Right(null) without calling deleteMatch when search term is empty after trim',
+        () async {
+          fakeSupabaseWrapper.setCurrentUser(
+            FakeUser(
+              id: testUserId,
+              email: 'test@test.com',
+              createdAt: fakeClock.now().toIso8601String(),
+            ),
+          );
+
+          final result = await repository.deleteRecentSearch(
+            '   ',
+            SearchScope.dashboard,
+          );
+
+          expect(result.isRight(), isTrue);
+          expect(fakeSupabaseWrapper.getMethodCallsFor('deleteMatch'), isEmpty);
+        },
+      );
+
+      test(
+        'should call deleteMatch on search_history with correct filters',
+        () async {
+          fakeSupabaseWrapper.setCurrentUser(
+            FakeUser(
+              id: testUserId,
+              email: 'test@test.com',
+              createdAt: fakeClock.now().toIso8601String(),
+            ),
+          );
+
+          await repository.deleteRecentSearch('wall', SearchScope.dashboard);
+
+          final deleteCalls = fakeSupabaseWrapper.getMethodCallsFor(
+            'deleteMatch',
+          );
+          expect(deleteCalls, hasLength(1));
+          expect(
+            deleteCalls.first['table'],
+            equals(DatabaseConstants.searchHistoryTable),
+          );
+          final filters = deleteCalls.first['filters'] as Map<String, dynamic>;
+          expect(filters[DatabaseConstants.userIdColumn], equals(testUserId));
+          expect(filters[DatabaseConstants.searchTermColumn], equals('wall'));
+          expect(
+            filters[DatabaseConstants.scopeColumn],
+            equals(SearchScope.dashboard.name),
+          );
+        },
+      );
+
+      test(
+        'should return timeoutError failure when data source throws TimeoutException',
+        () async {
+          fakeSupabaseWrapper.setCurrentUser(
+            FakeUser(
+              id: testUserId,
+              email: 'test@test.com',
+              createdAt: fakeClock.now().toIso8601String(),
+            ),
+          );
+          fakeSupabaseWrapper.shouldThrowOnDeleteMatch = true;
+          fakeSupabaseWrapper.deleteMatchExceptionType =
+              SupabaseExceptionType.timeout;
+          fakeSupabaseWrapper.deleteMatchErrorMessage = errorMsgTimeout;
+
+          final result = await repository.deleteRecentSearch(
+            'wall',
+            SearchScope.dashboard,
+          );
+
+          expect(result.isLeft(), isTrue);
+          expectLeft(
+            result,
+            (failure) => expect(
+              failure,
+              SearchFailure(errorType: SearchErrorType.timeoutError),
+            ),
+          );
+        },
+      );
+
+      test(
+        'should return connectionError failure when data source throws SocketException',
+        () async {
+          fakeSupabaseWrapper.setCurrentUser(
+            FakeUser(
+              id: testUserId,
+              email: 'test@test.com',
+              createdAt: fakeClock.now().toIso8601String(),
+            ),
+          );
+          fakeSupabaseWrapper.shouldThrowOnDeleteMatch = true;
+          fakeSupabaseWrapper.deleteMatchExceptionType =
+              SupabaseExceptionType.socket;
+          fakeSupabaseWrapper.deleteMatchErrorMessage = errorMsgNetwork;
+
+          final result = await repository.deleteRecentSearch(
+            'wall',
+            SearchScope.dashboard,
+          );
+
+          expect(result.isLeft(), isTrue);
+          expectLeft(
+            result,
+            (failure) => expect(
+              failure,
+              SearchFailure(errorType: SearchErrorType.connectionError),
+            ),
+          );
+        },
+      );
+
+      test(
+        'should return connectionError failure when data source throws PostgrestException with connection failure code',
+        () async {
+          fakeSupabaseWrapper.setCurrentUser(
+            FakeUser(
+              id: testUserId,
+              email: 'test@test.com',
+              createdAt: fakeClock.now().toIso8601String(),
+            ),
+          );
+          fakeSupabaseWrapper.shouldThrowOnDeleteMatch = true;
+          fakeSupabaseWrapper.deleteMatchExceptionType =
+              SupabaseExceptionType.postgrest;
+          fakeSupabaseWrapper.postgrestErrorCode =
+              PostgresErrorCode.connectionFailure;
+          fakeSupabaseWrapper.deleteMatchErrorMessage = 'Connection lost';
+
+          final result = await repository.deleteRecentSearch(
+            'wall',
+            SearchScope.dashboard,
+          );
+
+          expect(result.isLeft(), isTrue);
+          expectLeft(
+            result,
+            (failure) => expect(
+              failure,
+              SearchFailure(errorType: SearchErrorType.connectionError),
+            ),
+          );
+        },
+      );
+
+      test(
+        'should return duplicateEntryError failure when data source throws PostgrestException with unique violation code',
+        () async {
+          fakeSupabaseWrapper.setCurrentUser(
+            FakeUser(
+              id: testUserId,
+              email: 'test@test.com',
+              createdAt: fakeClock.now().toIso8601String(),
+            ),
+          );
+          fakeSupabaseWrapper.shouldThrowOnDeleteMatch = true;
+          fakeSupabaseWrapper.deleteMatchExceptionType =
+              SupabaseExceptionType.postgrest;
+          fakeSupabaseWrapper.postgrestErrorCode =
+              PostgresErrorCode.uniqueViolation;
+          fakeSupabaseWrapper.deleteMatchErrorMessage = 'DB error';
+
+          final result = await repository.deleteRecentSearch(
+            'wall',
+            SearchScope.dashboard,
+          );
+
+          expect(result.isLeft(), isTrue);
+          expectLeft(
+            result,
+            (failure) => expect(
+              failure,
+              SearchFailure(errorType: SearchErrorType.duplicateEntryError),
+            ),
+          );
+        },
+      );
+
+      test(
+        'should return UnexpectedFailure when data source throws unknown error',
+        () async {
+          fakeSupabaseWrapper.setCurrentUser(
+            FakeUser(
+              id: testUserId,
+              email: 'test@test.com',
+              createdAt: fakeClock.now().toIso8601String(),
+            ),
+          );
+          fakeSupabaseWrapper.shouldThrowOnDeleteMatch = true;
+          fakeSupabaseWrapper.deleteMatchExceptionType =
+              SupabaseExceptionType.unknown;
+          fakeSupabaseWrapper.deleteMatchErrorMessage = errorMsgServer;
+
+          final result = await repository.deleteRecentSearch(
+            'wall',
+            SearchScope.dashboard,
+          );
+
+          expect(result.isLeft(), isTrue);
+          expectLeft(
+            result,
+            (failure) => expect(failure, isA<UnexpectedFailure>()),
+          );
+        },
+      );
+    });
+
+    // -----------------------------------------------------------------------
+    // getSearchSuggestions
+    // -----------------------------------------------------------------------
+
+    group('getSearchSuggestions', () {
+      test('should return list of suggestion strings on success', () async {
+        fakeSupabaseWrapper.setCurrentUser(
+          FakeUser(
+            id: testUserId,
+            email: 'test@test.com',
+            createdAt: fakeClock.now().toIso8601String(),
+          ),
+        );
+        fakeSupabaseWrapper.setRpcResponse(
+          DatabaseConstants.searchSuggestionsRpcFunction,
+          ['foundation', 'concrete mix', 'steel frame'],
+        );
+
+        final result = await repository.getSearchSuggestions();
+
+        expect(result.isRight(), isTrue);
+        expectRight(result, (suggestions) {
+          expect(suggestions, hasLength(3));
+          expect(
+            suggestions,
+            containsAll(['foundation', 'concrete mix', 'steel frame']),
+          );
+        });
+      });
+
+      test('should return empty list when user is not authenticated', () async {
+        fakeSupabaseWrapper.setCurrentUser(null);
+
+        final result = await repository.getSearchSuggestions();
+
+        expect(result.isRight(), isTrue);
+        expectRight(result, (suggestions) => expect(suggestions, isEmpty));
+        final rpcCalls = fakeSupabaseWrapper.getMethodCallsFor('rpc');
+        expect(
+          rpcCalls.any(
+            (c) =>
+                c['functionName'] ==
+                DatabaseConstants.searchSuggestionsRpcFunction,
+          ),
+          isFalse,
+        );
+      });
+
+      test('should return empty list when RPC returns empty', () async {
+        fakeSupabaseWrapper.setCurrentUser(
+          FakeUser(
+            id: testUserId,
+            email: 'test@test.com',
+            createdAt: fakeClock.now().toIso8601String(),
+          ),
+        );
+        fakeSupabaseWrapper.setRpcResponse(
+          DatabaseConstants.searchSuggestionsRpcFunction,
+          [],
+        );
+
+        final result = await repository.getSearchSuggestions();
+
+        expect(result.isRight(), isTrue);
+        expectRight(result, (suggestions) => expect(suggestions, isEmpty));
+      });
+
+      test(
+        'should return timeoutError failure when data source throws TimeoutException',
+        () async {
+          fakeSupabaseWrapper.setCurrentUser(
+            FakeUser(
+              id: testUserId,
+              email: 'test@test.com',
+              createdAt: fakeClock.now().toIso8601String(),
+            ),
+          );
+          fakeSupabaseWrapper.shouldThrowOnRpc = true;
+          fakeSupabaseWrapper.rpcExceptionType = SupabaseExceptionType.timeout;
+          fakeSupabaseWrapper.rpcErrorMessage = errorMsgTimeout;
+
+          final result = await repository.getSearchSuggestions();
+
+          expect(result.isLeft(), isTrue);
+          expectLeft(
+            result,
+            (failure) => expect(
+              failure,
+              SearchFailure(errorType: SearchErrorType.timeoutError),
+            ),
+          );
+        },
+      );
+
+      test(
+        'should return connectionError failure when data source throws SocketException',
+        () async {
+          fakeSupabaseWrapper.setCurrentUser(
+            FakeUser(
+              id: testUserId,
+              email: 'test@test.com',
+              createdAt: fakeClock.now().toIso8601String(),
+            ),
+          );
+          fakeSupabaseWrapper.shouldThrowOnRpc = true;
+          fakeSupabaseWrapper.rpcExceptionType = SupabaseExceptionType.socket;
+          fakeSupabaseWrapper.rpcErrorMessage = errorMsgNetwork;
+
+          final result = await repository.getSearchSuggestions();
+
+          expect(result.isLeft(), isTrue);
+          expectLeft(
+            result,
+            (failure) => expect(
+              failure,
+              SearchFailure(errorType: SearchErrorType.connectionError),
+            ),
+          );
+        },
+      );
+
+      test(
+        'should return connectionError failure when data source throws PostgrestException with connection failure code',
+        () async {
+          fakeSupabaseWrapper.setCurrentUser(
+            FakeUser(
+              id: testUserId,
+              email: 'test@test.com',
+              createdAt: fakeClock.now().toIso8601String(),
+            ),
+          );
+          fakeSupabaseWrapper.shouldThrowOnRpc = true;
+          fakeSupabaseWrapper.rpcExceptionType =
+              SupabaseExceptionType.postgrest;
+          fakeSupabaseWrapper.postgrestErrorCode =
+              PostgresErrorCode.connectionFailure;
+          fakeSupabaseWrapper.rpcErrorMessage = 'Connection lost';
+
+          final result = await repository.getSearchSuggestions();
+
+          expect(result.isLeft(), isTrue);
+          expectLeft(
+            result,
+            (failure) => expect(
+              failure,
+              SearchFailure(errorType: SearchErrorType.connectionError),
+            ),
+          );
+        },
+      );
+
+      test(
+        'should return duplicateEntryError failure when data source throws PostgrestException with unique violation code',
+        () async {
+          fakeSupabaseWrapper.setCurrentUser(
+            FakeUser(
+              id: testUserId,
+              email: 'test@test.com',
+              createdAt: fakeClock.now().toIso8601String(),
+            ),
+          );
+          fakeSupabaseWrapper.shouldThrowOnRpc = true;
+          fakeSupabaseWrapper.rpcExceptionType =
+              SupabaseExceptionType.postgrest;
+          fakeSupabaseWrapper.postgrestErrorCode =
+              PostgresErrorCode.uniqueViolation;
+          fakeSupabaseWrapper.rpcErrorMessage = 'DB error';
+
+          final result = await repository.getSearchSuggestions();
+
+          expect(result.isLeft(), isTrue);
+          expectLeft(
+            result,
+            (failure) => expect(
+              failure,
+              SearchFailure(errorType: SearchErrorType.duplicateEntryError),
+            ),
+          );
+        },
+      );
+
+      test(
+        'should return notFoundError failure when data source throws PostgrestException with no data found code',
+        () async {
+          fakeSupabaseWrapper.setCurrentUser(
+            FakeUser(
+              id: testUserId,
+              email: 'test@test.com',
+              createdAt: fakeClock.now().toIso8601String(),
+            ),
+          );
+          fakeSupabaseWrapper.shouldThrowOnRpc = true;
+          fakeSupabaseWrapper.rpcExceptionType =
+              SupabaseExceptionType.postgrest;
+          fakeSupabaseWrapper.postgrestErrorCode =
+              PostgresErrorCode.noDataFound;
+          fakeSupabaseWrapper.rpcErrorMessage = 'No data found';
+
+          final result = await repository.getSearchSuggestions();
+
+          expect(result.isLeft(), isTrue);
+          expectLeft(
+            result,
+            (failure) => expect(
+              failure,
+              SearchFailure(errorType: SearchErrorType.notFoundError),
+            ),
+          );
+        },
+      );
+
+      test(
+        'should return parsingError failure when data source throws TypeError',
+        () async {
+          fakeSupabaseWrapper.setCurrentUser(
+            FakeUser(
+              id: testUserId,
+              email: 'test@test.com',
+              createdAt: fakeClock.now().toIso8601String(),
+            ),
+          );
+          fakeSupabaseWrapper.shouldThrowOnRpc = true;
+          fakeSupabaseWrapper.rpcExceptionType = SupabaseExceptionType.type;
+
+          final result = await repository.getSearchSuggestions();
+
+          expect(result.isLeft(), isTrue);
+          expectLeft(
+            result,
+            (failure) => expect(
+              failure,
+              SearchFailure(errorType: SearchErrorType.parsingError),
+            ),
+          );
+        },
+      );
+
+      test(
+        'should return UnexpectedFailure when data source throws unknown error',
+        () async {
+          fakeSupabaseWrapper.setCurrentUser(
+            FakeUser(
+              id: testUserId,
+              email: 'test@test.com',
+              createdAt: fakeClock.now().toIso8601String(),
+            ),
+          );
+          fakeSupabaseWrapper.shouldThrowOnRpc = true;
+          fakeSupabaseWrapper.rpcExceptionType = SupabaseExceptionType.unknown;
+          fakeSupabaseWrapper.rpcErrorMessage = errorMsgServer;
+
+          final result = await repository.getSearchSuggestions();
+
+          expect(result.isLeft(), isTrue);
+          expectLeft(
+            result,
+            (failure) => expect(failure, isA<UnexpectedFailure>()),
+          );
+        },
+      );
+    });
+  });
+}

--- a/test/libraries/supabase/units/fakes/fake_supabase_wrapper_test.dart
+++ b/test/libraries/supabase/units/fakes/fake_supabase_wrapper_test.dart
@@ -1116,6 +1116,25 @@ void main() {
             );
           },
         );
+
+        test('records call before delay completes', () async {
+          fakeWrapper.shouldDelayOperations = true;
+          fakeWrapper.completer = Completer();
+
+          final future = fakeWrapper.deleteMatch(
+            table: 'items',
+            filters: {'id': '1'},
+          );
+
+          expect(
+            fakeWrapper.getMethodCallsFor('deleteMatch'),
+            hasLength(1),
+            reason: 'Call must be recorded before the delay resolves',
+          );
+
+          fakeWrapper.completer!.complete();
+          await future;
+        });
       });
 
       group('update', () {
@@ -1497,25 +1516,10 @@ void main() {
         });
 
         test('emits updated table data to stream after upsert', () async {
-          final emissions = <List<Map<String, dynamic>>>[];
-          final done = Completer<void>();
-
-          final subscription = fakeWrapper
-              .watchTable(table: 'profiles', primaryKey: ['user_id'])
-              .listen(
-                (data) {
-                  emissions.add(data);
-                  if (emissions.length >= 2 && !done.isCompleted) {
-                    done.complete();
-                  }
-                },
-                onDone: () {
-                  if (!done.isCompleted) done.complete();
-                },
-                onError: (e, s) => done.completeError(e, s),
-              );
-
-          await pumpEventQueue();
+          final stream = fakeWrapper.watchTable(
+            table: 'profiles',
+            primaryKey: ['user_id'],
+          );
 
           await fakeWrapper.upsert(
             table: 'profiles',
@@ -1523,11 +1527,12 @@ void main() {
             onConflict: 'user_id',
           );
 
-          await done.future;
-          await subscription.cancel();
-
-          expect(emissions.length, greaterThanOrEqualTo(2));
-          expect(emissions.last.single['bio'], equals('Hello'));
+          await expectLater(
+            stream,
+            emitsThrough(
+              contains(containsPair('bio', 'Hello')),
+            ),
+          );
         });
 
         test('throws exception when configured to fail', () async {

--- a/test/libraries/supabase/units/fakes/fake_supabase_wrapper_test.dart
+++ b/test/libraries/supabase/units/fakes/fake_supabase_wrapper_test.dart
@@ -1049,6 +1049,75 @@ void main() {
         });
       });
 
+      group('deleteMatch', () {
+        test('removes rows matching all filter criteria', () async {
+          fakeWrapper.addTableData('items', [
+            {'id': '1', 'project_id': 'p1', 'status': 'active'},
+            {'id': '2', 'project_id': 'p1', 'status': 'archived'},
+            {'id': '3', 'project_id': 'p2', 'status': 'active'},
+          ]);
+
+          await fakeWrapper.deleteMatch(
+            table: 'items',
+            filters: {'project_id': 'p1', 'status': 'active'},
+          );
+
+          final remaining = await fakeWrapper.selectMatch(
+            table: 'items',
+            filters: {'project_id': 'p1'},
+          );
+          expect(remaining, hasLength(1));
+          expect(remaining.single['id'], equals('2'));
+        });
+
+        test(
+          'throws exception independently of shouldThrowOnDelete',
+          () async {
+            fakeWrapper.shouldThrowOnDeleteMatch = true;
+            fakeWrapper.deleteMatchErrorMessage = 'Delete match failed';
+
+            await expectLater(
+              () async => fakeWrapper.deleteMatch(
+                table: 'items',
+                filters: {'id': '1'},
+              ),
+              throwsA(
+                isA<ServerException>().having(
+                  (e) => e.toString(),
+                  'message',
+                  contains('Delete match failed'),
+                ),
+              ),
+            );
+          },
+        );
+
+        test(
+          'shouldThrowOnDelete does not affect deleteMatch',
+          () async {
+            fakeWrapper.addTableData('items', [
+              {'id': '1', 'project_id': 'p1'},
+            ]);
+            fakeWrapper.shouldThrowOnDelete = true;
+
+            await fakeWrapper.deleteMatch(
+              table: 'items',
+              filters: {'project_id': 'p1'},
+            );
+
+            final result = await fakeWrapper.selectMatch(
+              table: 'items',
+              filters: {'project_id': 'p1'},
+            );
+            expect(
+              result,
+              isEmpty,
+              reason: 'deleteMatch must not be affected by shouldThrowOnDelete',
+            );
+          },
+        );
+      });
+
       group('update', () {
         test('modifies existing record and returns updated data', () async {
           final initialTime = '2023-01-01T00:00:00Z';
@@ -1214,8 +1283,8 @@ void main() {
           fakeWrapper.shouldThrowOnSelectMatch = true;
           fakeWrapper.selectMatchErrorMessage = 'Select match failed';
 
-          expect(
-            () async => await fakeWrapper.selectMatch(
+          await expectLater(
+            () async => fakeWrapper.selectMatch(
               table: 'items',
               filters: {'id': '1'},
             ),
@@ -1465,8 +1534,8 @@ void main() {
           fakeWrapper.shouldThrowOnUpsert = true;
           fakeWrapper.upsertErrorMessage = 'Upsert failed';
 
-          expect(
-            () async => await fakeWrapper.upsert(
+          await expectLater(
+            () async => fakeWrapper.upsert(
               table: 'profiles',
               data: {'user_id': 'u1'},
               onConflict: 'user_id',
@@ -2104,6 +2173,7 @@ void main() {
         fakeWrapper.shouldThrowOnSelectMultiple = true;
         fakeWrapper.shouldThrowOnSelectMatch = true;
         fakeWrapper.shouldThrowOnDelete = true;
+        fakeWrapper.shouldThrowOnDeleteMatch = true;
         fakeWrapper.shouldThrowOnUpsert = true;
         fakeWrapper.shouldThrowOnRpc = true;
         fakeWrapper.shouldReturnEmptyOnSelectMatch = true;
@@ -2119,6 +2189,7 @@ void main() {
         fakeWrapper.insertErrorMessage = 'Insert failed';
         fakeWrapper.updateErrorMessage = 'Update failed';
         fakeWrapper.deleteErrorMessage = 'Delete failed';
+        fakeWrapper.deleteMatchErrorMessage = 'Delete match failed';
         fakeWrapper.rpcErrorMessage = 'RPC failed';
         fakeWrapper.selectExceptionType = SupabaseExceptionType.postgrest;
         fakeWrapper.selectMultipleExceptionType = SupabaseExceptionType.socket;
@@ -2127,6 +2198,7 @@ void main() {
         fakeWrapper.insertExceptionType = SupabaseExceptionType.timeout;
         fakeWrapper.updateExceptionType = SupabaseExceptionType.auth;
         fakeWrapper.deleteExceptionType = SupabaseExceptionType.type;
+        fakeWrapper.deleteMatchExceptionType = SupabaseExceptionType.type;
         fakeWrapper.rpcExceptionType = SupabaseExceptionType.postgrest;
         fakeWrapper.postgrestErrorCode = PostgresErrorCode.uniqueViolation;
         fakeWrapper.shouldReturnNullUser = true;
@@ -2162,6 +2234,7 @@ void main() {
         expect(fakeWrapper.shouldThrowOnSelectMultiple, isFalse);
         expect(fakeWrapper.shouldThrowOnSelectMatch, isFalse);
         expect(fakeWrapper.shouldThrowOnDelete, isFalse);
+        expect(fakeWrapper.shouldThrowOnDeleteMatch, isFalse);
         expect(fakeWrapper.shouldThrowOnUpsert, isFalse);
         expect(fakeWrapper.shouldThrowOnRpc, isFalse);
         expect(fakeWrapper.shouldReturnEmptyOnSelectMatch, isFalse);
@@ -2177,6 +2250,7 @@ void main() {
         expect(fakeWrapper.insertErrorMessage, isNull);
         expect(fakeWrapper.updateErrorMessage, isNull);
         expect(fakeWrapper.deleteErrorMessage, isNull);
+        expect(fakeWrapper.deleteMatchErrorMessage, isNull);
         expect(fakeWrapper.rpcErrorMessage, isNull);
         expect(fakeWrapper.selectExceptionType, isNull);
         expect(fakeWrapper.selectMultipleExceptionType, isNull);
@@ -2185,6 +2259,7 @@ void main() {
         expect(fakeWrapper.insertExceptionType, isNull);
         expect(fakeWrapper.updateExceptionType, isNull);
         expect(fakeWrapper.deleteExceptionType, isNull);
+        expect(fakeWrapper.deleteMatchExceptionType, isNull);
         expect(fakeWrapper.rpcExceptionType, isNull);
         expect(fakeWrapper.postgrestErrorCode, isNull);
         expect(fakeWrapper.shouldReturnNullUser, isFalse);

--- a/test/libraries/supabase/units/fakes/fake_supabase_wrapper_test.dart
+++ b/test/libraries/supabase/units/fakes/fake_supabase_wrapper_test.dart
@@ -1131,6 +1131,388 @@ void main() {
         );
       });
 
+      group('selectMatch', () {
+        test('returns rows matching all filter criteria', () async {
+          fakeWrapper.addTableData('items', [
+            {'id': '1', 'project_id': 'p1', 'status': 'active'},
+            {'id': '2', 'project_id': 'p1', 'status': 'archived'},
+            {'id': '3', 'project_id': 'p2', 'status': 'active'},
+          ]);
+
+          final result = await fakeWrapper.selectMatch(
+            table: 'items',
+            filters: {'project_id': 'p1', 'status': 'active'},
+          );
+
+          expect(result, hasLength(1));
+          expect(result.single['id'], equals('1'));
+        });
+
+        test('returns empty list when no rows match all filters', () async {
+          fakeWrapper.addTableData('items', [
+            {'id': '1', 'project_id': 'p1', 'status': 'archived'},
+          ]);
+
+          final result = await fakeWrapper.selectMatch(
+            table: 'items',
+            filters: {'project_id': 'p1', 'status': 'active'},
+          );
+
+          expect(result, isEmpty);
+        });
+
+        test('returns empty list when table does not exist', () async {
+          final result = await fakeWrapper.selectMatch(
+            table: 'nonexistent',
+            filters: {'id': '1'},
+          );
+
+          expect(result, isEmpty);
+        });
+
+        test('records method call with all parameters', () async {
+          fakeWrapper.addTableData('items', []);
+
+          await fakeWrapper.selectMatch(
+            table: 'items',
+            columns: 'id,status',
+            filters: {'project_id': 'p1', 'status': 'active'},
+          );
+
+          final calls = fakeWrapper.getMethodCallsFor('selectMatch');
+          expect(calls, hasLength(1));
+          final call = calls.first;
+          expect(call['table'], equals('items'));
+          expect(call['columns'], equals('id,status'));
+          expect(
+            call['filters'],
+            equals({'project_id': 'p1', 'status': 'active'}),
+          );
+        });
+
+        test('records call before delay completes', () async {
+          fakeWrapper.addTableData('items', []);
+          fakeWrapper.shouldDelayOperations = true;
+          fakeWrapper.completer = Completer();
+
+          final future = fakeWrapper.selectMatch(
+            table: 'items',
+            filters: {'id': '1'},
+          );
+
+          expect(
+            fakeWrapper.getMethodCallsFor('selectMatch'),
+            hasLength(1),
+            reason: 'Call must be recorded before the delay resolves',
+          );
+
+          fakeWrapper.completer!.complete();
+          await future;
+        });
+
+        test('throws exception when configured to fail', () async {
+          fakeWrapper.shouldThrowOnSelectMatch = true;
+          fakeWrapper.selectMatchErrorMessage = 'Select match failed';
+
+          expect(
+            () async => await fakeWrapper.selectMatch(
+              table: 'items',
+              filters: {'id': '1'},
+            ),
+            throwsA(
+              isA<ServerException>().having(
+                (e) => e.toString(),
+                'message',
+                contains('Select match failed'),
+              ),
+            ),
+          );
+        });
+
+        test('returns empty list when shouldReturnEmptyOnSelectMatch is true',
+            () async {
+          fakeWrapper.addTableData('items', [
+            {'id': '1', 'project_id': 'p1'},
+          ]);
+          fakeWrapper.shouldReturnEmptyOnSelectMatch = true;
+
+          final result = await fakeWrapper.selectMatch(
+            table: 'items',
+            filters: {'project_id': 'p1'},
+          );
+
+          expect(result, isEmpty);
+        });
+
+        test(
+          'shouldThrowOnSelectMultiple does not affect selectMatch',
+          () async {
+            fakeWrapper.addTableData('items', [
+              {'id': '1', 'project_id': 'p1'},
+            ]);
+            fakeWrapper.shouldThrowOnSelectMultiple = true;
+
+            final result = await fakeWrapper.selectMatch(
+              table: 'items',
+              filters: {'project_id': 'p1'},
+            );
+
+            expect(
+              result,
+              hasLength(1),
+              reason:
+                  'selectMatch must not be affected by shouldThrowOnSelectMultiple',
+            );
+          },
+        );
+
+        test('defaults to all columns when columns not specified', () async {
+          fakeWrapper.addTableData('items', []);
+
+          await fakeWrapper.selectMatch(
+            table: 'items',
+            filters: {'id': '1'},
+          );
+
+          final call = fakeWrapper.getMethodCallsFor('selectMatch').first;
+          expect(call['columns'], equals('*'));
+        });
+      });
+
+      group('upsert', () {
+        test('inserts a new record when no conflict exists', () async {
+          await fakeWrapper.upsert(
+            table: 'profiles',
+            data: {'user_id': 'u1', 'bio': 'Hello'},
+            onConflict: 'user_id',
+          );
+
+          final result = await fakeWrapper.selectSingle(
+            table: 'profiles',
+            filterColumn: 'user_id',
+            filterValue: 'u1',
+          );
+
+          expect(result, isNotNull);
+          expect(result!['bio'], equals('Hello'));
+          expect(result['created_at'], isNotNull);
+          expect(result['updated_at'], isNotNull);
+        });
+
+        test('updates an existing record when a conflict is found', () async {
+          fakeWrapper.addTableData('profiles', [
+            {
+              'id': '1',
+              'user_id': 'u1',
+              'bio': 'Old bio',
+              'created_at': '2024-01-01T00:00:00Z',
+              'updated_at': '2024-01-01T00:00:00Z',
+            },
+          ]);
+
+          await fakeWrapper.upsert(
+            table: 'profiles',
+            data: {'user_id': 'u1', 'bio': 'New bio'},
+            onConflict: 'user_id',
+          );
+
+          final result = await fakeWrapper.selectSingle(
+            table: 'profiles',
+            filterColumn: 'user_id',
+            filterValue: 'u1',
+          );
+
+          expect(result!['bio'], equals('New bio'));
+        });
+
+        test('preserves created_at on update and only sets it on insert',
+            () async {
+          const originalCreatedAt = '2024-01-01T00:00:00Z';
+          fakeWrapper.addTableData('profiles', [
+            {
+              'id': '1',
+              'user_id': 'u1',
+              'bio': 'Old bio',
+              'created_at': originalCreatedAt,
+              'updated_at': originalCreatedAt,
+            },
+          ]);
+
+          await fakeWrapper.upsert(
+            table: 'profiles',
+            data: {'user_id': 'u1', 'bio': 'Updated bio'},
+            onConflict: 'user_id',
+          );
+
+          final result = await fakeWrapper.selectSingle(
+            table: 'profiles',
+            filterColumn: 'user_id',
+            filterValue: 'u1',
+          );
+
+          expect(
+            result!['created_at'],
+            equals(originalCreatedAt),
+            reason: 'created_at must not change on upsert update path',
+          );
+          expect(
+            result['updated_at'],
+            isNot(equals(originalCreatedAt)),
+            reason: 'updated_at must be refreshed on upsert update path',
+          );
+        });
+
+        test('does not mutate other rows when upserting on conflict', () async {
+          fakeWrapper.addTableData('profiles', [
+            {
+              'id': '1',
+              'user_id': 'u1',
+              'bio': 'User 1',
+              'created_at': '2024-01-01T00:00:00Z',
+            },
+            {
+              'id': '2',
+              'user_id': 'u2',
+              'bio': 'User 2',
+              'created_at': '2024-01-01T00:00:00Z',
+            },
+          ]);
+
+          await fakeWrapper.upsert(
+            table: 'profiles',
+            data: {'user_id': 'u1', 'bio': 'Updated User 1'},
+            onConflict: 'user_id',
+          );
+
+          final untouched = await fakeWrapper.selectSingle(
+            table: 'profiles',
+            filterColumn: 'user_id',
+            filterValue: 'u2',
+          );
+          expect(untouched!['bio'], equals('User 2'));
+        });
+
+        test('records method call with all parameters', () async {
+          await fakeWrapper.upsert(
+            table: 'profiles',
+            data: {'user_id': 'u1', 'bio': 'Hello'},
+            onConflict: 'user_id',
+          );
+
+          final calls = fakeWrapper.getMethodCallsFor('upsert');
+          expect(calls, hasLength(1));
+          final call = calls.first;
+          expect(call['table'], equals('profiles'));
+          expect(call['data'], equals({'user_id': 'u1', 'bio': 'Hello'}));
+          expect(call['onConflict'], equals('user_id'));
+        });
+
+        test('records call before delay completes', () async {
+          fakeWrapper.shouldDelayOperations = true;
+          fakeWrapper.completer = Completer();
+
+          final future = fakeWrapper.upsert(
+            table: 'profiles',
+            data: {'user_id': 'u1'},
+            onConflict: 'user_id',
+          );
+
+          expect(
+            fakeWrapper.getMethodCallsFor('upsert'),
+            hasLength(1),
+            reason: 'Call must be recorded before the delay resolves',
+          );
+
+          fakeWrapper.completer!.complete();
+          await future;
+        });
+
+        test('emits updated table data to stream after upsert', () async {
+          final emissions = <List<Map<String, dynamic>>>[];
+          final done = Completer<void>();
+
+          final subscription = fakeWrapper
+              .watchTable(table: 'profiles', primaryKey: ['user_id'])
+              .listen(
+                (data) {
+                  emissions.add(data);
+                  if (emissions.length >= 2 && !done.isCompleted) {
+                    done.complete();
+                  }
+                },
+                onDone: () {
+                  if (!done.isCompleted) done.complete();
+                },
+                onError: (e, s) => done.completeError(e, s),
+              );
+
+          await pumpEventQueue();
+
+          await fakeWrapper.upsert(
+            table: 'profiles',
+            data: {'user_id': 'u1', 'bio': 'Hello'},
+            onConflict: 'user_id',
+          );
+
+          await done.future;
+          await subscription.cancel();
+
+          expect(emissions.length, greaterThanOrEqualTo(2));
+          expect(emissions.last.single['bio'], equals('Hello'));
+        });
+
+        test('throws exception when configured to fail', () async {
+          fakeWrapper.shouldThrowOnUpsert = true;
+          fakeWrapper.upsertErrorMessage = 'Upsert failed';
+
+          expect(
+            () async => await fakeWrapper.upsert(
+              table: 'profiles',
+              data: {'user_id': 'u1'},
+              onConflict: 'user_id',
+            ),
+            throwsA(
+              isA<ServerException>().having(
+                (e) => e.toString(),
+                'message',
+                contains('Upsert failed'),
+              ),
+            ),
+          );
+        });
+
+        test('supports compound conflict columns', () async {
+          fakeWrapper.addTableData('memberships', [
+            {
+              'id': '1',
+              'project_id': 'p1',
+              'user_id': 'u1',
+              'role': 'viewer',
+              'created_at': '2024-01-01T00:00:00Z',
+            },
+          ]);
+
+          await fakeWrapper.upsert(
+            table: 'memberships',
+            data: {'project_id': 'p1', 'user_id': 'u1', 'role': 'editor'},
+            onConflict: 'project_id, user_id',
+          );
+
+          final rows = await fakeWrapper.select(
+            table: 'memberships',
+            filterColumn: 'project_id',
+            filterValue: 'p1',
+          );
+
+          expect(
+            rows,
+            hasLength(1),
+            reason: 'Compound conflict should update, not insert a duplicate',
+          );
+          expect(rows.single['role'], equals('editor'));
+        });
+      });
+
       group('rpc', () {
         test('returns configured response for successful RPC call', () async {
           fakeWrapper.setRpcResponse('check_email_exists', true);
@@ -1720,8 +2102,11 @@ void main() {
         fakeWrapper.shouldThrowOnInsert = true;
         fakeWrapper.shouldThrowOnUpdate = true;
         fakeWrapper.shouldThrowOnSelectMultiple = true;
+        fakeWrapper.shouldThrowOnSelectMatch = true;
         fakeWrapper.shouldThrowOnDelete = true;
+        fakeWrapper.shouldThrowOnUpsert = true;
         fakeWrapper.shouldThrowOnRpc = true;
+        fakeWrapper.shouldReturnEmptyOnSelectMatch = true;
         fakeWrapper.signInErrorMessage = 'Sign in failed';
         fakeWrapper.signUpErrorMessage = 'Sign up failed';
         fakeWrapper.otpErrorMessage = 'OTP failed';
@@ -1729,12 +2114,16 @@ void main() {
         fakeWrapper.resetPasswordErrorMessage = 'Reset password failed';
         fakeWrapper.signOutErrorMessage = 'Sign out failed';
         fakeWrapper.selectErrorMessage = 'Select failed';
+        fakeWrapper.selectMatchErrorMessage = 'Select match failed';
+        fakeWrapper.upsertErrorMessage = 'Upsert failed';
         fakeWrapper.insertErrorMessage = 'Insert failed';
         fakeWrapper.updateErrorMessage = 'Update failed';
         fakeWrapper.deleteErrorMessage = 'Delete failed';
         fakeWrapper.rpcErrorMessage = 'RPC failed';
         fakeWrapper.selectExceptionType = SupabaseExceptionType.postgrest;
         fakeWrapper.selectMultipleExceptionType = SupabaseExceptionType.socket;
+        fakeWrapper.selectMatchExceptionType = SupabaseExceptionType.socket;
+        fakeWrapper.upsertExceptionType = SupabaseExceptionType.timeout;
         fakeWrapper.insertExceptionType = SupabaseExceptionType.timeout;
         fakeWrapper.updateExceptionType = SupabaseExceptionType.auth;
         fakeWrapper.deleteExceptionType = SupabaseExceptionType.type;
@@ -1771,8 +2160,11 @@ void main() {
         expect(fakeWrapper.shouldThrowOnInsert, isFalse);
         expect(fakeWrapper.shouldThrowOnUpdate, isFalse);
         expect(fakeWrapper.shouldThrowOnSelectMultiple, isFalse);
+        expect(fakeWrapper.shouldThrowOnSelectMatch, isFalse);
         expect(fakeWrapper.shouldThrowOnDelete, isFalse);
+        expect(fakeWrapper.shouldThrowOnUpsert, isFalse);
         expect(fakeWrapper.shouldThrowOnRpc, isFalse);
+        expect(fakeWrapper.shouldReturnEmptyOnSelectMatch, isFalse);
         expect(fakeWrapper.signInErrorMessage, isNull);
         expect(fakeWrapper.signUpErrorMessage, isNull);
         expect(fakeWrapper.otpErrorMessage, isNull);
@@ -1780,12 +2172,16 @@ void main() {
         expect(fakeWrapper.resetPasswordErrorMessage, isNull);
         expect(fakeWrapper.signOutErrorMessage, isNull);
         expect(fakeWrapper.selectErrorMessage, isNull);
+        expect(fakeWrapper.selectMatchErrorMessage, isNull);
+        expect(fakeWrapper.upsertErrorMessage, isNull);
         expect(fakeWrapper.insertErrorMessage, isNull);
         expect(fakeWrapper.updateErrorMessage, isNull);
         expect(fakeWrapper.deleteErrorMessage, isNull);
         expect(fakeWrapper.rpcErrorMessage, isNull);
         expect(fakeWrapper.selectExceptionType, isNull);
         expect(fakeWrapper.selectMultipleExceptionType, isNull);
+        expect(fakeWrapper.selectMatchExceptionType, isNull);
+        expect(fakeWrapper.upsertExceptionType, isNull);
         expect(fakeWrapper.insertExceptionType, isNull);
         expect(fakeWrapper.updateExceptionType, isNull);
         expect(fakeWrapper.deleteExceptionType, isNull);


### PR DESCRIPTION
## Summary

This PR extends the `SupabaseWrapper` abstraction layer with three new multi-column database operations: `selectMatch` (composite-key equality queries), `upsert` (conflict-aware insert-or-update), and `deleteMatch` (composite-key row deletion). The changes are applied consistently across the abstract interface (`supabase_wrapper.dart`), the production implementation (`SupabaseWrapperImpl`), the in-memory test double (`FakeSupabaseWrapper`), and the corresponding unit test suite. The primary motivation is to support the global search feature domain, which requires querying and mutating rows identified by compound keys rather than single-column filters.

---

## Changes Overview

### Impact Stats

| Category                     | Value                                                  |
|------------------------------|--------------------------------------------------------|
| **Files Modified**           | 4                                                      |
| **Production Line Changes**  | +85 lines (Interface: +45, Impl: +40)                  |
| **Test / Fake Line Changes** | +562 lines (Fake: +166, Tests: +396)                   |
| **Total Line Changes**       | +647 lines                                             |
| **New Classes Introduced**   | 0                                                      |
| **New Methods Introduced**   | 3 (`selectMatch`, `upsert`, `deleteMatch`)             |
| **PR Size Classification**   | **S** (50–100 production lines)                        |
| **Test-to-Production Ratio** | ~6.6 : 1                                               |

---

## Rule-Based Review

| Rule | Status | Notes |
|------|--------|-------|
| **Rule 1 — Digestible PR** | ✅ Pass | Production code totals 85 lines, placing this PR firmly in the **S** tier (50–100 lines). The change has a single, well-defined purpose. No action required. |
| **Rule 2 — Class Naming Convention** | ✅ Pass | No new classes are introduced. All three methods are additions to the existing `SupabaseWrapper` / `SupabaseWrapperImpl` / `FakeSupabaseWrapper` classes, which already comply with the `NounWrapper`/`NounWrapperImpl` naming pattern. |
| **Rule 3 — Test Double Pattern** | ✅ Pass | `FakeSupabaseWrapper` is the correct test double for the external Supabase client dependency. Tests in `fake_supabase_wrapper_test.dart` validate the fake itself — this is the expected contract-testing pattern. No Mocks or Stubs are used. The fake is extended, not replaced, preserving all existing test doubles for dependent layers. |
| **Rule 5 — UI & Business Logic Separation** | ✅ N/A | This PR contains no UI layer changes. All modifications are confined to the data infrastructure and testing layers. Rule does not apply. |
| **Rule 6 — Stream-Based Performance & Lifecycle** | ✅ Pass | `upsert` and `deleteMatch` in the fake correctly call `_emitTableData(table)` to propagate changes to active stream subscribers. The real `SupabaseWrapperImpl` does not manage streams directly; stream emissions are delegated to the Supabase SDK. No new `StreamController` instances are created without a corresponding cleanup strategy. |
