### PR TITLE
CA-543: add Sentry breadcrumbs and error tracking to AppLogger

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -47,6 +47,8 @@ custom_lint:
         - 'Map'
         - 'CancelableOperation'
         - 'AppLocalizationsEn'
+        - 'Breadcrumb'
+
 linter:
   # The lint rules applied to this project can be customized in the
   # section below to disable rules from the `package:flutter_lints/flutter.yaml`

--- a/lib/libraries/sentry/interfaces/sentry_wrapper.dart
+++ b/lib/libraries/sentry/interfaces/sentry_wrapper.dart
@@ -1,3 +1,22 @@
+/// Enum for Sentry event levels
+/// This provides type-safe log levels and prevents invalid states
+enum SentryEventLevel {
+  /// Debug level - detailed information for diagnosing issues
+  debug,
+
+  /// Info level - general informational messages
+  info,
+
+  /// Warning level - potentially harmful situations
+  warning,
+
+  /// Error level - error events that might still allow the app to continue
+  error,
+
+  /// Fatal level - severe error events that will presumably lead the app to abort
+  fatal,
+}
+
 /// Interface that wraps Sentry functionality
 /// This allows for easier testing by providing a clean abstraction layer
 abstract class SentryWrapper {
@@ -11,4 +30,41 @@ abstract class SentryWrapper {
   ///
   /// [appRunner] The function that runs the Flutter app
   Future<void> initialize(void Function() appRunner);
+
+  /// Add a breadcrumb to track user actions leading up to an error
+  ///
+  /// [message] The breadcrumb message
+  /// [level] The severity level
+  /// [category] Optional category for grouping breadcrumbs
+  /// [data] Optional additional data
+  Future<void> addBreadcrumb({
+    required String message,
+    required SentryEventLevel level,
+    String? category,
+    Map<String, dynamic>? data,
+  });
+
+  /// Capture an exception with optional stack trace
+  ///
+  /// [exception] The exception to capture
+  /// [stackTrace] Optional stack trace
+  /// [tags] Optional tags for categorization
+  /// [contexts] Optional additional context data
+  Future<void> captureException(
+    dynamic exception, {
+    dynamic stackTrace,
+    Map<String, String>? tags,
+    Map<String, dynamic>? contexts,
+  });
+
+  /// Capture a message with a specified level
+  ///
+  /// [message] The message to capture
+  /// [level] The severity level
+  /// [tags] Optional tags for categorization
+  Future<void> captureMessage(
+    String message, {
+    required SentryEventLevel level,
+    Map<String, String>? tags,
+  });
 }

--- a/lib/libraries/sentry/sentry_wrapper_impl.dart
+++ b/lib/libraries/sentry/sentry_wrapper_impl.dart
@@ -1,13 +1,19 @@
 // coverage:ignore-file
+// Sentry SDK relies on native platform channels and a running host app,
+// making it impossible to unit test without a full integration environment.
+
 import 'package:construculator/libraries/config/env_constants.dart';
 import 'package:construculator/libraries/config/interfaces/config.dart';
 import 'package:construculator/libraries/config/interfaces/env_loader.dart';
 import 'package:construculator/libraries/sentry/interfaces/sentry_wrapper.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
 
+// TODO: https://ripplearc.youtrack.cloud/issue/CA-543/Integrate-Sentry-into-AppLogger-with-full-test-coverage (add fake for sentry wrapp)
 class SentryWrapperImpl implements SentryWrapper {
   final EnvLoader _envLoader;
   final Config _config;
+  // Guarded by _isInitialized; all callers are expected to call initialize() first.
+  bool _isInitialized = false;
 
   SentryWrapperImpl({required EnvLoader envLoader, required Config config})
     : _envLoader = envLoader,
@@ -35,5 +41,78 @@ class SentryWrapperImpl implements SentryWrapper {
       options.enableAutoSessionTracking = true;
       options.captureFailedRequests = true;
     }, appRunner: appRunner);
+
+    _isInitialized = true;
+  }
+
+  @override
+  Future<void> addBreadcrumb({
+    required String message,
+    required SentryEventLevel level,
+    String? category,
+    Map<String, dynamic>? data,
+  }) async {
+    if (!_isInitialized) return;
+
+    await Sentry.addBreadcrumb(
+      Breadcrumb(
+        message: message,
+        level: _getSentryLevel(level),
+        category: category,
+        data: data,
+      ),
+    );
+  }
+
+  @override
+  Future<void> captureException(
+    dynamic exception, {
+    dynamic stackTrace,
+    Map<String, String>? tags,
+    Map<String, dynamic>? contexts,
+  }) async {
+    if (!_isInitialized) return;
+
+    await Sentry.captureException(
+      exception,
+      stackTrace: stackTrace,
+      withScope: (scope) {
+        if (tags != null) {
+          tags.forEach((key, value) => scope.setTag(key, value));
+        }
+        if (contexts != null) {
+          contexts.forEach((key, value) => scope.setContexts(key, value));
+        }
+      },
+    );
+  }
+
+  @override
+  Future<void> captureMessage(
+    String message, {
+    required SentryEventLevel level,
+    Map<String, String>? tags,
+  }) async {
+    if (!_isInitialized) return;
+
+    await Sentry.captureMessage(
+      message,
+      level: _getSentryLevel(level),
+      withScope: (scope) {
+        if (tags != null) {
+          tags.forEach((key, value) => scope.setTag(key, value));
+        }
+      },
+    );
+  }
+
+  SentryLevel _getSentryLevel(SentryEventLevel level) {
+    return switch (level) {
+      SentryEventLevel.debug => SentryLevel.debug,
+      SentryEventLevel.info => SentryLevel.info,
+      SentryEventLevel.warning => SentryLevel.warning,
+      SentryEventLevel.error => SentryLevel.error,
+      SentryEventLevel.fatal => SentryLevel.fatal,
+    };
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -969,18 +969,18 @@ packages:
     dependency: transitive
     description:
       name: sentry
-      sha256: a49b4fb1cba576fe216347dc2a0e6d76076fb998e6012857db96f991c23b7b3c
+      sha256: "288aee3d35f252ac0dc3a4b0accbbe7212fa2867604027f2cc5bc65334afd743"
       url: "https://pub.dev"
     source: hosted
-    version: "9.15.0"
+    version: "9.16.0"
   sentry_flutter:
     dependency: "direct main"
     description:
       name: sentry_flutter
-      sha256: "25150030c93bd1d4b727ab61cfb09e99121c69ce90fa820bb9ca16dab433e43a"
+      sha256: f9e87d5895cc437902aa2b081727ee7e46524fe7cc2e1910f535480a3eeb8bed
       url: "https://pub.dev"
     source: hosted
-    version: "9.15.0"
+    version: "9.16.0"
   shared_preferences:
     dependency: transitive
     description:


### PR DESCRIPTION
### 1. PR SUMMARY

This PR extends the existing Sentry wrapper abstraction by adding three new capabilities to both the interface and its implementation: breadcrumb tracking (`addBreadcrumb`), exception capturing (`captureException`), and message capturing (`captureMessage`). It also introduces an `_isInitialized` guard flag to safely no-op all three methods when Sentry has not been initialized (e.g., when the DSN is empty). A minor `analysis_options.yaml` update suppresses a custom lint warning for Sentry's `Breadcrumb` type. The PR is **M-size** (~121 production lines) and has a single, clear purpose.

---

### 2. REVIEW SUMMARY

---

## REVIEW SUMMARY

| Issue Name | Description | Status | Notes |
|---|---|---|---|
| Missing Unit Tests | No tests are included for any of the three new methods (`addBreadcrumb`, `captureException`, `captureMessage`) or the `_getSentryLevel` private helper. The `_isInitialized` guard logic (both the happy path where Sentry initializes and the early-return path where DSN is empty) also has no test coverage. |  | Disagree: This implementation is a thin wrapper. It mostly just forwards calls to the Sentry SDK. As for creating fake and testing it pleases check [the next PR](url) |
| `addBreadcrumb` Should Be `Future<void>` | `Sentry.addBreadcrumb()` returns a `Future<void>`, but both the interface and implementation declare `addBreadcrumb` as synchronous `void`. | ✅ | |
| Stringly-Typed `level` Parameter Leaks Fragility Into the Public API | Both `addBreadcrumb` and `captureMessage` accept a `String level` that is then mapped to `SentryLevel` via a manual switch. | ✅ | |
| Redundant `_isInitialized = false` Assignment | In the early-return branch (empty DSN), `_isInitialized` is explicitly set to `false` before returning. | ✅ | |

---
