### PR TITLE
CA-543: feat: enhance AppLogger with Sentry integration and add unit tests

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -48,6 +48,8 @@ custom_lint:
         - 'CancelableOperation'
         - 'AppLocalizationsEn'
         - 'Breadcrumb'
+        - 'LogEvent'
+        - 'AppLogFilter'
 
 linter:
   # The lint rules applied to this project can be customized in the

--- a/lib/libraries/logging/app_logger.dart
+++ b/lib/libraries/logging/app_logger.dart
@@ -1,6 +1,6 @@
-// coverage:ignore-file
-import 'package:construculator/libraries/config/env_constants.dart';
-import 'package:flutter/foundation.dart' show kDebugMode;
+import 'package:construculator/libraries/config/interfaces/config.dart';
+import 'package:construculator/libraries/sentry/interfaces/sentry_wrapper.dart';
+import 'package:flutter/foundation.dart' show kDebugMode, visibleForTesting;
 import 'package:logger/logger.dart';
 
 /// Global Logger For The App
@@ -8,15 +8,45 @@ class AppLogger {
   final String _tag;
   final String _emojiPrefix;
   final Logger _internalLogger;
+  final SentryWrapper? _sentryWrapper;
+  final Config? _config;
+
+  /// Static default SentryWrapper instance used when none is provided
+  static SentryWrapper? _defaultSentryWrapper;
+
+  /// Static default Config instance used when none is provided
+  static Config? _defaultConfig;
+
+  /// Set the default SentryWrapper to be used by all AppLogger instances
+  /// This should be called once during app initialization
+  static void setSentryWrapper(SentryWrapper? wrapper) {
+    _defaultSentryWrapper = wrapper;
+  }
+
+  /// Set the default Config to be used by all AppLogger instances
+  /// This should be called once during app initialization
+  static void setConfig(Config? config) {
+    _defaultConfig = config;
+  }
 
   /// Private constructor for internal instantiation by tag() and emoji()
-  AppLogger._private(this._tag, this._emojiPrefix, this._internalLogger);
+  AppLogger._private(
+    this._tag,
+    this._emojiPrefix,
+    this._internalLogger,
+    this._sentryWrapper,
+    this._config,
+  );
 
-  AppLogger()
+  /// Creates an [AppLogger] with optional [sentryWrapper] and [config] overrides.
+  /// Falls back to the static defaults set via [setSentryWrapper] and [setConfig].
+  AppLogger({SentryWrapper? sentryWrapper, Config? config})
     : _tag = 'Construculator',
       _emojiPrefix = '',
+      _sentryWrapper = sentryWrapper ?? _defaultSentryWrapper,
+      _config = config ?? _defaultConfig,
       _internalLogger = Logger(
-        filter: _AppLogFilter(),
+        filter: AppLogFilter(config: config ?? _defaultConfig),
         printer: PrettyPrinter(
           methodCount: 1,
           errorMethodCount: 5,
@@ -39,45 +69,101 @@ class AppLogger {
   /// Return a new instance with the default tag and emoji prefix,
   /// and sharing the same internal logger
   AppLogger fresh() {
-    return AppLogger._private('Construculator', '', _internalLogger);
+    return AppLogger._private(
+      'Construculator',
+      '',
+      _internalLogger,
+      _sentryWrapper,
+      _config,
+    );
   }
 
   /// Return a new instance with the new tag, preserving the current emojiPrefix
   /// and sharing the same internal logger
   AppLogger tag(String newTag) {
-    return AppLogger._private(newTag, _emojiPrefix, _internalLogger);
+    return AppLogger._private(
+      newTag,
+      _emojiPrefix,
+      _internalLogger,
+      _sentryWrapper,
+      _config,
+    );
   }
 
   /// Return a new instance with the new emojiPrefix, preserving the current tag
   /// and sharing the same internal logger
   AppLogger emoji(String newEmojiPrefix) {
-    return AppLogger._private(_tag, newEmojiPrefix, _internalLogger);
+    return AppLogger._private(
+      _tag,
+      newEmojiPrefix,
+      _internalLogger,
+      _sentryWrapper,
+      _config,
+    );
   }
 
+  /// Logs an informational message.
+  /// Writes to console (filtered by environment) and adds a Sentry breadcrumb.
   void info(String message, [dynamic error, StackTrace? stackTrace]) {
     _internalLogger.i(
       _formatMessage(message),
       error: error,
       stackTrace: stackTrace,
     );
+
+    _sentryWrapper?.addBreadcrumb(
+      message: _formatMessage(message),
+      level: SentryEventLevel.info,
+      category: _tag,
+    );
   }
 
+  /// Logs a warning message.
+  /// Writes to console and adds a Sentry breadcrumb with optional error data.
   void warning(String message, [dynamic error, StackTrace? stackTrace]) {
     _internalLogger.w(
       _formatMessage(message),
       error: error,
       stackTrace: stackTrace,
     );
+
+    _sentryWrapper?.addBreadcrumb(
+      message: _formatMessage(message),
+      level: SentryEventLevel.warning,
+      category: _tag,
+      data: error != null ? {'error': error.toString()} : null,
+    );
   }
 
+  /// Logs an error message.
+  /// Writes to console and captures either an exception or message to Sentry.
   void error(String message, [dynamic error, StackTrace? stackTrace]) {
     _internalLogger.e(
       _formatMessage(message),
       error: error,
       stackTrace: stackTrace,
     );
+
+    if (error != null) {
+      _sentryWrapper?.captureException(
+        error,
+        stackTrace: stackTrace,
+        tags: {'logger_tag': _tag},
+        contexts: {
+          'log': {'message': _formatMessage(message)},
+        },
+      );
+    } else {
+      _sentryWrapper?.captureMessage(
+        _formatMessage(message),
+        level: SentryEventLevel.error,
+        tags: {'logger_tag': _tag},
+      );
+    }
   }
 
+  /// Logs a debug message.
+  /// Only writes to console (filtered by environment); no Sentry tracking.
   void debug(String message, [dynamic error, StackTrace? stackTrace]) {
     _internalLogger.d(
       _formatMessage(message),
@@ -86,31 +172,48 @@ class AppLogger {
     );
   }
 
+  /// Logs a fatal error message.
+  /// Writes to console and always captures an exception to Sentry with 'fatal' severity.
   void omg(String message, [dynamic error, StackTrace? stackTrace]) {
     _internalLogger.f(
       _formatMessage(message),
       error: error,
       stackTrace: stackTrace,
     );
+
+    _sentryWrapper?.captureException(
+      error ?? Exception(message),
+      stackTrace: stackTrace,
+      tags: {'logger_tag': _tag, 'severity': 'fatal'},
+      contexts: {
+        'log': {'message': _formatMessage(message)},
+      },
+    );
   }
 }
 
-class _AppLogFilter extends LogFilter {
+@visibleForTesting
+class AppLogFilter extends LogFilter {
+  final Config? config;
+  final bool isDebugMode;
+
+  AppLogFilter({this.config, bool? debugMode})
+    : isDebugMode = debugMode ?? kDebugMode;
+
   @override
   bool shouldLog(LogEvent event) {
-    final env = String.fromEnvironment('APP_ENV', defaultValue: devEnv);
-    if (env == prodEnv && !kDebugMode) {
-      return event.level.index >=
-          Level
-              .warning
-              .index; // Only log warnings and errors and fatal/omg in production
+    if (config == null) {
+      return true;
     }
 
-    if (env == qaEnv && !kDebugMode) {
-      return event.level.index >=
-          Level.info.index; // Only log info and above in qa
+    if ((config?.isProd == true) && !isDebugMode) {
+      return event.level.index >= Level.warning.index;
     }
 
-    return true; // Log all messages in dev
+    if ((config?.isQa == true) && !isDebugMode) {
+      return event.level.index >= Level.info.index;
+    }
+
+    return true;
   }
 }

--- a/lib/libraries/sentry/fake_sentry_wrapper.dart
+++ b/lib/libraries/sentry/fake_sentry_wrapper.dart
@@ -1,0 +1,149 @@
+import 'package:construculator/libraries/sentry/interfaces/sentry_wrapper.dart';
+import 'package:equatable/equatable.dart';
+
+/// Fake implementation of SentryWrapper for testing purposes.
+///
+/// Tracks all method calls and their parameters so tests can verify
+/// that the correct methods are called with the expected arguments.
+class FakeSentryWrapper implements SentryWrapper {
+  /// Recorded calls to [addBreadcrumb].
+  final List<BreadcrumbCall> breadcrumbs = [];
+
+  /// Recorded calls to [captureException].
+  final List<ExceptionCall> exceptions = [];
+
+  /// Recorded calls to [captureMessage].
+  final List<MessageCall> messages = [];
+
+  /// Executes [appRunner] immediately for tests.
+  @override
+  Future<void> initialize(void Function() appRunner) async {
+    appRunner();
+  }
+
+  /// Stores breadcrumb details so tests can assert on them.
+  @override
+  Future<void> addBreadcrumb({
+    required String message,
+    required SentryEventLevel level,
+    String? category,
+    Map<String, dynamic>? data,
+  }) async {
+    breadcrumbs.add(
+      BreadcrumbCall(
+        message: message,
+        level: level,
+        category: category,
+        data: data,
+      ),
+    );
+  }
+
+  /// Stores exception details so tests can assert on them.
+  @override
+  Future<void> captureException(
+    Object exception, {
+    StackTrace? stackTrace,
+    Map<String, String>? tags,
+    Map<String, dynamic>? contexts,
+  }) async {
+    exceptions.add(
+      ExceptionCall(
+        exception: exception,
+        stackTrace: stackTrace,
+        tags: tags,
+        contexts: contexts,
+      ),
+    );
+  }
+
+  /// Stores message details so tests can assert on them.
+  @override
+  Future<void> captureMessage(
+    String message, {
+    required SentryEventLevel level,
+    Map<String, String>? tags,
+  }) async {
+    messages.add(MessageCall(message: message, level: level, tags: tags));
+  }
+
+  /// Clears all recorded calls.
+  void reset() {
+    breadcrumbs.clear();
+    exceptions.clear();
+    messages.clear();
+  }
+}
+
+/// Represents a call to addBreadcrumb
+class BreadcrumbCall extends Equatable {
+  /// Breadcrumb message.
+  final String message;
+
+  /// Breadcrumb level.
+  final SentryEventLevel level;
+
+  /// Optional breadcrumb category.
+  final String? category;
+
+  /// Optional breadcrumb metadata.
+  final Map<String, dynamic>? data;
+
+  /// Creates a recorded breadcrumb call.
+  const BreadcrumbCall({
+    required this.message,
+    required this.level,
+    this.category,
+    this.data,
+  });
+
+  @override
+  /// Values used for equality checks.
+  List<Object?> get props => [message, level, category, data];
+}
+
+/// Represents a call to captureException
+class ExceptionCall extends Equatable {
+  /// Captured exception object.
+  final Object exception;
+
+  /// Captured stack trace.
+  final StackTrace? stackTrace;
+
+  /// Optional tags included with the exception.
+  final Map<String, String>? tags;
+
+  /// Optional contexts included with the exception.
+  final Map<String, dynamic>? contexts;
+
+  /// Creates a recorded exception call.
+  const ExceptionCall({
+    required this.exception,
+    this.stackTrace,
+    this.tags,
+    this.contexts,
+  });
+
+  @override
+  /// Values used for equality checks.
+  List<Object?> get props => [exception, stackTrace, tags, contexts];
+}
+
+/// Represents a call to captureMessage
+class MessageCall extends Equatable {
+  /// Captured message text.
+  final String message;
+
+  /// Captured message level.
+  final SentryEventLevel level;
+
+  /// Optional tags included with the message.
+  final Map<String, String>? tags;
+
+  /// Creates a recorded message call.
+  const MessageCall({required this.message, required this.level, this.tags});
+
+  @override
+  /// Values used for equality checks.
+  List<Object?> get props => [message, level, tags];
+}

--- a/lib/libraries/sentry/interfaces/sentry_wrapper.dart
+++ b/lib/libraries/sentry/interfaces/sentry_wrapper.dart
@@ -51,8 +51,8 @@ abstract class SentryWrapper {
   /// [tags] Optional tags for categorization
   /// [contexts] Optional additional context data
   Future<void> captureException(
-    dynamic exception, {
-    dynamic stackTrace,
+    Object exception, {
+    StackTrace? stackTrace,
     Map<String, String>? tags,
     Map<String, dynamic>? contexts,
   });

--- a/lib/libraries/sentry/sentry_wrapper_impl.dart
+++ b/lib/libraries/sentry/sentry_wrapper_impl.dart
@@ -8,7 +8,6 @@ import 'package:construculator/libraries/config/interfaces/env_loader.dart';
 import 'package:construculator/libraries/sentry/interfaces/sentry_wrapper.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
 
-// TODO: https://ripplearc.youtrack.cloud/issue/CA-543/Integrate-Sentry-into-AppLogger-with-full-test-coverage (add fake for sentry wrapp)
 class SentryWrapperImpl implements SentryWrapper {
   final EnvLoader _envLoader;
   final Config _config;
@@ -66,8 +65,8 @@ class SentryWrapperImpl implements SentryWrapper {
 
   @override
   Future<void> captureException(
-    dynamic exception, {
-    dynamic stackTrace,
+    Object exception, {
+    StackTrace? stackTrace,
     Map<String, String>? tags,
     Map<String, dynamic>? contexts,
   }) async {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -4,6 +4,7 @@ import 'package:construculator/app/app_module.dart';
 import 'package:construculator/libraries/config/app_config_impl.dart';
 import 'package:construculator/libraries/config/env_constants.dart';
 import 'package:construculator/libraries/config/env_loader_impl.dart';
+import 'package:construculator/libraries/logging/app_logger.dart';
 import 'package:construculator/libraries/sentry/sentry_wrapper_impl.dart';
 import 'package:construculator/libraries/supabase/supabase_wrapper_impl.dart';
 import 'package:flutter/material.dart';
@@ -18,6 +19,9 @@ Future<void> main() async {
     envLoader: appBootstrap.envLoader,
     config: appBootstrap.config,
   );
+
+  AppLogger.setSentryWrapper(sentryWrapper);
+  AppLogger.setConfig(appBootstrap.config);
 
   await sentryWrapper.initialize(
     () => runApp(

--- a/test/libraries/logging/units/app_logger_test.dart
+++ b/test/libraries/logging/units/app_logger_test.dart
@@ -1,0 +1,279 @@
+import 'package:construculator/libraries/config/env_constants.dart';
+import 'package:construculator/libraries/config/testing/fake_app_config.dart';
+import 'package:construculator/libraries/logging/app_logger.dart';
+import 'package:construculator/libraries/sentry/fake_sentry_wrapper.dart';
+import 'package:construculator/libraries/sentry/interfaces/sentry_wrapper.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:logger/logger.dart';
+
+void main() {
+  late AppLogger logger;
+  late FakeSentryWrapper fakeSentry;
+  late FakeAppConfig fakeConfig;
+
+  setUp(() {
+    fakeSentry = FakeSentryWrapper();
+    fakeConfig = FakeAppConfig();
+    logger = AppLogger(sentryWrapper: fakeSentry, config: fakeConfig);
+  });
+
+  tearDown(() {
+    fakeSentry.reset();
+    AppLogger.setSentryWrapper(null);
+    AppLogger.setConfig(null);
+  });
+
+  group('Instance creation', () {
+    test('creates instance with tag chaining', () {
+      final customLogger = logger.tag('Auth').emoji('🔐');
+      expect(customLogger, isNotNull);
+    });
+
+    test('fresh() resets to default tag and emoji', () {
+      final customLogger = logger.tag('CustomTag').emoji('🚀');
+      final freshLogger = customLogger.fresh();
+
+      freshLogger.info('Fresh logger test');
+
+      expect(
+        fakeSentry.breadcrumbs,
+        contains(
+          const BreadcrumbCall(
+            message: '[Construculator] Fresh logger test',
+            level: SentryEventLevel.info,
+            category: 'Construculator',
+          ),
+        ),
+      );
+    });
+  });
+
+  group('debug()', () {
+    test('does not send any data to Sentry', () {
+      logger.debug('Debug message');
+
+      expect(fakeSentry.breadcrumbs, isEmpty);
+      expect(fakeSentry.exceptions, isEmpty);
+      expect(fakeSentry.messages, isEmpty);
+    });
+  });
+
+  group('info()', () {
+    test('adds breadcrumb with correct parameters', () {
+      logger.tag('TestTag').info('Info message');
+
+      expect(
+        fakeSentry.breadcrumbs,
+        contains(
+          const BreadcrumbCall(
+            message: '[TestTag] Info message',
+            level: SentryEventLevel.info,
+            category: 'TestTag',
+          ),
+        ),
+      );
+    });
+  });
+
+  group('warning()', () {
+    test('adds breadcrumb with error data when provided', () {
+      final error = Exception('Test error');
+      logger.warning('Warning message', error);
+
+      expect(fakeSentry.breadcrumbs.length, 1);
+      expect(fakeSentry.breadcrumbs.first.level, SentryEventLevel.warning);
+      expect(
+        fakeSentry.breadcrumbs.first.data!['error'],
+        contains('Test error'),
+      );
+    });
+
+    test('adds breadcrumb without error data when not provided', () {
+      logger.warning('Warning without error');
+
+      expect(fakeSentry.breadcrumbs.length, 1);
+      expect(fakeSentry.breadcrumbs.first.level, SentryEventLevel.warning);
+      expect(fakeSentry.breadcrumbs.first.data, isNull);
+    });
+  });
+
+  group('error()', () {
+    test('captures exception when error object provided', () {
+      final error = Exception('Test error');
+      logger.tag('ErrorTag').error('Error occurred', error);
+
+      expect(fakeSentry.exceptions.length, 1);
+      expect(fakeSentry.exceptions.first.exception, error);
+      expect(fakeSentry.exceptions.first.tags!['logger_tag'], 'ErrorTag');
+      expect(
+        fakeSentry.exceptions.first.contexts!['log']['message'],
+        contains('Error occurred'),
+      );
+    });
+
+    test('captures message when no error object provided', () {
+      logger.tag('ErrorTag').error('Error message only');
+
+      expect(
+        fakeSentry.messages,
+        contains(
+          const MessageCall(
+            message: '[ErrorTag] Error message only',
+            level: SentryEventLevel.error,
+            tags: {'logger_tag': 'ErrorTag'},
+          ),
+        ),
+      );
+    });
+  });
+
+  group('omg()', () {
+    test('captures exception with fatal severity tag', () {
+      final error = Exception('Fatal error');
+      logger.tag('FatalTag').omg('Fatal occurred', error);
+
+      expect(fakeSentry.exceptions.length, 1);
+      expect(fakeSentry.exceptions.first.exception, error);
+      expect(fakeSentry.exceptions.first.tags!['logger_tag'], 'FatalTag');
+      expect(fakeSentry.exceptions.first.tags!['severity'], 'fatal');
+    });
+
+    test('creates exception from message when no error provided', () {
+      logger.omg('Fatal message only');
+
+      expect(fakeSentry.exceptions.length, 1);
+      expect(fakeSentry.exceptions.first.exception, isA<Exception>());
+    });
+  });
+
+  group('Dependency injection', () {
+    test('uses injected SentryWrapper', () {
+      final customLogger = AppLogger(sentryWrapper: fakeSentry);
+      customLogger.info('Test');
+
+      expect(fakeSentry.breadcrumbs, isNotEmpty);
+    });
+
+    test('uses static default SentryWrapper when none provided', () {
+      final defaultWrapper = FakeSentryWrapper();
+      AppLogger.setSentryWrapper(defaultWrapper);
+
+      final customLogger = AppLogger();
+      customLogger.info('Test');
+
+      expect(defaultWrapper.breadcrumbs, isNotEmpty);
+    });
+
+    test('uses injected Config', () {
+      final prodConfig = FakeAppConfig();
+      prodConfig.setEnvironment(Environment.prod);
+      final prodLogger = AppLogger(
+        sentryWrapper: fakeSentry,
+        config: prodConfig,
+      );
+
+      prodLogger.info('Info in prod');
+
+      expect(fakeSentry.breadcrumbs, isNotEmpty);
+    });
+  });
+
+  group('AppLogFilter', () {
+    test('prod mode suppresses debug and info in console', () {
+      final prodConfig = FakeAppConfig();
+      prodConfig.setEnvironment(Environment.prod);
+      final filter = AppLogFilter(config: prodConfig, debugMode: false);
+
+      expect(
+        filter.shouldLog(LogEvent(Level.debug, 'test', error: null, stackTrace: null)),
+        isFalse,
+      );
+      expect(
+        filter.shouldLog(LogEvent(Level.info, 'test', error: null, stackTrace: null)),
+        isFalse,
+      );
+      expect(
+        filter.shouldLog(LogEvent(Level.warning, 'test', error: null, stackTrace: null)),
+        isTrue,
+      );
+      expect(
+        filter.shouldLog(LogEvent(Level.error, 'test', error: null, stackTrace: null)),
+        isTrue,
+      );
+      expect(
+        filter.shouldLog(LogEvent(Level.fatal, 'test', error: null, stackTrace: null)),
+        isTrue,
+      );
+    });
+
+    test('qa mode suppresses debug in console', () {
+      final qaConfig = FakeAppConfig();
+      qaConfig.setEnvironment(Environment.qa);
+      final filter = AppLogFilter(config: qaConfig, debugMode: false);
+
+      expect(
+        filter.shouldLog(LogEvent(Level.debug, 'test', error: null, stackTrace: null)),
+        isFalse,
+      );
+      expect(
+        filter.shouldLog(LogEvent(Level.info, 'test', error: null, stackTrace: null)),
+        isTrue,
+      );
+      expect(
+        filter.shouldLog(LogEvent(Level.warning, 'test', error: null, stackTrace: null)),
+        isTrue,
+      );
+      expect(
+        filter.shouldLog(LogEvent(Level.error, 'test', error: null, stackTrace: null)),
+        isTrue,
+      );
+    });
+
+    test('dev mode logs all levels', () {
+      final devConfig = FakeAppConfig();
+      devConfig.setEnvironment(Environment.dev);
+      final filter = AppLogFilter(config: devConfig, debugMode: false);
+
+      expect(
+        filter.shouldLog(LogEvent(Level.debug, 'test', error: null, stackTrace: null)),
+        isTrue,
+      );
+      expect(
+        filter.shouldLog(LogEvent(Level.info, 'test', error: null, stackTrace: null)),
+        isTrue,
+      );
+      expect(
+        filter.shouldLog(LogEvent(Level.warning, 'test', error: null, stackTrace: null)),
+        isTrue,
+      );
+    });
+
+    test('debug mode overrides environment filtering', () {
+      final prodConfig = FakeAppConfig();
+      prodConfig.setEnvironment(Environment.prod);
+      final filter = AppLogFilter(config: prodConfig, debugMode: true);
+
+      expect(
+        filter.shouldLog(LogEvent(Level.debug, 'test', error: null, stackTrace: null)),
+        isTrue,
+      );
+      expect(
+        filter.shouldLog(LogEvent(Level.info, 'test', error: null, stackTrace: null)),
+        isTrue,
+      );
+    });
+
+    test('null config allows all logs', () {
+      final filter = AppLogFilter(config: null);
+
+      expect(
+        filter.shouldLog(LogEvent(Level.debug, 'test', error: null, stackTrace: null)),
+        isTrue,
+      );
+      expect(
+        filter.shouldLog(LogEvent(Level.info, 'test', error: null, stackTrace: null)),
+        isTrue,
+      );
+    });
+  });
+}


### PR DESCRIPTION
### 1. PR SUMMARY

This PR wires `SentryWrapper` and `Config` into `AppLogger`, implementing the actual Sentry integration for each log level: `info`/`warning` add breadcrumbs, `error` captures either an exception or a message depending on whether an error object is present, and `omg` always captures an exception (synthesizing one from the message string when no error is passed). A static service-locator pattern (`setSentryWrapper` / `setConfig`) bootstraps defaults in `main.dart`. The PR ships with a `FakeSentryWrapper` test double and unit tests for `AppLogger`. **PR size is S (~97 production lines).**

---

## REVIEW SUMMARY

| Issue Name | Description | Status | Notes |
|---|---|---|---|
| Static state leaks across tests | `setSentryWrapper` and `setConfig` write to static fields (`_defaultSentryWrapper`, `_defaultConfig`).| ✅ | |
| Vacuous config test | The test "uses static default Config when none provided" asserts only `expect(customLogger, isNotNull)`. A non-null instance is trivially guaranteed by the constructor| ✅ |  |
| Missing coverage: `warning()` without an error | There is a test for `warning()` with an error (verifying the `data` field is populated), but no test for `warning()` without an error (verifying the breadcrumb is still added and `data` is null).| ✅ | |
| Missing coverage: `_AppLogFilter` level filtering | The environment-based log filtering logic (`isProd` / `isQa`) has no behavioral test coverage. There are no tests confirming that `debug()` and `info()` are suppressed in prod mode, or that `debug()` is suppressed in QA mode. This is logic-heavy enough to require direct tests. | ✅  | |
| Implementation comments in production code | Rule 7 prohibits inline comments that narrate what the code does. Two violations in `app_logger.dart` / `_AppLogFilter` | ✅ | |
