### PR TITLE
CA-228: Feat global search domain entities

### DIFF
--- a/lib/features/global_search/data/models/search_results_dto.dart
+++ b/lib/features/global_search/data/models/search_results_dto.dart
@@ -1,4 +1,5 @@
 import 'package:construculator/features/estimation/data/models/cost_estimate_dto.dart';
+import 'package:construculator/features/global_search/domain/entities/search_results.dart';
 import 'package:construculator/libraries/auth/data/models/user_profile_dto.dart';
 import 'package:construculator/libraries/project/data/models/project_dto.dart';
 import 'package:equatable/equatable.dart';
@@ -28,6 +29,15 @@ class SearchResultsDto extends Equatable {
       projects: projects ?? this.projects,
       estimations: estimations ?? this.estimations,
       members: members ?? this.members,
+    );
+  }
+
+  /// Converts this DTO to the [SearchResults] domain entity.
+  SearchResults toDomain() {
+    return SearchResults(
+      projects: projects.map((p) => p.toDomain()).toList(),
+      estimations: estimations.map((e) => e.toDomain()).toList(),
+      members: members.map((m) => m.toDomain()).toList(),
     );
   }
 

--- a/lib/features/global_search/data/repositories/global_search_repository_impl.dart
+++ b/lib/features/global_search/data/repositories/global_search_repository_impl.dart
@@ -1,0 +1,206 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:construculator/features/global_search/data/data_source/interfaces/global_search_data_source.dart';
+import 'package:construculator/features/global_search/data/models/pagination_params_dto.dart';
+import 'package:construculator/features/global_search/data/models/search_params_dto.dart';
+import 'package:construculator/features/global_search/data/models/search_scope.dart';
+import 'package:construculator/features/global_search/domain/entities/search_params_entity.dart';
+import 'package:construculator/features/global_search/domain/entities/search_results.dart';
+import 'package:construculator/features/global_search/domain/entities/search_scope_entity.dart';
+import 'package:construculator/features/global_search/domain/repositories/global_search_repository.dart';
+import 'package:construculator/libraries/either/either.dart';
+import 'package:construculator/libraries/errors/failures.dart';
+import 'package:construculator/libraries/global_search/domain/search_error_type.dart';
+import 'package:construculator/libraries/logging/app_logger.dart';
+import 'package:construculator/libraries/supabase/data/supabase_types.dart';
+import 'package:supabase_flutter/supabase_flutter.dart' as supabase;
+
+/// Supabase-backed implementation of [GlobalSearchRepository].
+///
+/// Delegates all operations to [GlobalSearchDataSource] and maps any thrown
+/// exceptions to typed [Failure] values so callers never have to catch.
+class GlobalSearchRepositoryImpl implements GlobalSearchRepository {
+  final GlobalSearchDataSource _dataSource;
+  static final _logger = AppLogger().tag('GlobalSearchRepositoryImpl');
+
+  GlobalSearchRepositoryImpl({required GlobalSearchDataSource dataSource})
+    : _dataSource = dataSource;
+
+  SearchScopeDto _toDataScope(SearchScope entity) {
+    switch (entity) {
+      case SearchScope.dashboard:
+        return SearchScopeDto.dashboard;
+      case SearchScope.calculation:
+        return SearchScopeDto.calculation;
+      case SearchScope.estimation:
+        return SearchScopeDto.estimation;
+      case SearchScope.member:
+        return SearchScopeDto.member;
+    }
+  }
+
+  SearchParamsDto _toDataParams(SearchParams entity) {
+    final entityScope = entity.scope;
+    return SearchParamsDto(
+      query: entity.query,
+      filterByTag: entity.filterByTag,
+      filterByDate: entity.filterByDate,
+      filterByOwner: entity.filterByOwner,
+      scope: entityScope != null ? _toDataScope(entityScope) : null,
+      pagination: PaginationParamsDto(
+        offset: entity.pagination.offset,
+        limit: entity.pagination.limit,
+      ),
+    );
+  }
+
+  Failure _handleError(Object error, String operation) {
+    if (error is TimeoutException) {
+      _logger.warning(
+        'Timeout error $operation: '
+        'message=${error.message}, duration=${error.duration}',
+      );
+      return SearchFailure(errorType: SearchErrorType.timeoutError);
+    }
+
+    if (error is SocketException) {
+      _logger.warning(
+        'Connection error $operation: '
+        'message=${error.message}, address=${error.address}, '
+        'port=${error.port}, osError=${error.osError}',
+      );
+      return SearchFailure(errorType: SearchErrorType.connectionError);
+    }
+
+    if (error is TypeError) {
+      _logger.error(
+        'Parsing error $operation: ${error.toString()}',
+        'returning parsing failure',
+      );
+      return SearchFailure(errorType: SearchErrorType.parsingError);
+    }
+
+    if (error is supabase.PostgrestException) {
+      final postgresErrorCode = PostgresErrorCode.fromCode(error.code);
+
+      if (postgresErrorCode == PostgresErrorCode.noDataFound) {
+        _logger.warning(
+          'No data found $operation: '
+          'code=${error.code}, message=${error.message}',
+        );
+        return SearchFailure(errorType: SearchErrorType.notFoundError);
+      }
+
+      if (postgresErrorCode == PostgresErrorCode.uniqueViolation) {
+        _logger.warning(
+          'Unique constraint violation $operation: '
+          'code=${error.code}, message=${error.message}',
+        );
+        return SearchFailure(errorType: SearchErrorType.duplicateEntryError);
+      }
+
+      if (postgresErrorCode == PostgresErrorCode.connectionFailure ||
+          postgresErrorCode == PostgresErrorCode.unableToConnect ||
+          postgresErrorCode == PostgresErrorCode.connectionDoesNotExist) {
+        _logger.error(
+          'PostgreSQL connection error $operation: '
+          'code=${error.code}, message=${error.message}, '
+          'details=${error.details}, hint=${error.hint}',
+        );
+        return SearchFailure(errorType: SearchErrorType.connectionError);
+      }
+
+      _logger.error(
+        'Unexpected PostgreSQL error $operation: '
+        'code=${error.code}, message=${error.message}, '
+        'details=${error.details}, hint=${error.hint}',
+      );
+      return SearchFailure(errorType: SearchErrorType.unexpectedDatabaseError);
+    }
+
+    _logger.error('Unexpected error $operation: $error');
+    return UnexpectedFailure();
+  }
+
+  @override
+  Future<Either<Failure, SearchResults>> search(SearchParams params) async {
+    try {
+      _logger.debug('Performing global search for query: ${params.query}');
+      final dto = await _dataSource.search(_toDataParams(params));
+      _logger.debug(
+        'Search completed: ${dto.projects.length} projects, '
+        '${dto.estimations.length} estimations, '
+        '${dto.members.length} members',
+      );
+      return Right(dto.toDomain());
+    } catch (e) {
+      return Left(_handleError(e, 'performing global search'));
+    }
+  }
+
+  @override
+  Future<Either<Failure, List<String>>> getRecentSearches(
+    SearchScope scope,
+  ) async {
+    try {
+      _logger.debug('Getting recent searches for scope: ${scope.name}');
+      final terms = await _dataSource.getRecentSearches(_toDataScope(scope));
+      _logger.debug('Retrieved ${terms.length} recent searches');
+      return Right(terms);
+    } catch (e) {
+      return Left(_handleError(e, 'getting recent searches'));
+    }
+  }
+
+  @override
+  Future<Either<Failure, void>> saveRecentSearch(
+    String searchTerm,
+    SearchScope scope, {
+    String? projectId,
+    bool hasResults = false,
+  }) async {
+    try {
+      _logger.debug(
+        'Saving recent search: $searchTerm for scope: ${scope.name}',
+      );
+      await _dataSource.saveRecentSearch(
+        searchTerm,
+        _toDataScope(scope),
+        projectId: projectId,
+        hasResults: hasResults,
+      );
+      return const Right(null);
+    } catch (e) {
+      return Left(_handleError(e, 'saving recent search'));
+    }
+  }
+
+  @override
+  Future<Either<Failure, void>> deleteRecentSearch(
+    String searchTerm,
+    SearchScope scope,
+  ) async {
+    try {
+      _logger.debug(
+        'Deleting recent search: $searchTerm for scope: ${scope.name}',
+      );
+      await _dataSource.deleteRecentSearch(searchTerm, _toDataScope(scope));
+      return const Right(null);
+    } catch (e) {
+      return Left(_handleError(e, 'deleting recent search'));
+    }
+  }
+
+  @override
+  Future<Either<Failure, List<String>>> getSearchSuggestions() async {
+    try {
+      _logger.debug('Fetching search suggestions');
+      final suggestions = await _dataSource.getSearchSuggestions();
+      _logger.debug('Retrieved ${suggestions.length} search suggestions');
+      return Right(suggestions);
+    } catch (e) {
+      return Left(_handleError(e, 'fetching search suggestions'));
+    }
+  }
+}

--- a/lib/features/global_search/domain/entities/pagination_params.dart
+++ b/lib/features/global_search/domain/entities/pagination_params.dart
@@ -18,6 +18,7 @@ class PaginationParams extends Equatable {
     this.limit = 20,
   });
 
+  /// Returns a copy of this [PaginationParams] with the given fields replaced.
   PaginationParams copyWith({int? offset, int? limit}) {
     return PaginationParams(
       offset: offset ?? this.offset,

--- a/lib/features/global_search/domain/entities/pagination_params.dart
+++ b/lib/features/global_search/domain/entities/pagination_params.dart
@@ -1,0 +1,30 @@
+import 'package:equatable/equatable.dart';
+
+/// Domain value object encapsulating offset/limit pagination for a search operation.
+///
+/// - [offset] is the number of records to skip (default: 0).
+/// - [limit] is the maximum number of records to return per page (default: 20).
+///
+/// Example — fetching the second page of 20 results:
+/// ```dart
+/// const PaginationParams(offset: 20, limit: 20)
+/// ```
+class PaginationParams extends Equatable {
+  final int offset;
+  final int limit;
+
+  const PaginationParams({
+    this.offset = 0,
+    this.limit = 20,
+  });
+
+  PaginationParams copyWith({int? offset, int? limit}) {
+    return PaginationParams(
+      offset: offset ?? this.offset,
+      limit: limit ?? this.limit,
+    );
+  }
+
+  @override
+  List<Object?> get props => [offset, limit];
+}

--- a/lib/features/global_search/domain/entities/search_params_entity.dart
+++ b/lib/features/global_search/domain/entities/search_params_entity.dart
@@ -12,14 +12,23 @@ import 'package:equatable/equatable.dart';
 /// lets users pick a calendar date (e.g. March 20th), truncate to start of day
 /// (00:00:00) before passing, or ensure the backend RPC treats it as a date range.
 class SearchParams extends Equatable {
+  /// The search query text.
   final String query;
+
+  /// Optional tag to restrict results to items with this tag.
   final String? filterByTag;
 
   /// Date filter. Truncate to start of day (00:00:00) if picking a calendar date
   /// to avoid exact-timestamp mismatch with backend.
   final DateTime? filterByDate;
+
+  /// Optional owner identifier to restrict results to items owned by this user.
   final String? filterByOwner;
+
+  /// Optional scope limiting which areas or entity types are searched.
   final SearchScope? scope;
+
+  /// Pagination settings for the search request and result pages.
   final PaginationParams pagination;
 
   const SearchParams({
@@ -33,6 +42,7 @@ class SearchParams extends Equatable {
 
   static const Object _absent = Object();
 
+  /// Returns a copy of this [SearchParams] with the given fields replaced.
   SearchParams copyWith({
     String? query,
     Object? filterByTag = _absent,

--- a/lib/features/global_search/domain/entities/search_params_entity.dart
+++ b/lib/features/global_search/domain/entities/search_params_entity.dart
@@ -1,17 +1,17 @@
-import 'package:construculator/features/global_search/data/models/pagination_params.dart';
+import 'package:construculator/features/global_search/domain/entities/pagination_params.dart';
 import 'package:construculator/features/global_search/domain/entities/search_scope_entity.dart';
 import 'package:equatable/equatable.dart';
 
 /// Domain entity representing the parameters for a global search operation.
 ///
-/// Mirrors [SearchParams] in the data layer without introducing a data-layer
-/// dependency into the domain. The data layer maps this entity to [SearchParams]
+/// Mirrors [SearchParamsDto] in the data layer without introducing a data-layer
+/// dependency into the domain. The data layer maps this entity to [SearchParamsDto]
 /// before passing it to the data source.
 ///
 /// **Date filtering**: [filterByDate] is sent as an ISO8601 string. If the UI
 /// lets users pick a calendar date (e.g. March 20th), truncate to start of day
 /// (00:00:00) before passing, or ensure the backend RPC treats it as a date range.
-class SearchParamsEntity extends Equatable {
+class SearchParams extends Equatable {
   final String query;
   final String? filterByTag;
 
@@ -19,10 +19,10 @@ class SearchParamsEntity extends Equatable {
   /// to avoid exact-timestamp mismatch with backend.
   final DateTime? filterByDate;
   final String? filterByOwner;
-  final SearchScopeEntity? scope;
+  final SearchScope? scope;
   final PaginationParams pagination;
 
-  const SearchParamsEntity({
+  const SearchParams({
     required this.query,
     this.filterByTag,
     this.filterByDate,
@@ -33,7 +33,7 @@ class SearchParamsEntity extends Equatable {
 
   static const Object _absent = Object();
 
-  SearchParamsEntity copyWith({
+  SearchParams copyWith({
     String? query,
     Object? filterByTag = _absent,
     Object? filterByDate = _absent,
@@ -41,12 +41,12 @@ class SearchParamsEntity extends Equatable {
     Object? scope = _absent,
     PaginationParams? pagination,
   }) {
-    return SearchParamsEntity(
+    return SearchParams(
       query: query ?? this.query,
       filterByTag: filterByTag == _absent ? this.filterByTag : filterByTag as String?,
       filterByDate: filterByDate == _absent ? this.filterByDate : filterByDate as DateTime?,
       filterByOwner: filterByOwner == _absent ? this.filterByOwner : filterByOwner as String?,
-      scope: scope == _absent ? this.scope : scope as SearchScopeEntity?,
+      scope: scope == _absent ? this.scope : scope as SearchScope?,
       pagination: pagination ?? this.pagination,
     );
   }

--- a/lib/features/global_search/domain/entities/search_params_entity.dart
+++ b/lib/features/global_search/domain/entities/search_params_entity.dart
@@ -1,0 +1,56 @@
+import 'package:construculator/features/global_search/data/models/pagination_params.dart';
+import 'package:construculator/features/global_search/domain/entities/search_scope_entity.dart';
+import 'package:equatable/equatable.dart';
+
+/// Domain entity representing the parameters for a global search operation.
+///
+/// Mirrors [SearchParams] in the data layer without introducing a data-layer
+/// dependency into the domain. The data layer maps this entity to [SearchParams]
+/// before passing it to the data source.
+///
+/// **Date filtering**: [filterByDate] is sent as an ISO8601 string. If the UI
+/// lets users pick a calendar date (e.g. March 20th), truncate to start of day
+/// (00:00:00) before passing, or ensure the backend RPC treats it as a date range.
+class SearchParamsEntity extends Equatable {
+  final String query;
+  final String? filterByTag;
+
+  /// Date filter. Truncate to start of day (00:00:00) if picking a calendar date
+  /// to avoid exact-timestamp mismatch with backend.
+  final DateTime? filterByDate;
+  final String? filterByOwner;
+  final SearchScopeEntity? scope;
+  final PaginationParams pagination;
+
+  const SearchParamsEntity({
+    required this.query,
+    this.filterByTag,
+    this.filterByDate,
+    this.filterByOwner,
+    this.scope,
+    this.pagination = const PaginationParams(),
+  });
+
+  static const Object _absent = Object();
+
+  SearchParamsEntity copyWith({
+    String? query,
+    Object? filterByTag = _absent,
+    Object? filterByDate = _absent,
+    Object? filterByOwner = _absent,
+    Object? scope = _absent,
+    PaginationParams? pagination,
+  }) {
+    return SearchParamsEntity(
+      query: query ?? this.query,
+      filterByTag: filterByTag == _absent ? this.filterByTag : filterByTag as String?,
+      filterByDate: filterByDate == _absent ? this.filterByDate : filterByDate as DateTime?,
+      filterByOwner: filterByOwner == _absent ? this.filterByOwner : filterByOwner as String?,
+      scope: scope == _absent ? this.scope : scope as SearchScopeEntity?,
+      pagination: pagination ?? this.pagination,
+    );
+  }
+
+  @override
+  List<Object?> get props => [query, filterByTag, filterByDate, filterByOwner, scope, pagination];
+}

--- a/lib/features/global_search/domain/entities/search_results.dart
+++ b/lib/features/global_search/domain/entities/search_results.dart
@@ -1,0 +1,42 @@
+import 'package:construculator/features/estimation/domain/entities/cost_estimate_entity.dart';
+import 'package:construculator/libraries/auth/domain/entities/user_profile_entity.dart';
+import 'package:construculator/libraries/project/domain/entities/project_entity.dart';
+import 'package:equatable/equatable.dart';
+
+/// Domain entity representing the results of a global search.
+///
+/// Holds the matched [projects], cost [estimations], and [members] returned
+/// after executing a search query against the backend.
+///
+/// All lists default to empty, so callers can always iterate without null checks.
+class SearchResults extends Equatable {
+  /// Projects matching the search query.
+  final List<Project> projects;
+
+  /// Cost estimations matching the search query.
+  final List<CostEstimate> estimations;
+
+  /// Team members matching the search query.
+  final List<UserProfile> members;
+
+  const SearchResults({
+    this.projects = const [],
+    this.estimations = const [],
+    this.members = const [],
+  });
+
+  SearchResults copyWith({
+    List<Project>? projects,
+    List<CostEstimate>? estimations,
+    List<UserProfile>? members,
+  }) {
+    return SearchResults(
+      projects: projects ?? this.projects,
+      estimations: estimations ?? this.estimations,
+      members: members ?? this.members,
+    );
+  }
+
+  @override
+  List<Object?> get props => [projects, estimations, members];
+}

--- a/lib/features/global_search/domain/entities/search_results.dart
+++ b/lib/features/global_search/domain/entities/search_results.dart
@@ -25,6 +25,7 @@ class SearchResults extends Equatable {
     this.members = const [],
   });
 
+  /// Returns a copy of this [SearchResults] with the given fields replaced.
   SearchResults copyWith({
     List<Project>? projects,
     List<CostEstimate>? estimations,

--- a/lib/features/global_search/domain/entities/search_scope_entity.dart
+++ b/lib/features/global_search/domain/entities/search_scope_entity.dart
@@ -3,9 +3,4 @@
 /// Mirrors [SearchScope] in the data layer without introducing a data-layer
 /// dependency into the domain. The data layer maps to this type via
 /// [SearchScope.values.byName].
-enum SearchScopeEntity {
-  dashboard,
-  calculation,
-  estimation,
-  member,
-}
+enum SearchScope { dashboard, calculation, estimation, member }

--- a/lib/features/global_search/domain/entities/search_scope_entity.dart
+++ b/lib/features/global_search/domain/entities/search_scope_entity.dart
@@ -1,0 +1,11 @@
+/// Domain-level enum identifying which domain(s) the global search operates across.
+///
+/// Mirrors [SearchScope] in the data layer without introducing a data-layer
+/// dependency into the domain. The data layer maps to this type via
+/// [SearchScope.values.byName].
+enum SearchScopeEntity {
+  dashboard,
+  calculation,
+  estimation,
+  member,
+}

--- a/lib/features/global_search/domain/repositories/global_search_repository.dart
+++ b/lib/features/global_search/domain/repositories/global_search_repository.dart
@@ -1,0 +1,75 @@
+import 'package:construculator/features/global_search/domain/entities/search_params_entity.dart';
+import 'package:construculator/features/global_search/domain/entities/search_results.dart';
+import 'package:construculator/features/global_search/domain/entities/search_scope_entity.dart';
+import 'package:construculator/libraries/either/interfaces/either.dart';
+import 'package:construculator/libraries/errors/failures.dart';
+
+/// Abstract repository interface for global search operations.
+///
+/// This repository defines the contract for searching across projects,
+/// cost estimations, and members, as well as managing per-user search history
+/// and suggestions. It follows the repository pattern to decouple the domain
+/// layer from the specific data source implementation.
+///
+/// All methods return [Either] so that callers receive a typed [Failure] on
+/// error rather than catching exceptions directly.
+abstract class GlobalSearchRepository {
+  /// Performs a global search using the supplied [params].
+  ///
+  /// Returns a [Future] that completes with an [Either] containing either
+  /// a [Failure] or a [SearchResults] holding matched projects, estimations,
+  /// and members.
+  ///
+  /// Filtering (tag, date, owner, scope) and pagination are driven by [params].
+  Future<Either<Failure, SearchResults>> search(SearchParams params);
+
+  /// Fetches the authenticated user's recent search terms for the given [scope].
+  ///
+  /// Returns a [Future] that completes with an [Either] containing either
+  /// a [Failure] or a [List<String>] ordered by most recent first.
+  /// Returns an empty list when the user is not authenticated.
+  Future<Either<Failure, List<String>>> getRecentSearches(SearchScope scope);
+
+  /// Saves [searchTerm] to the authenticated user's history for [scope].
+  ///
+  /// [projectId] is the project context in which the search was performed.
+  /// It is nullable for searches not scoped to a specific project (e.g. dashboard).
+  /// [hasResults] should be `true` only when the search returned at least one result.
+  /// Terms saved with [hasResults] = false are kept in history but excluded from
+  /// suggestions.
+  ///
+  /// Returns a [Future] that completes with an [Either] containing either
+  /// a [Failure] or void on success.
+  /// Does nothing when the user is not authenticated or the term is empty.
+  Future<Either<Failure, void>> saveRecentSearch(
+    String searchTerm,
+    SearchScope scope, {
+    String? projectId,
+    bool hasResults = false,
+  });
+
+  /// Removes [searchTerm] from the authenticated user's history for [scope].
+  ///
+  /// Does NOT affect global suggestion counts — the term's analytics record is
+  /// preserved.
+  ///
+  /// Returns a [Future] that completes with an [Either] containing either
+  /// a [Failure] or void on success.
+  /// Does nothing when the user is not authenticated or the term is empty.
+  Future<Either<Failure, void>> deleteRecentSearch(
+    String searchTerm,
+    SearchScope scope,
+  );
+
+  /// Fetches personalized search suggestions for the authenticated user.
+  ///
+  /// Priority 1: user's own search history (has_results = true), sorted by
+  /// frequency.
+  /// Priority 2: searches by teammates within shared projects (has_results = true).
+  ///
+  /// Returns a [Future] that completes with an [Either] containing either
+  /// a [Failure] or a [List<String>].
+  /// Returns an empty list when no suggestions are found or the user is not
+  /// authenticated.
+  Future<Either<Failure, List<String>>> getSearchSuggestions();
+}

--- a/lib/features/global_search/global_search_module.dart
+++ b/lib/features/global_search/global_search_module.dart
@@ -1,12 +1,16 @@
 import 'package:construculator/app/app_bootstrap.dart';
 import 'package:construculator/features/global_search/data/data_source/interfaces/global_search_data_source.dart';
 import 'package:construculator/features/global_search/data/data_source/remote_global_search_data_source.dart';
+import 'package:construculator/features/global_search/data/repositories/global_search_repository_impl.dart';
+import 'package:construculator/features/global_search/domain/repositories/global_search_repository.dart';
+import 'package:construculator/features/global_search/presentation/bloc/global_search_bloc/global_search_bloc.dart';
 import 'package:construculator/libraries/supabase/supabase_module.dart';
 import 'package:flutter_modular/flutter_modular.dart';
 
 /// Module for the global search feature.
 ///
-/// Provides [GlobalSearchDataSource] binding for dependency injection.
+/// Provides [GlobalSearchDataSource] and [GlobalSearchRepository] bindings
+/// for dependency injection.
 class GlobalSearchModule extends Module {
   final AppBootstrap appBootstrap;
 
@@ -21,6 +25,12 @@ class GlobalSearchModule extends Module {
       () => RemoteGlobalSearchDataSource(
         supabaseWrapper: appBootstrap.supabaseWrapper,
       ),
+    );
+    i.addLazySingleton<GlobalSearchRepository>(
+      () => GlobalSearchRepositoryImpl(dataSource: i()),
+    );
+    i.add<GlobalSearchBloc>(
+      () => GlobalSearchBloc(repository: i()),
     );
   }
 }

--- a/lib/features/global_search/presentation/bloc/global_search_bloc/global_search_bloc.dart
+++ b/lib/features/global_search/presentation/bloc/global_search_bloc/global_search_bloc.dart
@@ -1,0 +1,193 @@
+import 'dart:async' show unawaited;
+import 'package:construculator/features/global_search/domain/entities/search_params_entity.dart';
+import 'package:construculator/features/global_search/domain/entities/search_results.dart';
+import 'package:construculator/features/global_search/domain/entities/search_scope_entity.dart';
+import 'package:construculator/features/global_search/domain/repositories/global_search_repository.dart';
+import 'package:construculator/libraries/errors/failures.dart';
+import 'package:construculator/libraries/logging/app_logger.dart';
+import 'package:equatable/equatable.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:rxdart/rxdart.dart';
+
+part 'global_search_event.dart';
+part 'global_search_state.dart';
+
+/// Debounce duration applied to [GlobalSearchQueryUpdated] events.
+/// Kept here so the BLoC owns the contract — no UI-side debouncing required.
+const Duration _kQueryDebounceDuration = Duration(milliseconds: 300);
+
+/// Returns an [EventTransformer] that debounces events by [duration] and
+/// switches to the latest mapper stream, cancelling any in-flight processing.
+///
+/// Extracted so any future event that needs the same treatment can reuse it
+/// without duplicating the rxdart pipeline inline.
+EventTransformer<E> _debounce<E>(Duration duration) =>
+    (events, mapper) => events.debounceTime(duration).switchMap(mapper);
+
+/// Bloc for managing global search state across projects, estimations, and members
+class GlobalSearchBloc extends Bloc<GlobalSearchEvent, GlobalSearchState> {
+  static final _logger = AppLogger().tag('GlobalSearchBloc');
+  final GlobalSearchRepository _repository;
+
+  List<String> _recentSearches = const [];
+
+  List<String> _suggestions = const [];
+
+  String _currentQuery = '';
+
+  GlobalSearchBloc({required GlobalSearchRepository repository})
+    : _repository = repository,
+      super(const GlobalSearchInitial()) {
+    on<GlobalSearchStarted>(_onStarted);
+    on<GlobalSearchQueryUpdated>(
+      _onQueryUpdated,
+      // Debounce at the BLoC level so the UI can dispatch on every keystroke
+      // without triggering redundant state emissions.
+      transformer: _debounce(_kQueryDebounceDuration),
+    );
+    on<GlobalSearchPerformed>(_onPerformed);
+    on<GlobalSearchRecentRemoved>(_onRecentRemoved);
+    on<GlobalSearchSuggestionsRequested>(_onSuggestionsRequested);
+  }
+
+  Future<void> _onStarted(
+    GlobalSearchStarted event,
+    Emitter<GlobalSearchState> emit,
+  ) async {
+    final result = await _repository.getRecentSearches(event.scope);
+    result.fold((failure) => emit(GlobalSearchLoadFailure(failure: failure)), (
+      recentSearches,
+    ) {
+      _recentSearches = recentSearches;
+      _suggestions = const [];
+      _currentQuery = '';
+      emit(
+        GlobalSearchReady(
+          recentSearches: recentSearches,
+          query: '',
+          suggestions: const [],
+          suggestionsLoading: false,
+        ),
+      );
+    });
+  }
+
+  void _onQueryUpdated(
+    GlobalSearchQueryUpdated event,
+    Emitter<GlobalSearchState> emit,
+  ) {
+    _currentQuery = event.query;
+    emit(
+      GlobalSearchReady(
+        recentSearches: _recentSearches,
+        query: event.query,
+        suggestions: _suggestions,
+        suggestionsLoading: false,
+      ),
+    );
+  }
+
+  Future<void> _onPerformed(
+    GlobalSearchPerformed event,
+    Emitter<GlobalSearchState> emit,
+  ) async {
+    _currentQuery = event.query;
+    emit(GlobalSearchLoadInProgress(query: event.query));
+
+    final result = await _repository.search(
+      SearchParams(query: event.query, scope: event.scope),
+    );
+
+    result.fold((failure) => emit(GlobalSearchLoadFailure(failure: failure)), (
+      searchResults,
+    ) {
+      final hasResults =
+          searchResults.projects.isNotEmpty ||
+          searchResults.estimations.isNotEmpty ||
+          searchResults.members.isNotEmpty;
+
+      if (hasResults) {
+        emit(GlobalSearchLoadSuccess(results: searchResults));
+      } else {
+        emit(GlobalSearchLoadEmpty(query: event.query));
+      }
+
+      if (!_recentSearches.contains(event.query)) {
+        _recentSearches = [event.query, ..._recentSearches];
+      }
+
+      // Non-blocking: persistence runs after results are shown.
+      // Do NOT call emit() inside this callback — the Emitter is already
+      // closed when _onPerformed returns.
+      unawaited(
+        _repository
+            .saveRecentSearch(event.query, event.scope, hasResults: hasResults)
+            .then(
+              (saveResult) => saveResult.fold(
+                (_) => _logger.warning(
+                  'Recent search save failed silently (non-blocking; search results already shown)',
+                ),
+                (_) {},
+              ),
+            ),
+      );
+    });
+  }
+
+  Future<void> _onRecentRemoved(
+    GlobalSearchRecentRemoved event,
+    Emitter<GlobalSearchState> emit,
+  ) async {
+    final result = await _repository.deleteRecentSearch(
+      event.searchTerm,
+      event.scope,
+    );
+
+    result.fold(
+      (failure) => emit(GlobalSearchRecentDeleteFailure(failure: failure)),
+      (_) {
+        _recentSearches = List<String>.from(_recentSearches)
+          ..removeWhere((term) => term == event.searchTerm);
+        emit(
+          GlobalSearchReady(
+            recentSearches: _recentSearches,
+            query: _currentQuery,
+            suggestions: _suggestions,
+            suggestionsLoading: false,
+          ),
+        );
+      },
+    );
+  }
+
+  Future<void> _onSuggestionsRequested(
+    GlobalSearchSuggestionsRequested event,
+    Emitter<GlobalSearchState> emit,
+  ) async {
+    emit(
+      GlobalSearchReady(
+        recentSearches: _recentSearches,
+        query: _currentQuery,
+        suggestions: _suggestions,
+        suggestionsLoading: true,
+      ),
+    );
+
+    final result = await _repository.getSearchSuggestions();
+
+    result.fold(
+      (failure) => emit(GlobalSearchSuggestionsLoadFailure(failure: failure)),
+      (suggestions) {
+        _suggestions = suggestions;
+        emit(
+          GlobalSearchReady(
+            recentSearches: _recentSearches,
+            query: _currentQuery,
+            suggestions: suggestions,
+            suggestionsLoading: false,
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/features/global_search/presentation/bloc/global_search_bloc/global_search_event.dart
+++ b/lib/features/global_search/presentation/bloc/global_search_bloc/global_search_event.dart
@@ -1,0 +1,74 @@
+// coverage:ignore-file
+part of 'global_search_bloc.dart';
+
+/// Base sealed class for all GlobalSearch events
+sealed class GlobalSearchEvent extends Equatable {
+  const GlobalSearchEvent();
+
+  @override
+  List<Object?> get props => [];
+}
+
+/// Event for initializing the search screen and loading recent search history
+class GlobalSearchStarted extends GlobalSearchEvent {
+  /// The scope to load recent searches for, defaults to [SearchScope.dashboard]
+  final SearchScope scope;
+
+  const GlobalSearchStarted({this.scope = SearchScope.dashboard});
+
+  @override
+  List<Object?> get props => [scope];
+}
+
+/// Event for updating the search query text field.
+///
+/// Can be dispatched on every keystroke — the BLoC applies a debounce
+/// transformer so redundant rapid emissions are coalesced automatically.
+class GlobalSearchQueryUpdated extends GlobalSearchEvent {
+  /// The current value of the search input field
+  final String query;
+
+  const GlobalSearchQueryUpdated({required this.query});
+
+  @override
+  List<Object?> get props => [query];
+}
+
+/// Event for submitting a search query
+class GlobalSearchPerformed extends GlobalSearchEvent {
+  /// The search query entered by the user
+  final String query;
+
+  /// The scope to search within, defaults to [SearchScope.dashboard]
+  final SearchScope scope;
+
+  const GlobalSearchPerformed({
+    required this.query,
+    this.scope = SearchScope.dashboard,
+  });
+
+  @override
+  List<Object?> get props => [query, scope];
+}
+
+/// Event for removing a term from the user's recent search history
+class GlobalSearchRecentRemoved extends GlobalSearchEvent {
+  /// The search term to remove
+  final String searchTerm;
+
+  /// The scope the search term belongs to
+  final SearchScope scope;
+
+  const GlobalSearchRecentRemoved({
+    required this.searchTerm,
+    required this.scope,
+  });
+
+  @override
+  List<Object?> get props => [searchTerm, scope];
+}
+
+/// Event for loading personalized search suggestions
+class GlobalSearchSuggestionsRequested extends GlobalSearchEvent {
+  const GlobalSearchSuggestionsRequested();
+}

--- a/lib/features/global_search/presentation/bloc/global_search_bloc/global_search_state.dart
+++ b/lib/features/global_search/presentation/bloc/global_search_bloc/global_search_state.dart
@@ -1,0 +1,123 @@
+// coverage:ignore-file
+part of 'global_search_bloc.dart';
+
+/// Base sealed class for all GlobalSearch states.
+sealed class GlobalSearchState extends Equatable {
+  const GlobalSearchState();
+
+  @override
+  List<Object?> get props => [];
+}
+
+/// Cold start before [GlobalSearchStarted] has completed (no history loaded yet).
+class GlobalSearchInitial extends GlobalSearchState {
+  const GlobalSearchInitial();
+}
+
+/// Idle / interactive state after history has been loaded at least once.
+///
+/// Emitted after [GlobalSearchStarted], on [GlobalSearchQueryUpdated], while
+/// loading suggestions, and after history or suggestions change.
+class GlobalSearchReady extends GlobalSearchState {
+  /// Recent search terms previously submitted by the user.
+  final List<String> recentSearches;
+
+  /// The current text typed into the search field.
+  final String query;
+
+  /// Personalized search suggestions fetched from the repository.
+  final List<String> suggestions;
+
+  /// Whether a suggestions fetch is currently in flight.
+  final bool suggestionsLoading;
+
+  const GlobalSearchReady({
+    this.recentSearches = const [],
+    this.query = '',
+    this.suggestions = const [],
+    this.suggestionsLoading = false,
+  });
+
+  GlobalSearchReady copyWith({
+    List<String>? recentSearches,
+    String? query,
+    List<String>? suggestions,
+    bool? suggestionsLoading,
+  }) {
+    return GlobalSearchReady(
+      recentSearches: recentSearches ?? this.recentSearches,
+      query: query ?? this.query,
+      suggestions: suggestions ?? this.suggestions,
+      suggestionsLoading: suggestionsLoading ?? this.suggestionsLoading,
+    );
+  }
+
+  @override
+  List<Object?> get props => [recentSearches, query, suggestions, suggestionsLoading];
+}
+
+/// Emitted while a search request is in flight.
+class GlobalSearchLoadInProgress extends GlobalSearchState {
+  /// The search query that triggered this in-progress request.
+  final String query;
+
+  const GlobalSearchLoadInProgress({required this.query});
+
+  @override
+  List<Object?> get props => [query];
+}
+
+/// Emitted when a search returns at least one result.
+class GlobalSearchLoadSuccess extends GlobalSearchState {
+  /// The results returned by a successful search request.
+  final SearchResults results;
+
+  const GlobalSearchLoadSuccess({required this.results});
+
+  @override
+  List<Object?> get props => [results];
+}
+
+/// Emitted when a search completes successfully but returns no results.
+class GlobalSearchLoadEmpty extends GlobalSearchState {
+  /// The search query that produced no results.
+  final String query;
+
+  const GlobalSearchLoadEmpty({required this.query});
+
+  @override
+  List<Object?> get props => [query];
+}
+
+/// Emitted when a search or history fetch fails.
+class GlobalSearchLoadFailure extends GlobalSearchState {
+  /// The failure describing why the search request failed.
+  final Failure failure;
+
+  const GlobalSearchLoadFailure({required this.failure});
+
+  @override
+  List<Object?> get props => [failure];
+}
+
+/// Emitted when loading personalized suggestions fails.
+class GlobalSearchSuggestionsLoadFailure extends GlobalSearchState {
+  /// The failure describing why the suggestions fetch failed.
+  final Failure failure;
+
+  const GlobalSearchSuggestionsLoadFailure({required this.failure});
+
+  @override
+  List<Object?> get props => [failure];
+}
+
+/// Emitted when removing a recent search term from history fails.
+class GlobalSearchRecentDeleteFailure extends GlobalSearchState {
+  /// The failure describing why the recent search deletion failed.
+  final Failure failure;
+
+  const GlobalSearchRecentDeleteFailure({required this.failure});
+
+  @override
+  List<Object?> get props => [failure];
+}

--- a/lib/libraries/auth/data/models/user_profile_dto.dart
+++ b/lib/libraries/auth/data/models/user_profile_dto.dart
@@ -1,4 +1,5 @@
 import 'package:construculator/libraries/auth/domain/entities/user_profile_entity.dart';
+import 'package:construculator/libraries/supabase/database_constants.dart';
 import 'package:equatable/equatable.dart';
 
 /// Data Transfer Object for UserProfile entity.
@@ -40,12 +41,12 @@ class UserProfileDto extends Equatable {
   /// to the DTO structure, mapping snake_case JSON keys to camelCase Dart properties.
   factory UserProfileDto.fromJson(Map<String, dynamic> json) {
     return UserProfileDto(
-      id: json['id'] as String,
-      credentialId: json['credential_id'] as String?,
-      firstName: json['first_name'] as String,
-      lastName: json['last_name'] as String,
-      professionalRole: json['professional_role'] as String,
-      profilePhotoUrl: json['profile_photo_url'] as String?,
+      id: json[DatabaseConstants.idColumn] as String,
+      credentialId: json[DatabaseConstants.credentialIdColumn] as String?,
+      firstName: json[DatabaseConstants.firstNameColumn] as String,
+      lastName: json[DatabaseConstants.lastNameColumn] as String,
+      professionalRole: json[DatabaseConstants.professionalRoleColumn] as String,
+      profilePhotoUrl: json[DatabaseConstants.profilePhotoUrlColumn] as String?,
     );
   }
 
@@ -58,12 +59,12 @@ class UserProfileDto extends Equatable {
   /// (e.g., `'credential_id': null`). It is intended for read/display
   /// serialization only
   Map<String, dynamic> toJson() => {
-    'id': id,
-    'credential_id': credentialId,
-    'first_name': firstName,
-    'last_name': lastName,
-    'professional_role': professionalRole,
-    'profile_photo_url': profilePhotoUrl,
+    DatabaseConstants.idColumn: id,
+    DatabaseConstants.credentialIdColumn: credentialId,
+    DatabaseConstants.firstNameColumn: firstName,
+    DatabaseConstants.lastNameColumn: lastName,
+    DatabaseConstants.professionalRoleColumn: professionalRole,
+    DatabaseConstants.profilePhotoUrlColumn: profilePhotoUrl,
   };
 
   /// Converts this DTO to a domain [UserProfile] entity.

--- a/lib/libraries/auth/domain/entities/user_profile_entity.dart
+++ b/lib/libraries/auth/domain/entities/user_profile_entity.dart
@@ -15,7 +15,10 @@ class UserProfile extends Equatable {
   /// Unique identifier for the user
   final String id;
 
-  /// The credential ID associated with the user
+  // TODO: [CA-614] credentialId is an internal Supabase Auth identifier (used in
+  // RLS/JWT) with no domain meaning. Strip from UserProfile and UserProfileDto.toDomain()
+  // once all 31 consumers are audited. Do not read or surface this field outside the
+  // auth library. https://ripplearc.youtrack.cloud/issue/CA-614
   final String? credentialId;
 
   /// User's first name

--- a/lib/libraries/errors/failures.dart
+++ b/lib/libraries/errors/failures.dart
@@ -1,5 +1,6 @@
 import 'package:construculator/libraries/auth/domain/types/auth_types.dart';
 import 'package:construculator/libraries/estimation/domain/estimation_error_type.dart';
+import 'package:construculator/libraries/global_search/domain/search_error_type.dart';
 import 'package:equatable/equatable.dart';
 
 /// Failure represents specific, anticipated error conditions or alternative outcomes of an operation (e.g., a use case or repository method).
@@ -58,6 +59,16 @@ class EstimationFailure extends Failure {
   /// The type of estimation error that occurred.
   final EstimationErrorType errorType;
   const EstimationFailure({required this.errorType});
+
+  @override
+  List<Object?> get props => [errorType];
+}
+
+/// Failure thrown when a global search error occurs.
+class SearchFailure extends Failure {
+  /// The type of search error that occurred.
+  final SearchErrorType errorType;
+  const SearchFailure({required this.errorType});
 
   @override
   List<Object?> get props => [errorType];

--- a/lib/libraries/errors/failures.dart
+++ b/lib/libraries/errors/failures.dart
@@ -68,6 +68,8 @@ class EstimationFailure extends Failure {
 class SearchFailure extends Failure {
   /// The type of search error that occurred.
   final SearchErrorType errorType;
+
+  /// Creates a [SearchFailure] with the given [errorType].
   const SearchFailure({required this.errorType});
 
   @override

--- a/lib/libraries/global_search/domain/search_error_type.dart
+++ b/lib/libraries/global_search/domain/search_error_type.dart
@@ -7,10 +7,12 @@
 /// - [timeoutError]: the operation timed out before completing
 /// - [unexpectedDatabaseError]: a database query or operation failed unexpectedly
 /// - [notFoundError]: the requested record was not found
+/// - [duplicateEntryError]: a unique constraint was violated (e.g. concurrent upsert)
 enum SearchErrorType {
   connectionError,
   parsingError,
   timeoutError,
   unexpectedDatabaseError,
   notFoundError,
+  duplicateEntryError,
 }

--- a/lib/libraries/global_search/domain/search_error_type.dart
+++ b/lib/libraries/global_search/domain/search_error_type.dart
@@ -1,0 +1,16 @@
+// coverage:ignore-file
+
+/// Error types for global search operations.
+///
+/// - [connectionError]: network connectivity issue prevented the operation
+/// - [parsingError]: data parsing or mapping from the response failed
+/// - [timeoutError]: the operation timed out before completing
+/// - [unexpectedDatabaseError]: a database query or operation failed unexpectedly
+/// - [notFoundError]: the requested record was not found
+enum SearchErrorType {
+  connectionError,
+  parsingError,
+  timeoutError,
+  unexpectedDatabaseError,
+  notFoundError,
+}

--- a/lib/libraries/supabase/database_constants.dart
+++ b/lib/libraries/supabase/database_constants.dart
@@ -50,7 +50,7 @@ class DatabaseConstants {
   static const String searchHistoryUpsertConflictColumns =
       '$userIdColumn,$searchTermColumn,$scopeColumn';
 
-  // User profile columns
+  // User profile columns (id field uses the shared idColumn above)
   static const String credentialIdColumn = 'credential_id';
   static const String firstNameColumn = 'first_name';
   static const String lastNameColumn = 'last_name';

--- a/lib/libraries/supabase/database_constants.dart
+++ b/lib/libraries/supabase/database_constants.dart
@@ -50,6 +50,13 @@ class DatabaseConstants {
   static const String searchHistoryUpsertConflictColumns =
       '$userIdColumn,$searchTermColumn,$scopeColumn';
 
+  // User profile columns
+  static const String credentialIdColumn = 'credential_id';
+  static const String firstNameColumn = 'first_name';
+  static const String lastNameColumn = 'last_name';
+  static const String professionalRoleColumn = 'professional_role';
+  static const String profilePhotoUrlColumn = 'profile_photo_url';
+
   // Cost Estimation Logs columns
   static const String estimateIdColumn = 'estimate_id';
   static const String activityColumn = 'activity';

--- a/test/features/global_search/units/blocs/global_search_bloc_test.dart
+++ b/test/features/global_search/units/blocs/global_search_bloc_test.dart
@@ -1,0 +1,711 @@
+import 'package:bloc_test/bloc_test.dart';
+import 'package:construculator/app/app_bootstrap.dart';
+import 'package:construculator/features/global_search/domain/entities/search_scope_entity.dart';
+import 'package:construculator/features/global_search/global_search_module.dart';
+import 'package:construculator/features/global_search/presentation/bloc/global_search_bloc/global_search_bloc.dart';
+import 'package:construculator/libraries/config/testing/fake_app_config.dart';
+import 'package:construculator/libraries/config/testing/fake_env_loader.dart';
+import 'package:construculator/libraries/errors/failures.dart';
+import 'package:construculator/libraries/global_search/domain/search_error_type.dart';
+import 'package:construculator/libraries/supabase/data/supabase_types.dart';
+import 'package:construculator/libraries/supabase/database_constants.dart';
+import 'package:construculator/libraries/supabase/interfaces/supabase_wrapper.dart';
+import 'package:construculator/libraries/supabase/testing/fake_supabase_user.dart';
+import 'package:construculator/libraries/supabase/testing/fake_supabase_wrapper.dart';
+import 'package:construculator/libraries/time/testing/fake_clock_impl.dart';
+import 'package:flutter_modular/flutter_modular.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../../../estimations/helpers/estimation_test_data_map_factory.dart'
+    as estimation_factory;
+
+// ---------------------------------------------------------------------------
+// Test data helpers
+// ---------------------------------------------------------------------------
+
+const String _testUserId = 'user-bloc-test';
+const String _testUserEmail = 'bloc@test.com';
+
+Map<String, dynamic> _fakeMemberData({String? id, String? firstName}) {
+  return <String, dynamic>{
+    DatabaseConstants.idColumn: id ?? 'member-1',
+    DatabaseConstants.credentialIdColumn: null,
+    DatabaseConstants.firstNameColumn: firstName ?? 'John',
+    DatabaseConstants.lastNameColumn: 'Doe',
+    DatabaseConstants.professionalRoleColumn: 'Engineer',
+    DatabaseConstants.profilePhotoUrlColumn: null,
+  };
+}
+
+Map<String, dynamic> _fakeProjectData({String? id, String? projectName}) {
+  return {
+    DatabaseConstants.idColumn: id ?? 'project-1',
+    DatabaseConstants.projectNameColumn: projectName ?? 'Test Project',
+    DatabaseConstants.descriptionColumn: 'Test description',
+    DatabaseConstants.creatorUserIdColumn: _testUserId,
+    DatabaseConstants.owningCompanyIdColumn: null,
+    DatabaseConstants.exportFolderLinkColumn: null,
+    DatabaseConstants.exportStorageProviderColumn: null,
+    DatabaseConstants.createdAtColumn: '2024-01-01T00:00:00.000Z',
+    DatabaseConstants.updatedAtColumn: '2024-01-01T00:00:00.000Z',
+    DatabaseConstants.statusColumn: 'active',
+  };
+}
+
+Map<String, dynamic> _fakeSearchHistoryData({
+  required String userId,
+  required String searchTerm,
+  SearchScope scope = SearchScope.dashboard,
+}) {
+  return {
+    DatabaseConstants.idColumn: '1',
+    DatabaseConstants.userIdColumn: userId,
+    DatabaseConstants.searchTermColumn: searchTerm,
+    DatabaseConstants.scopeColumn: scope.name,
+    DatabaseConstants.searchCountColumn: 1,
+    DatabaseConstants.createdAtColumn: '2024-01-01T00:00:00.000Z',
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+void main() {
+  group('GlobalSearchBloc', () {
+    late FakeSupabaseWrapper fakeSupabase;
+    late FakeClockImpl fakeClock;
+
+    setUpAll(() {
+      fakeClock = FakeClockImpl();
+      Modular.init(
+        GlobalSearchModule(
+          AppBootstrap(
+            supabaseWrapper: FakeSupabaseWrapper(clock: fakeClock),
+            config: FakeAppConfig(),
+            envLoader: FakeEnvLoader(),
+          ),
+        ),
+      );
+      fakeSupabase = Modular.get<SupabaseWrapper>() as FakeSupabaseWrapper;
+    });
+
+    tearDownAll(() {
+      Modular.destroy();
+    });
+
+    setUp(() {
+      fakeSupabase.reset();
+    });
+
+    test('initial state is GlobalSearchInitial (cold start, no history yet)', () {
+      final bloc = Modular.get<GlobalSearchBloc>();
+      expect(bloc.state, const GlobalSearchInitial());
+      expect(bloc.state is GlobalSearchInitial, isTrue);
+      bloc.close();
+    });
+
+    group('GlobalSearchStarted', () {
+      blocTest<GlobalSearchBloc, GlobalSearchState>(
+        'emits GlobalSearchReady with recentSearches when history exists',
+        setUp: () {
+          fakeSupabase.setCurrentUser(
+            FakeUser(
+              id: _testUserId,
+              email: _testUserEmail,
+              createdAt: fakeClock.now().toIso8601String(),
+            ),
+          );
+          fakeSupabase.addTableData(DatabaseConstants.searchHistoryTable, [
+            _fakeSearchHistoryData(userId: _testUserId, searchTerm: 'wall'),
+            _fakeSearchHistoryData(userId: _testUserId, searchTerm: 'concrete'),
+          ]);
+        },
+        build: () => Modular.get<GlobalSearchBloc>(),
+        act: (bloc) => bloc.add(const GlobalSearchStarted()),
+        expect: () => [
+          isA<GlobalSearchReady>().having(
+            (s) => s.recentSearches,
+            'recentSearches',
+            containsAll(['wall', 'concrete']),
+          ),
+        ],
+      );
+
+      blocTest<GlobalSearchBloc, GlobalSearchState>(
+        'emits GlobalSearchReady with empty recentSearches when user is not authenticated',
+        setUp: () {
+          fakeSupabase.setCurrentUser(null);
+        },
+        build: () => Modular.get<GlobalSearchBloc>(),
+        act: (bloc) => bloc.add(const GlobalSearchStarted()),
+        expect: () => [
+          const GlobalSearchReady(),
+        ],
+      );
+
+      blocTest<GlobalSearchBloc, GlobalSearchState>(
+        'emits GlobalSearchLoadFailure when Supabase throws on getRecentSearches',
+        setUp: () {
+          fakeSupabase.setCurrentUser(
+            FakeUser(
+              id: _testUserId,
+              email: _testUserEmail,
+              createdAt: fakeClock.now().toIso8601String(),
+            ),
+          );
+          fakeSupabase.shouldThrowOnSelectMatch = true;
+          fakeSupabase.selectMatchExceptionType = SupabaseExceptionType.timeout;
+        },
+        build: () => Modular.get<GlobalSearchBloc>(),
+        act: (bloc) => bloc.add(const GlobalSearchStarted()),
+        expect: () => [
+          isA<GlobalSearchLoadFailure>().having(
+            (s) => s.failure,
+            'failure',
+            SearchFailure(errorType: SearchErrorType.timeoutError),
+          ),
+        ],
+      );
+
+      blocTest<GlobalSearchBloc, GlobalSearchState>(
+        'uses supplied scope — loads estimation-scoped recents when scope is estimation',
+        setUp: () {
+          fakeSupabase.setCurrentUser(
+            FakeUser(
+              id: _testUserId,
+              email: _testUserEmail,
+              createdAt: fakeClock.now().toIso8601String(),
+            ),
+          );
+          fakeSupabase.addTableData(DatabaseConstants.searchHistoryTable, [
+            _fakeSearchHistoryData(
+              userId: _testUserId,
+              searchTerm: 'estimation-term',
+              scope: SearchScope.estimation,
+            ),
+            _fakeSearchHistoryData(
+              userId: _testUserId,
+              searchTerm: 'dashboard-term',
+            ),
+          ]);
+        },
+        build: () => Modular.get<GlobalSearchBloc>(),
+        act: (bloc) =>
+            bloc.add(const GlobalSearchStarted(scope: SearchScope.estimation)),
+        expect: () => [
+          isA<GlobalSearchReady>()
+              .having(
+                (s) => s.recentSearches,
+                'estimation-scoped recents',
+                contains('estimation-term'),
+              )
+              .having(
+                (s) => s.recentSearches,
+                'no dashboard recents',
+                isNot(contains('dashboard-term')),
+              ),
+        ],
+      );
+
+      blocTest<GlobalSearchBloc, GlobalSearchState>(
+        'resets query to empty when re-opened after a previous search session',
+        setUp: () {
+          fakeSupabase.setCurrentUser(null);
+        },
+        build: () => Modular.get<GlobalSearchBloc>(),
+        act: (bloc) async {
+          bloc.add(const GlobalSearchQueryUpdated(query: 'stale-query'));
+          // Await the debounced GlobalSearchReady emission before re-opening
+          // the screen, so the state sequence is deterministic.
+          await bloc.stream.first;
+          bloc.add(const GlobalSearchStarted());
+        },
+        wait: const Duration(milliseconds: 310),
+        expect: () => [
+          const GlobalSearchReady(recentSearches: [], query: 'stale-query'),
+          isA<GlobalSearchReady>().having(
+            (s) => s.query,
+            'query is reset to empty on fresh start',
+            isEmpty,
+          ),
+        ],
+      );
+    });
+
+    group('GlobalSearchPerformed', () {
+      blocTest<GlobalSearchBloc, GlobalSearchState>(
+        'emits [GlobalSearchLoadInProgress, GlobalSearchLoadSuccess] when search returns results',
+        setUp: () {
+          fakeSupabase.setRpcResponse(
+            DatabaseConstants.globalSearchRpcFunction,
+            {
+              'projects': [_fakeProjectData(projectName: 'Foundation Work')],
+              'estimations': [
+                estimation_factory
+                    .EstimationTestDataMapFactory.createFakeEstimationData(
+                  estimateName: 'Steel Frame',
+                ),
+              ],
+              'members': [],
+            },
+          );
+        },
+        build: () => Modular.get<GlobalSearchBloc>(),
+        act: (bloc) =>
+            bloc.add(const GlobalSearchPerformed(query: 'foundation')),
+        expect: () => [
+          const GlobalSearchLoadInProgress(query: 'foundation'),
+          isA<GlobalSearchLoadSuccess>().having(
+            (s) => s.results.projects,
+            'projects',
+            hasLength(1),
+          ),
+        ],
+      );
+
+      blocTest<GlobalSearchBloc, GlobalSearchState>(
+        'emits [GlobalSearchLoadInProgress, GlobalSearchLoadEmpty] when search returns no results',
+        setUp: () {
+          fakeSupabase.setRpcResponse(
+            DatabaseConstants.globalSearchRpcFunction,
+            {'projects': [], 'estimations': [], 'members': []},
+          );
+        },
+        build: () => Modular.get<GlobalSearchBloc>(),
+        act: (bloc) =>
+            bloc.add(const GlobalSearchPerformed(query: 'nonexistent')),
+        expect: () => [
+          const GlobalSearchLoadInProgress(query: 'nonexistent'),
+          const GlobalSearchLoadEmpty(query: 'nonexistent'),
+        ],
+      );
+
+      blocTest<GlobalSearchBloc, GlobalSearchState>(
+        'emits [GlobalSearchLoadInProgress, GlobalSearchLoadFailure] when Supabase throws on search',
+        setUp: () {
+          fakeSupabase.shouldThrowOnRpc = true;
+          fakeSupabase.rpcExceptionType = SupabaseExceptionType.socket;
+        },
+        build: () => Modular.get<GlobalSearchBloc>(),
+        act: (bloc) => bloc.add(const GlobalSearchPerformed(query: 'test')),
+        expect: () => [
+          const GlobalSearchLoadInProgress(query: 'test'),
+          isA<GlobalSearchLoadFailure>().having(
+            (s) => s.failure,
+            'failure',
+            SearchFailure(errorType: SearchErrorType.connectionError),
+          ),
+        ],
+      );
+
+      blocTest<GlobalSearchBloc, GlobalSearchState>(
+        'emits [GlobalSearchLoadInProgress, GlobalSearchLoadFailure] with timeoutError when RPC times out',
+        setUp: () {
+          fakeSupabase.shouldThrowOnRpc = true;
+          fakeSupabase.rpcExceptionType = SupabaseExceptionType.timeout;
+        },
+        build: () => Modular.get<GlobalSearchBloc>(),
+        act: (bloc) => bloc.add(const GlobalSearchPerformed(query: 'test')),
+        expect: () => [
+          const GlobalSearchLoadInProgress(query: 'test'),
+          isA<GlobalSearchLoadFailure>().having(
+            (s) => s.failure,
+            'failure',
+            SearchFailure(errorType: SearchErrorType.timeoutError),
+          ),
+        ],
+      );
+
+      blocTest<GlobalSearchBloc, GlobalSearchState>(
+        'emits [GlobalSearchLoadInProgress, GlobalSearchLoadFailure] with parsingError on TypeError',
+        setUp: () {
+          fakeSupabase.shouldThrowOnRpc = true;
+          fakeSupabase.rpcExceptionType = SupabaseExceptionType.type;
+        },
+        build: () => Modular.get<GlobalSearchBloc>(),
+        act: (bloc) => bloc.add(const GlobalSearchPerformed(query: 'test')),
+        expect: () => [
+          const GlobalSearchLoadInProgress(query: 'test'),
+          isA<GlobalSearchLoadFailure>(),
+        ],
+      );
+
+      blocTest<GlobalSearchBloc, GlobalSearchState>(
+        'GlobalSearchLoadSuccess carries all three result lists',
+        setUp: () {
+          fakeSupabase.setRpcResponse(
+            DatabaseConstants.globalSearchRpcFunction,
+            {
+              'projects': [_fakeProjectData(id: 'p1')],
+              'estimations': [
+                estimation_factory
+                    .EstimationTestDataMapFactory.createFakeEstimationData(
+                  id: 'e1',
+                ),
+              ],
+              'members': [_fakeMemberData(id: 'm1', firstName: 'Alice')],
+            },
+          );
+        },
+        build: () => Modular.get<GlobalSearchBloc>(),
+        act: (bloc) => bloc.add(const GlobalSearchPerformed(query: 'alice')),
+        verify: (bloc) {
+          final state = bloc.state as GlobalSearchLoadSuccess;
+          expect(state.results.projects, hasLength(1));
+          expect(state.results.estimations, hasLength(1));
+          expect(state.results.members, hasLength(1));
+        },
+      );
+
+      blocTest<GlobalSearchBloc, GlobalSearchState>(
+        'uses supplied scope — emits correct states when scope is estimation',
+        setUp: () {
+          fakeSupabase.setCurrentUser(
+            FakeUser(
+              id: _testUserId,
+              email: _testUserEmail,
+              createdAt: fakeClock.now().toIso8601String(),
+            ),
+          );
+          fakeSupabase.setRpcResponse(
+            DatabaseConstants.globalSearchRpcFunction,
+            {
+              'projects': [_fakeProjectData()],
+              'estimations': [],
+              'members': [],
+            },
+          );
+        },
+        build: () => Modular.get<GlobalSearchBloc>(),
+        act: (bloc) => bloc.add(
+          const GlobalSearchPerformed(
+            query: 'steel',
+            scope: SearchScope.estimation,
+          ),
+        ),
+        expect: () => [
+          const GlobalSearchLoadInProgress(query: 'steel'),
+          isA<GlobalSearchLoadSuccess>(),
+        ],
+        verify: (_) {
+          final rpcCalls = fakeSupabase.getMethodCallsFor('rpc');
+          expect(
+            rpcCalls,
+            isNotEmpty,
+            reason: 'RPC must be called for a search',
+          );
+          final rpcParams = rpcCalls.first['params'] as Map<String, dynamic>?;
+          expect(
+            rpcParams?['scope'],
+            equals(SearchScope.estimation.name),
+            reason: 'scope must be forwarded to the RPC',
+          );
+        },
+      );
+
+      blocTest<GlobalSearchBloc, GlobalSearchState>(
+        'optimistically adds query to recentSearches so GlobalSearchQueryUpdated sees it immediately',
+        setUp: () {
+          fakeSupabase.setCurrentUser(
+            FakeUser(
+              id: _testUserId,
+              email: _testUserEmail,
+              createdAt: fakeClock.now().toIso8601String(),
+            ),
+          );
+          fakeSupabase.setRpcResponse(
+            DatabaseConstants.globalSearchRpcFunction,
+            {
+              'projects': [_fakeProjectData()],
+              'estimations': [],
+              'members': [],
+            },
+          );
+        },
+        build: () => Modular.get<GlobalSearchBloc>(),
+        act: (bloc) async {
+          bloc.add(const GlobalSearchPerformed(query: 'steel'));
+          await bloc.stream.firstWhere((s) => s is GlobalSearchLoadSuccess);
+          bloc.add(const GlobalSearchQueryUpdated(query: ''));
+        },
+        wait: const Duration(milliseconds: 310),
+        expect: () => [
+          const GlobalSearchLoadInProgress(query: 'steel'),
+          isA<GlobalSearchLoadSuccess>(),
+          isA<GlobalSearchReady>().having(
+            (s) => s.recentSearches,
+            'searched term is present without reopening the screen',
+            contains('steel'),
+          ),
+        ],
+      );
+
+      blocTest<GlobalSearchBloc, GlobalSearchState>(
+        'does not duplicate query in recentSearches if already present',
+        setUp: () {
+          fakeSupabase.setCurrentUser(
+            FakeUser(
+              id: _testUserId,
+              email: _testUserEmail,
+              createdAt: fakeClock.now().toIso8601String(),
+            ),
+          );
+          fakeSupabase.addTableData(
+            DatabaseConstants.searchHistoryTable,
+            [_fakeSearchHistoryData(userId: _testUserId, searchTerm: 'steel')],
+          );
+          fakeSupabase.setRpcResponse(
+            DatabaseConstants.globalSearchRpcFunction,
+            {
+              'projects': [_fakeProjectData()],
+              'estimations': [],
+              'members': [],
+            },
+          );
+        },
+        build: () => Modular.get<GlobalSearchBloc>(),
+        act: (bloc) async {
+          bloc.add(const GlobalSearchStarted());
+          await bloc.stream.firstWhere((s) => s is GlobalSearchReady);
+          bloc.add(const GlobalSearchPerformed(query: 'steel'));
+          await bloc.stream.firstWhere((s) => s is GlobalSearchLoadSuccess);
+          bloc.add(const GlobalSearchQueryUpdated(query: ''));
+        },
+        wait: const Duration(milliseconds: 310),
+        verify: (bloc) {
+          final state = bloc.state as GlobalSearchReady;
+          expect(
+            state.recentSearches.where((t) => t == 'steel'),
+            hasLength(1),
+            reason: 'steel must appear exactly once',
+          );
+        },
+      );
+    });
+
+    group('GlobalSearchQueryUpdated', () {
+      blocTest<GlobalSearchBloc, GlobalSearchState>(
+        'emits GlobalSearchReady with updated query and empty recentSearches',
+        build: () => Modular.get<GlobalSearchBloc>(),
+        act: (bloc) =>
+            bloc.add(const GlobalSearchQueryUpdated(query: 'foundation')),
+        wait: const Duration(milliseconds: 310),
+        expect: () => [
+          const GlobalSearchReady(recentSearches: [], query: 'foundation'),
+        ],
+      );
+
+      blocTest<GlobalSearchBloc, GlobalSearchState>(
+        'emits GlobalSearchReady with empty query when query is cleared',
+        build: () => Modular.get<GlobalSearchBloc>(),
+        act: (bloc) => bloc.add(const GlobalSearchQueryUpdated(query: '')),
+        wait: const Duration(milliseconds: 310),
+        expect: () => [
+          const GlobalSearchReady(),
+        ],
+      );
+
+      blocTest<GlobalSearchBloc, GlobalSearchState>(
+        'does not make any Supabase calls when query is updated',
+        build: () => Modular.get<GlobalSearchBloc>(),
+        act: (bloc) =>
+            bloc.add(const GlobalSearchQueryUpdated(query: 'concrete')),
+        wait: const Duration(milliseconds: 310),
+        verify: (_) {
+          expect(fakeSupabase.getMethodCallsFor('rpc'), isEmpty);
+          expect(fakeSupabase.getMethodCallsFor('selectMatch'), isEmpty);
+        },
+      );
+
+      blocTest<GlobalSearchBloc, GlobalSearchState>(
+        'preserves recentSearches loaded by GlobalSearchStarted when query is updated',
+        setUp: () {
+          fakeSupabase.setCurrentUser(
+            FakeUser(
+              id: _testUserId,
+              email: _testUserEmail,
+              createdAt: fakeClock.now().toIso8601String(),
+            ),
+          );
+          fakeSupabase.addTableData(DatabaseConstants.searchHistoryTable, [
+            _fakeSearchHistoryData(userId: _testUserId, searchTerm: 'steel'),
+          ]);
+        },
+        build: () => Modular.get<GlobalSearchBloc>(),
+        act: (bloc) async {
+          bloc.add(const GlobalSearchStarted());
+          await bloc.stream.firstWhere((s) {
+            if (s is! GlobalSearchReady) {
+              return false;
+            }
+            return s.recentSearches.contains('steel');
+          });
+          bloc.add(const GlobalSearchQueryUpdated(query: 'concrete'));
+        },
+        wait: const Duration(milliseconds: 310),
+        expect: () => [
+          isA<GlobalSearchReady>().having(
+            (s) => s.recentSearches,
+            'recentSearches after Started',
+            contains('steel'),
+          ),
+          isA<GlobalSearchReady>()
+              .having((s) => s.query, 'query after QueryUpdated', 'concrete')
+              .having(
+                (s) => s.recentSearches,
+                'recentSearches preserved after QueryUpdated',
+                contains('steel'),
+              ),
+        ],
+      );
+    });
+
+    group('GlobalSearchSuggestionsRequested', () {
+      blocTest<GlobalSearchBloc, GlobalSearchState>(
+        'emits [GlobalSearchReady loading, GlobalSearchReady with suggestions] when RPC succeeds',
+        setUp: () {
+          fakeSupabase.setCurrentUser(
+            FakeUser(
+              id: _testUserId,
+              email: _testUserEmail,
+              createdAt: fakeClock.now().toIso8601String(),
+            ),
+          );
+          fakeSupabase.setRpcResponse(
+            DatabaseConstants.searchSuggestionsRpcFunction,
+            ['foundation', 'concrete mix', 'steel frame'],
+          );
+        },
+        build: () => Modular.get<GlobalSearchBloc>(),
+        act: (bloc) => bloc.add(const GlobalSearchSuggestionsRequested()),
+        expect: () => [
+          isA<GlobalSearchReady>().having(
+            (s) => s.suggestionsLoading,
+            'suggestionsLoading',
+            isTrue,
+          ),
+          isA<GlobalSearchReady>()
+              .having(
+                (s) => s.suggestions,
+                'suggestions',
+                containsAll(['foundation', 'concrete mix', 'steel frame']),
+              )
+              .having(
+                (s) => s.suggestionsLoading,
+                'suggestionsLoading',
+                isFalse,
+              ),
+        ],
+      );
+
+      blocTest<GlobalSearchBloc, GlobalSearchState>(
+        'emits GlobalSearchSuggestionsLoadFailure when RPC throws',
+        setUp: () {
+          fakeSupabase.setCurrentUser(
+            FakeUser(
+              id: _testUserId,
+              email: _testUserEmail,
+              createdAt: fakeClock.now().toIso8601String(),
+            ),
+          );
+          fakeSupabase.shouldThrowOnRpc = true;
+          fakeSupabase.rpcExceptionType = SupabaseExceptionType.timeout;
+        },
+        build: () => Modular.get<GlobalSearchBloc>(),
+        act: (bloc) => bloc.add(const GlobalSearchSuggestionsRequested()),
+        expect: () => [
+          isA<GlobalSearchReady>().having(
+            (s) => s.suggestionsLoading,
+            'suggestionsLoading',
+            isTrue,
+          ),
+          isA<GlobalSearchSuggestionsLoadFailure>().having(
+            (s) => s.failure,
+            'failure',
+            SearchFailure(errorType: SearchErrorType.timeoutError),
+          ),
+        ],
+      );
+    });
+
+    group('GlobalSearchRecentRemoved', () {
+      blocTest<GlobalSearchBloc, GlobalSearchState>(
+        'emits GlobalSearchReady without removed term when delete succeeds',
+        setUp: () {
+          fakeSupabase.setCurrentUser(
+            FakeUser(
+              id: _testUserId,
+              email: _testUserEmail,
+              createdAt: fakeClock.now().toIso8601String(),
+            ),
+          );
+          fakeSupabase.addTableData(DatabaseConstants.searchHistoryTable, [
+            _fakeSearchHistoryData(userId: _testUserId, searchTerm: 'wall'),
+            _fakeSearchHistoryData(userId: _testUserId, searchTerm: 'concrete'),
+          ]);
+        },
+        build: () => Modular.get<GlobalSearchBloc>(),
+        act: (bloc) async {
+          bloc.add(const GlobalSearchStarted());
+          await bloc.stream.firstWhere((s) {
+            if (s is! GlobalSearchReady) {
+              return false;
+            }
+            return s.recentSearches.length == 2;
+          });
+          bloc.add(
+            const GlobalSearchRecentRemoved(
+              searchTerm: 'wall',
+              scope: SearchScope.dashboard,
+            ),
+          );
+        },
+        expect: () => [
+          isA<GlobalSearchReady>().having(
+            (s) => s.recentSearches,
+            'recentSearches after Started',
+            containsAll(['wall', 'concrete']),
+          ),
+          isA<GlobalSearchReady>().having(
+            (s) => s.recentSearches,
+            'recentSearches after Removed',
+            allOf(isNot(contains('wall')), contains('concrete')),
+          ),
+        ],
+      );
+
+      blocTest<GlobalSearchBloc, GlobalSearchState>(
+        'emits GlobalSearchRecentDeleteFailure when delete throws',
+        setUp: () {
+          fakeSupabase.setCurrentUser(
+            FakeUser(
+              id: _testUserId,
+              email: _testUserEmail,
+              createdAt: fakeClock.now().toIso8601String(),
+            ),
+          );
+          fakeSupabase.addTableData(DatabaseConstants.searchHistoryTable, [
+            _fakeSearchHistoryData(userId: _testUserId, searchTerm: 'wall'),
+          ]);
+          fakeSupabase.shouldThrowOnDeleteMatch = true;
+          fakeSupabase.deleteMatchExceptionType = SupabaseExceptionType.socket;
+        },
+        build: () => Modular.get<GlobalSearchBloc>(),
+        act: (bloc) => bloc.add(
+          const GlobalSearchRecentRemoved(
+            searchTerm: 'wall',
+            scope: SearchScope.dashboard,
+          ),
+        ),
+        expect: () => [
+          isA<GlobalSearchRecentDeleteFailure>().having(
+            (s) => s.failure,
+            'failure',
+            SearchFailure(errorType: SearchErrorType.connectionError),
+          ),
+        ],
+      );
+    });
+  });
+}

--- a/test/features/global_search/units/data/models/search_results_dto_test.dart
+++ b/test/features/global_search/units/data/models/search_results_dto_test.dart
@@ -1,8 +1,13 @@
+import 'package:construculator/features/estimation/data/models/cost_estimate_dto.dart';
 import 'package:construculator/features/global_search/data/models/search_results_dto.dart';
+import 'package:construculator/features/global_search/domain/entities/search_results.dart';
 import 'package:construculator/libraries/auth/data/models/user_profile_dto.dart';
 import 'package:construculator/libraries/project/data/models/project_dto.dart';
 import 'package:construculator/libraries/project/domain/entities/enums.dart';
 import 'package:flutter_test/flutter_test.dart';
+
+import '../../../../estimations/helpers/estimation_test_data_map_factory.dart'
+    as estimation_factory;
 
 void main() {
   group('SearchResultsDto', () {
@@ -140,6 +145,124 @@ void main() {
         const empty = SearchResultsDto();
 
         expect(populated, isNot(equals(empty)));
+      });
+    });
+
+    group('toDomain', () {
+      test('returns empty SearchResults when all lists are empty', () {
+        const dto = SearchResultsDto();
+
+        final result = dto.toDomain();
+
+        expect(result, const SearchResults());
+        expect(result.projects, isEmpty);
+        expect(result.estimations, isEmpty);
+        expect(result.members, isEmpty);
+      });
+
+      test('maps projects to Project domain entities', () {
+        final dto = SearchResultsDto(projects: [testProject]);
+
+        final result = dto.toDomain();
+
+        expect(result.projects, hasLength(1));
+        expect(result.projects.first.id, equals(testProject.id));
+        expect(
+          result.projects.first.projectName,
+          equals(testProject.projectName),
+        );
+        expect(
+          result.projects.first.creatorUserId,
+          equals(testProject.creatorUserId),
+        );
+      });
+
+      test('maps members to UserProfile domain entities', () {
+        const dto = SearchResultsDto(members: [testMember]);
+
+        final result = dto.toDomain();
+
+        expect(result.members, hasLength(1));
+        expect(result.members.first.id, equals(testMember.id));
+        expect(result.members.first.firstName, equals(testMember.firstName));
+        expect(result.members.first.lastName, equals(testMember.lastName));
+        expect(
+          result.members.first.professionalRole,
+          equals(testMember.professionalRole),
+        );
+      });
+
+      test('maps estimations to CostEstimate domain entities', () {
+        final estimationDto = CostEstimateDto.fromJson(
+          estimation_factory.EstimationTestDataMapFactory
+              .createFakeEstimationData(),
+        );
+        final dto = SearchResultsDto(estimations: [estimationDto]);
+
+        final result = dto.toDomain();
+
+        expect(result.estimations, hasLength(1));
+        expect(result.estimations.first.id, equals(estimationDto.id));
+        expect(
+          result.estimations.first.estimateName,
+          equals(estimationDto.estimateName),
+        );
+        expect(
+          result.estimations.first.projectId,
+          equals(estimationDto.projectId),
+        );
+      });
+
+      test('maps all three lists simultaneously', () {
+        final estimationDto = CostEstimateDto.fromJson(
+          estimation_factory.EstimationTestDataMapFactory
+              .createFakeEstimationData(),
+        );
+        final dto = SearchResultsDto(
+          projects: [testProject],
+          estimations: [estimationDto],
+          members: [testMember],
+        );
+
+        final result = dto.toDomain();
+
+        expect(result.projects, hasLength(1));
+        expect(result.estimations, hasLength(1));
+        expect(result.members, hasLength(1));
+      });
+
+      test('preserves order of items within each list', () {
+        final projectB = ProjectDto(
+          id: 'project-2',
+          projectName: 'Road Project',
+          creatorUserId: 'user-1',
+          createdAt: DateTime(2025, 3, 1),
+          updatedAt: DateTime(2025, 3, 2),
+          status: ProjectStatus.active,
+        );
+        final dto = SearchResultsDto(projects: [testProject, projectB]);
+
+        final result = dto.toDomain();
+
+        expect(result.projects[0].id, equals(testProject.id));
+        expect(result.projects[1].id, equals(projectB.id));
+      });
+
+      test('result equals manually constructed SearchResults', () {
+        final dto = SearchResultsDto(
+          projects: [testProject],
+          members: [testMember],
+        );
+
+        final result = dto.toDomain();
+
+        expect(
+          result,
+          SearchResults(
+            projects: [testProject.toDomain()],
+            members: [testMember.toDomain()],
+          ),
+        );
       });
     });
   });

--- a/test/features/global_search/units/data/models/search_results_dto_test.dart
+++ b/test/features/global_search/units/data/models/search_results_dto_test.dart
@@ -213,7 +213,7 @@ void main() {
         );
       });
 
-      test('maps all three lists simultaneously', () {
+      test('lists are independent — items do not bleed across lists', () {
         final estimationDto = CostEstimateDto.fromJson(
           estimation_factory.EstimationTestDataMapFactory
               .createFakeEstimationData(),
@@ -227,8 +227,11 @@ void main() {
         final result = dto.toDomain();
 
         expect(result.projects, hasLength(1));
+        expect(result.projects.first.id, equals(testProject.id));
         expect(result.estimations, hasLength(1));
+        expect(result.estimations.first.id, equals(estimationDto.id));
         expect(result.members, hasLength(1));
+        expect(result.members.first.id, equals(testMember.id));
       });
 
       test('preserves order of items within each list', () {

--- a/test/features/global_search/units/data/repositories/global_search_repository_impl_test.dart
+++ b/test/features/global_search/units/data/repositories/global_search_repository_impl_test.dart
@@ -1,0 +1,1441 @@
+import 'package:construculator/app/app_bootstrap.dart';
+import 'package:construculator/features/global_search/data/repositories/global_search_repository_impl.dart';
+import 'package:construculator/features/global_search/domain/entities/pagination_params.dart';
+import 'package:construculator/features/global_search/domain/entities/search_params_entity.dart';
+import 'package:construculator/features/global_search/domain/entities/search_results.dart';
+import 'package:construculator/features/global_search/domain/entities/search_scope_entity.dart';
+import 'package:construculator/features/global_search/domain/repositories/global_search_repository.dart';
+import 'package:construculator/features/global_search/global_search_module.dart';
+import 'package:construculator/libraries/config/testing/fake_app_config.dart';
+import 'package:construculator/libraries/config/testing/fake_env_loader.dart';
+import 'package:construculator/libraries/either/either.dart';
+import 'package:construculator/libraries/errors/failures.dart';
+import 'package:construculator/libraries/global_search/domain/search_error_type.dart';
+import 'package:construculator/libraries/supabase/data/supabase_types.dart';
+import 'package:construculator/libraries/supabase/database_constants.dart';
+import 'package:construculator/libraries/supabase/interfaces/supabase_wrapper.dart';
+import 'package:construculator/libraries/supabase/testing/fake_supabase_user.dart';
+import 'package:construculator/libraries/supabase/testing/fake_supabase_wrapper.dart';
+import 'package:construculator/libraries/time/testing/fake_clock_impl.dart';
+import 'package:flutter_modular/flutter_modular.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../../../../estimations/helpers/estimation_test_data_map_factory.dart'
+    as estimation_factory;
+
+// ---------------------------------------------------------------------------
+// Test data helpers
+// ---------------------------------------------------------------------------
+
+Map<String, dynamic> _fakeProjectData({
+  String? id,
+  String? projectName,
+  String? creatorUserId,
+  String? createdAt,
+  String? updatedAt,
+  String? status,
+}) {
+  return {
+    DatabaseConstants.idColumn: id ?? 'project-1',
+    DatabaseConstants.projectNameColumn: projectName ?? 'Test Project',
+    DatabaseConstants.descriptionColumn: 'Test description',
+    DatabaseConstants.creatorUserIdColumn: creatorUserId ?? 'user-1',
+    DatabaseConstants.owningCompanyIdColumn: null,
+    DatabaseConstants.exportFolderLinkColumn: null,
+    DatabaseConstants.exportStorageProviderColumn: null,
+    DatabaseConstants.createdAtColumn: createdAt ?? '2024-01-01T00:00:00.000Z',
+    DatabaseConstants.updatedAtColumn: updatedAt ?? '2024-01-01T00:00:00.000Z',
+    DatabaseConstants.statusColumn: status ?? 'active',
+  };
+}
+
+Map<String, dynamic> _fakeMemberData({String? id, String? firstName}) {
+  return {
+    DatabaseConstants.idColumn: id ?? 'member-1',
+    DatabaseConstants.credentialIdColumn: null,
+    DatabaseConstants.firstNameColumn: firstName ?? 'John',
+    DatabaseConstants.lastNameColumn: 'Doe',
+    DatabaseConstants.professionalRoleColumn: 'Engineer',
+    DatabaseConstants.profilePhotoUrlColumn: null,
+  };
+}
+
+Map<String, dynamic> _fakeSearchHistoryData({
+  required String userId,
+  required String searchTerm,
+  required String scope,
+  String? id,
+  String? createdAt,
+}) {
+  return {
+    DatabaseConstants.idColumn: id ?? '1',
+    DatabaseConstants.userIdColumn: userId,
+    DatabaseConstants.searchTermColumn: searchTerm,
+    DatabaseConstants.scopeColumn: scope,
+    DatabaseConstants.searchCountColumn: 1,
+    DatabaseConstants.createdAtColumn: createdAt ?? '2024-01-01T00:00:00.000Z',
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers shared across groups
+// ---------------------------------------------------------------------------
+
+void expectRight<L, R>(Either<L, R> result, void Function(R value) assertions) {
+  result.fold((_) => fail('Expected Right but got Left'), assertions);
+}
+
+void expectLeft<L, R>(Either<L, R> result, void Function(L error) assertions) {
+  result.fold(assertions, (_) => fail('Expected Left but got Right'));
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+void main() {
+  const String testUserId = 'user-123';
+  const String errorMsgServer = 'Server error occurred';
+  const String errorMsgTimeout = 'Request timed out';
+  const String errorMsgNetwork = 'Network connection failed';
+
+  group('GlobalSearchRepositoryImpl', () {
+    late GlobalSearchRepositoryImpl repository;
+    late FakeSupabaseWrapper fakeSupabaseWrapper;
+    late FakeClockImpl fakeClock;
+
+    setUpAll(() {
+      fakeClock = FakeClockImpl();
+      Modular.init(
+        GlobalSearchModule(
+          AppBootstrap(
+            supabaseWrapper: FakeSupabaseWrapper(clock: fakeClock),
+            config: FakeAppConfig(),
+            envLoader: FakeEnvLoader(),
+          ),
+        ),
+      );
+      fakeSupabaseWrapper =
+          Modular.get<SupabaseWrapper>() as FakeSupabaseWrapper;
+      repository =
+          Modular.get<GlobalSearchRepository>() as GlobalSearchRepositoryImpl;
+    });
+
+    tearDownAll(() {
+      Modular.destroy();
+    });
+
+    setUp(() {
+      fakeSupabaseWrapper.reset();
+    });
+
+    // -----------------------------------------------------------------------
+    // search
+    // -----------------------------------------------------------------------
+
+    group('search', () {
+      test(
+        'should return SearchResults with mapped domain entities on success',
+        () async {
+          final projectData = _fakeProjectData(
+            id: 'project-1',
+            projectName: 'Foundation Work',
+          );
+          final estimationData =
+              estimation_factory
+                  .EstimationTestDataMapFactory.createFakeEstimationData(
+                id: 'estimate-1',
+                estimateName: 'Steel Frame',
+              );
+          final memberData = _fakeMemberData(
+            id: 'member-1',
+            firstName: 'Alice',
+          );
+
+          fakeSupabaseWrapper.setRpcResponse(
+            DatabaseConstants.globalSearchRpcFunction,
+            {
+              'projects': [projectData],
+              'estimations': [estimationData],
+              'members': [memberData],
+            },
+          );
+
+          final result = await repository.search(
+            const SearchParams(query: 'foundation'),
+          );
+
+          expect(result.isRight(), isTrue);
+          expectRight(result, (searchResults) {
+            expect(searchResults, isA<SearchResults>());
+            expect(searchResults.projects, hasLength(1));
+            expect(searchResults.projects.first.projectName, 'Foundation Work');
+            expect(searchResults.estimations, hasLength(1));
+            expect(searchResults.estimations.first.estimateName, 'Steel Frame');
+            expect(searchResults.members, hasLength(1));
+            expect(searchResults.members.first.firstName, 'Alice');
+          });
+        },
+      );
+
+      test(
+        'should return empty SearchResults when RPC returns empty lists',
+        () async {
+          fakeSupabaseWrapper.setRpcResponse(
+            DatabaseConstants.globalSearchRpcFunction,
+            {'projects': [], 'estimations': [], 'members': []},
+          );
+
+          final result = await repository.search(
+            const SearchParams(query: 'nonexistent'),
+          );
+
+          expect(result.isRight(), isTrue);
+          expectRight(result, (searchResults) {
+            expect(searchResults.projects, isEmpty);
+            expect(searchResults.estimations, isEmpty);
+            expect(searchResults.members, isEmpty);
+          });
+        },
+      );
+
+      test(
+        'should pass all filter parameters through to the data source',
+        () async {
+          fakeSupabaseWrapper.setRpcResponse(
+            DatabaseConstants.globalSearchRpcFunction,
+            {'projects': [], 'estimations': [], 'members': []},
+          );
+
+          final filterDate = DateTime(2024, 6, 1);
+          final params = SearchParams(
+            query: 'concrete',
+            filterByTag: 'structural',
+            filterByDate: filterDate,
+            filterByOwner: 'owner-42',
+            scope: SearchScope.estimation,
+            pagination: const PaginationParams(offset: 5, limit: 10),
+          );
+
+          await repository.search(params);
+
+          final rpcCalls = fakeSupabaseWrapper.getMethodCallsFor('rpc');
+          expect(rpcCalls, hasLength(1));
+          final rpcParams = rpcCalls.first['params'] as Map<String, dynamic>?;
+          expect(rpcParams, isNotNull);
+          expect(rpcParams!['query'], equals('concrete'));
+          expect(rpcParams['filter_by_tag'], equals('structural'));
+          expect(
+            rpcParams['filter_by_date'],
+            equals(filterDate.toIso8601String()),
+          );
+          expect(rpcParams['filter_by_owner'], equals('owner-42'));
+          expect(rpcParams['scope'], equals('estimation'));
+          expect(rpcParams['offset'], equals(5));
+          expect(rpcParams['limit'], equals(10));
+        },
+      );
+
+      test(
+        'should return timeoutError failure when data source throws TimeoutException',
+        () async {
+          fakeSupabaseWrapper.shouldThrowOnRpc = true;
+          fakeSupabaseWrapper.rpcExceptionType = SupabaseExceptionType.timeout;
+          fakeSupabaseWrapper.rpcErrorMessage = errorMsgTimeout;
+
+          final result = await repository.search(
+            const SearchParams(query: 'test'),
+          );
+
+          expect(result.isLeft(), isTrue);
+          expectLeft(
+            result,
+            (failure) => expect(
+              failure,
+              SearchFailure(errorType: SearchErrorType.timeoutError),
+            ),
+          );
+        },
+      );
+
+      test(
+        'should return connectionError failure when data source throws SocketException',
+        () async {
+          fakeSupabaseWrapper.shouldThrowOnRpc = true;
+          fakeSupabaseWrapper.rpcExceptionType = SupabaseExceptionType.socket;
+          fakeSupabaseWrapper.rpcErrorMessage = errorMsgNetwork;
+
+          final result = await repository.search(
+            const SearchParams(query: 'test'),
+          );
+
+          expect(result.isLeft(), isTrue);
+          expectLeft(
+            result,
+            (failure) => expect(
+              failure,
+              SearchFailure(errorType: SearchErrorType.connectionError),
+            ),
+          );
+        },
+      );
+
+      test(
+        'should return parsingError failure when data source throws TypeError',
+        () async {
+          fakeSupabaseWrapper.shouldThrowOnRpc = true;
+          fakeSupabaseWrapper.rpcExceptionType = SupabaseExceptionType.type;
+
+          final result = await repository.search(
+            const SearchParams(query: 'test'),
+          );
+
+          expect(result.isLeft(), isTrue);
+          expectLeft(
+            result,
+            (failure) => expect(
+              failure,
+              SearchFailure(errorType: SearchErrorType.parsingError),
+            ),
+          );
+        },
+      );
+
+      test(
+        'should return connectionError failure when data source throws PostgrestException with connection failure code',
+        () async {
+          fakeSupabaseWrapper.shouldThrowOnRpc = true;
+          fakeSupabaseWrapper.rpcExceptionType =
+              SupabaseExceptionType.postgrest;
+          fakeSupabaseWrapper.postgrestErrorCode =
+              PostgresErrorCode.connectionFailure;
+          fakeSupabaseWrapper.rpcErrorMessage = 'Connection lost';
+
+          final result = await repository.search(
+            const SearchParams(query: 'test'),
+          );
+
+          expect(result.isLeft(), isTrue);
+          expectLeft(
+            result,
+            (failure) => expect(
+              failure,
+              SearchFailure(errorType: SearchErrorType.connectionError),
+            ),
+          );
+        },
+      );
+
+      test(
+        'should return notFoundError failure when data source throws PostgrestException with no data found code',
+        () async {
+          fakeSupabaseWrapper.shouldThrowOnRpc = true;
+          fakeSupabaseWrapper.rpcExceptionType =
+              SupabaseExceptionType.postgrest;
+          fakeSupabaseWrapper.postgrestErrorCode =
+              PostgresErrorCode.noDataFound;
+          fakeSupabaseWrapper.rpcErrorMessage = 'No data found';
+
+          final result = await repository.search(
+            const SearchParams(query: 'test'),
+          );
+
+          expect(result.isLeft(), isTrue);
+          expectLeft(
+            result,
+            (failure) => expect(
+              failure,
+              SearchFailure(errorType: SearchErrorType.notFoundError),
+            ),
+          );
+        },
+      );
+
+      test(
+        'should return duplicateEntryError failure when data source throws PostgrestException with unique violation code',
+        () async {
+          fakeSupabaseWrapper.shouldThrowOnRpc = true;
+          fakeSupabaseWrapper.rpcExceptionType =
+              SupabaseExceptionType.postgrest;
+          fakeSupabaseWrapper.postgrestErrorCode =
+              PostgresErrorCode.uniqueViolation;
+          fakeSupabaseWrapper.rpcErrorMessage = 'Unique violation';
+
+          final result = await repository.search(
+            const SearchParams(query: 'test'),
+          );
+
+          expect(result.isLeft(), isTrue);
+          expectLeft(
+            result,
+            (failure) => expect(
+              failure,
+              SearchFailure(errorType: SearchErrorType.duplicateEntryError),
+            ),
+          );
+        },
+      );
+
+      test(
+        'should return UnexpectedFailure when data source throws unknown error',
+        () async {
+          fakeSupabaseWrapper.shouldThrowOnRpc = true;
+          fakeSupabaseWrapper.rpcExceptionType = SupabaseExceptionType.unknown;
+          fakeSupabaseWrapper.rpcErrorMessage = errorMsgServer;
+
+          final result = await repository.search(
+            const SearchParams(query: 'test'),
+          );
+
+          expect(result.isLeft(), isTrue);
+          expectLeft(
+            result,
+            (failure) => expect(failure, isA<UnexpectedFailure>()),
+          );
+        },
+      );
+    });
+
+    // -----------------------------------------------------------------------
+    // getRecentSearches
+    // -----------------------------------------------------------------------
+
+    group('getRecentSearches', () {
+      test('should return list of search terms on success', () async {
+        fakeSupabaseWrapper.setCurrentUser(
+          FakeUser(
+            id: testUserId,
+            email: 'test@test.com',
+            createdAt: fakeClock.now().toIso8601String(),
+          ),
+        );
+        fakeSupabaseWrapper.addTableData(DatabaseConstants.searchHistoryTable, [
+          _fakeSearchHistoryData(
+            userId: testUserId,
+            searchTerm: 'wall',
+            scope: SearchScope.dashboard.name,
+          ),
+          _fakeSearchHistoryData(
+            userId: testUserId,
+            searchTerm: 'concrete',
+            scope: SearchScope.dashboard.name,
+          ),
+        ]);
+
+        final result = await repository.getRecentSearches(
+          SearchScope.dashboard,
+        );
+
+        expect(result.isRight(), isTrue);
+        expectRight(result, (terms) {
+          expect(terms, hasLength(2));
+          expect(terms, containsAll(['wall', 'concrete']));
+        });
+      });
+
+      test('should return empty list when user is not authenticated', () async {
+        fakeSupabaseWrapper.setCurrentUser(null);
+
+        final result = await repository.getRecentSearches(
+          SearchScope.dashboard,
+        );
+
+        expect(result.isRight(), isTrue);
+        expectRight(result, (terms) => expect(terms, isEmpty));
+      });
+
+      test(
+        'should return empty list when no history exists for the given scope',
+        () async {
+          fakeSupabaseWrapper.setCurrentUser(
+            FakeUser(
+              id: testUserId,
+              email: 'test@test.com',
+              createdAt: fakeClock.now().toIso8601String(),
+            ),
+          );
+          fakeSupabaseWrapper
+              .addTableData(DatabaseConstants.searchHistoryTable, [
+                _fakeSearchHistoryData(
+                  userId: testUserId,
+                  searchTerm: 'steel',
+                  scope: SearchScope.estimation.name,
+                ),
+              ]);
+
+          final result = await repository.getRecentSearches(
+            SearchScope.dashboard,
+          );
+
+          expect(result.isRight(), isTrue);
+          expectRight(result, (terms) => expect(terms, isEmpty));
+        },
+      );
+
+      test(
+        'should return timeoutError failure when data source throws TimeoutException',
+        () async {
+          fakeSupabaseWrapper.setCurrentUser(
+            FakeUser(
+              id: testUserId,
+              email: 'test@test.com',
+              createdAt: fakeClock.now().toIso8601String(),
+            ),
+          );
+          fakeSupabaseWrapper.shouldThrowOnSelectMatch = true;
+          fakeSupabaseWrapper.selectMatchExceptionType =
+              SupabaseExceptionType.timeout;
+          fakeSupabaseWrapper.selectMatchErrorMessage = errorMsgTimeout;
+
+          final result = await repository.getRecentSearches(
+            SearchScope.dashboard,
+          );
+
+          expect(result.isLeft(), isTrue);
+          expectLeft(
+            result,
+            (failure) => expect(
+              failure,
+              SearchFailure(errorType: SearchErrorType.timeoutError),
+            ),
+          );
+        },
+      );
+
+      test(
+        'should return connectionError failure when data source throws SocketException',
+        () async {
+          fakeSupabaseWrapper.setCurrentUser(
+            FakeUser(
+              id: testUserId,
+              email: 'test@test.com',
+              createdAt: fakeClock.now().toIso8601String(),
+            ),
+          );
+          fakeSupabaseWrapper.shouldThrowOnSelectMatch = true;
+          fakeSupabaseWrapper.selectMatchExceptionType =
+              SupabaseExceptionType.socket;
+          fakeSupabaseWrapper.selectMatchErrorMessage = errorMsgNetwork;
+
+          final result = await repository.getRecentSearches(
+            SearchScope.dashboard,
+          );
+
+          expect(result.isLeft(), isTrue);
+          expectLeft(
+            result,
+            (failure) => expect(
+              failure,
+              SearchFailure(errorType: SearchErrorType.connectionError),
+            ),
+          );
+        },
+      );
+
+      test(
+        'should return connectionError failure when data source throws PostgrestException with connection failure code',
+        () async {
+          fakeSupabaseWrapper.setCurrentUser(
+            FakeUser(
+              id: testUserId,
+              email: 'test@test.com',
+              createdAt: fakeClock.now().toIso8601String(),
+            ),
+          );
+          fakeSupabaseWrapper.shouldThrowOnSelectMatch = true;
+          fakeSupabaseWrapper.selectMatchExceptionType =
+              SupabaseExceptionType.postgrest;
+          fakeSupabaseWrapper.postgrestErrorCode =
+              PostgresErrorCode.connectionFailure;
+          fakeSupabaseWrapper.selectMatchErrorMessage = 'Connection lost';
+
+          final result = await repository.getRecentSearches(
+            SearchScope.dashboard,
+          );
+
+          expect(result.isLeft(), isTrue);
+          expectLeft(
+            result,
+            (failure) => expect(
+              failure,
+              SearchFailure(errorType: SearchErrorType.connectionError),
+            ),
+          );
+        },
+      );
+
+      test(
+        'should return duplicateEntryError failure when data source throws PostgrestException with unique violation code',
+        () async {
+          fakeSupabaseWrapper.setCurrentUser(
+            FakeUser(
+              id: testUserId,
+              email: 'test@test.com',
+              createdAt: fakeClock.now().toIso8601String(),
+            ),
+          );
+          fakeSupabaseWrapper.shouldThrowOnSelectMatch = true;
+          fakeSupabaseWrapper.selectMatchExceptionType =
+              SupabaseExceptionType.postgrest;
+          fakeSupabaseWrapper.postgrestErrorCode =
+              PostgresErrorCode.uniqueViolation;
+          fakeSupabaseWrapper.selectMatchErrorMessage = 'Unique violation';
+
+          final result = await repository.getRecentSearches(
+            SearchScope.dashboard,
+          );
+
+          expect(result.isLeft(), isTrue);
+          expectLeft(
+            result,
+            (failure) => expect(
+              failure,
+              SearchFailure(errorType: SearchErrorType.duplicateEntryError),
+            ),
+          );
+        },
+      );
+
+      test(
+        'should return notFoundError failure when data source throws PostgrestException with no data found code',
+        () async {
+          fakeSupabaseWrapper.setCurrentUser(
+            FakeUser(
+              id: testUserId,
+              email: 'test@test.com',
+              createdAt: fakeClock.now().toIso8601String(),
+            ),
+          );
+          fakeSupabaseWrapper.shouldThrowOnSelectMatch = true;
+          fakeSupabaseWrapper.selectMatchExceptionType =
+              SupabaseExceptionType.postgrest;
+          fakeSupabaseWrapper.postgrestErrorCode =
+              PostgresErrorCode.noDataFound;
+          fakeSupabaseWrapper.selectMatchErrorMessage = 'No data found';
+
+          final result = await repository.getRecentSearches(
+            SearchScope.dashboard,
+          );
+
+          expect(result.isLeft(), isTrue);
+          expectLeft(
+            result,
+            (failure) => expect(
+              failure,
+              SearchFailure(errorType: SearchErrorType.notFoundError),
+            ),
+          );
+        },
+      );
+
+      test(
+        'should return parsingError failure when data source throws TypeError',
+        () async {
+          fakeSupabaseWrapper.setCurrentUser(
+            FakeUser(
+              id: testUserId,
+              email: 'test@test.com',
+              createdAt: fakeClock.now().toIso8601String(),
+            ),
+          );
+          fakeSupabaseWrapper.shouldThrowOnSelectMatch = true;
+          fakeSupabaseWrapper.selectMatchExceptionType =
+              SupabaseExceptionType.type;
+
+          final result = await repository.getRecentSearches(
+            SearchScope.dashboard,
+          );
+
+          expect(result.isLeft(), isTrue);
+          expectLeft(
+            result,
+            (failure) => expect(
+              failure,
+              SearchFailure(errorType: SearchErrorType.parsingError),
+            ),
+          );
+        },
+      );
+
+      test(
+        'should return UnexpectedFailure when data source throws unknown error',
+        () async {
+          fakeSupabaseWrapper.setCurrentUser(
+            FakeUser(
+              id: testUserId,
+              email: 'test@test.com',
+              createdAt: fakeClock.now().toIso8601String(),
+            ),
+          );
+          fakeSupabaseWrapper.shouldThrowOnSelectMatch = true;
+          fakeSupabaseWrapper.selectMatchExceptionType =
+              SupabaseExceptionType.unknown;
+          fakeSupabaseWrapper.selectMatchErrorMessage = errorMsgServer;
+
+          final result = await repository.getRecentSearches(
+            SearchScope.dashboard,
+          );
+
+          expect(result.isLeft(), isTrue);
+          expectLeft(
+            result,
+            (failure) => expect(failure, isA<UnexpectedFailure>()),
+          );
+        },
+      );
+    });
+
+    // -----------------------------------------------------------------------
+    // saveRecentSearch
+    // -----------------------------------------------------------------------
+
+    group('saveRecentSearch', () {
+      test('should return Right(null) on success', () async {
+        fakeSupabaseWrapper.setCurrentUser(
+          FakeUser(
+            id: testUserId,
+            email: 'test@test.com',
+            createdAt: fakeClock.now().toIso8601String(),
+          ),
+        );
+
+        final result = await repository.saveRecentSearch(
+          'wall',
+          SearchScope.dashboard,
+        );
+
+        expect(result.isRight(), isTrue);
+      });
+
+      test(
+        'should return Right(null) without calling upsert when user is not authenticated',
+        () async {
+          fakeSupabaseWrapper.setCurrentUser(null);
+
+          final result = await repository.saveRecentSearch(
+            'wall',
+            SearchScope.dashboard,
+          );
+
+          expect(result.isRight(), isTrue);
+          expect(fakeSupabaseWrapper.getMethodCallsFor('upsert'), isEmpty);
+        },
+      );
+
+      test(
+        'should return Right(null) without calling upsert when search term is empty after trim',
+        () async {
+          fakeSupabaseWrapper.setCurrentUser(
+            FakeUser(
+              id: testUserId,
+              email: 'test@test.com',
+              createdAt: fakeClock.now().toIso8601String(),
+            ),
+          );
+
+          final result = await repository.saveRecentSearch(
+            '   ',
+            SearchScope.dashboard,
+          );
+
+          expect(result.isRight(), isTrue);
+          expect(fakeSupabaseWrapper.getMethodCallsFor('upsert'), isEmpty);
+        },
+      );
+
+      test('should pass hasResults and projectId to the data source', () async {
+        fakeSupabaseWrapper.setCurrentUser(
+          FakeUser(
+            id: testUserId,
+            email: 'test@test.com',
+            createdAt: fakeClock.now().toIso8601String(),
+          ),
+        );
+
+        await repository.saveRecentSearch(
+          'concrete',
+          SearchScope.dashboard,
+          hasResults: true,
+          projectId: 'project-42',
+        );
+
+        final upsertCalls = fakeSupabaseWrapper.getMethodCallsFor('upsert');
+        expect(upsertCalls, hasLength(1));
+        final data = upsertCalls.first['data'] as Map<String, dynamic>;
+        expect(data[DatabaseConstants.hasResultsColumn], isTrue);
+        expect(data[DatabaseConstants.projectIdColumn], equals('project-42'));
+      });
+
+      test(
+        'should return timeoutError failure when data source throws TimeoutException',
+        () async {
+          fakeSupabaseWrapper.setCurrentUser(
+            FakeUser(
+              id: testUserId,
+              email: 'test@test.com',
+              createdAt: fakeClock.now().toIso8601String(),
+            ),
+          );
+          fakeSupabaseWrapper.shouldThrowOnUpsert = true;
+          fakeSupabaseWrapper.upsertExceptionType =
+              SupabaseExceptionType.timeout;
+          fakeSupabaseWrapper.upsertErrorMessage = errorMsgTimeout;
+
+          final result = await repository.saveRecentSearch(
+            'wall',
+            SearchScope.dashboard,
+          );
+
+          expect(result.isLeft(), isTrue);
+          expectLeft(
+            result,
+            (failure) => expect(
+              failure,
+              SearchFailure(errorType: SearchErrorType.timeoutError),
+            ),
+          );
+        },
+      );
+
+      test(
+        'should return connectionError failure when data source throws SocketException',
+        () async {
+          fakeSupabaseWrapper.setCurrentUser(
+            FakeUser(
+              id: testUserId,
+              email: 'test@test.com',
+              createdAt: fakeClock.now().toIso8601String(),
+            ),
+          );
+          fakeSupabaseWrapper.shouldThrowOnUpsert = true;
+          fakeSupabaseWrapper.upsertExceptionType =
+              SupabaseExceptionType.socket;
+          fakeSupabaseWrapper.upsertErrorMessage = errorMsgNetwork;
+
+          final result = await repository.saveRecentSearch(
+            'wall',
+            SearchScope.dashboard,
+          );
+
+          expect(result.isLeft(), isTrue);
+          expectLeft(
+            result,
+            (failure) => expect(
+              failure,
+              SearchFailure(errorType: SearchErrorType.connectionError),
+            ),
+          );
+        },
+      );
+
+      test(
+        'should return connectionError failure when data source throws PostgrestException with connection failure code',
+        () async {
+          fakeSupabaseWrapper.setCurrentUser(
+            FakeUser(
+              id: testUserId,
+              email: 'test@test.com',
+              createdAt: fakeClock.now().toIso8601String(),
+            ),
+          );
+          fakeSupabaseWrapper.shouldThrowOnUpsert = true;
+          fakeSupabaseWrapper.upsertExceptionType =
+              SupabaseExceptionType.postgrest;
+          fakeSupabaseWrapper.postgrestErrorCode =
+              PostgresErrorCode.connectionFailure;
+          fakeSupabaseWrapper.upsertErrorMessage = 'Connection lost';
+
+          final result = await repository.saveRecentSearch(
+            'wall',
+            SearchScope.dashboard,
+          );
+
+          expect(result.isLeft(), isTrue);
+          expectLeft(
+            result,
+            (failure) => expect(
+              failure,
+              SearchFailure(errorType: SearchErrorType.connectionError),
+            ),
+          );
+        },
+      );
+
+      test(
+        'should return duplicateEntryError failure when data source throws PostgrestException with unique violation code',
+        () async {
+          fakeSupabaseWrapper.setCurrentUser(
+            FakeUser(
+              id: testUserId,
+              email: 'test@test.com',
+              createdAt: fakeClock.now().toIso8601String(),
+            ),
+          );
+          fakeSupabaseWrapper.shouldThrowOnUpsert = true;
+          fakeSupabaseWrapper.upsertExceptionType =
+              SupabaseExceptionType.postgrest;
+          fakeSupabaseWrapper.postgrestErrorCode =
+              PostgresErrorCode.uniqueViolation;
+          fakeSupabaseWrapper.upsertErrorMessage = 'DB error';
+
+          final result = await repository.saveRecentSearch(
+            'wall',
+            SearchScope.dashboard,
+          );
+
+          expect(result.isLeft(), isTrue);
+          expectLeft(
+            result,
+            (failure) => expect(
+              failure,
+              SearchFailure(errorType: SearchErrorType.duplicateEntryError),
+            ),
+          );
+        },
+      );
+
+      test(
+        'should return UnexpectedFailure when data source throws unknown error',
+        () async {
+          fakeSupabaseWrapper.setCurrentUser(
+            FakeUser(
+              id: testUserId,
+              email: 'test@test.com',
+              createdAt: fakeClock.now().toIso8601String(),
+            ),
+          );
+          fakeSupabaseWrapper.shouldThrowOnUpsert = true;
+          fakeSupabaseWrapper.upsertExceptionType =
+              SupabaseExceptionType.unknown;
+          fakeSupabaseWrapper.upsertErrorMessage = errorMsgServer;
+
+          final result = await repository.saveRecentSearch(
+            'wall',
+            SearchScope.dashboard,
+          );
+
+          expect(result.isLeft(), isTrue);
+          expectLeft(
+            result,
+            (failure) => expect(failure, isA<UnexpectedFailure>()),
+          );
+        },
+      );
+    });
+
+    // -----------------------------------------------------------------------
+    // deleteRecentSearch
+    // -----------------------------------------------------------------------
+
+    group('deleteRecentSearch', () {
+      test('should return Right(null) on success', () async {
+        fakeSupabaseWrapper.setCurrentUser(
+          FakeUser(
+            id: testUserId,
+            email: 'test@test.com',
+            createdAt: fakeClock.now().toIso8601String(),
+          ),
+        );
+        fakeSupabaseWrapper.addTableData(DatabaseConstants.searchHistoryTable, [
+          _fakeSearchHistoryData(
+            userId: testUserId,
+            searchTerm: 'wall',
+            scope: SearchScope.dashboard.name,
+          ),
+        ]);
+
+        final result = await repository.deleteRecentSearch(
+          'wall',
+          SearchScope.dashboard,
+        );
+
+        expect(result.isRight(), isTrue);
+      });
+
+      test(
+        'should return Right(null) without calling deleteMatch when user is not authenticated',
+        () async {
+          fakeSupabaseWrapper.setCurrentUser(null);
+
+          final result = await repository.deleteRecentSearch(
+            'wall',
+            SearchScope.dashboard,
+          );
+
+          expect(result.isRight(), isTrue);
+          expect(fakeSupabaseWrapper.getMethodCallsFor('deleteMatch'), isEmpty);
+        },
+      );
+
+      test(
+        'should return Right(null) without calling deleteMatch when search term is empty after trim',
+        () async {
+          fakeSupabaseWrapper.setCurrentUser(
+            FakeUser(
+              id: testUserId,
+              email: 'test@test.com',
+              createdAt: fakeClock.now().toIso8601String(),
+            ),
+          );
+
+          final result = await repository.deleteRecentSearch(
+            '   ',
+            SearchScope.dashboard,
+          );
+
+          expect(result.isRight(), isTrue);
+          expect(fakeSupabaseWrapper.getMethodCallsFor('deleteMatch'), isEmpty);
+        },
+      );
+
+      test(
+        'should call deleteMatch on search_history with correct filters',
+        () async {
+          fakeSupabaseWrapper.setCurrentUser(
+            FakeUser(
+              id: testUserId,
+              email: 'test@test.com',
+              createdAt: fakeClock.now().toIso8601String(),
+            ),
+          );
+
+          await repository.deleteRecentSearch('wall', SearchScope.dashboard);
+
+          final deleteCalls = fakeSupabaseWrapper.getMethodCallsFor(
+            'deleteMatch',
+          );
+          expect(deleteCalls, hasLength(1));
+          expect(
+            deleteCalls.first['table'],
+            equals(DatabaseConstants.searchHistoryTable),
+          );
+          final filters = deleteCalls.first['filters'] as Map<String, dynamic>;
+          expect(filters[DatabaseConstants.userIdColumn], equals(testUserId));
+          expect(filters[DatabaseConstants.searchTermColumn], equals('wall'));
+          expect(
+            filters[DatabaseConstants.scopeColumn],
+            equals(SearchScope.dashboard.name),
+          );
+        },
+      );
+
+      test(
+        'should return timeoutError failure when data source throws TimeoutException',
+        () async {
+          fakeSupabaseWrapper.setCurrentUser(
+            FakeUser(
+              id: testUserId,
+              email: 'test@test.com',
+              createdAt: fakeClock.now().toIso8601String(),
+            ),
+          );
+          fakeSupabaseWrapper.shouldThrowOnDeleteMatch = true;
+          fakeSupabaseWrapper.deleteMatchExceptionType =
+              SupabaseExceptionType.timeout;
+          fakeSupabaseWrapper.deleteMatchErrorMessage = errorMsgTimeout;
+
+          final result = await repository.deleteRecentSearch(
+            'wall',
+            SearchScope.dashboard,
+          );
+
+          expect(result.isLeft(), isTrue);
+          expectLeft(
+            result,
+            (failure) => expect(
+              failure,
+              SearchFailure(errorType: SearchErrorType.timeoutError),
+            ),
+          );
+        },
+      );
+
+      test(
+        'should return connectionError failure when data source throws SocketException',
+        () async {
+          fakeSupabaseWrapper.setCurrentUser(
+            FakeUser(
+              id: testUserId,
+              email: 'test@test.com',
+              createdAt: fakeClock.now().toIso8601String(),
+            ),
+          );
+          fakeSupabaseWrapper.shouldThrowOnDeleteMatch = true;
+          fakeSupabaseWrapper.deleteMatchExceptionType =
+              SupabaseExceptionType.socket;
+          fakeSupabaseWrapper.deleteMatchErrorMessage = errorMsgNetwork;
+
+          final result = await repository.deleteRecentSearch(
+            'wall',
+            SearchScope.dashboard,
+          );
+
+          expect(result.isLeft(), isTrue);
+          expectLeft(
+            result,
+            (failure) => expect(
+              failure,
+              SearchFailure(errorType: SearchErrorType.connectionError),
+            ),
+          );
+        },
+      );
+
+      test(
+        'should return connectionError failure when data source throws PostgrestException with connection failure code',
+        () async {
+          fakeSupabaseWrapper.setCurrentUser(
+            FakeUser(
+              id: testUserId,
+              email: 'test@test.com',
+              createdAt: fakeClock.now().toIso8601String(),
+            ),
+          );
+          fakeSupabaseWrapper.shouldThrowOnDeleteMatch = true;
+          fakeSupabaseWrapper.deleteMatchExceptionType =
+              SupabaseExceptionType.postgrest;
+          fakeSupabaseWrapper.postgrestErrorCode =
+              PostgresErrorCode.connectionFailure;
+          fakeSupabaseWrapper.deleteMatchErrorMessage = 'Connection lost';
+
+          final result = await repository.deleteRecentSearch(
+            'wall',
+            SearchScope.dashboard,
+          );
+
+          expect(result.isLeft(), isTrue);
+          expectLeft(
+            result,
+            (failure) => expect(
+              failure,
+              SearchFailure(errorType: SearchErrorType.connectionError),
+            ),
+          );
+        },
+      );
+
+      test(
+        'should return duplicateEntryError failure when data source throws PostgrestException with unique violation code',
+        () async {
+          fakeSupabaseWrapper.setCurrentUser(
+            FakeUser(
+              id: testUserId,
+              email: 'test@test.com',
+              createdAt: fakeClock.now().toIso8601String(),
+            ),
+          );
+          fakeSupabaseWrapper.shouldThrowOnDeleteMatch = true;
+          fakeSupabaseWrapper.deleteMatchExceptionType =
+              SupabaseExceptionType.postgrest;
+          fakeSupabaseWrapper.postgrestErrorCode =
+              PostgresErrorCode.uniqueViolation;
+          fakeSupabaseWrapper.deleteMatchErrorMessage = 'DB error';
+
+          final result = await repository.deleteRecentSearch(
+            'wall',
+            SearchScope.dashboard,
+          );
+
+          expect(result.isLeft(), isTrue);
+          expectLeft(
+            result,
+            (failure) => expect(
+              failure,
+              SearchFailure(errorType: SearchErrorType.duplicateEntryError),
+            ),
+          );
+        },
+      );
+
+      test(
+        'should return UnexpectedFailure when data source throws unknown error',
+        () async {
+          fakeSupabaseWrapper.setCurrentUser(
+            FakeUser(
+              id: testUserId,
+              email: 'test@test.com',
+              createdAt: fakeClock.now().toIso8601String(),
+            ),
+          );
+          fakeSupabaseWrapper.shouldThrowOnDeleteMatch = true;
+          fakeSupabaseWrapper.deleteMatchExceptionType =
+              SupabaseExceptionType.unknown;
+          fakeSupabaseWrapper.deleteMatchErrorMessage = errorMsgServer;
+
+          final result = await repository.deleteRecentSearch(
+            'wall',
+            SearchScope.dashboard,
+          );
+
+          expect(result.isLeft(), isTrue);
+          expectLeft(
+            result,
+            (failure) => expect(failure, isA<UnexpectedFailure>()),
+          );
+        },
+      );
+    });
+
+    // -----------------------------------------------------------------------
+    // getSearchSuggestions
+    // -----------------------------------------------------------------------
+
+    group('getSearchSuggestions', () {
+      test('should return list of suggestion strings on success', () async {
+        fakeSupabaseWrapper.setCurrentUser(
+          FakeUser(
+            id: testUserId,
+            email: 'test@test.com',
+            createdAt: fakeClock.now().toIso8601String(),
+          ),
+        );
+        fakeSupabaseWrapper.setRpcResponse(
+          DatabaseConstants.searchSuggestionsRpcFunction,
+          ['foundation', 'concrete mix', 'steel frame'],
+        );
+
+        final result = await repository.getSearchSuggestions();
+
+        expect(result.isRight(), isTrue);
+        expectRight(result, (suggestions) {
+          expect(suggestions, hasLength(3));
+          expect(
+            suggestions,
+            containsAll(['foundation', 'concrete mix', 'steel frame']),
+          );
+        });
+      });
+
+      test('should return empty list when user is not authenticated', () async {
+        fakeSupabaseWrapper.setCurrentUser(null);
+
+        final result = await repository.getSearchSuggestions();
+
+        expect(result.isRight(), isTrue);
+        expectRight(result, (suggestions) => expect(suggestions, isEmpty));
+        final rpcCalls = fakeSupabaseWrapper.getMethodCallsFor('rpc');
+        expect(
+          rpcCalls.any(
+            (c) =>
+                c['functionName'] ==
+                DatabaseConstants.searchSuggestionsRpcFunction,
+          ),
+          isFalse,
+        );
+      });
+
+      test('should return empty list when RPC returns empty', () async {
+        fakeSupabaseWrapper.setCurrentUser(
+          FakeUser(
+            id: testUserId,
+            email: 'test@test.com',
+            createdAt: fakeClock.now().toIso8601String(),
+          ),
+        );
+        fakeSupabaseWrapper.setRpcResponse(
+          DatabaseConstants.searchSuggestionsRpcFunction,
+          [],
+        );
+
+        final result = await repository.getSearchSuggestions();
+
+        expect(result.isRight(), isTrue);
+        expectRight(result, (suggestions) => expect(suggestions, isEmpty));
+      });
+
+      test(
+        'should return timeoutError failure when data source throws TimeoutException',
+        () async {
+          fakeSupabaseWrapper.setCurrentUser(
+            FakeUser(
+              id: testUserId,
+              email: 'test@test.com',
+              createdAt: fakeClock.now().toIso8601String(),
+            ),
+          );
+          fakeSupabaseWrapper.shouldThrowOnRpc = true;
+          fakeSupabaseWrapper.rpcExceptionType = SupabaseExceptionType.timeout;
+          fakeSupabaseWrapper.rpcErrorMessage = errorMsgTimeout;
+
+          final result = await repository.getSearchSuggestions();
+
+          expect(result.isLeft(), isTrue);
+          expectLeft(
+            result,
+            (failure) => expect(
+              failure,
+              SearchFailure(errorType: SearchErrorType.timeoutError),
+            ),
+          );
+        },
+      );
+
+      test(
+        'should return connectionError failure when data source throws SocketException',
+        () async {
+          fakeSupabaseWrapper.setCurrentUser(
+            FakeUser(
+              id: testUserId,
+              email: 'test@test.com',
+              createdAt: fakeClock.now().toIso8601String(),
+            ),
+          );
+          fakeSupabaseWrapper.shouldThrowOnRpc = true;
+          fakeSupabaseWrapper.rpcExceptionType = SupabaseExceptionType.socket;
+          fakeSupabaseWrapper.rpcErrorMessage = errorMsgNetwork;
+
+          final result = await repository.getSearchSuggestions();
+
+          expect(result.isLeft(), isTrue);
+          expectLeft(
+            result,
+            (failure) => expect(
+              failure,
+              SearchFailure(errorType: SearchErrorType.connectionError),
+            ),
+          );
+        },
+      );
+
+      test(
+        'should return connectionError failure when data source throws PostgrestException with connection failure code',
+        () async {
+          fakeSupabaseWrapper.setCurrentUser(
+            FakeUser(
+              id: testUserId,
+              email: 'test@test.com',
+              createdAt: fakeClock.now().toIso8601String(),
+            ),
+          );
+          fakeSupabaseWrapper.shouldThrowOnRpc = true;
+          fakeSupabaseWrapper.rpcExceptionType =
+              SupabaseExceptionType.postgrest;
+          fakeSupabaseWrapper.postgrestErrorCode =
+              PostgresErrorCode.connectionFailure;
+          fakeSupabaseWrapper.rpcErrorMessage = 'Connection lost';
+
+          final result = await repository.getSearchSuggestions();
+
+          expect(result.isLeft(), isTrue);
+          expectLeft(
+            result,
+            (failure) => expect(
+              failure,
+              SearchFailure(errorType: SearchErrorType.connectionError),
+            ),
+          );
+        },
+      );
+
+      test(
+        'should return duplicateEntryError failure when data source throws PostgrestException with unique violation code',
+        () async {
+          fakeSupabaseWrapper.setCurrentUser(
+            FakeUser(
+              id: testUserId,
+              email: 'test@test.com',
+              createdAt: fakeClock.now().toIso8601String(),
+            ),
+          );
+          fakeSupabaseWrapper.shouldThrowOnRpc = true;
+          fakeSupabaseWrapper.rpcExceptionType =
+              SupabaseExceptionType.postgrest;
+          fakeSupabaseWrapper.postgrestErrorCode =
+              PostgresErrorCode.uniqueViolation;
+          fakeSupabaseWrapper.rpcErrorMessage = 'DB error';
+
+          final result = await repository.getSearchSuggestions();
+
+          expect(result.isLeft(), isTrue);
+          expectLeft(
+            result,
+            (failure) => expect(
+              failure,
+              SearchFailure(errorType: SearchErrorType.duplicateEntryError),
+            ),
+          );
+        },
+      );
+
+      test(
+        'should return notFoundError failure when data source throws PostgrestException with no data found code',
+        () async {
+          fakeSupabaseWrapper.setCurrentUser(
+            FakeUser(
+              id: testUserId,
+              email: 'test@test.com',
+              createdAt: fakeClock.now().toIso8601String(),
+            ),
+          );
+          fakeSupabaseWrapper.shouldThrowOnRpc = true;
+          fakeSupabaseWrapper.rpcExceptionType =
+              SupabaseExceptionType.postgrest;
+          fakeSupabaseWrapper.postgrestErrorCode =
+              PostgresErrorCode.noDataFound;
+          fakeSupabaseWrapper.rpcErrorMessage = 'No data found';
+
+          final result = await repository.getSearchSuggestions();
+
+          expect(result.isLeft(), isTrue);
+          expectLeft(
+            result,
+            (failure) => expect(
+              failure,
+              SearchFailure(errorType: SearchErrorType.notFoundError),
+            ),
+          );
+        },
+      );
+
+      test(
+        'should return parsingError failure when data source throws TypeError',
+        () async {
+          fakeSupabaseWrapper.setCurrentUser(
+            FakeUser(
+              id: testUserId,
+              email: 'test@test.com',
+              createdAt: fakeClock.now().toIso8601String(),
+            ),
+          );
+          fakeSupabaseWrapper.shouldThrowOnRpc = true;
+          fakeSupabaseWrapper.rpcExceptionType = SupabaseExceptionType.type;
+
+          final result = await repository.getSearchSuggestions();
+
+          expect(result.isLeft(), isTrue);
+          expectLeft(
+            result,
+            (failure) => expect(
+              failure,
+              SearchFailure(errorType: SearchErrorType.parsingError),
+            ),
+          );
+        },
+      );
+
+      test(
+        'should return UnexpectedFailure when data source throws unknown error',
+        () async {
+          fakeSupabaseWrapper.setCurrentUser(
+            FakeUser(
+              id: testUserId,
+              email: 'test@test.com',
+              createdAt: fakeClock.now().toIso8601String(),
+            ),
+          );
+          fakeSupabaseWrapper.shouldThrowOnRpc = true;
+          fakeSupabaseWrapper.rpcExceptionType = SupabaseExceptionType.unknown;
+          fakeSupabaseWrapper.rpcErrorMessage = errorMsgServer;
+
+          final result = await repository.getSearchSuggestions();
+
+          expect(result.isLeft(), isTrue);
+          expectLeft(
+            result,
+            (failure) => expect(failure, isA<UnexpectedFailure>()),
+          );
+        },
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary

This PR establishes the domain layer foundation for the global search feature by introducing four new domain entities and value objects (`SearchResults`, `SearchParams`, `PaginationParams`, `SearchScope`), a shared error taxonomy (`SearchErrorType`, `SearchFailure`), and a `toDomain()` mapping method on `SearchResultsDto`. The changes are purely additive and confined to the domain and data-model layers — no UI, BLoC, or stream logic is introduced. The PR also extends the existing `search_results_dto_test.dart` suite with seven focused `toDomain()` tests, using real implementations throughout and no mocks or stubs.

---

## Changes Overview

### Impact Stats

| Category                   | Value                              |
|----------------------------|------------------------------------|
| **Files Modified**         | 2                                  |
| **Files Added**            | 6                                  |
| **Total Files Touched**    | 8                                  |
| **Production Lines Added** | 164                                |
| **Test Lines Added**       | 123                                |
| **PR Size Classification** | **M** *(100–200 production lines)* |

> Size breakdown (production code only): `search_params_entity.dart` (+56), `pagination_params.dart` (+30), `search_results.dart` (+30), `search_error_type.dart` (+16), `search_scope_entity.dart` (+11), `failures.dart` (+11), `search_results_dto.dart` (+10)

---

## Rule-Based Review

| Rule | Status | Notes |
|------|--------|-------|
| **Rule 1 – Digestible PR** | ✅ Pass | PR is classified **M** (164 production lines). It has a single, clear purpose — establishing domain entities for global search — and can be reviewed and tested independently. No recommendation to split. |
| **Rule 2 – Class Naming Convention** | ✅ Pass | All class names follow the established project convention: the `_entity` suffix belongs on the **filename** only; the class name carries the pure domain concept (e.g., `project_entity.dart` → `Project`, `cost_estimate_entity.dart` → `CostEstimate`). `search_params_entity.dart` → `SearchParams` and `search_scope_entity.dart` → `SearchScope` are correct. `SearchErrorType` placement under `lib/libraries/global_search/domain/` is also correct — it mirrors `lib/libraries/estimation/domain/estimation_error_type.dart`, confirming that error types are shared infrastructure consumed by `lib/libraries/errors/failures.dart`. |
| **Rule 3 – Test Double Pattern** | ✅ Pass | All seven new tests use real DTO and domain implementations. `EstimationTestDataMapFactory` is used solely for data construction, not as a mock or stub. No `MockX` / `StubX` / `WhenX` patterns detected. |
| **Rule 5 – UI & Business Logic Separation** | ✅ N/A | This PR contains no UI or widget code. The rule is not applicable to this changeset. |
| **Rule 6 – Stream-Based Performance & Lifecycle** | ✅ N/A | No `StreamController`, BLoC subscription, or reactive pipeline is introduced. The rule is not applicable to this changeset. |

