### PR TITLE
CA-243: feat global-search Bloc Implementation

### DIFF
--- a/lib/features/global_search/global_search_module.dart
+++ b/lib/features/global_search/global_search_module.dart
@@ -3,6 +3,7 @@ import 'package:construculator/features/global_search/data/data_source/interface
 import 'package:construculator/features/global_search/data/data_source/remote_global_search_data_source.dart';
 import 'package:construculator/features/global_search/data/repositories/global_search_repository_impl.dart';
 import 'package:construculator/features/global_search/domain/repositories/global_search_repository.dart';
+import 'package:construculator/features/global_search/presentation/bloc/global_search_bloc/global_search_bloc.dart';
 import 'package:construculator/libraries/supabase/supabase_module.dart';
 import 'package:flutter_modular/flutter_modular.dart';
 
@@ -27,6 +28,9 @@ class GlobalSearchModule extends Module {
     );
     i.addLazySingleton<GlobalSearchRepository>(
       () => GlobalSearchRepositoryImpl(dataSource: i()),
+    );
+    i.add<GlobalSearchBloc>(
+      () => GlobalSearchBloc(repository: i()),
     );
   }
 }

--- a/lib/features/global_search/presentation/bloc/global_search_bloc/global_search_bloc.dart
+++ b/lib/features/global_search/presentation/bloc/global_search_bloc/global_search_bloc.dart
@@ -16,6 +16,14 @@ part 'global_search_state.dart';
 /// Kept here so the BLoC owns the contract — no UI-side debouncing required.
 const Duration _kQueryDebounceDuration = Duration(milliseconds: 300);
 
+/// Returns an [EventTransformer] that debounces events by [duration] and
+/// switches to the latest mapper stream, cancelling any in-flight processing.
+///
+/// Extracted so any future event that needs the same treatment can reuse it
+/// without duplicating the rxdart pipeline inline.
+EventTransformer<E> _debounce<E>(Duration duration) =>
+    (events, mapper) => events.debounceTime(duration).switchMap(mapper);
+
 /// Bloc for managing global search state across projects, estimations, and members
 class GlobalSearchBloc extends Bloc<GlobalSearchEvent, GlobalSearchState> {
   static final _logger = AppLogger().tag('GlobalSearchBloc');
@@ -35,8 +43,7 @@ class GlobalSearchBloc extends Bloc<GlobalSearchEvent, GlobalSearchState> {
       _onQueryUpdated,
       // Debounce at the BLoC level so the UI can dispatch on every keystroke
       // without triggering redundant state emissions.
-      transformer: (events, mapper) =>
-          events.debounceTime(_kQueryDebounceDuration).switchMap(mapper),
+      transformer: _debounce(_kQueryDebounceDuration),
     );
     on<GlobalSearchPerformed>(_onPerformed);
     on<GlobalSearchRecentRemoved>(_onRecentRemoved);

--- a/lib/features/global_search/presentation/bloc/global_search_bloc/global_search_bloc.dart
+++ b/lib/features/global_search/presentation/bloc/global_search_bloc/global_search_bloc.dart
@@ -1,3 +1,4 @@
+import 'dart:async' show unawaited;
 import 'package:construculator/features/global_search/domain/entities/search_params_entity.dart';
 import 'package:construculator/features/global_search/domain/entities/search_results.dart';
 import 'package:construculator/features/global_search/domain/entities/search_scope_entity.dart';
@@ -6,9 +7,14 @@ import 'package:construculator/libraries/errors/failures.dart';
 import 'package:construculator/libraries/logging/app_logger.dart';
 import 'package:equatable/equatable.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:rxdart/rxdart.dart';
 
 part 'global_search_event.dart';
 part 'global_search_state.dart';
+
+/// Debounce duration applied to [GlobalSearchQueryUpdated] events.
+/// Kept here so the BLoC owns the contract — no UI-side debouncing required.
+const Duration _kQueryDebounceDuration = Duration(milliseconds: 300);
 
 /// Bloc for managing global search state across projects, estimations, and members
 class GlobalSearchBloc extends Bloc<GlobalSearchEvent, GlobalSearchState> {
@@ -25,7 +31,13 @@ class GlobalSearchBloc extends Bloc<GlobalSearchEvent, GlobalSearchState> {
     : _repository = repository,
       super(const GlobalSearchInitial()) {
     on<GlobalSearchStarted>(_onStarted);
-    on<GlobalSearchQueryUpdated>(_onQueryUpdated);
+    on<GlobalSearchQueryUpdated>(
+      _onQueryUpdated,
+      // Debounce at the BLoC level so the UI can dispatch on every keystroke
+      // without triggering redundant state emissions.
+      transformer: (events, mapper) =>
+          events.debounceTime(_kQueryDebounceDuration).switchMap(mapper),
+    );
     on<GlobalSearchPerformed>(_onPerformed);
     on<GlobalSearchRecentRemoved>(_onRecentRemoved);
     on<GlobalSearchSuggestionsRequested>(_onSuggestionsRequested);
@@ -43,7 +55,7 @@ class GlobalSearchBloc extends Bloc<GlobalSearchEvent, GlobalSearchState> {
       _suggestions = const [];
       _currentQuery = '';
       emit(
-        GlobalSearchInitial(
+        GlobalSearchReady(
           recentSearches: recentSearches,
           query: '',
           suggestions: const [],
@@ -59,7 +71,7 @@ class GlobalSearchBloc extends Bloc<GlobalSearchEvent, GlobalSearchState> {
   ) {
     _currentQuery = event.query;
     emit(
-      GlobalSearchInitial(
+      GlobalSearchReady(
         recentSearches: _recentSearches,
         query: event.query,
         suggestions: _suggestions,
@@ -97,20 +109,21 @@ class GlobalSearchBloc extends Bloc<GlobalSearchEvent, GlobalSearchState> {
         _recentSearches = [event.query, ..._recentSearches];
       }
 
-      _repository
-          .saveRecentSearch(
-            event.query,
-            event.scope,
-            hasResults: hasResults,
-          )
-          .then(
-            (saveResult) => saveResult.fold(
-              (_) => _logger.warning(
-                'Recent search save failed silently (non-blocking; search results already shown)',
+      // Non-blocking: persistence runs after results are shown.
+      // Do NOT call emit() inside this callback — the Emitter is already
+      // closed when _onPerformed returns.
+      unawaited(
+        _repository
+            .saveRecentSearch(event.query, event.scope, hasResults: hasResults)
+            .then(
+              (saveResult) => saveResult.fold(
+                (_) => _logger.warning(
+                  'Recent search save failed silently (non-blocking; search results already shown)',
+                ),
+                (_) {},
               ),
-              (_) {},
             ),
-          );
+      );
     });
   }
 
@@ -129,7 +142,7 @@ class GlobalSearchBloc extends Bloc<GlobalSearchEvent, GlobalSearchState> {
         _recentSearches = List<String>.from(_recentSearches)
           ..removeWhere((term) => term == event.searchTerm);
         emit(
-          GlobalSearchInitial(
+          GlobalSearchReady(
             recentSearches: _recentSearches,
             query: _currentQuery,
             suggestions: _suggestions,
@@ -145,7 +158,7 @@ class GlobalSearchBloc extends Bloc<GlobalSearchEvent, GlobalSearchState> {
     Emitter<GlobalSearchState> emit,
   ) async {
     emit(
-      GlobalSearchInitial(
+      GlobalSearchReady(
         recentSearches: _recentSearches,
         query: _currentQuery,
         suggestions: _suggestions,
@@ -160,7 +173,7 @@ class GlobalSearchBloc extends Bloc<GlobalSearchEvent, GlobalSearchState> {
       (suggestions) {
         _suggestions = suggestions;
         emit(
-          GlobalSearchInitial(
+          GlobalSearchReady(
             recentSearches: _recentSearches,
             query: _currentQuery,
             suggestions: suggestions,

--- a/lib/features/global_search/presentation/bloc/global_search_bloc/global_search_bloc.dart
+++ b/lib/features/global_search/presentation/bloc/global_search_bloc/global_search_bloc.dart
@@ -1,0 +1,173 @@
+import 'package:construculator/features/global_search/domain/entities/search_params_entity.dart';
+import 'package:construculator/features/global_search/domain/entities/search_results.dart';
+import 'package:construculator/features/global_search/domain/entities/search_scope_entity.dart';
+import 'package:construculator/features/global_search/domain/repositories/global_search_repository.dart';
+import 'package:construculator/libraries/errors/failures.dart';
+import 'package:construculator/libraries/logging/app_logger.dart';
+import 'package:equatable/equatable.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+part 'global_search_event.dart';
+part 'global_search_state.dart';
+
+/// Bloc for managing global search state across projects, estimations, and members
+class GlobalSearchBloc extends Bloc<GlobalSearchEvent, GlobalSearchState> {
+  static final _logger = AppLogger().tag('GlobalSearchBloc');
+  final GlobalSearchRepository _repository;
+
+  List<String> _recentSearches = const [];
+
+  List<String> _suggestions = const [];
+
+  String _currentQuery = '';
+
+  GlobalSearchBloc({required GlobalSearchRepository repository})
+    : _repository = repository,
+      super(const GlobalSearchInitial()) {
+    on<GlobalSearchStarted>(_onStarted);
+    on<GlobalSearchQueryUpdated>(_onQueryUpdated);
+    on<GlobalSearchPerformed>(_onPerformed);
+    on<GlobalSearchRecentRemoved>(_onRecentRemoved);
+    on<GlobalSearchSuggestionsRequested>(_onSuggestionsRequested);
+  }
+
+  Future<void> _onStarted(
+    GlobalSearchStarted event,
+    Emitter<GlobalSearchState> emit,
+  ) async {
+    final result = await _repository.getRecentSearches(event.scope);
+    result.fold((failure) => emit(GlobalSearchLoadFailure(failure: failure)), (
+      recentSearches,
+    ) {
+      _recentSearches = recentSearches;
+      _suggestions = const [];
+      _currentQuery = '';
+      emit(
+        GlobalSearchInitial(
+          recentSearches: recentSearches,
+          query: '',
+          suggestions: const [],
+          suggestionsLoading: false,
+        ),
+      );
+    });
+  }
+
+  void _onQueryUpdated(
+    GlobalSearchQueryUpdated event,
+    Emitter<GlobalSearchState> emit,
+  ) {
+    _currentQuery = event.query;
+    emit(
+      GlobalSearchInitial(
+        recentSearches: _recentSearches,
+        query: event.query,
+        suggestions: _suggestions,
+        suggestionsLoading: false,
+      ),
+    );
+  }
+
+  Future<void> _onPerformed(
+    GlobalSearchPerformed event,
+    Emitter<GlobalSearchState> emit,
+  ) async {
+    _currentQuery = event.query;
+    emit(GlobalSearchLoadInProgress(query: event.query));
+
+    final result = await _repository.search(
+      SearchParams(query: event.query, scope: event.scope),
+    );
+
+    result.fold((failure) => emit(GlobalSearchLoadFailure(failure: failure)), (
+      searchResults,
+    ) {
+      final hasResults =
+          searchResults.projects.isNotEmpty ||
+          searchResults.estimations.isNotEmpty ||
+          searchResults.members.isNotEmpty;
+
+      if (hasResults) {
+        emit(GlobalSearchLoadSuccess(results: searchResults));
+      } else {
+        emit(GlobalSearchLoadEmpty(query: event.query));
+      }
+
+      if (!_recentSearches.contains(event.query)) {
+        _recentSearches = [event.query, ..._recentSearches];
+      }
+
+      _repository
+          .saveRecentSearch(
+            event.query,
+            event.scope,
+            hasResults: hasResults,
+          )
+          .then(
+            (saveResult) => saveResult.fold(
+              (_) => _logger.warning(
+                'Recent search save failed silently (non-blocking; search results already shown)',
+              ),
+              (_) {},
+            ),
+          );
+    });
+  }
+
+  Future<void> _onRecentRemoved(
+    GlobalSearchRecentRemoved event,
+    Emitter<GlobalSearchState> emit,
+  ) async {
+    final result = await _repository.deleteRecentSearch(
+      event.searchTerm,
+      event.scope,
+    );
+
+    result.fold(
+      (failure) => emit(GlobalSearchRecentDeleteFailure(failure: failure)),
+      (_) {
+        _recentSearches = List<String>.from(_recentSearches)
+          ..removeWhere((term) => term == event.searchTerm);
+        emit(
+          GlobalSearchInitial(
+            recentSearches: _recentSearches,
+            query: _currentQuery,
+            suggestions: _suggestions,
+            suggestionsLoading: false,
+          ),
+        );
+      },
+    );
+  }
+
+  Future<void> _onSuggestionsRequested(
+    GlobalSearchSuggestionsRequested event,
+    Emitter<GlobalSearchState> emit,
+  ) async {
+    emit(
+      GlobalSearchInitial(
+        recentSearches: _recentSearches,
+        query: _currentQuery,
+        suggestions: _suggestions,
+        suggestionsLoading: true,
+      ),
+    );
+
+    final result = await _repository.getSearchSuggestions();
+
+    result.fold(
+      (failure) => emit(GlobalSearchSuggestionsLoadFailure(failure: failure)),
+      (suggestions) {
+        _suggestions = suggestions;
+        emit(
+          GlobalSearchInitial(
+            recentSearches: _recentSearches,
+            query: _currentQuery,
+            suggestions: suggestions,
+            suggestionsLoading: false,
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/features/global_search/presentation/bloc/global_search_bloc/global_search_event.dart
+++ b/lib/features/global_search/presentation/bloc/global_search_bloc/global_search_event.dart
@@ -1,0 +1,73 @@
+// coverage:ignore-file
+part of 'global_search_bloc.dart';
+
+/// Base sealed class for all GlobalSearch events
+sealed class GlobalSearchEvent extends Equatable {
+  const GlobalSearchEvent();
+
+  @override
+  List<Object?> get props => [];
+}
+
+/// Event for initializing the search screen and loading recent search history
+class GlobalSearchStarted extends GlobalSearchEvent {
+  /// The scope to load recent searches for, defaults to [SearchScope.dashboard]
+  final SearchScope scope;
+
+  const GlobalSearchStarted({this.scope = SearchScope.dashboard});
+
+  @override
+  List<Object?> get props => [scope];
+}
+
+/// Event for updating the search query text field
+///
+/// The UI must debounce before dispatching this event to avoid emitting on every keystroke
+class GlobalSearchQueryUpdated extends GlobalSearchEvent {
+  /// The current value of the search input field
+  final String query;
+
+  const GlobalSearchQueryUpdated({required this.query});
+
+  @override
+  List<Object?> get props => [query];
+}
+
+/// Event for submitting a search query
+class GlobalSearchPerformed extends GlobalSearchEvent {
+  /// The search query entered by the user
+  final String query;
+
+  /// The scope to search within, defaults to [SearchScope.dashboard]
+  final SearchScope scope;
+
+  const GlobalSearchPerformed({
+    required this.query,
+    this.scope = SearchScope.dashboard,
+  });
+
+  @override
+  List<Object?> get props => [query, scope];
+}
+
+/// Event for removing a term from the user's recent search history
+class GlobalSearchRecentRemoved extends GlobalSearchEvent {
+  /// The search term to remove
+  final String searchTerm;
+
+  /// The scope the search term belongs to
+  final SearchScope scope;
+
+  const GlobalSearchRecentRemoved({
+    required this.searchTerm,
+    required this.scope,
+  });
+
+  @override
+  List<Object?> get props => [searchTerm, scope];
+}
+
+/// Event for loading personalized search suggestions
+class GlobalSearchSuggestionsRequested extends GlobalSearchEvent {
+  const GlobalSearchSuggestionsRequested();
+}

--- a/lib/features/global_search/presentation/bloc/global_search_bloc/global_search_event.dart
+++ b/lib/features/global_search/presentation/bloc/global_search_bloc/global_search_event.dart
@@ -20,9 +20,10 @@ class GlobalSearchStarted extends GlobalSearchEvent {
   List<Object?> get props => [scope];
 }
 
-/// Event for updating the search query text field
+/// Event for updating the search query text field.
 ///
-/// The UI must debounce before dispatching this event to avoid emitting on every keystroke
+/// Can be dispatched on every keystroke — the BLoC applies a debounce
+/// transformer so redundant rapid emissions are coalesced automatically.
 class GlobalSearchQueryUpdated extends GlobalSearchEvent {
   /// The current value of the search input field
   final String query;

--- a/lib/features/global_search/presentation/bloc/global_search_bloc/global_search_state.dart
+++ b/lib/features/global_search/presentation/bloc/global_search_bloc/global_search_state.dart
@@ -9,30 +9,42 @@ sealed class GlobalSearchState extends Equatable {
   List<Object?> get props => [];
 }
 
-/// Ready / idle state for the search UI, reused after every non-search operation.
-///
-/// Cold-start and post-load-with-no-history emit identical instances; the UI
-/// must track its own `_isInitialized` flag if it needs to distinguish them.
+/// Cold start before [GlobalSearchStarted] has completed (no history loaded yet).
 class GlobalSearchInitial extends GlobalSearchState {
+  const GlobalSearchInitial();
+}
+
+/// Idle / interactive state after history has been loaded at least once.
+///
+/// Emitted after [GlobalSearchStarted], on [GlobalSearchQueryUpdated], while
+/// loading suggestions, and after history or suggestions change.
+class GlobalSearchReady extends GlobalSearchState {
+  /// Recent search terms previously submitted by the user.
   final List<String> recentSearches;
+
+  /// The current text typed into the search field.
   final String query;
+
+  /// Personalized search suggestions fetched from the repository.
   final List<String> suggestions;
+
+  /// Whether a suggestions fetch is currently in flight.
   final bool suggestionsLoading;
 
-  const GlobalSearchInitial({
+  const GlobalSearchReady({
     this.recentSearches = const [],
     this.query = '',
     this.suggestions = const [],
     this.suggestionsLoading = false,
   });
 
-  GlobalSearchInitial copyWith({
+  GlobalSearchReady copyWith({
     List<String>? recentSearches,
     String? query,
     List<String>? suggestions,
     bool? suggestionsLoading,
   }) {
-    return GlobalSearchInitial(
+    return GlobalSearchReady(
       recentSearches: recentSearches ?? this.recentSearches,
       query: query ?? this.query,
       suggestions: suggestions ?? this.suggestions,
@@ -46,6 +58,7 @@ class GlobalSearchInitial extends GlobalSearchState {
 
 /// Emitted while a search request is in flight.
 class GlobalSearchLoadInProgress extends GlobalSearchState {
+  /// The search query that triggered this in-progress request.
   final String query;
 
   const GlobalSearchLoadInProgress({required this.query});
@@ -56,6 +69,7 @@ class GlobalSearchLoadInProgress extends GlobalSearchState {
 
 /// Emitted when a search returns at least one result.
 class GlobalSearchLoadSuccess extends GlobalSearchState {
+  /// The results returned by a successful search request.
   final SearchResults results;
 
   const GlobalSearchLoadSuccess({required this.results});
@@ -66,6 +80,7 @@ class GlobalSearchLoadSuccess extends GlobalSearchState {
 
 /// Emitted when a search completes successfully but returns no results.
 class GlobalSearchLoadEmpty extends GlobalSearchState {
+  /// The search query that produced no results.
   final String query;
 
   const GlobalSearchLoadEmpty({required this.query});
@@ -76,6 +91,7 @@ class GlobalSearchLoadEmpty extends GlobalSearchState {
 
 /// Emitted when a search or history fetch fails.
 class GlobalSearchLoadFailure extends GlobalSearchState {
+  /// The failure describing why the search request failed.
   final Failure failure;
 
   const GlobalSearchLoadFailure({required this.failure});
@@ -86,6 +102,7 @@ class GlobalSearchLoadFailure extends GlobalSearchState {
 
 /// Emitted when loading personalized suggestions fails.
 class GlobalSearchSuggestionsLoadFailure extends GlobalSearchState {
+  /// The failure describing why the suggestions fetch failed.
   final Failure failure;
 
   const GlobalSearchSuggestionsLoadFailure({required this.failure});
@@ -96,6 +113,7 @@ class GlobalSearchSuggestionsLoadFailure extends GlobalSearchState {
 
 /// Emitted when removing a recent search term from history fails.
 class GlobalSearchRecentDeleteFailure extends GlobalSearchState {
+  /// The failure describing why the recent search deletion failed.
   final Failure failure;
 
   const GlobalSearchRecentDeleteFailure({required this.failure});

--- a/lib/features/global_search/presentation/bloc/global_search_bloc/global_search_state.dart
+++ b/lib/features/global_search/presentation/bloc/global_search_bloc/global_search_state.dart
@@ -1,0 +1,105 @@
+// coverage:ignore-file
+part of 'global_search_bloc.dart';
+
+/// Base sealed class for all GlobalSearch states.
+sealed class GlobalSearchState extends Equatable {
+  const GlobalSearchState();
+
+  @override
+  List<Object?> get props => [];
+}
+
+/// Ready / idle state for the search UI, reused after every non-search operation.
+///
+/// Cold-start and post-load-with-no-history emit identical instances; the UI
+/// must track its own `_isInitialized` flag if it needs to distinguish them.
+class GlobalSearchInitial extends GlobalSearchState {
+  final List<String> recentSearches;
+  final String query;
+  final List<String> suggestions;
+  final bool suggestionsLoading;
+
+  const GlobalSearchInitial({
+    this.recentSearches = const [],
+    this.query = '',
+    this.suggestions = const [],
+    this.suggestionsLoading = false,
+  });
+
+  GlobalSearchInitial copyWith({
+    List<String>? recentSearches,
+    String? query,
+    List<String>? suggestions,
+    bool? suggestionsLoading,
+  }) {
+    return GlobalSearchInitial(
+      recentSearches: recentSearches ?? this.recentSearches,
+      query: query ?? this.query,
+      suggestions: suggestions ?? this.suggestions,
+      suggestionsLoading: suggestionsLoading ?? this.suggestionsLoading,
+    );
+  }
+
+  @override
+  List<Object?> get props => [recentSearches, query, suggestions, suggestionsLoading];
+}
+
+/// Emitted while a search request is in flight.
+class GlobalSearchLoadInProgress extends GlobalSearchState {
+  final String query;
+
+  const GlobalSearchLoadInProgress({required this.query});
+
+  @override
+  List<Object?> get props => [query];
+}
+
+/// Emitted when a search returns at least one result.
+class GlobalSearchLoadSuccess extends GlobalSearchState {
+  final SearchResults results;
+
+  const GlobalSearchLoadSuccess({required this.results});
+
+  @override
+  List<Object?> get props => [results];
+}
+
+/// Emitted when a search completes successfully but returns no results.
+class GlobalSearchLoadEmpty extends GlobalSearchState {
+  final String query;
+
+  const GlobalSearchLoadEmpty({required this.query});
+
+  @override
+  List<Object?> get props => [query];
+}
+
+/// Emitted when a search or history fetch fails.
+class GlobalSearchLoadFailure extends GlobalSearchState {
+  final Failure failure;
+
+  const GlobalSearchLoadFailure({required this.failure});
+
+  @override
+  List<Object?> get props => [failure];
+}
+
+/// Emitted when loading personalized suggestions fails.
+class GlobalSearchSuggestionsLoadFailure extends GlobalSearchState {
+  final Failure failure;
+
+  const GlobalSearchSuggestionsLoadFailure({required this.failure});
+
+  @override
+  List<Object?> get props => [failure];
+}
+
+/// Emitted when removing a recent search term from history fails.
+class GlobalSearchRecentDeleteFailure extends GlobalSearchState {
+  final Failure failure;
+
+  const GlobalSearchRecentDeleteFailure({required this.failure});
+
+  @override
+  List<Object?> get props => [failure];
+}

--- a/test/features/global_search/units/blocs/global_search_bloc_test.dart
+++ b/test/features/global_search/units/blocs/global_search_bloc_test.dart
@@ -1,0 +1,716 @@
+import 'package:bloc_test/bloc_test.dart';
+import 'package:construculator/app/app_bootstrap.dart';
+import 'package:construculator/features/global_search/domain/entities/search_scope_entity.dart';
+import 'package:construculator/features/global_search/global_search_module.dart';
+import 'package:construculator/features/global_search/presentation/bloc/global_search_bloc/global_search_bloc.dart';
+import 'package:construculator/libraries/config/testing/fake_app_config.dart';
+import 'package:construculator/libraries/config/testing/fake_env_loader.dart';
+import 'package:construculator/libraries/errors/failures.dart';
+import 'package:construculator/libraries/global_search/domain/search_error_type.dart';
+import 'package:construculator/libraries/supabase/data/supabase_types.dart';
+import 'package:construculator/libraries/supabase/database_constants.dart';
+import 'package:construculator/libraries/supabase/interfaces/supabase_wrapper.dart';
+import 'package:construculator/libraries/supabase/testing/fake_supabase_user.dart';
+import 'package:construculator/libraries/supabase/testing/fake_supabase_wrapper.dart';
+import 'package:construculator/libraries/time/testing/fake_clock_impl.dart';
+import 'package:flutter_modular/flutter_modular.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../../../estimations/helpers/estimation_test_data_map_factory.dart'
+    as estimation_factory;
+
+// ---------------------------------------------------------------------------
+// Test data helpers
+// ---------------------------------------------------------------------------
+
+const String _testUserId = 'user-bloc-test';
+const String _testUserEmail = 'bloc@test.com';
+
+Map<String, dynamic> _fakeMemberData({String? id, String? firstName}) {
+  return <String, dynamic>{
+    DatabaseConstants.idColumn: id ?? 'member-1',
+    DatabaseConstants.credentialIdColumn: null,
+    DatabaseConstants.firstNameColumn: firstName ?? 'John',
+    DatabaseConstants.lastNameColumn: 'Doe',
+    DatabaseConstants.professionalRoleColumn: 'Engineer',
+    DatabaseConstants.profilePhotoUrlColumn: null,
+  };
+}
+
+Map<String, dynamic> _fakeProjectData({String? id, String? projectName}) {
+  return {
+    DatabaseConstants.idColumn: id ?? 'project-1',
+    DatabaseConstants.projectNameColumn: projectName ?? 'Test Project',
+    DatabaseConstants.descriptionColumn: 'Test description',
+    DatabaseConstants.creatorUserIdColumn: _testUserId,
+    DatabaseConstants.owningCompanyIdColumn: null,
+    DatabaseConstants.exportFolderLinkColumn: null,
+    DatabaseConstants.exportStorageProviderColumn: null,
+    DatabaseConstants.createdAtColumn: '2024-01-01T00:00:00.000Z',
+    DatabaseConstants.updatedAtColumn: '2024-01-01T00:00:00.000Z',
+    DatabaseConstants.statusColumn: 'active',
+  };
+}
+
+Map<String, dynamic> _fakeSearchHistoryData({
+  required String userId,
+  required String searchTerm,
+  SearchScope scope = SearchScope.dashboard,
+}) {
+  return {
+    DatabaseConstants.idColumn: '1',
+    DatabaseConstants.userIdColumn: userId,
+    DatabaseConstants.searchTermColumn: searchTerm,
+    DatabaseConstants.scopeColumn: scope.name,
+    DatabaseConstants.searchCountColumn: 1,
+    DatabaseConstants.createdAtColumn: '2024-01-01T00:00:00.000Z',
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+void main() {
+  group('GlobalSearchBloc', () {
+    late FakeSupabaseWrapper fakeSupabase;
+    late FakeClockImpl fakeClock;
+
+    setUpAll(() {
+      fakeClock = FakeClockImpl();
+      Modular.init(
+        GlobalSearchModule(
+          AppBootstrap(
+            supabaseWrapper: FakeSupabaseWrapper(clock: fakeClock),
+            config: FakeAppConfig(),
+            envLoader: FakeEnvLoader(),
+          ),
+        ),
+      );
+      fakeSupabase = Modular.get<SupabaseWrapper>() as FakeSupabaseWrapper;
+    });
+
+    tearDownAll(() {
+      Modular.destroy();
+    });
+
+    setUp(() {
+      fakeSupabase.reset();
+    });
+
+    test(
+      'initial state is GlobalSearchInitial with empty recentSearches and empty query',
+      () {
+        final bloc = Modular.get<GlobalSearchBloc>();
+        expect(bloc.state, const GlobalSearchInitial());
+        expect(
+          bloc.state,
+          isA<GlobalSearchInitial>().having(
+            (s) => s.recentSearches,
+            'recentSearches',
+            isEmpty,
+          ),
+        );
+        expect(
+          bloc.state,
+          isA<GlobalSearchInitial>().having((s) => s.query, 'query', ''),
+        );
+        bloc.close();
+      },
+    );
+
+    group('GlobalSearchStarted', () {
+      blocTest<GlobalSearchBloc, GlobalSearchState>(
+        'emits GlobalSearchInitial with recentSearches when history exists',
+        setUp: () {
+          fakeSupabase.setCurrentUser(
+            FakeUser(
+              id: _testUserId,
+              email: _testUserEmail,
+              createdAt: fakeClock.now().toIso8601String(),
+            ),
+          );
+          fakeSupabase.addTableData(DatabaseConstants.searchHistoryTable, [
+            _fakeSearchHistoryData(userId: _testUserId, searchTerm: 'wall'),
+            _fakeSearchHistoryData(userId: _testUserId, searchTerm: 'concrete'),
+          ]);
+        },
+        build: () => Modular.get<GlobalSearchBloc>(),
+        act: (bloc) => bloc.add(const GlobalSearchStarted()),
+        expect: () => [
+          isA<GlobalSearchInitial>().having(
+            (s) => s.recentSearches,
+            'recentSearches',
+            containsAll(['wall', 'concrete']),
+          ),
+        ],
+      );
+
+      blocTest<GlobalSearchBloc, GlobalSearchState>(
+        'emits GlobalSearchInitial with empty recentSearches when user is not authenticated',
+        setUp: () {
+          fakeSupabase.setCurrentUser(null);
+        },
+        build: () => Modular.get<GlobalSearchBloc>(),
+        act: (bloc) => bloc.add(const GlobalSearchStarted()),
+        expect: () => [
+          const GlobalSearchInitial(recentSearches: [], query: ''),
+        ],
+      );
+
+      blocTest<GlobalSearchBloc, GlobalSearchState>(
+        'emits GlobalSearchLoadFailure when Supabase throws on getRecentSearches',
+        setUp: () {
+          fakeSupabase.setCurrentUser(
+            FakeUser(
+              id: _testUserId,
+              email: _testUserEmail,
+              createdAt: fakeClock.now().toIso8601String(),
+            ),
+          );
+          fakeSupabase.shouldThrowOnSelectMatch = true;
+          fakeSupabase.selectMatchExceptionType = SupabaseExceptionType.timeout;
+        },
+        build: () => Modular.get<GlobalSearchBloc>(),
+        act: (bloc) => bloc.add(const GlobalSearchStarted()),
+        expect: () => [
+          isA<GlobalSearchLoadFailure>().having(
+            (s) => s.failure,
+            'failure',
+            SearchFailure(errorType: SearchErrorType.timeoutError),
+          ),
+        ],
+      );
+
+      blocTest<GlobalSearchBloc, GlobalSearchState>(
+        'uses supplied scope — loads estimation-scoped recents when scope is estimation',
+        setUp: () {
+          fakeSupabase.setCurrentUser(
+            FakeUser(
+              id: _testUserId,
+              email: _testUserEmail,
+              createdAt: fakeClock.now().toIso8601String(),
+            ),
+          );
+          fakeSupabase.addTableData(DatabaseConstants.searchHistoryTable, [
+            _fakeSearchHistoryData(
+              userId: _testUserId,
+              searchTerm: 'estimation-term',
+              scope: SearchScope.estimation,
+            ),
+            _fakeSearchHistoryData(
+              userId: _testUserId,
+              searchTerm: 'dashboard-term',
+            ),
+          ]);
+        },
+        build: () => Modular.get<GlobalSearchBloc>(),
+        act: (bloc) =>
+            bloc.add(const GlobalSearchStarted(scope: SearchScope.estimation)),
+        expect: () => [
+          isA<GlobalSearchInitial>()
+              .having(
+                (s) => s.recentSearches,
+                'estimation-scoped recents',
+                contains('estimation-term'),
+              )
+              .having(
+                (s) => s.recentSearches,
+                'no dashboard recents',
+                isNot(contains('dashboard-term')),
+              ),
+        ],
+      );
+
+      blocTest<GlobalSearchBloc, GlobalSearchState>(
+        'resets query to empty when re-opened after a previous search session',
+        setUp: () {
+          fakeSupabase.setCurrentUser(null);
+        },
+        build: () => Modular.get<GlobalSearchBloc>(),
+        act: (bloc) async {
+          bloc.add(const GlobalSearchQueryUpdated(query: 'stale-query'));
+          await bloc.stream.first;
+          bloc.add(const GlobalSearchStarted());
+        },
+        expect: () => [
+          const GlobalSearchInitial(recentSearches: [], query: 'stale-query'),
+          isA<GlobalSearchInitial>().having(
+            (s) => s.query,
+            'query is reset to empty on fresh start',
+            isEmpty,
+          ),
+        ],
+      );
+    });
+
+    group('GlobalSearchPerformed', () {
+      blocTest<GlobalSearchBloc, GlobalSearchState>(
+        'emits [GlobalSearchLoadInProgress, GlobalSearchLoadSuccess] when search returns results',
+        setUp: () {
+          fakeSupabase.setRpcResponse(
+            DatabaseConstants.globalSearchRpcFunction,
+            {
+              'projects': [_fakeProjectData(projectName: 'Foundation Work')],
+              'estimations': [
+                estimation_factory
+                    .EstimationTestDataMapFactory.createFakeEstimationData(
+                  estimateName: 'Steel Frame',
+                ),
+              ],
+              'members': [],
+            },
+          );
+        },
+        build: () => Modular.get<GlobalSearchBloc>(),
+        act: (bloc) =>
+            bloc.add(const GlobalSearchPerformed(query: 'foundation')),
+        expect: () => [
+          const GlobalSearchLoadInProgress(query: 'foundation'),
+          isA<GlobalSearchLoadSuccess>().having(
+            (s) => s.results.projects,
+            'projects',
+            hasLength(1),
+          ),
+        ],
+      );
+
+      blocTest<GlobalSearchBloc, GlobalSearchState>(
+        'emits [GlobalSearchLoadInProgress, GlobalSearchLoadEmpty] when search returns no results',
+        setUp: () {
+          fakeSupabase.setRpcResponse(
+            DatabaseConstants.globalSearchRpcFunction,
+            {'projects': [], 'estimations': [], 'members': []},
+          );
+        },
+        build: () => Modular.get<GlobalSearchBloc>(),
+        act: (bloc) =>
+            bloc.add(const GlobalSearchPerformed(query: 'nonexistent')),
+        expect: () => [
+          const GlobalSearchLoadInProgress(query: 'nonexistent'),
+          const GlobalSearchLoadEmpty(query: 'nonexistent'),
+        ],
+      );
+
+      blocTest<GlobalSearchBloc, GlobalSearchState>(
+        'emits [GlobalSearchLoadInProgress, GlobalSearchLoadFailure] when Supabase throws on search',
+        setUp: () {
+          fakeSupabase.shouldThrowOnRpc = true;
+          fakeSupabase.rpcExceptionType = SupabaseExceptionType.socket;
+        },
+        build: () => Modular.get<GlobalSearchBloc>(),
+        act: (bloc) => bloc.add(const GlobalSearchPerformed(query: 'test')),
+        expect: () => [
+          const GlobalSearchLoadInProgress(query: 'test'),
+          isA<GlobalSearchLoadFailure>().having(
+            (s) => s.failure,
+            'failure',
+            SearchFailure(errorType: SearchErrorType.connectionError),
+          ),
+        ],
+      );
+
+      blocTest<GlobalSearchBloc, GlobalSearchState>(
+        'emits [GlobalSearchLoadInProgress, GlobalSearchLoadFailure] with timeoutError when RPC times out',
+        setUp: () {
+          fakeSupabase.shouldThrowOnRpc = true;
+          fakeSupabase.rpcExceptionType = SupabaseExceptionType.timeout;
+        },
+        build: () => Modular.get<GlobalSearchBloc>(),
+        act: (bloc) => bloc.add(const GlobalSearchPerformed(query: 'test')),
+        expect: () => [
+          const GlobalSearchLoadInProgress(query: 'test'),
+          isA<GlobalSearchLoadFailure>().having(
+            (s) => s.failure,
+            'failure',
+            SearchFailure(errorType: SearchErrorType.timeoutError),
+          ),
+        ],
+      );
+
+      blocTest<GlobalSearchBloc, GlobalSearchState>(
+        'emits [GlobalSearchLoadInProgress, GlobalSearchLoadFailure] with parsingError on TypeError',
+        setUp: () {
+          fakeSupabase.shouldThrowOnRpc = true;
+          fakeSupabase.rpcExceptionType = SupabaseExceptionType.type;
+        },
+        build: () => Modular.get<GlobalSearchBloc>(),
+        act: (bloc) => bloc.add(const GlobalSearchPerformed(query: 'test')),
+        expect: () => [
+          const GlobalSearchLoadInProgress(query: 'test'),
+          isA<GlobalSearchLoadFailure>(),
+        ],
+      );
+
+      blocTest<GlobalSearchBloc, GlobalSearchState>(
+        'GlobalSearchLoadSuccess carries all three result lists',
+        setUp: () {
+          fakeSupabase.setRpcResponse(
+            DatabaseConstants.globalSearchRpcFunction,
+            {
+              'projects': [_fakeProjectData(id: 'p1')],
+              'estimations': [
+                estimation_factory
+                    .EstimationTestDataMapFactory.createFakeEstimationData(
+                  id: 'e1',
+                ),
+              ],
+              'members': [_fakeMemberData(id: 'm1', firstName: 'Alice')],
+            },
+          );
+        },
+        build: () => Modular.get<GlobalSearchBloc>(),
+        act: (bloc) => bloc.add(const GlobalSearchPerformed(query: 'alice')),
+        verify: (bloc) {
+          final state = bloc.state as GlobalSearchLoadSuccess;
+          expect(state.results.projects, hasLength(1));
+          expect(state.results.estimations, hasLength(1));
+          expect(state.results.members, hasLength(1));
+        },
+      );
+
+      blocTest<GlobalSearchBloc, GlobalSearchState>(
+        'uses supplied scope — emits correct states when scope is estimation',
+        setUp: () {
+          fakeSupabase.setCurrentUser(
+            FakeUser(
+              id: _testUserId,
+              email: _testUserEmail,
+              createdAt: fakeClock.now().toIso8601String(),
+            ),
+          );
+          fakeSupabase.setRpcResponse(
+            DatabaseConstants.globalSearchRpcFunction,
+            {
+              'projects': [_fakeProjectData()],
+              'estimations': [],
+              'members': [],
+            },
+          );
+        },
+        build: () => Modular.get<GlobalSearchBloc>(),
+        act: (bloc) => bloc.add(
+          const GlobalSearchPerformed(
+            query: 'steel',
+            scope: SearchScope.estimation,
+          ),
+        ),
+        expect: () => [
+          const GlobalSearchLoadInProgress(query: 'steel'),
+          isA<GlobalSearchLoadSuccess>(),
+        ],
+        verify: (_) {
+          final rpcCalls = fakeSupabase.getMethodCallsFor('rpc');
+          expect(
+            rpcCalls,
+            isNotEmpty,
+            reason: 'RPC must be called for a search',
+          );
+          final rpcParams = rpcCalls.first['params'] as Map<String, dynamic>?;
+          expect(
+            rpcParams?['scope'],
+            equals(SearchScope.estimation.name),
+            reason: 'scope must be forwarded to the RPC',
+          );
+        },
+      );
+
+      blocTest<GlobalSearchBloc, GlobalSearchState>(
+        'optimistically adds query to recentSearches so GlobalSearchQueryUpdated sees it immediately',
+        setUp: () {
+          fakeSupabase.setCurrentUser(
+            FakeUser(
+              id: _testUserId,
+              email: _testUserEmail,
+              createdAt: fakeClock.now().toIso8601String(),
+            ),
+          );
+          fakeSupabase.setRpcResponse(
+            DatabaseConstants.globalSearchRpcFunction,
+            {
+              'projects': [_fakeProjectData()],
+              'estimations': [],
+              'members': [],
+            },
+          );
+        },
+        build: () => Modular.get<GlobalSearchBloc>(),
+        act: (bloc) async {
+          bloc.add(const GlobalSearchPerformed(query: 'steel'));
+          await bloc.stream.firstWhere((s) => s is GlobalSearchLoadSuccess);
+          bloc.add(const GlobalSearchQueryUpdated(query: ''));
+        },
+        expect: () => [
+          const GlobalSearchLoadInProgress(query: 'steel'),
+          isA<GlobalSearchLoadSuccess>(),
+          isA<GlobalSearchInitial>().having(
+            (s) => s.recentSearches,
+            'searched term is present without reopening the screen',
+            contains('steel'),
+          ),
+        ],
+      );
+
+      blocTest<GlobalSearchBloc, GlobalSearchState>(
+        'does not duplicate query in recentSearches if already present',
+        setUp: () {
+          fakeSupabase.setCurrentUser(
+            FakeUser(
+              id: _testUserId,
+              email: _testUserEmail,
+              createdAt: fakeClock.now().toIso8601String(),
+            ),
+          );
+          fakeSupabase.addTableData(
+            DatabaseConstants.searchHistoryTable,
+            [_fakeSearchHistoryData(userId: _testUserId, searchTerm: 'steel')],
+          );
+          fakeSupabase.setRpcResponse(
+            DatabaseConstants.globalSearchRpcFunction,
+            {
+              'projects': [_fakeProjectData()],
+              'estimations': [],
+              'members': [],
+            },
+          );
+        },
+        build: () => Modular.get<GlobalSearchBloc>(),
+        act: (bloc) async {
+          bloc.add(const GlobalSearchStarted());
+          await bloc.stream.firstWhere((s) => s is GlobalSearchInitial);
+          bloc.add(const GlobalSearchPerformed(query: 'steel'));
+          await bloc.stream.firstWhere((s) => s is GlobalSearchLoadSuccess);
+          bloc.add(const GlobalSearchQueryUpdated(query: ''));
+        },
+        verify: (bloc) {
+          final state = bloc.state as GlobalSearchInitial;
+          expect(
+            state.recentSearches.where((t) => t == 'steel'),
+            hasLength(1),
+            reason: 'steel must appear exactly once',
+          );
+        },
+      );
+    });
+
+    group('GlobalSearchQueryUpdated', () {
+      blocTest<GlobalSearchBloc, GlobalSearchState>(
+        'emits GlobalSearchInitial with updated query and empty recentSearches',
+        build: () => Modular.get<GlobalSearchBloc>(),
+        act: (bloc) =>
+            bloc.add(const GlobalSearchQueryUpdated(query: 'foundation')),
+        expect: () => [
+          const GlobalSearchInitial(recentSearches: [], query: 'foundation'),
+        ],
+      );
+
+      blocTest<GlobalSearchBloc, GlobalSearchState>(
+        'emits GlobalSearchInitial with empty query when query is cleared',
+        build: () => Modular.get<GlobalSearchBloc>(),
+        act: (bloc) => bloc.add(const GlobalSearchQueryUpdated(query: '')),
+        expect: () => [
+          const GlobalSearchInitial(recentSearches: [], query: ''),
+        ],
+      );
+
+      blocTest<GlobalSearchBloc, GlobalSearchState>(
+        'does not make any Supabase calls when query is updated',
+        build: () => Modular.get<GlobalSearchBloc>(),
+        act: (bloc) =>
+            bloc.add(const GlobalSearchQueryUpdated(query: 'concrete')),
+        verify: (_) {
+          expect(fakeSupabase.getMethodCallsFor('rpc'), isEmpty);
+          expect(fakeSupabase.getMethodCallsFor('selectMatch'), isEmpty);
+        },
+      );
+
+      blocTest<GlobalSearchBloc, GlobalSearchState>(
+        'preserves recentSearches loaded by GlobalSearchStarted when query is updated',
+        setUp: () {
+          fakeSupabase.setCurrentUser(
+            FakeUser(
+              id: _testUserId,
+              email: _testUserEmail,
+              createdAt: fakeClock.now().toIso8601String(),
+            ),
+          );
+          fakeSupabase.addTableData(DatabaseConstants.searchHistoryTable, [
+            _fakeSearchHistoryData(userId: _testUserId, searchTerm: 'steel'),
+          ]);
+        },
+        build: () => Modular.get<GlobalSearchBloc>(),
+        act: (bloc) async {
+          bloc.add(const GlobalSearchStarted());
+          await bloc.stream.firstWhere((s) {
+            if (s is! GlobalSearchInitial) {
+              return false;
+            }
+            return s.recentSearches.contains('steel');
+          });
+          bloc.add(const GlobalSearchQueryUpdated(query: 'concrete'));
+        },
+        expect: () => [
+          isA<GlobalSearchInitial>().having(
+            (s) => s.recentSearches,
+            'recentSearches after Started',
+            contains('steel'),
+          ),
+          isA<GlobalSearchInitial>()
+              .having((s) => s.query, 'query after QueryUpdated', 'concrete')
+              .having(
+                (s) => s.recentSearches,
+                'recentSearches preserved after QueryUpdated',
+                contains('steel'),
+              ),
+        ],
+      );
+    });
+
+    group('GlobalSearchSuggestionsRequested', () {
+      blocTest<GlobalSearchBloc, GlobalSearchState>(
+        'emits [GlobalSearchInitial suggestionsLoading, GlobalSearchInitial with suggestions] when RPC succeeds',
+        setUp: () {
+          fakeSupabase.setCurrentUser(
+            FakeUser(
+              id: _testUserId,
+              email: _testUserEmail,
+              createdAt: fakeClock.now().toIso8601String(),
+            ),
+          );
+          fakeSupabase.setRpcResponse(
+            DatabaseConstants.searchSuggestionsRpcFunction,
+            ['foundation', 'concrete mix', 'steel frame'],
+          );
+        },
+        build: () => Modular.get<GlobalSearchBloc>(),
+        act: (bloc) => bloc.add(const GlobalSearchSuggestionsRequested()),
+        expect: () => [
+          isA<GlobalSearchInitial>().having(
+            (s) => s.suggestionsLoading,
+            'suggestionsLoading',
+            isTrue,
+          ),
+          isA<GlobalSearchInitial>()
+              .having(
+                (s) => s.suggestions,
+                'suggestions',
+                containsAll(['foundation', 'concrete mix', 'steel frame']),
+              )
+              .having(
+                (s) => s.suggestionsLoading,
+                'suggestionsLoading',
+                isFalse,
+              ),
+        ],
+      );
+
+      blocTest<GlobalSearchBloc, GlobalSearchState>(
+        'emits GlobalSearchSuggestionsLoadFailure when RPC throws',
+        setUp: () {
+          fakeSupabase.setCurrentUser(
+            FakeUser(
+              id: _testUserId,
+              email: _testUserEmail,
+              createdAt: fakeClock.now().toIso8601String(),
+            ),
+          );
+          fakeSupabase.shouldThrowOnRpc = true;
+          fakeSupabase.rpcExceptionType = SupabaseExceptionType.timeout;
+        },
+        build: () => Modular.get<GlobalSearchBloc>(),
+        act: (bloc) => bloc.add(const GlobalSearchSuggestionsRequested()),
+        expect: () => [
+          isA<GlobalSearchInitial>().having(
+            (s) => s.suggestionsLoading,
+            'suggestionsLoading',
+            isTrue,
+          ),
+          isA<GlobalSearchSuggestionsLoadFailure>().having(
+            (s) => s.failure,
+            'failure',
+            SearchFailure(errorType: SearchErrorType.timeoutError),
+          ),
+        ],
+      );
+    });
+
+    group('GlobalSearchRecentRemoved', () {
+      blocTest<GlobalSearchBloc, GlobalSearchState>(
+        'emits GlobalSearchInitial without removed term when delete succeeds',
+        setUp: () {
+          fakeSupabase.setCurrentUser(
+            FakeUser(
+              id: _testUserId,
+              email: _testUserEmail,
+              createdAt: fakeClock.now().toIso8601String(),
+            ),
+          );
+          fakeSupabase.addTableData(DatabaseConstants.searchHistoryTable, [
+            _fakeSearchHistoryData(userId: _testUserId, searchTerm: 'wall'),
+            _fakeSearchHistoryData(userId: _testUserId, searchTerm: 'concrete'),
+          ]);
+        },
+        build: () => Modular.get<GlobalSearchBloc>(),
+        act: (bloc) async {
+          bloc.add(const GlobalSearchStarted());
+          await bloc.stream.firstWhere((s) {
+            if (s is! GlobalSearchInitial) {
+              return false;
+            }
+            return s.recentSearches.length == 2;
+          });
+          bloc.add(
+            const GlobalSearchRecentRemoved(
+              searchTerm: 'wall',
+              scope: SearchScope.dashboard,
+            ),
+          );
+        },
+        expect: () => [
+          isA<GlobalSearchInitial>().having(
+            (s) => s.recentSearches,
+            'recentSearches after Started',
+            containsAll(['wall', 'concrete']),
+          ),
+          isA<GlobalSearchInitial>().having(
+            (s) => s.recentSearches,
+            'recentSearches after Removed',
+            allOf(isNot(contains('wall')), contains('concrete')),
+          ),
+        ],
+      );
+
+      blocTest<GlobalSearchBloc, GlobalSearchState>(
+        'emits GlobalSearchRecentDeleteFailure when delete throws',
+        setUp: () {
+          fakeSupabase.setCurrentUser(
+            FakeUser(
+              id: _testUserId,
+              email: _testUserEmail,
+              createdAt: fakeClock.now().toIso8601String(),
+            ),
+          );
+          fakeSupabase.addTableData(DatabaseConstants.searchHistoryTable, [
+            _fakeSearchHistoryData(userId: _testUserId, searchTerm: 'wall'),
+          ]);
+          fakeSupabase.shouldThrowOnDeleteMatch = true;
+          fakeSupabase.deleteMatchExceptionType = SupabaseExceptionType.socket;
+        },
+        build: () => Modular.get<GlobalSearchBloc>(),
+        act: (bloc) => bloc.add(
+          const GlobalSearchRecentRemoved(
+            searchTerm: 'wall',
+            scope: SearchScope.dashboard,
+          ),
+        ),
+        expect: () => [
+          isA<GlobalSearchRecentDeleteFailure>().having(
+            (s) => s.failure,
+            'failure',
+            SearchFailure(errorType: SearchErrorType.connectionError),
+          ),
+        ],
+      );
+    });
+  });
+}

--- a/test/features/global_search/units/blocs/global_search_bloc_test.dart
+++ b/test/features/global_search/units/blocs/global_search_bloc_test.dart
@@ -98,30 +98,16 @@ void main() {
       fakeSupabase.reset();
     });
 
-    test(
-      'initial state is GlobalSearchInitial with empty recentSearches and empty query',
-      () {
-        final bloc = Modular.get<GlobalSearchBloc>();
-        expect(bloc.state, const GlobalSearchInitial());
-        expect(
-          bloc.state,
-          isA<GlobalSearchInitial>().having(
-            (s) => s.recentSearches,
-            'recentSearches',
-            isEmpty,
-          ),
-        );
-        expect(
-          bloc.state,
-          isA<GlobalSearchInitial>().having((s) => s.query, 'query', ''),
-        );
-        bloc.close();
-      },
-    );
+    test('initial state is GlobalSearchInitial (cold start, no history yet)', () {
+      final bloc = Modular.get<GlobalSearchBloc>();
+      expect(bloc.state, const GlobalSearchInitial());
+      expect(bloc.state is GlobalSearchInitial, isTrue);
+      bloc.close();
+    });
 
     group('GlobalSearchStarted', () {
       blocTest<GlobalSearchBloc, GlobalSearchState>(
-        'emits GlobalSearchInitial with recentSearches when history exists',
+        'emits GlobalSearchReady with recentSearches when history exists',
         setUp: () {
           fakeSupabase.setCurrentUser(
             FakeUser(
@@ -138,7 +124,7 @@ void main() {
         build: () => Modular.get<GlobalSearchBloc>(),
         act: (bloc) => bloc.add(const GlobalSearchStarted()),
         expect: () => [
-          isA<GlobalSearchInitial>().having(
+          isA<GlobalSearchReady>().having(
             (s) => s.recentSearches,
             'recentSearches',
             containsAll(['wall', 'concrete']),
@@ -147,14 +133,14 @@ void main() {
       );
 
       blocTest<GlobalSearchBloc, GlobalSearchState>(
-        'emits GlobalSearchInitial with empty recentSearches when user is not authenticated',
+        'emits GlobalSearchReady with empty recentSearches when user is not authenticated',
         setUp: () {
           fakeSupabase.setCurrentUser(null);
         },
         build: () => Modular.get<GlobalSearchBloc>(),
         act: (bloc) => bloc.add(const GlobalSearchStarted()),
         expect: () => [
-          const GlobalSearchInitial(recentSearches: [], query: ''),
+          const GlobalSearchReady(),
         ],
       );
 
@@ -208,7 +194,7 @@ void main() {
         act: (bloc) =>
             bloc.add(const GlobalSearchStarted(scope: SearchScope.estimation)),
         expect: () => [
-          isA<GlobalSearchInitial>()
+          isA<GlobalSearchReady>()
               .having(
                 (s) => s.recentSearches,
                 'estimation-scoped recents',
@@ -230,12 +216,15 @@ void main() {
         build: () => Modular.get<GlobalSearchBloc>(),
         act: (bloc) async {
           bloc.add(const GlobalSearchQueryUpdated(query: 'stale-query'));
+          // Await the debounced GlobalSearchReady emission before re-opening
+          // the screen, so the state sequence is deterministic.
           await bloc.stream.first;
           bloc.add(const GlobalSearchStarted());
         },
+        wait: const Duration(milliseconds: 310),
         expect: () => [
-          const GlobalSearchInitial(recentSearches: [], query: 'stale-query'),
-          isA<GlobalSearchInitial>().having(
+          const GlobalSearchReady(recentSearches: [], query: 'stale-query'),
+          isA<GlobalSearchReady>().having(
             (s) => s.query,
             'query is reset to empty on fresh start',
             isEmpty,
@@ -440,10 +429,11 @@ void main() {
           await bloc.stream.firstWhere((s) => s is GlobalSearchLoadSuccess);
           bloc.add(const GlobalSearchQueryUpdated(query: ''));
         },
+        wait: const Duration(milliseconds: 310),
         expect: () => [
           const GlobalSearchLoadInProgress(query: 'steel'),
           isA<GlobalSearchLoadSuccess>(),
-          isA<GlobalSearchInitial>().having(
+          isA<GlobalSearchReady>().having(
             (s) => s.recentSearches,
             'searched term is present without reopening the screen',
             contains('steel'),
@@ -477,13 +467,14 @@ void main() {
         build: () => Modular.get<GlobalSearchBloc>(),
         act: (bloc) async {
           bloc.add(const GlobalSearchStarted());
-          await bloc.stream.firstWhere((s) => s is GlobalSearchInitial);
+          await bloc.stream.firstWhere((s) => s is GlobalSearchReady);
           bloc.add(const GlobalSearchPerformed(query: 'steel'));
           await bloc.stream.firstWhere((s) => s is GlobalSearchLoadSuccess);
           bloc.add(const GlobalSearchQueryUpdated(query: ''));
         },
+        wait: const Duration(milliseconds: 310),
         verify: (bloc) {
-          final state = bloc.state as GlobalSearchInitial;
+          final state = bloc.state as GlobalSearchReady;
           expect(
             state.recentSearches.where((t) => t == 'steel'),
             hasLength(1),
@@ -495,21 +486,23 @@ void main() {
 
     group('GlobalSearchQueryUpdated', () {
       blocTest<GlobalSearchBloc, GlobalSearchState>(
-        'emits GlobalSearchInitial with updated query and empty recentSearches',
+        'emits GlobalSearchReady with updated query and empty recentSearches',
         build: () => Modular.get<GlobalSearchBloc>(),
         act: (bloc) =>
             bloc.add(const GlobalSearchQueryUpdated(query: 'foundation')),
+        wait: const Duration(milliseconds: 310),
         expect: () => [
-          const GlobalSearchInitial(recentSearches: [], query: 'foundation'),
+          const GlobalSearchReady(recentSearches: [], query: 'foundation'),
         ],
       );
 
       blocTest<GlobalSearchBloc, GlobalSearchState>(
-        'emits GlobalSearchInitial with empty query when query is cleared',
+        'emits GlobalSearchReady with empty query when query is cleared',
         build: () => Modular.get<GlobalSearchBloc>(),
         act: (bloc) => bloc.add(const GlobalSearchQueryUpdated(query: '')),
+        wait: const Duration(milliseconds: 310),
         expect: () => [
-          const GlobalSearchInitial(recentSearches: [], query: ''),
+          const GlobalSearchReady(),
         ],
       );
 
@@ -518,6 +511,7 @@ void main() {
         build: () => Modular.get<GlobalSearchBloc>(),
         act: (bloc) =>
             bloc.add(const GlobalSearchQueryUpdated(query: 'concrete')),
+        wait: const Duration(milliseconds: 310),
         verify: (_) {
           expect(fakeSupabase.getMethodCallsFor('rpc'), isEmpty);
           expect(fakeSupabase.getMethodCallsFor('selectMatch'), isEmpty);
@@ -542,20 +536,21 @@ void main() {
         act: (bloc) async {
           bloc.add(const GlobalSearchStarted());
           await bloc.stream.firstWhere((s) {
-            if (s is! GlobalSearchInitial) {
+            if (s is! GlobalSearchReady) {
               return false;
             }
             return s.recentSearches.contains('steel');
           });
           bloc.add(const GlobalSearchQueryUpdated(query: 'concrete'));
         },
+        wait: const Duration(milliseconds: 310),
         expect: () => [
-          isA<GlobalSearchInitial>().having(
+          isA<GlobalSearchReady>().having(
             (s) => s.recentSearches,
             'recentSearches after Started',
             contains('steel'),
           ),
-          isA<GlobalSearchInitial>()
+          isA<GlobalSearchReady>()
               .having((s) => s.query, 'query after QueryUpdated', 'concrete')
               .having(
                 (s) => s.recentSearches,
@@ -568,7 +563,7 @@ void main() {
 
     group('GlobalSearchSuggestionsRequested', () {
       blocTest<GlobalSearchBloc, GlobalSearchState>(
-        'emits [GlobalSearchInitial suggestionsLoading, GlobalSearchInitial with suggestions] when RPC succeeds',
+        'emits [GlobalSearchReady loading, GlobalSearchReady with suggestions] when RPC succeeds',
         setUp: () {
           fakeSupabase.setCurrentUser(
             FakeUser(
@@ -585,12 +580,12 @@ void main() {
         build: () => Modular.get<GlobalSearchBloc>(),
         act: (bloc) => bloc.add(const GlobalSearchSuggestionsRequested()),
         expect: () => [
-          isA<GlobalSearchInitial>().having(
+          isA<GlobalSearchReady>().having(
             (s) => s.suggestionsLoading,
             'suggestionsLoading',
             isTrue,
           ),
-          isA<GlobalSearchInitial>()
+          isA<GlobalSearchReady>()
               .having(
                 (s) => s.suggestions,
                 'suggestions',
@@ -620,7 +615,7 @@ void main() {
         build: () => Modular.get<GlobalSearchBloc>(),
         act: (bloc) => bloc.add(const GlobalSearchSuggestionsRequested()),
         expect: () => [
-          isA<GlobalSearchInitial>().having(
+          isA<GlobalSearchReady>().having(
             (s) => s.suggestionsLoading,
             'suggestionsLoading',
             isTrue,
@@ -636,7 +631,7 @@ void main() {
 
     group('GlobalSearchRecentRemoved', () {
       blocTest<GlobalSearchBloc, GlobalSearchState>(
-        'emits GlobalSearchInitial without removed term when delete succeeds',
+        'emits GlobalSearchReady without removed term when delete succeeds',
         setUp: () {
           fakeSupabase.setCurrentUser(
             FakeUser(
@@ -654,7 +649,7 @@ void main() {
         act: (bloc) async {
           bloc.add(const GlobalSearchStarted());
           await bloc.stream.firstWhere((s) {
-            if (s is! GlobalSearchInitial) {
+            if (s is! GlobalSearchReady) {
               return false;
             }
             return s.recentSearches.length == 2;
@@ -667,12 +662,12 @@ void main() {
           );
         },
         expect: () => [
-          isA<GlobalSearchInitial>().having(
+          isA<GlobalSearchReady>().having(
             (s) => s.recentSearches,
             'recentSearches after Started',
             containsAll(['wall', 'concrete']),
           ),
-          isA<GlobalSearchInitial>().having(
+          isA<GlobalSearchReady>().having(
             (s) => s.recentSearches,
             'recentSearches after Removed',
             allOf(isNot(contains('wall')), contains('concrete')),


### PR DESCRIPTION
## Summary

This pull request adds a presentation-layer `GlobalSearchBloc` for the global search feature, including sealed `GlobalSearchEvent` and `GlobalSearchState` types, wiring through `GlobalSearchModule` (factory registration with `GlobalSearchRepository`), and a substantial `global_search_bloc_test.dart` suite that exercises the bloc against a real modular stack with `FakeSupabaseWrapper` and related test doubles. The bloc orchestrates recent-search loading, query updates, search execution (success, empty, and failure paths), non-blocking persistence of recents after search, suggestion loading, and removal of recent terms, delegating domain and data concerns to `GlobalSearchRepository` and emitting states aligned with load phases (`Initial`, `InProgress`, `Success`, `Empty`, and targeted failure variants).

---

## Changes Overview

### Impact stats

| Category | Value |
|----------|-------|
| **PR size classification (production code only)** | **L** (200+ lines) — approx. **355** production lines across module + bloc + event + state files |
| **Production files touched** | 4 (`global_search_module.dart` modified; `global_search_bloc.dart`, `global_search_event.dart`, `global_search_state.dart` added) |
| **Test files added** | 1 (`global_search_bloc_test.dart`, ~716 lines) |
| **Approx. total diff size (prod + tests)** | ~1,070 lines |
| **Primary layers** | Presentation (BLoC), dependency injection (module) |

*Production line estimate: ~4 (module) + ~173 (bloc) + ~73 (events) + ~105 (states).*

---

## Rule-Based Review

| Rule | Status | Notes |
|------|--------|-------|
| **Rule 1 — Digestible PR** | **Attention** | Production-only size falls in the **L** band (200+ lines). Per project guidance, consider whether this should remain a single focused change or be split (e.g., bloc + states/events vs. tests in a follow-up) if the team enforces sub-**M** PRs for reviewability. Scope is still one feature (global search presentation). |
| **Rule 2 — Class naming convention** | **Pass** | `GlobalSearchBloc`, `GlobalSearchEvent`, `GlobalSearchState`, and concrete types follow the `NounBloc` / `NounEvent` / `NounState` pattern; dependencies use `GlobalSearchRepository`. No forbidden `Helper`/`Util` suffixes introduced. |
| **Rule 3 — Test double pattern** | **Pass** | Tests resolve a real `GlobalSearchBloc` via `Modular.get` with `GlobalSearchModule` and fake **external** infrastructure (`FakeSupabaseWrapper`, fakes for config/env/clock), exercising integration through real repository wiring rather than mocking the bloc or repository. |
| **Rule 5 — UI & business logic separation** | **Pass (layer)** | This PR contains no widget/UI code. The bloc exposes events and states only; business rules and I/O stay behind `GlobalSearchRepository`. **Follow-up:** when UI lands, it should dispatch events and render states only (no duplicated domain checks in widgets). |
| **Rule 6 — Stream-based performance & lifecycle** | **Pass** | No `StreamController` usage or manual subscriptions shown in the bloc; asynchronous work uses `async`/`await` and bloc handlers. Fire-and-forget `saveRecentSearch` uses `.then` with logging on failure—acceptable if product expectation is non-blocking persistence; confirm no requirement to surface save failures to the user. |

---

## REVIEW SUMMARY

| Issue Name | Description | Status | Notes |
|------------|-------------|--------|-------|
| Large PR size (Rule 1) | Production changes exceed the **M** threshold (~355 lines). | Not Fixed | The files are interdependent. |
