### PR TITLE
CA-544: feat: integrate Sentry for user tracking in AuthManager and A…

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -50,6 +50,7 @@ custom_lint:
         - 'Breadcrumb'
         - 'LogEvent'
         - 'AppLogFilter'
+        - 'SentryUser'
 
 linter:
   # The lint rules applied to this project can be customized in the

--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -2,9 +2,21 @@ import 'package:construculator/l10n/generated/app_localizations.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_modular/flutter_modular.dart';
 import 'package:ripplearc_coreui/ripplearc_coreui.dart';
+import 'package:sentry_flutter/sentry_flutter.dart';
 
-class AppWidget extends StatelessWidget {
+class AppWidget extends StatefulWidget {
   const AppWidget({super.key});
+
+  @override
+  State<AppWidget> createState() => _AppWidgetState();
+}
+
+class _AppWidgetState extends State<AppWidget> {
+  @override
+  void initState() {
+    super.initState();
+    Modular.routerDelegate.setObservers([SentryNavigatorObserver()]);
+  }
 
   @override
   Widget build(BuildContext context) {

--- a/lib/app/app_bootstrap.dart
+++ b/lib/app/app_bootstrap.dart
@@ -1,5 +1,6 @@
 import 'package:construculator/libraries/config/interfaces/config.dart';
 import 'package:construculator/libraries/config/interfaces/env_loader.dart';
+import 'package:construculator/libraries/sentry/interfaces/sentry_wrapper.dart';
 import 'package:construculator/libraries/supabase/interfaces/supabase_wrapper.dart';
 
 /// The application requires that certain services—such as the Supabase client—are fully
@@ -35,6 +36,7 @@ import 'package:construculator/libraries/supabase/interfaces/supabase_wrapper.da
 /// - [Config] — Manages environment selection and config loading
 /// - [EnvLoader] — Loads `.env` or secret configuration
 /// - [SupabaseWrapper] — Initializes and exposes the Supabase client
+/// - [SentryWrapper] — Initializes error tracking and user context
 ///
 /// These are grouped into [AppBootstrap] and passed to the [AppModule].
 ///
@@ -51,15 +53,21 @@ import 'package:construculator/libraries/supabase/interfaces/supabase_wrapper.da
 /// final supabaseWrapper = SupabaseWrapperImpl(envLoader: envLoader);
 /// await supabaseWrapper.initialize();
 ///
+/// final sentryWrapper = SentryWrapperImpl(envLoader: envLoader, config: config);
+///
 /// final bootstrap = AppBootstrap(
 ///   config: config,
 ///   envLoader: envLoader,
 ///   supabaseWrapper: supabaseWrapper,
+///   sentryWrapper: sentryWrapper,
 /// );
 ///
-/// runApp(ModularApp(
-///   module: AppModule(bootstrap),
-///   child: const AppWidget(),
+/// // Initialize Sentry SDK and wrap app execution for error tracking
+/// await sentryWrapper.initialize(() => runApp(
+///   ModularApp(
+///     module: AppModule(bootstrap),
+///     child: const AppWidget(),
+///   ),
 /// ));
 /// ```
 ///
@@ -73,12 +81,19 @@ class AppBootstrap {
   /// The app config, required by supabase wrapper for initialization.
   final Config config;
 
-  /// The supabase wrapper, has to be instantiated before passing to the app module.
+  /// The Supabase wrapper, must be fully initialized before passing to the app module.
+  /// Used for authentication, database operations, and real-time subscriptions.
   final SupabaseWrapper supabaseWrapper;
+
+  /// The Sentry wrapper, must be created before app initialization.
+  /// Wraps app execution to capture errors, tracks user context, and logs breadcrumbs.
+  /// Its [initialize] method must be called with the app runner to enable error tracking.
+  final SentryWrapper sentryWrapper;
 
   AppBootstrap({
     required this.envLoader,
     required this.config,
     required this.supabaseWrapper,
+    required this.sentryWrapper,
   });
 }

--- a/lib/features/auth/testing/auth_test_module.dart
+++ b/lib/features/auth/testing/auth_test_module.dart
@@ -24,6 +24,7 @@ import 'package:construculator/libraries/auth/testing/fake_auth_repository.dart'
 import 'package:construculator/libraries/config/testing/fake_app_config.dart';
 import 'package:construculator/libraries/config/testing/fake_env_loader.dart';
 import 'package:construculator/libraries/router/testing/router_test_module.dart';
+import 'package:construculator/libraries/sentry/fake_sentry_wrapper.dart';
 import 'package:construculator/libraries/supabase/testing/fake_supabase_wrapper.dart';
 import 'package:construculator/libraries/time/interfaces/clock.dart';
 import 'package:construculator/libraries/time/testing/clock_test_module.dart';
@@ -39,6 +40,7 @@ class AuthTestModule extends Module {
         envLoader: FakeEnvLoader(),
         config: FakeAppConfig(),
         supabaseWrapper: FakeSupabaseWrapper(clock: FakeClockImpl()),
+        sentryWrapper: FakeSentryWrapper(),
       ),
     ),
     RouterTestModule(),

--- a/lib/libraries/auth/auth_library_module.dart
+++ b/lib/libraries/auth/auth_library_module.dart
@@ -27,8 +27,12 @@ class AuthLibraryModule extends Module {
   void exportedBinds(Injector i) {
     i.addLazySingleton<AuthNotifier>(() => authNotifierImpl);
     i.addLazySingleton<AuthManager>(
-      () =>
-          AuthManagerImpl(wrapper: i(), authRepository: i(), authNotifier: i()),
+      () => AuthManagerImpl(
+        wrapper: i(),
+        authRepository: i(),
+        authNotifier: i(),
+        sentryWrapper: appBootstrap.sentryWrapper,
+      ),
     );
   }
 }

--- a/lib/libraries/auth/auth_manager_impl.dart
+++ b/lib/libraries/auth/auth_manager_impl.dart
@@ -9,6 +9,7 @@ import 'package:construculator/libraries/auth/interfaces/auth_manager.dart';
 import 'package:construculator/libraries/auth/interfaces/auth_notifier_controller.dart';
 import 'package:construculator/libraries/auth/interfaces/auth_repository.dart';
 import 'package:construculator/libraries/logging/app_logger.dart';
+import 'package:construculator/libraries/sentry/interfaces/sentry_wrapper.dart';
 import 'package:construculator/libraries/supabase/data/supabase_types.dart';
 import 'package:construculator/libraries/supabase/interfaces/supabase_wrapper.dart';
 import 'package:supabase_flutter/supabase_flutter.dart' as supabase;
@@ -17,15 +18,18 @@ class AuthManagerImpl implements AuthManager {
   final SupabaseWrapper _wrapper;
   final AuthNotifierController _authNotifier;
   final AuthRepository _authRepository;
+  final SentryWrapper _sentryWrapper;
   final _logger = AppLogger().tag('AuthManagerImpl');
 
   AuthManagerImpl({
     required SupabaseWrapper wrapper,
     required AuthRepository authRepository,
     required AuthNotifierController authNotifier,
+    required SentryWrapper sentryWrapper,
   }) : _wrapper = wrapper,
        _authRepository = authRepository,
-       _authNotifier = authNotifier {
+       _authNotifier = authNotifier,
+       _sentryWrapper = sentryWrapper {
     _initAuthListener();
   }
 
@@ -51,7 +55,7 @@ class AuthManagerImpl implements AuthManager {
         }
       },
       onError: (error) {
-        _logger.error('Error in auth state stream', error);
+        _logger.warning('Error in auth state stream', error);
         if (error is supabase.AuthSessionMissingException) {
           _logger.warning('Auth-specific error, emitting unauthenticated');
           _emitAuthStateChanged(AuthStatus.unauthenticated, null);
@@ -88,21 +92,48 @@ class AuthManagerImpl implements AuthManager {
   }
 
   AuthResult<T> _handleException<T>(dynamic error, String operation) {
-    _logger.error('$operation failed with error', error);
-
     if (error is supabase.AuthException) {
       final code = SupabaseAuthErrorCode.fromCode(error.code ?? 'unknown');
-      return AuthResult.failure(code.toAuthErrorType());
+      final errorType = code.toAuthErrorType();
+
+      if (_isExpectedAuthError(errorType)) {
+        _logger.warning('$operation failed with expected error', error);
+      } else {
+        _logger.error('$operation failed with error', error);
+      }
+
+      return AuthResult.failure(errorType);
     }
 
     if (error is TimeoutException) {
+      _logger.error('$operation failed with timeout', error);
       return AuthResult.failure(AuthErrorType.timeout);
     }
+
     if (error is supabase.PostgrestException) {
       final code = PostgresErrorCode.fromCode(error.code ?? 'unknown');
-      return AuthResult.failure(code.toAuthErrorType());
+      final errorType = code.toAuthErrorType();
+
+      if (errorType == AuthErrorType.uniqueViolation) {
+        _logger.warning('$operation failed with expected error', error);
+      } else {
+        _logger.error('$operation failed with error', error);
+      }
+
+      return AuthResult.failure(errorType);
     }
+
+    _logger.error('$operation failed with error', error);
     return AuthResult.failure(AuthErrorType.serverError);
+  }
+
+  bool _isExpectedAuthError(AuthErrorType type) {
+    return type == AuthErrorType.invalidCredentials ||
+        type == AuthErrorType.registrationFailure ||
+        type == AuthErrorType.uniqueViolation ||
+        type == AuthErrorType.invalidEmail ||
+        type == AuthErrorType.invalidPhone ||
+        type == AuthErrorType.invalidOtp;
   }
 
   @override
@@ -112,13 +143,11 @@ class AuthManagerImpl implements AuthManager {
   ) async {
     _logger.info('Attempting login for user: $email');
 
-    // Validate email
     final emailError = AuthValidation.validateEmail(email);
     if (emailError != null) {
       return AuthResult.failure(emailError);
     }
 
-    // Validate password
     final passwordError = AuthValidation.validatePassword(password);
     if (passwordError != null) {
       return AuthResult.failure(passwordError);
@@ -135,6 +164,8 @@ class AuthManagerImpl implements AuthManager {
         return AuthResult.failure(AuthErrorType.invalidCredentials);
       }
 
+      await _sentryWrapper.setUser(user.id);
+
       _logger.info('Login successful for user: $email');
       return AuthResult.success(_mapSupabaseUserToCredential(user));
     } catch (e) {
@@ -149,13 +180,11 @@ class AuthManagerImpl implements AuthManager {
   ) async {
     _logger.info('Attempting registration for user: $email');
 
-    // Validate email
     final emailError = AuthValidation.validateEmail(email);
     if (emailError != null) {
       return AuthResult.failure(emailError);
     }
 
-    // Validate password
     final passwordError = AuthValidation.validatePassword(password);
     if (passwordError != null) {
       return AuthResult.failure(passwordError);
@@ -170,6 +199,8 @@ class AuthManagerImpl implements AuthManager {
         );
         return AuthResult.failure(AuthErrorType.registrationFailure);
       }
+
+      await _sentryWrapper.setUser(user.id);
 
       _logger.info('Registration successful for user: $email');
       return AuthResult.success(_mapSupabaseUserToCredential(user));
@@ -219,7 +250,6 @@ class AuthManagerImpl implements AuthManager {
       return AuthResult.failure(addressError);
     }
 
-    // Validate OTP
     final otpError = AuthValidation.validateOtp(otp);
     if (otpError != null) {
       return AuthResult.failure(otpError);
@@ -242,6 +272,8 @@ class AuthManagerImpl implements AuthManager {
         return AuthResult.failure(AuthErrorType.invalidCredentials);
       }
 
+      await _sentryWrapper.setUser(user.id);
+
       _logger.info('OTP verification successful for: $address');
       return AuthResult.success(_mapSupabaseUserToCredential(user));
     } catch (e) {
@@ -253,7 +285,6 @@ class AuthManagerImpl implements AuthManager {
   Future<AuthResult<bool>> resetPassword(String email) async {
     _logger.info('Initiating password reset for: $email');
 
-    // Validate email
     final emailError = AuthValidation.validateEmail(email);
     if (emailError != null) {
       return AuthResult.failure(emailError);
@@ -296,6 +327,9 @@ class AuthManagerImpl implements AuthManager {
     _logger.info('Logging out user');
     try {
       await _wrapper.signOut();
+
+      await _sentryWrapper.setUser(null);
+
       _logger.info('Logout successful');
       return AuthResult.success(null);
     } catch (e) {

--- a/lib/libraries/auth/testing/auth_test_module.dart
+++ b/lib/libraries/auth/testing/auth_test_module.dart
@@ -7,6 +7,7 @@ import 'package:construculator/libraries/auth/interfaces/auth_repository.dart';
 import 'package:construculator/libraries/auth/repositories/supabase_repository_impl.dart';
 import 'package:construculator/libraries/auth/testing/fake_auth_notifier.dart';
 import 'package:construculator/libraries/auth/testing/fake_auth_repository.dart';
+import 'package:construculator/libraries/sentry/fake_sentry_wrapper.dart';
 import 'package:construculator/libraries/supabase/testing/supabase_test_module.dart';
 import 'package:construculator/libraries/time/testing/clock_test_module.dart';
 import 'package:flutter_modular/flutter_modular.dart';
@@ -27,8 +28,12 @@ class AuthTestModule extends Module {
     i.add<AuthNotifier>(() => FakeAuthNotifier(), key: 'fakeAuthNotifier');
     i.add<AuthNotifier>(() => AuthNotifierImpl(), key: 'authNotifier');
     i.add<AuthManager>(
-      () =>
-          AuthManagerImpl(wrapper: i(), authRepository: i(), authNotifier: i()),
+      () => AuthManagerImpl(
+        wrapper: i(),
+        authRepository: i(),
+        authNotifier: i(),
+        sentryWrapper: FakeSentryWrapper(),
+      ),
       key: 'authManagerWithFakeDep',
     );
   }

--- a/lib/libraries/sentry/fake_sentry_wrapper.dart
+++ b/lib/libraries/sentry/fake_sentry_wrapper.dart
@@ -15,6 +15,9 @@ class FakeSentryWrapper implements SentryWrapper {
   /// Recorded calls to [captureMessage].
   final List<MessageCall> messages = [];
 
+  /// Current user ID set via [setUser].
+  String? userId;
+
   /// Executes [appRunner] immediately for tests.
   @override
   Future<void> initialize(void Function() appRunner) async {
@@ -67,11 +70,18 @@ class FakeSentryWrapper implements SentryWrapper {
     messages.add(MessageCall(message: message, level: level, tags: tags));
   }
 
+  /// Sets the user context for Sentry events.
+  @override
+  Future<void> setUser(String? userId) async {
+    this.userId = userId;
+  }
+
   /// Clears all recorded calls.
   void reset() {
     breadcrumbs.clear();
     exceptions.clear();
     messages.clear();
+    userId = null;
   }
 }
 

--- a/lib/libraries/sentry/interfaces/sentry_wrapper.dart
+++ b/lib/libraries/sentry/interfaces/sentry_wrapper.dart
@@ -67,4 +67,9 @@ abstract class SentryWrapper {
     required SentryEventLevel level,
     Map<String, String>? tags,
   });
+
+  /// Configure the Sentry user context
+  ///
+  /// [userId] The user ID to associate with events. If null, clears the user context.
+  Future<void> setUser(String? userId);
 }

--- a/lib/libraries/sentry/sentry_wrapper_impl.dart
+++ b/lib/libraries/sentry/sentry_wrapper_impl.dart
@@ -105,6 +105,24 @@ class SentryWrapperImpl implements SentryWrapper {
     );
   }
 
+  /// Sets the Sentry user context for all subsequent events.
+  ///
+  /// Configures the active Sentry scope with [userId]. Passing `null`
+  /// clears the user context on logout. No-ops if [_isInitialized] is
+  /// false (e.g. DSN not configured in environment).
+  @override
+  Future<void> setUser(String? userId) async {
+    if (!_isInitialized) return;
+
+    await Sentry.configureScope((scope) {
+      if (userId != null) {
+        scope.setUser(SentryUser(id: userId));
+      } else {
+        scope.setUser(null);
+      }
+    });
+  }
+
   SentryLevel _getSentryLevel(SentryEventLevel level) {
     return switch (level) {
       SentryEventLevel.debug => SentryLevel.debug,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -15,15 +15,10 @@ Future<void> main() async {
 
   final appBootstrap = await _initializeApp();
 
-  final sentryWrapper = SentryWrapperImpl(
-    envLoader: appBootstrap.envLoader,
-    config: appBootstrap.config,
-  );
-
-  AppLogger.setSentryWrapper(sentryWrapper);
+  AppLogger.setSentryWrapper(appBootstrap.sentryWrapper);
   AppLogger.setConfig(appBootstrap.config);
 
-  await sentryWrapper.initialize(
+  await appBootstrap.sentryWrapper.initialize(
     () => runApp(
       ModularApp(module: AppModule(appBootstrap), child: const AppWidget()),
     ),
@@ -42,10 +37,12 @@ Future<AppBootstrap> _initializeApp() async {
   await config.initialize(env);
   final wrapper = SupabaseWrapperImpl(envLoader: envLoader);
   await wrapper.initialize();
+  final sentryWrapper = SentryWrapperImpl(envLoader: envLoader, config: config);
   return AppBootstrap(
     config: config,
     envLoader: envLoader,
     supabaseWrapper: wrapper,
+    sentryWrapper: sentryWrapper,
   );
 }
 

--- a/test/features/auth/units/blocs/enter_password_bloc_test.dart
+++ b/test/features/auth/units/blocs/enter_password_bloc_test.dart
@@ -30,6 +30,7 @@ void main() {
 
   tearDown(() {
     fakeSupabase.reset();
+    bloc.close();
     Modular.destroy();
   });
 
@@ -85,12 +86,15 @@ void main() {
           fakeSupabase.shouldThrowOnSignIn = false;
           return bloc;
         },
-        act: (bloc) {
+        act: (bloc) async {
           bloc.add(
             EnterPasswordSubmitted(
               email: 'test@example.com',
               password: '@Password123!',
             ),
+          );
+          await bloc.stream.firstWhere(
+            (state) => state is EnterPasswordSubmitSuccess,
           );
           bloc.add(
             EnterPasswordSubmitted(

--- a/test/libraries/auth/units/auth_manager_test.dart
+++ b/test/libraries/auth/units/auth_manager_test.dart
@@ -8,6 +8,8 @@ import 'package:construculator/libraries/auth/interfaces/auth_notifier_controlle
 import 'package:construculator/libraries/auth/interfaces/auth_repository.dart';
 import 'package:construculator/libraries/auth/testing/fake_auth_notifier.dart';
 import 'package:construculator/libraries/auth/testing/fake_auth_repository.dart';
+import 'package:construculator/libraries/sentry/fake_sentry_wrapper.dart';
+import 'package:construculator/libraries/sentry/interfaces/sentry_wrapper.dart';
 import 'package:construculator/libraries/supabase/data/supabase_types.dart';
 import 'package:construculator/libraries/supabase/interfaces/supabase_wrapper.dart';
 import 'package:construculator/libraries/supabase/testing/fake_supabase_user.dart';
@@ -22,6 +24,7 @@ void main() {
   late FakeAuthNotifier authNotifier;
   late FakeAuthRepository authRepository;
   late FakeSupabaseWrapper supabaseWrapper;
+  late FakeSentryWrapper sentryWrapper;
   late AuthManager authManager;
   late Clock clock;
   const testEmail = 'test@example.com';
@@ -47,11 +50,13 @@ void main() {
     authNotifier = Modular.get<AuthNotifierController>() as FakeAuthNotifier;
     authRepository = Modular.get<AuthRepository>() as FakeAuthRepository;
     supabaseWrapper = Modular.get<SupabaseWrapper>() as FakeSupabaseWrapper;
+    sentryWrapper = Modular.get<SentryWrapper>() as FakeSentryWrapper;
     authManager = Modular.get<AuthManager>();
     clock = Modular.get<Clock>();
   });
 
   tearDown(() {
+    sentryWrapper.reset();
     Modular.destroy();
   });
 
@@ -932,6 +937,117 @@ void main() {
         expect(result.errorType, AuthErrorType.serverError);
       });
     });
+
+    group('Sentry Integration', () {
+      test(
+        'loginWithEmail should call setUser with user ID on success',
+        () async {
+          final result = await authManager.loginWithEmail(
+            testEmail,
+            testPassword,
+          );
+
+          expect(result.isSuccess, true);
+          expect(sentryWrapper.userId, result.data!.id);
+        },
+      );
+
+      test('loginWithEmail should not call setUser on failure', () async {
+        supabaseWrapper.shouldThrowOnSignIn = true;
+        supabaseWrapper.signInErrorMessage = 'Invalid credentials';
+        supabaseWrapper.authErrorCode =
+            SupabaseAuthErrorCode.invalidCredentials;
+
+        final result = await authManager.loginWithEmail(
+          testEmail,
+          testPassword,
+        );
+
+        expect(result.isSuccess, false);
+        expect(sentryWrapper.userId, isNull);
+      });
+
+      test(
+        'registerWithEmail should call setUser with user ID on success',
+        () async {
+          final result = await authManager.registerWithEmail(
+            testEmail,
+            testPassword,
+          );
+
+          expect(result.isSuccess, true);
+          expect(sentryWrapper.userId, isNotNull);
+          expect(sentryWrapper.userId, result.data!.id);
+        },
+      );
+
+      test('registerWithEmail should not call setUser on failure', () async {
+        supabaseWrapper.shouldThrowOnSignUp = true;
+        supabaseWrapper.signUpErrorMessage = 'Registration failed';
+        supabaseWrapper.authErrorCode =
+            SupabaseAuthErrorCode.registrationFailure;
+
+        final result = await authManager.registerWithEmail(
+          testEmail,
+          testPassword,
+        );
+
+        expect(result.isSuccess, false);
+        expect(sentryWrapper.userId, isNull);
+      });
+
+      test('verifyOtp should call setUser with user ID on success', () async {
+        final result = await authManager.verifyOtp(
+          testEmail,
+          '123456',
+          OtpReceiver.email,
+        );
+
+        expect(result.isSuccess, true);
+        expect(sentryWrapper.userId, isNotNull);
+        expect(sentryWrapper.userId, result.data!.id);
+      });
+
+      test('verifyOtp should not call setUser on failure', () async {
+        supabaseWrapper.shouldThrowOnVerifyOtp = true;
+        supabaseWrapper.verifyOtpErrorMessage = 'Invalid OTP';
+        supabaseWrapper.authErrorCode =
+            SupabaseAuthErrorCode.invalidCredentials;
+
+        final result = await authManager.verifyOtp(
+          testEmail,
+          '123456',
+          OtpReceiver.email,
+        );
+
+        expect(result.isSuccess, false);
+        expect(sentryWrapper.userId, isNull);
+      });
+
+      test('logout should call setUser with null', () async {
+        await authManager.loginWithEmail(testEmail, testPassword);
+        expect(sentryWrapper.userId, isNotNull);
+
+        final result = await authManager.logout();
+
+        expect(result.isSuccess, true);
+        expect(sentryWrapper.userId, isNull);
+      });
+
+      test('logout should not call setUser(null) on failure', () async {
+        await authManager.loginWithEmail(testEmail, testPassword);
+        final userId = sentryWrapper.userId;
+        expect(userId, isNotNull);
+
+        supabaseWrapper.shouldThrowOnSignOut = true;
+        supabaseWrapper.signOutErrorMessage = 'Logout failed';
+
+        final result = await authManager.logout();
+
+        expect(result.isSuccess, false);
+        expect(sentryWrapper.userId, userId);
+      });
+    });
   });
 }
 
@@ -943,9 +1059,14 @@ class _TestAppModule extends Module {
     i.addSingleton<AuthNotifierController>(() => FakeAuthNotifier());
     i.addSingleton<AuthRepository>(() => FakeAuthRepository(clock: i()));
     i.addSingleton<SupabaseWrapper>(() => FakeSupabaseWrapper(clock: i()));
+    i.addSingleton<SentryWrapper>(() => FakeSentryWrapper());
     i.add<AuthManager>(
-      () =>
-          AuthManagerImpl(wrapper: i(), authRepository: i(), authNotifier: i()),
+      () => AuthManagerImpl(
+        wrapper: i(),
+        authRepository: i(),
+        authNotifier: i(),
+        sentryWrapper: i<SentryWrapper>(),
+      ),
     );
   }
 }

--- a/test/utils/fake_app_bootstrap_factory.dart
+++ b/test/utils/fake_app_bootstrap_factory.dart
@@ -3,6 +3,7 @@ import 'package:construculator/libraries/config/interfaces/config.dart';
 import 'package:construculator/libraries/config/interfaces/env_loader.dart';
 import 'package:construculator/libraries/config/testing/fake_app_config.dart';
 import 'package:construculator/libraries/config/testing/fake_env_loader.dart';
+import 'package:construculator/libraries/sentry/fake_sentry_wrapper.dart';
 import 'package:construculator/libraries/supabase/testing/fake_supabase_wrapper.dart';
 import 'package:construculator/libraries/time/testing/fake_clock_impl.dart';
 
@@ -42,6 +43,7 @@ class FakeAppBootstrapFactory {
           supabaseWrapper ?? FakeSupabaseWrapper(clock: FakeClockImpl()),
       config: config ?? FakeAppConfig(),
       envLoader: envLoader ?? FakeEnvLoader(),
+      sentryWrapper: FakeSentryWrapper(),
     );
   }
 }


### PR DESCRIPTION
# PR Review: feat/add-additionla-sentry-features → feat/integrate-sentry2

**PR Branch:** feat/add-additionla-sentry-features (with changes)
**Base Branch:** feat/integrate-sentry2 (target)
**Date:** Fri Apr 3 16:17:43 EAT 2026
**Reviewer:** Claude Code

---

## 1. PR SUMMARY

This PR integrates Sentry user tracking and navigation observability into the authentication flow and app-wide navigation. The main changes include:

1. **User Context Tracking**: Adds `setUser()` method to `SentryWrapper` interface to associate user IDs with Sentry events
2. **Authentication Integration**: Updates `AuthManagerImpl` to call `setUser()` on login/registration/OTP verification success and clear user context on logout
3. **Navigation Tracking**: Adds `SentryNavigatorObserver` to track screen navigation events
4. **Testing**: Comprehensive unit tests for Sentry integration in auth flows using the Test Double pattern with `FakeSentryWrapper`

**Production Code Size**: ~30 lines (Small PR - meets digestibility requirements)

---

## 2. REVIEW SUMMARY

## REVIEW SUMMARY

| Issue Name | Description | Status | Notes |
|------------|-------------|--------|-------|
| Potential Error Logging Issue in AuthManager | Using `error()` for expected Supabase auth errors (invalid credentials) may send unnecessary events to Sentry, consuming quota | ✅ | Out of scope but I have addressed it. |
| Duplicate Logging Risk | `_handleException()` in AuthManagerImpl logs errors, and callers may also log, potentially creating duplicate Sentry events | ✅ | Still out of scope, I have tried to address it. |
