### PR TITLE
CA-546: feat: add environment-specific configuration and generate_env…

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -92,7 +92,7 @@ workflows:
           else
               LH_SUM=$(echo "$LH_RAW" | awk '{sum+=$1} END {print sum}')
           fi
-          
+
           if ! [[ "$LF_SUM" =~ ^[0-9]+$ ]]; then
               echo "❌ LF_SUM ($LF_SUM) is not a valid number. Cannot calculate coverage."
               exit 1
@@ -123,7 +123,7 @@ workflows:
           export PATH="$PATH":"$HOME/.pub-cache/bin":"$FCI_BUILD_DIR/.fvm/flutter_sdk/bin"
           # Find the common ancestor commit between source and target branches
           BASE_COMMIT=$(git merge-base HEAD origin/$CM_PULL_REQUEST_DEST)
-          
+
           # Find changed test files
           CHANGED_UNIT_TESTS=$(git diff --name-only --diff-filter=d $BASE_COMMIT HEAD -- "test/features/**/units/*.dart" "test/libraries/**/units/*.dart")
           CHANGED_WIDGET_TESTS=$(git diff --name-only --diff-filter=d $BASE_COMMIT HEAD -- "test/features/**/widgets/*.dart")
@@ -146,7 +146,7 @@ workflows:
           success: true
           failure: true
       slack:
-        channel: '#build-notifications'
+        channel: "#build-notifications"
         notify_on_build_start: true
         notify:
           success: true
@@ -241,9 +241,9 @@ workflows:
           else
             COVERAGE_PERCENT=$(echo "scale=2; $LH_SUM*100/$LF_SUM" | bc)
           fi
-          
+
           echo "Code Coverage: ${COVERAGE_PERCENT}%"
-          
+
           if (( $(echo "$COVERAGE_PERCENT < $TARGET" | bc -l) )); then
             echo "❌ Coverage is $COVERAGE_PERCENT%, below $TARGET%"
             exit 1
@@ -320,7 +320,7 @@ workflows:
           success: true
           failure: true
       slack:
-        channel: '#build-notifications'
+        channel: "#build-notifications"
         notify_on_build_start: true
         notify:
           success: true
@@ -481,7 +481,7 @@ workflows:
           success: true
           failure: true
       slack:
-        channel: '#build-notifications'
+        channel: "#build-notifications"
         notify_on_build_start: true
         notify:
           success: true
@@ -551,7 +551,7 @@ workflows:
           success: true
           failure: true
       slack:
-        channel: '#build-notifications'
+        channel: "#build-notifications"
         notify_on_build_start: true
         notify:
           success: true
@@ -560,7 +560,7 @@ workflows:
     name: Dogfood Release Build (QA)
     instance_type: linux_x2
     triggering:
-      events: []  # Manual trigger only
+      events: [] # Manual trigger only
     environment:
       groups:
         - construculator_qa
@@ -579,10 +579,6 @@ workflows:
         script: dart pub global activate fvm
       - name: Install Flutter version via FVM
         script: fvm install
-      - name: Clone and Checkout
-        script: |
-          git clone "$CM_REPO_URL" .
-          git checkout "$CM_COMMIT"
       - name: Install Dependencies
         script: |
           export PATH="$PATH":"$HOME/.pub-cache/bin":"$FCI_BUILD_DIR/.fvm/flutter_sdk/bin"
@@ -590,9 +586,14 @@ workflows:
       - name: Generate env file
         script: |
           export PATH="$PATH":"$HOME/.pub-cache/bin":"$FCI_BUILD_DIR/.fvm/flutter_sdk/bin"
+
+          echo "=== Script exists? ==="
+          ls -la scripts/ci/generate_env_file.sh || echo "FILE NOT FOUND"
+
+          sed -i 's/\r//' scripts/ci/generate_env_file.sh
           chmod +x scripts/ci/generate_env_file.sh
-          bash scripts/ci/generate_env_file.sh
-      - name: Build Android Release APK
+          bash -x scripts/ci/generate_env_file.sh
+      - name: Build Android APK
         script: |
           export PATH="$PATH":"$HOME/.pub-cache/bin":"$FCI_BUILD_DIR/.fvm/flutter_sdk/bin"
           fvm flutter build apk \
@@ -609,7 +610,7 @@ workflows:
           success: true
           failure: true
       slack:
-        channel: '#build-notifications'
+        channel: "#build-notifications"
         notify_on_build_start: true
         notify:
           success: true

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -158,6 +158,7 @@ workflows:
       groups:
         - notification_emails
         - ripple_arc
+        - construculator_dev
       flutter: 3.32.0
     cache:
       cache_paths:
@@ -286,16 +287,25 @@ workflows:
           echo "✅ No changed mutation config files detected (checked test/features/**/mutations, test/libraries/**/mutations). Skipping mutation tests."
           exit 0
           fi
-          
+
           echo "Found changed mutation config files:"
           echo "$CHANGED_FILES"
-          
+
           echo "🧪 Running mutation tests..."
           fvm dart run mutation_test $CHANGED_FILES --no-builtin
 
+      - name: Generate env file
+        script: |
+          export PATH="$PATH":"$HOME/.pub-cache/bin":"$FCI_BUILD_DIR/.fvm/flutter_sdk/bin"
+          chmod +x scripts/ci/generate_env_file.sh
+          bash scripts/ci/generate_env_file.sh
+
       - name: Build Android Debug
         script: |
-          fvm flutter build apk --flavor fishfood
+          export PATH="$PATH":"$HOME/.pub-cache/bin":"$FCI_BUILD_DIR/.fvm/flutter_sdk/bin"
+          fvm flutter build apk \
+            --flavor fishfood \
+            --dart-define=ENVIRONMENT=dev
 
     artifacts:
       - build/app/outputs/flutter-apk/*.apk
@@ -322,6 +332,7 @@ workflows:
       groups:
         - notification_emails
         - ripple_arc
+        - construculator_dev
       flutter: 3.32.0
       ubuntu: 24.04
     cache:
@@ -443,9 +454,18 @@ workflows:
           echo "🧪 Running mutation tests on: $CONFIG_FILES"
           fvm dart run mutation_test $CONFIG_FILES --no-builtin
 
+      - name: Generate env file
+        script: |
+          export PATH="$PATH":"$HOME/.pub-cache/bin":"$FCI_BUILD_DIR/.fvm/flutter_sdk/bin"
+          chmod +x scripts/ci/generate_env_file.sh
+          bash scripts/ci/generate_env_file.sh
+
       - name: Build Android Debug
         script: |
-          fvm flutter build apk --flavor fishfood
+          export PATH="$PATH":"$HOME/.pub-cache/bin":"$FCI_BUILD_DIR/.fvm/flutter_sdk/bin"
+          fvm flutter build apk \
+            --flavor fishfood \
+            --dart-define=ENVIRONMENT=dev
 
     artifacts:
       - build/app/outputs/flutter-apk/*.apk
@@ -473,6 +493,7 @@ workflows:
       groups:
         - notification_emails
         - ripple_arc
+        - construculator_dev
       flutter: 3.32.0
     cache:
       cache_paths:
@@ -506,14 +527,80 @@ workflows:
           cd ios
           pod install
           cd ..
+      - name: Generate env file
+        script: |
+          export PATH="$PATH":"$HOME/.pub-cache/bin":"$FCI_BUILD_DIR/.fvm/flutter_sdk/bin"
+          chmod +x scripts/ci/generate_env_file.sh
+          bash scripts/ci/generate_env_file.sh
       - name: Build Ios Debug
         script: |
           export PATH="$PATH":"$HOME/.pub-cache/bin":"$FCI_BUILD_DIR/.fvm/flutter_sdk/bin"
           echo "📦 Pre-caching iOS artifacts..."
           fvm flutter precache --ios
-          fvm flutter build ios --debug --no-codesign
+          fvm flutter build ios \
+            --debug \
+            --no-codesign \
+            --dart-define=ENVIRONMENT=dev
     artifacts:
       - build/ios/iphoneos/*.app
+    publishing:
+      email:
+        recipients:
+          - $EMAIL_DANIEL
+        notify:
+          success: true
+          failure: true
+      slack:
+        channel: '#build-notifications'
+        notify_on_build_start: true
+        notify:
+          success: true
+          failure: true
+  dogfood-release:
+    name: Dogfood Release Build (QA)
+    instance_type: linux_x2
+    triggering:
+      events: []  # Manual trigger only
+    environment:
+      groups:
+        - construculator_qa
+        - notification_emails
+        - ripple_arc
+      flutter: 3.32.0
+      ubuntu: 24.04
+    cache:
+      cache_paths:
+        - .fvm/
+        - ~/.pub-cache
+        - ~/.gradle/caches
+        - $FLUTTER_ROOT/.pub-cache
+    scripts:
+      - name: Install FVM
+        script: dart pub global activate fvm
+      - name: Install Flutter version via FVM
+        script: fvm install
+      - name: Clone and Checkout
+        script: |
+          git clone "$CM_REPO_URL" .
+          git checkout "$CM_COMMIT"
+      - name: Install Dependencies
+        script: |
+          export PATH="$PATH":"$HOME/.pub-cache/bin":"$FCI_BUILD_DIR/.fvm/flutter_sdk/bin"
+          fvm flutter pub get
+      - name: Generate env file
+        script: |
+          export PATH="$PATH":"$HOME/.pub-cache/bin":"$FCI_BUILD_DIR/.fvm/flutter_sdk/bin"
+          chmod +x scripts/ci/generate_env_file.sh
+          bash scripts/ci/generate_env_file.sh
+      - name: Build Android Release APK
+        script: |
+          export PATH="$PATH":"$HOME/.pub-cache/bin":"$FCI_BUILD_DIR/.fvm/flutter_sdk/bin"
+          fvm flutter build apk \
+            --release \
+            --flavor dogfood \
+            --dart-define=ENVIRONMENT=qa
+    artifacts:
+      - build/app/outputs/flutter-apk/*.apk
     publishing:
       email:
         recipients:

--- a/docs/Testing/CI-Scripts.md
+++ b/docs/Testing/CI-Scripts.md
@@ -262,6 +262,61 @@ MacOS developers should always verify iOS builds pass locally before creating PR
 
 If any required tool is missing, the script fails fast.
 
+### Environment-Specific Configuration
+
+The CI builds use environment-specific configuration files generated from Codemagic environment groups. This allows different builds (dev, qa, prod) to use different API endpoints, api keys, and service configurations without hardcoding secrets.
+
+**How it works:**
+
+1. **Environment groups in Codemagic UI** store variables like `SENTRY_DSN`, `API_URL`, `SUPABASE_URL`, etc.
+2. **Pre-build script** (`scripts/ci/generate_env_file.sh`) reads these variables and generates the appropriate `.env` file.
+3. **Build command** passes `--dart-define=ENVIRONMENT=xxx` to select which config the app loads at runtime.
+
+**Environment groups:**
+
+- `construculator_dev` → generates `assets/env/.env.dev` (used by fishfood builds)
+- `construculator_qa` → generates `assets/env/.env.qa` (used by dogfood builds)
+- `construculator_prod` → generates `assets/env/.env.prod` (production builds)
+
+**Workflow mapping:**
+
+- `comprehensive-check`, `periodic-check`, `ios-debug-build` → use `construculator_dev`
+- `dogfood-release` → uses `construculator_qa`
+
+**Adding new environment variables:**
+
+1. Update `scripts/ci/generate_env_file.sh` to read and write the new variable to the `.env` file.
+2. Add the variable to each environment group in Codemagic UI:
+   - Navigate to: Codemagic → construculator-app → Environment variables → Select group
+   - Select the environment group (`construculator_dev`, `construculator_qa`, or `construculator_prod`)
+   - Enter variable name (matches script expectations: `SENTRY_DSN`, `API_URL`, etc.)
+   - Enter value (environment-specific)
+   - Mark as "Secure" if it contains secrets (API keys, tokens, DSNs)
+   - Save
+
+
+Example variables in `construculator_dev`:
+
+```
+ENVIRONMENT=dev
+SENTRY_DSN=           (empty - Sentry disabled in dev)
+API_URL=http://localhost:8000/api
+SUPABASE_URL=http://localhost:54321
+DEBUG_MODE=true
+ANALYTICS_ENABLED=false
+```
+
+Example variables in `construculator_qa`:
+
+```
+ENVIRONMENT=qa
+SENTRY_DSN=https://...@sentry.io/...
+API_URL=https://qa-api.construculator.com/api
+SUPABASE_URL=https://qa-project.supabase.co
+DEBUG_MODE=false
+ANALYTICS_ENABLED=true
+```
+
 ### Common environment variables
 
 - `ARC_CODE_COVERAGE_TARGET`: standard required coverage.

--- a/scripts/ci/generate_env_file.sh
+++ b/scripts/ci/generate_env_file.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+#
+# Codemagic Pre-Build Script: Generate Environment File
+#
+# This script generates the appropriate .env file for the current build environment
+# using environment variables from Codemagic environment groups.
+#
+# Required environment variables (set in Codemagic environment groups):
+#   - ENVIRONMENT: The environment name (dev, qa, prod)
+#   - SENTRY_DSN: The Sentry Data Source Name for error tracking
+#   - SUPABASE_URL: The Supabase project URL
+#   - SUPABASE_ANON_KEY: The Supabase anonymous/public key
+#   - API_URL: The API base URL
+#
+# Usage:
+#   This script is automatically run by Codemagic before the build.
+#   It should be added to the "Pre-build script" section of your workflow.
+#
+
+set -e  # Exit on error
+set -u  # Exit on undefined variable
+
+# Validate required environment variables
+if [ -z "${ENVIRONMENT:-}" ]; then
+  echo "❌ ERROR: ENVIRONMENT variable is not set"
+  exit 1
+fi
+
+if [ -z "${SENTRY_DSN:-}" ]; then
+  echo "⚠️  WARNING: SENTRY_DSN is not set (Sentry will be disabled)"
+fi
+
+# Set default values for optional variables
+APP_NAME="${APP_NAME:-Construculator}"
+API_URL="${API_URL:-}"
+SUPABASE_URL="${SUPABASE_URL:-}"
+SUPABASE_ANON_KEY="${SUPABASE_ANON_KEY:-}"
+DEBUG_MODE="${DEBUG_MODE:-false}"
+ANALYTICS_ENABLED="${ANALYTICS_ENABLED:-false}"
+SENTRY_DSN="${SENTRY_DSN:-}"
+
+# Determine environment-specific values
+case "${ENVIRONMENT}" in
+  dev|fishfood)
+    ENV_FILE="assets/env/.env.dev"
+    DEBUG_MODE="true"
+    ANALYTICS_ENABLED="false"
+    ;;
+  qa|dogfood)
+    ENV_FILE="assets/env/.env.qa"
+    DEBUG_MODE="false"
+    ANALYTICS_ENABLED="true"
+    ;;
+  prod|production)
+    ENV_FILE="assets/env/.env.prod"
+    DEBUG_MODE="false"
+    ANALYTICS_ENABLED="true"
+    ;;
+  *)
+    echo "❌ ERROR: Invalid ENVIRONMENT value: ${ENVIRONMENT}"
+    echo "   Valid values: dev, qa, prod"
+    exit 1
+    ;;
+esac
+
+# Create the env file
+echo "📝 Generating ${ENV_FILE} for environment: ${ENVIRONMENT}"
+
+# Ensure directory exists
+mkdir -p "$(dirname "${ENV_FILE}")"
+
+cat > "${ENV_FILE}" <<EOF
+APP_ENV="${ENVIRONMENT}"
+APP_NAME="${APP_NAME}"
+API_URL="${API_URL}"
+SUPABASE_URL="${SUPABASE_URL}"
+SUPABASE_ANON_KEY="${SUPABASE_ANON_KEY}"
+DEBUG_MODE="${DEBUG_MODE}"
+ANALYTICS_ENABLED="${ANALYTICS_ENABLED}"
+SENTRY_DSN="${SENTRY_DSN}"
+EOF
+
+echo "✅ Environment file created successfully: ${ENV_FILE}"
+echo ""
+echo "📋 Configuration:"
+echo "   Environment: ${ENVIRONMENT}"
+echo "   Debug Mode: ${DEBUG_MODE}"
+echo "   Analytics: ${ANALYTICS_ENABLED}"
+echo "   Sentry: $([ -n "${SENTRY_DSN}" ] && echo "Enabled" || echo "Disabled")"
+echo ""
+
+# Verify the file was created
+if [ ! -f "${ENV_FILE}" ]; then
+  echo "❌ ERROR: Failed to create ${ENV_FILE}"
+  exit 1
+fi
+
+echo "✅ Pre-build script completed successfully"

--- a/scripts/ci/generate_env_file.sh
+++ b/scripts/ci/generate_env_file.sh
@@ -17,8 +17,7 @@
 #   It should be added to the "Pre-build script" section of your workflow.
 #
 
-set -e  # Exit on error
-set -u  # Exit on undefined variable
+set -euo pipefail
 
 # Validate required environment variables
 if [ -z "${ENVIRONMENT:-}" ]; then
@@ -41,17 +40,17 @@ SENTRY_DSN="${SENTRY_DSN:-}"
 
 # Determine environment-specific values
 case "${ENVIRONMENT}" in
-  dev|fishfood)
+  dev)
     ENV_FILE="assets/env/.env.dev"
     DEBUG_MODE="true"
     ANALYTICS_ENABLED="false"
     ;;
-  qa|dogfood)
+  qa)
     ENV_FILE="assets/env/.env.qa"
     DEBUG_MODE="false"
     ANALYTICS_ENABLED="true"
     ;;
-  prod|production)
+  prod)
     ENV_FILE="assets/env/.env.prod"
     DEBUG_MODE="false"
     ANALYTICS_ENABLED="true"


### PR DESCRIPTION
# PR Review: feat/setup-ci-and-env-variables-for-sentry → feat/add-additionla-sentry-features
**Reviewed:** Wed Apr 8 2026

---

## 1. PR SUMMARY

This PR introduces environment-specific configuration support for CI builds. It adds a new shell script (`generate_env_file.sh`) that reads variables from Codemagic environment groups and generates the appropriate `.env` file (dev/qa/prod) before each build. The `codemagic.yaml` is updated to wire this script into three existing workflows (`comprehensive-check`, `periodic-check`, `ios-debug-build`) and introduces a new `dogfood-release` workflow for QA builds. Documentation in `CI-Scripts.md` is updated to explain the new environment group setup. The primary objective is to support Sentry DSN injection and environment-aware builds without hardcoding secrets.

---

## REVIEW SUMMARY

| Issue Name | Description | Status | Notes |
|---|---|---|---|
| `set -u` + unset `SENTRY_DSN` crash | Bare `${SENTRY_DSN}` in heredoc will crash under `set -u` when variable is unset, contradicting the warning that treats this as valid | ✅ | |
| Missing `mkdir -p` guard | Script does not create `assets/env/` directory before writing; fails silently on clean agents | | |
| Inconsistent `.env` value quoting | Only `APP_ENV` is quoted; values with spaces or special characters in other variables will produce malformed env files | ✅ | |
| `dogfood-release` missing `ripple_arc` group | All other workflows include `ripple_arc`; its omission from the release workflow may cause silent variable resolution failures | ✅ | |
| `dogfood-release` unpinned OS | Release workflow does not pin `ubuntu: 24.04`, risking non-reproducible builds as Codemagic updates base images | ✅ | |
