### PR TITLE
Refactor test setup by introducing FakeAppBootstrapFactory

### DIFF
--- a/test/features/auth/widgets/accessibility/create_account_page_a11y_test.dart
+++ b/test/features/auth/widgets/accessibility/create_account_page_a11y_test.dart
@@ -3,8 +3,6 @@ import 'package:construculator/features/auth/auth_module.dart';
 import 'package:construculator/features/auth/presentation/bloc/create_account_bloc/create_account_bloc.dart';
 import 'package:construculator/features/auth/presentation/pages/create_account_page.dart';
 import 'package:construculator/l10n/generated/app_localizations.dart';
-import 'package:construculator/libraries/config/testing/fake_app_config.dart';
-import 'package:construculator/libraries/config/testing/fake_env_loader.dart';
 import 'package:construculator/libraries/router/testing/router_test_module.dart';
 import 'package:construculator/libraries/supabase/data/supabase_types.dart';
 import 'package:construculator/libraries/supabase/interfaces/supabase_wrapper.dart';
@@ -18,6 +16,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:ripplearc_coreui/ripplearc_coreui.dart';
 
 import '../../../../utils/a11y/a11y_guidelines.dart';
+import '../../../../utils/fake_app_bootstrap_factory.dart';
 import '../../../../utils/screenshot/font_loader.dart';
 
 class _CreateAccountPageA11yTestModule extends Module {
@@ -26,10 +25,10 @@ class _CreateAccountPageA11yTestModule extends Module {
 
   @override
   List<Module> get imports => [
-        RouterTestModule(),
-        ClockTestModule(),
-        AuthModule(appBootstrap),
-      ];
+    RouterTestModule(),
+    ClockTestModule(),
+    AuthModule(appBootstrap),
+  ];
 }
 
 void main() {
@@ -42,9 +41,7 @@ void main() {
     fakeSupabase = FakeSupabaseWrapper(clock: FakeClockImpl());
     CoreToast.disableTimers();
 
-    final appBootstrap = AppBootstrap(
-      config: FakeAppConfig(),
-      envLoader: FakeEnvLoader(),
+    final appBootstrap = FakeAppBootstrapFactory.create(
       supabaseWrapper: fakeSupabase,
     );
 
@@ -162,8 +159,9 @@ void main() {
   }
 
   group('CreateAccountPage – accessibility', () {
-    testWidgets('meets a11y guidelines for continue button in both themes',
-        (tester) async {
+    testWidgets('meets a11y guidelines for continue button in both themes', (
+      tester,
+    ) async {
       await renderPage(tester);
       final buttonLabel = l10n().agreeAndContinueButton;
       await setupA11yTest(tester);
@@ -185,24 +183,27 @@ void main() {
       );
     });
 
-    testWidgets('meets a11y guidelines for terms and services link in both themes',
-        (tester) async {
-      await renderPage(tester);
-      final termsLink = l10n().termsAndServicesLink;
-      await setupA11yTest(tester);
+    testWidgets(
+      'meets a11y guidelines for terms and services link in both themes',
+      (tester) async {
+        await renderPage(tester);
+        final termsLink = l10n().termsAndServicesLink;
+        await setupA11yTest(tester);
 
-      await expectMeetsTapTargetAndLabelGuidelinesForEachTheme(
-        tester,
-        (theme) => makeTestableWidget(
-          theme: theme,
-          child: CreateAccountPage(email: testEmail),
-        ),
-        find.text(termsLink),
-      );
-    });
+        await expectMeetsTapTargetAndLabelGuidelinesForEachTheme(
+          tester,
+          (theme) => makeTestableWidget(
+            theme: theme,
+            child: CreateAccountPage(email: testEmail),
+          ),
+          find.text(termsLink),
+        );
+      },
+    );
 
-    testWidgets('meets a11y guidelines for role selector in both themes',
-        (tester) async {
+    testWidgets('meets a11y guidelines for role selector in both themes', (
+      tester,
+    ) async {
       await renderPage(tester);
       final roleLabelText = l10n().roleLabel;
       await setupA11yTest(tester);
@@ -229,7 +230,8 @@ void main() {
           tester,
           (theme) {
             fakeSupabase.shouldThrowOnInsert = true;
-            fakeSupabase.authErrorCode = SupabaseAuthErrorCode.invalidCredentials;
+            fakeSupabase.authErrorCode =
+                SupabaseAuthErrorCode.invalidCredentials;
             return makeTestableWidget(
               theme: theme,
               child: CreateAccountPage(email: testEmail),

--- a/test/features/auth/widgets/accessibility/enter_password_page_a11y_test.dart
+++ b/test/features/auth/widgets/accessibility/enter_password_page_a11y_test.dart
@@ -3,8 +3,6 @@ import 'package:construculator/features/auth/auth_module.dart';
 import 'package:construculator/features/auth/presentation/bloc/enter_password_bloc/enter_password_bloc.dart';
 import 'package:construculator/features/auth/presentation/pages/enter_password_page.dart';
 import 'package:construculator/l10n/generated/app_localizations.dart';
-import 'package:construculator/libraries/config/testing/fake_app_config.dart';
-import 'package:construculator/libraries/config/testing/fake_env_loader.dart';
 import 'package:construculator/libraries/router/testing/router_test_module.dart';
 import 'package:construculator/libraries/supabase/data/supabase_types.dart';
 import 'package:construculator/libraries/supabase/interfaces/supabase_wrapper.dart';
@@ -18,6 +16,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:ripplearc_coreui/ripplearc_coreui.dart';
 
 import '../../../../utils/a11y/a11y_guidelines.dart';
+import '../../../../utils/fake_app_bootstrap_factory.dart';
 import '../../../../utils/screenshot/font_loader.dart';
 
 class _EnterPasswordPageA11yTestModule extends Module {
@@ -26,10 +25,10 @@ class _EnterPasswordPageA11yTestModule extends Module {
 
   @override
   List<Module> get imports => [
-        RouterTestModule(),
-        ClockTestModule(),
-        AuthModule(appBootstrap),
-      ];
+    RouterTestModule(),
+    ClockTestModule(),
+    AuthModule(appBootstrap),
+  ];
 }
 
 void main() {
@@ -41,9 +40,7 @@ void main() {
     fakeSupabase = FakeSupabaseWrapper(clock: FakeClockImpl());
     CoreToast.disableTimers();
 
-    final appBootstrap = AppBootstrap(
-      config: FakeAppConfig(),
-      envLoader: FakeEnvLoader(),
+    final appBootstrap = FakeAppBootstrapFactory.create(
       supabaseWrapper: fakeSupabase,
     );
 
@@ -102,8 +99,9 @@ void main() {
   }
 
   group('EnterPasswordPage – accessibility', () {
-    testWidgets('meets a11y guidelines for continue button in both themes',
-        (tester) async {
+    testWidgets('meets a11y guidelines for continue button in both themes', (
+      tester,
+    ) async {
       await setupA11yTest(tester);
       await renderPage(tester);
 
@@ -121,23 +119,26 @@ void main() {
       );
     });
 
-    testWidgets('meets a11y guidelines for forgot password link in both themes',
-        (tester) async {
-      await setupA11yTest(tester);
-      await renderPage(tester);
+    testWidgets(
+      'meets a11y guidelines for forgot password link in both themes',
+      (tester) async {
+        await setupA11yTest(tester);
+        await renderPage(tester);
 
-      await expectMeetsTapTargetAndLabelGuidelinesForEachTheme(
-        tester,
-        (theme) => makeTestableWidget(
-          theme: theme,
-          child: EnterPasswordPage(email: ''),
-        ),
-        find.text(l10n().forgotPasswordTitle),
-      );
-    });
+        await expectMeetsTapTargetAndLabelGuidelinesForEachTheme(
+          tester,
+          (theme) => makeTestableWidget(
+            theme: theme,
+            child: EnterPasswordPage(email: ''),
+          ),
+          find.text(l10n().forgotPasswordTitle),
+        );
+      },
+    );
 
-    testWidgets('meets a11y guidelines for edit link in both themes',
-        (tester) async {
+    testWidgets('meets a11y guidelines for edit link in both themes', (
+      tester,
+    ) async {
       await setupA11yTest(tester);
       await renderPage(tester);
 
@@ -192,10 +193,12 @@ void main() {
           find.byKey(const Key('toast_close_button')),
           setupAfterPump: (t) async {
             await enterPassword(t, 'WrongPassword123!');
-            await t.tap(find.descendant(
-              of: find.byType(ListView),
-              matching: find.text(l10n().continueButton),
-            ));
+            await t.tap(
+              find.descendant(
+                of: find.byType(ListView),
+                matching: find.text(l10n().continueButton),
+              ),
+            );
             await t.pumpAndSettle();
           },
         );

--- a/test/features/auth/widgets/accessibility/forgot_password_page_a11y_test.dart
+++ b/test/features/auth/widgets/accessibility/forgot_password_page_a11y_test.dart
@@ -4,8 +4,6 @@ import 'package:construculator/features/auth/presentation/bloc/forgot_password_b
 import 'package:construculator/features/auth/presentation/bloc/otp_verification_bloc/otp_verification_bloc.dart';
 import 'package:construculator/features/auth/presentation/pages/forgot_password_page.dart';
 import 'package:construculator/l10n/generated/app_localizations.dart';
-import 'package:construculator/libraries/config/testing/fake_app_config.dart';
-import 'package:construculator/libraries/config/testing/fake_env_loader.dart';
 import 'package:construculator/libraries/router/testing/router_test_module.dart';
 import 'package:construculator/libraries/supabase/data/supabase_types.dart';
 import 'package:construculator/libraries/supabase/interfaces/supabase_wrapper.dart';
@@ -19,6 +17,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:ripplearc_coreui/ripplearc_coreui.dart';
 
 import '../../../../utils/a11y/a11y_guidelines.dart';
+import '../../../../utils/fake_app_bootstrap_factory.dart';
 import '../../../../utils/screenshot/font_loader.dart';
 
 class _ForgotPasswordPageA11yTestModule extends Module {
@@ -27,10 +26,10 @@ class _ForgotPasswordPageA11yTestModule extends Module {
 
   @override
   List<Module> get imports => [
-        RouterTestModule(),
-        ClockTestModule(),
-        AuthModule(appBootstrap),
-      ];
+    RouterTestModule(),
+    ClockTestModule(),
+    AuthModule(appBootstrap),
+  ];
 }
 
 void main() {
@@ -41,9 +40,7 @@ void main() {
     fakeSupabase = FakeSupabaseWrapper(clock: FakeClockImpl());
     CoreToast.disableTimers();
 
-    final appBootstrap = AppBootstrap(
-      config: FakeAppConfig(),
-      envLoader: FakeEnvLoader(),
+    final appBootstrap = FakeAppBootstrapFactory.create(
       supabaseWrapper: fakeSupabase,
     );
 
@@ -125,17 +122,16 @@ void main() {
   }
 
   group('ForgotPasswordPage – accessibility', () {
-    testWidgets('meets a11y guidelines for continue button in both themes',
-        (tester) async {
+    testWidgets('meets a11y guidelines for continue button in both themes', (
+      tester,
+    ) async {
       await setupA11yTest(tester);
       await renderPage(tester);
 
       await expectMeetsTapTargetAndLabelGuidelinesForEachTheme(
         tester,
-        (theme) => makeTestableWidget(
-          theme: theme,
-          child: const ForgotPasswordPage(),
-        ),
+        (theme) =>
+            makeTestableWidget(theme: theme, child: const ForgotPasswordPage()),
         find.text(l10n().continueButton),
         setupAfterPump: (t) async {
           await enterEmail(t, 'reset@example.com');
@@ -182,28 +178,25 @@ void main() {
       },
     );
 
-    testWidgets(
-      'meets a11y guidelines for verify OTP button in both themes',
-      (tester) async {
-        await setupA11yTest(tester);
-        await renderPage(tester);
+    testWidgets('meets a11y guidelines for verify OTP button in both themes', (
+      tester,
+    ) async {
+      await setupA11yTest(tester);
+      await renderPage(tester);
 
-        await expectMeetsTapTargetAndLabelGuidelinesForEachTheme(
-          tester,
-          (theme) => makeTestableWidget(
-            theme: theme,
-            child: const ForgotPasswordPage(),
-          ),
-          find.text(l10n().verifyOtpButton),
-          setupAfterPump: (t) async {
-            await enterEmail(t, 'reset@example.com');
-            await tapContinueButton(t);
-            await enterOtp(t, '123456');
-            await t.pumpAndSettle();
-          },
-        );
-      },
-    );
+      await expectMeetsTapTargetAndLabelGuidelinesForEachTheme(
+        tester,
+        (theme) =>
+            makeTestableWidget(theme: theme, child: const ForgotPasswordPage()),
+        find.text(l10n().verifyOtpButton),
+        setupAfterPump: (t) async {
+          await enterEmail(t, 'reset@example.com');
+          await tapContinueButton(t);
+          await enterOtp(t, '123456');
+          await t.pumpAndSettle();
+        },
+      );
+    });
 
     testWidgets(
       'meets a11y guidelines for edit contact button in OTP modal in both themes',
@@ -231,8 +224,7 @@ void main() {
       'meets a11y guidelines when OTP error toast shown in both themes',
       (tester) async {
         fakeSupabase.shouldThrowOnVerifyOtp = true;
-        fakeSupabase.authErrorCode =
-            SupabaseAuthErrorCode.invalidCredentials;
+        fakeSupabase.authErrorCode = SupabaseAuthErrorCode.invalidCredentials;
         await setupA11yTest(tester);
         await renderPage(tester);
 
@@ -250,10 +242,12 @@ void main() {
           find.byKey(const Key('toast_close_button')),
           setupAfterPump: (t) async {
             await enterEmail(t, 'reset@example.com');
-            await t.tap(find.descendant(
-              of: find.byType(SingleChildScrollView),
-              matching: find.text(l10n().continueButton),
-            ));
+            await t.tap(
+              find.descendant(
+                of: find.byType(SingleChildScrollView),
+                matching: find.text(l10n().continueButton),
+              ),
+            );
             await t.pumpAndSettle();
             await enterOtp(t, '123456');
             await tapVerifyButton(t);
@@ -283,10 +277,12 @@ void main() {
           find.byKey(const Key('toast_close_button')),
           setupAfterPump: (t) async {
             await enterEmail(t, 'error@example.com');
-            await t.tap(find.descendant(
-              of: find.byType(SingleChildScrollView),
-              matching: find.text(l10n().continueButton),
-            ));
+            await t.tap(
+              find.descendant(
+                of: find.byType(SingleChildScrollView),
+                matching: find.text(l10n().continueButton),
+              ),
+            );
             await t.pumpAndSettle();
           },
         );

--- a/test/features/auth/widgets/accessibility/login_with_email_page_a11y_test.dart
+++ b/test/features/auth/widgets/accessibility/login_with_email_page_a11y_test.dart
@@ -3,8 +3,7 @@ import 'package:construculator/features/auth/auth_module.dart';
 import 'package:construculator/features/auth/presentation/bloc/login_with_email_bloc/login_with_email_bloc.dart';
 import 'package:construculator/features/auth/presentation/pages/login_with_email_page.dart';
 import 'package:construculator/l10n/generated/app_localizations.dart';
-import 'package:construculator/libraries/config/testing/fake_app_config.dart';
-import 'package:construculator/libraries/config/testing/fake_env_loader.dart';
+
 import 'package:construculator/libraries/router/testing/router_test_module.dart';
 import 'package:construculator/libraries/supabase/interfaces/supabase_wrapper.dart';
 import 'package:construculator/libraries/supabase/testing/fake_supabase_wrapper.dart';
@@ -17,6 +16,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:ripplearc_coreui/ripplearc_coreui.dart';
 
 import '../../../../utils/a11y/a11y_guidelines.dart';
+import '../../../../utils/fake_app_bootstrap_factory.dart';
 import '../../../../utils/screenshot/font_loader.dart';
 
 class _LoginWithEmailPageA11yTestModule extends Module {
@@ -25,10 +25,10 @@ class _LoginWithEmailPageA11yTestModule extends Module {
 
   @override
   List<Module> get imports => [
-        RouterTestModule(),
-        ClockTestModule(),
-        AuthModule(appBootstrap),
-      ];
+    RouterTestModule(),
+    ClockTestModule(),
+    AuthModule(appBootstrap),
+  ];
 }
 
 void main() {
@@ -39,9 +39,7 @@ void main() {
     fakeSupabase = FakeSupabaseWrapper(clock: FakeClockImpl());
     CoreToast.disableTimers();
 
-    final appBootstrap = AppBootstrap(
-      config: FakeAppConfig(),
-      envLoader: FakeEnvLoader(),
+    final appBootstrap = FakeAppBootstrapFactory.create(
       supabaseWrapper: fakeSupabase,
     );
 
@@ -97,8 +95,9 @@ void main() {
   }
 
   group('LoginWithEmailPage – accessibility', () {
-    testWidgets('meets a11y guidelines for continue button in both themes',
-        (tester) async {
+    testWidgets('meets a11y guidelines for continue button in both themes', (
+      tester,
+    ) async {
       fakeSupabase.setRpcResponse('check_email_exists', true);
       await setupA11yTest(tester);
 
@@ -114,8 +113,9 @@ void main() {
       );
     });
 
-    testWidgets('meets a11y guidelines for register link in both themes',
-        (tester) async {
+    testWidgets('meets a11y guidelines for register link in both themes', (
+      tester,
+    ) async {
       await setupA11yTest(tester);
 
       await renderPage(tester);
@@ -139,17 +139,15 @@ void main() {
         await enterEmail(tester, 'notregistered@example.com');
         await tester.pumpAndSettle();
 
-        await expectMeetsTapTargetAndLabelGuidelinesForEachTheme(
-          tester,
-          (theme) {
-            fakeSupabase.setRpcResponse('check_email_exists', false);
-            return makeTestableWidget(
-              theme: theme,
-              child: const LoginWithEmailPage(email: 'notregistered@example.com'),
-            );
-          },
-          find.byKey(const Key('Register')),
-        );
+        await expectMeetsTapTargetAndLabelGuidelinesForEachTheme(tester, (
+          theme,
+        ) {
+          fakeSupabase.setRpcResponse('check_email_exists', false);
+          return makeTestableWidget(
+            theme: theme,
+            child: const LoginWithEmailPage(email: 'notregistered@example.com'),
+          );
+        }, find.byKey(const Key('Register')));
       },
     );
 
@@ -200,17 +198,15 @@ void main() {
         await enterEmail(tester, 'error@example.com');
         await tester.pumpAndSettle();
 
-        await expectMeetsTapTargetAndLabelGuidelinesForEachTheme(
-          tester,
-          (theme) {
-            fakeSupabase.shouldThrowOnRpc = true;
-            return makeTestableWidget(
-              theme: theme,
-              child: const LoginWithEmailPage(email: 'error@example.com'),
-            );
-          },
-          find.text('Close'),
-        );
+        await expectMeetsTapTargetAndLabelGuidelinesForEachTheme(tester, (
+          theme,
+        ) {
+          fakeSupabase.shouldThrowOnRpc = true;
+          return makeTestableWidget(
+            theme: theme,
+            child: const LoginWithEmailPage(email: 'error@example.com'),
+          );
+        }, find.text('Close'));
       },
     );
   });

--- a/test/features/auth/widgets/accessibility/register_with_email_page_a11y_test.dart
+++ b/test/features/auth/widgets/accessibility/register_with_email_page_a11y_test.dart
@@ -4,8 +4,7 @@ import 'package:construculator/features/auth/presentation/bloc/otp_verification_
 import 'package:construculator/features/auth/presentation/bloc/register_with_email_bloc/register_with_email_bloc.dart';
 import 'package:construculator/features/auth/presentation/pages/register_with_email_page.dart';
 import 'package:construculator/l10n/generated/app_localizations.dart';
-import 'package:construculator/libraries/config/testing/fake_app_config.dart';
-import 'package:construculator/libraries/config/testing/fake_env_loader.dart';
+
 import 'package:construculator/libraries/router/testing/router_test_module.dart';
 import 'package:construculator/libraries/supabase/interfaces/supabase_wrapper.dart';
 import 'package:construculator/libraries/supabase/testing/fake_supabase_wrapper.dart';
@@ -18,6 +17,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:ripplearc_coreui/ripplearc_coreui.dart';
 
 import '../../../../utils/a11y/a11y_guidelines.dart';
+import '../../../../utils/fake_app_bootstrap_factory.dart';
 import '../../../../utils/screenshot/font_loader.dart';
 
 class _RegisterWithEmailPageA11yTestModule extends Module {
@@ -26,10 +26,10 @@ class _RegisterWithEmailPageA11yTestModule extends Module {
 
   @override
   List<Module> get imports => [
-        RouterTestModule(),
-        ClockTestModule(),
-        AuthModule(appBootstrap),
-      ];
+    RouterTestModule(),
+    ClockTestModule(),
+    AuthModule(appBootstrap),
+  ];
 }
 
 void main() {
@@ -40,9 +40,7 @@ void main() {
     fakeSupabase = FakeSupabaseWrapper(clock: FakeClockImpl());
     CoreToast.disableTimers();
 
-    final appBootstrap = AppBootstrap(
-      config: FakeAppConfig(),
-      envLoader: FakeEnvLoader(),
+    final appBootstrap = FakeAppBootstrapFactory.create(
       supabaseWrapper: fakeSupabase,
     );
 
@@ -103,8 +101,9 @@ void main() {
   }
 
   group('RegisterWithEmailPage – accessibility', () {
-    testWidgets('meets a11y guidelines for continue button in both themes',
-        (tester) async {
+    testWidgets('meets a11y guidelines for continue button in both themes', (
+      tester,
+    ) async {
       fakeSupabase.clearTableData('users');
       fakeSupabase.setRpcResponse('check_email_exists', false);
       await setupA11yTest(tester);
@@ -113,22 +112,19 @@ void main() {
       await enterEmail(tester, 'newuser@example.com');
       await tester.pumpAndSettle();
 
-      await expectMeetsTapTargetAndLabelGuidelinesForEachTheme(
-        tester,
-        (theme) {
-          fakeSupabase.clearTableData('users');
-          fakeSupabase.setRpcResponse('check_email_exists', false);
-          return makeTestableWidget(
-            theme: theme,
-            child: const RegisterWithEmailPage(email: 'newuser@example.com'),
-          );
-        },
-        find.text(l10n().continueButton),
-      );
+      await expectMeetsTapTargetAndLabelGuidelinesForEachTheme(tester, (theme) {
+        fakeSupabase.clearTableData('users');
+        fakeSupabase.setRpcResponse('check_email_exists', false);
+        return makeTestableWidget(
+          theme: theme,
+          child: const RegisterWithEmailPage(email: 'newuser@example.com'),
+        );
+      }, find.text(l10n().continueButton));
     });
 
-    testWidgets('meets a11y guidelines for login link in both themes',
-        (tester) async {
+    testWidgets('meets a11y guidelines for login link in both themes', (
+      tester,
+    ) async {
       await setupA11yTest(tester);
 
       await renderPage(tester);
@@ -152,17 +148,15 @@ void main() {
         await enterEmail(tester, 'registered@example.com');
         await tester.pumpAndSettle();
 
-        await expectMeetsTapTargetAndLabelGuidelinesForEachTheme(
-          tester,
-          (theme) {
-            fakeSupabase.setRpcResponse('check_email_exists', true);
-            return makeTestableWidget(
-              theme: theme,
-              child: const RegisterWithEmailPage(email: 'registered@example.com'),
-            );
-          },
-          find.byKey(Key(l10n().logginLink)),
-        );
+        await expectMeetsTapTargetAndLabelGuidelinesForEachTheme(tester, (
+          theme,
+        ) {
+          fakeSupabase.setRpcResponse('check_email_exists', true);
+          return makeTestableWidget(
+            theme: theme,
+            child: const RegisterWithEmailPage(email: 'registered@example.com'),
+          );
+        }, find.byKey(Key(l10n().logginLink)));
       },
     );
 
@@ -194,17 +188,15 @@ void main() {
         await enterEmail(tester, 'error@example.com');
         await tester.pumpAndSettle();
 
-        await expectMeetsTapTargetAndLabelGuidelinesForEachTheme(
-          tester,
-          (theme) {
-            fakeSupabase.shouldThrowOnSelect = true;
-            return makeTestableWidget(
-              theme: theme,
-              child: const RegisterWithEmailPage(email: 'error@example.com'),
-            );
-          },
-          find.byKey(const Key('toast_close_button')),
-        );
+        await expectMeetsTapTargetAndLabelGuidelinesForEachTheme(tester, (
+          theme,
+        ) {
+          fakeSupabase.shouldThrowOnSelect = true;
+          return makeTestableWidget(
+            theme: theme,
+            child: const RegisterWithEmailPage(email: 'error@example.com'),
+          );
+        }, find.byKey(const Key('toast_close_button')));
       },
     );
   });

--- a/test/features/auth/widgets/accessibility/set_new_password_page_a11y_test.dart
+++ b/test/features/auth/widgets/accessibility/set_new_password_page_a11y_test.dart
@@ -3,8 +3,7 @@ import 'package:construculator/features/auth/auth_module.dart';
 import 'package:construculator/features/auth/presentation/bloc/set_new_password_bloc/set_new_password_bloc.dart';
 import 'package:construculator/features/auth/presentation/pages/set_new_password_page.dart';
 import 'package:construculator/l10n/generated/app_localizations.dart';
-import 'package:construculator/libraries/config/testing/fake_app_config.dart';
-import 'package:construculator/libraries/config/testing/fake_env_loader.dart';
+
 import 'package:construculator/libraries/router/testing/router_test_module.dart';
 import 'package:construculator/libraries/supabase/interfaces/supabase_wrapper.dart';
 import 'package:construculator/libraries/supabase/testing/fake_supabase_user.dart';
@@ -18,6 +17,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:ripplearc_coreui/ripplearc_coreui.dart';
 
 import '../../../../utils/a11y/a11y_guidelines.dart';
+import '../../../../utils/fake_app_bootstrap_factory.dart';
 import '../../../../utils/screenshot/font_loader.dart';
 
 class _SetNewPasswordPageA11yTestModule extends Module {
@@ -26,10 +26,10 @@ class _SetNewPasswordPageA11yTestModule extends Module {
 
   @override
   List<Module> get imports => [
-        RouterTestModule(),
-        ClockTestModule(),
-        AuthModule(appBootstrap),
-      ];
+    RouterTestModule(),
+    ClockTestModule(),
+    AuthModule(appBootstrap),
+  ];
 }
 
 void main() {
@@ -48,9 +48,7 @@ void main() {
     fakeSupabase = FakeSupabaseWrapper(clock: FakeClockImpl());
     CoreToast.disableTimers();
 
-    final appBootstrap = AppBootstrap(
-      config: FakeAppConfig(),
-      envLoader: FakeEnvLoader(),
+    final appBootstrap = FakeAppBootstrapFactory.create(
       supabaseWrapper: fakeSupabase,
     );
 
@@ -121,33 +119,36 @@ void main() {
   }
 
   group('SetNewPasswordPage – accessibility', () {
-    testWidgets('meets a11y guidelines for set password button in both themes',
-        (tester) async {
-      const email = 'email@example.com';
-      fakeSupabase.setCurrentUser(createFakeUser(email));
-      await setupA11yTest(tester);
-      await renderPage(tester, email: email);
+    testWidgets(
+      'meets a11y guidelines for set password button in both themes',
+      (tester) async {
+        const email = 'email@example.com';
+        fakeSupabase.setCurrentUser(createFakeUser(email));
+        await setupA11yTest(tester);
+        await renderPage(tester, email: email);
 
-      await expectMeetsTapTargetAndLabelGuidelinesForEachTheme(
-        tester,
-        (theme) {
-          fakeSupabase.setCurrentUser(createFakeUser(email));
-          return makeTestableWidget(
-            theme: theme,
-            child: SetNewPasswordPage(email: email),
-          );
-        },
-        find.text(l10n().setPasswordButton),
-        setupAfterPump: (t) async {
-          await enterNewPassword(t, '@Password123!');
-          await enterConfirmPassword(t, '@Password123!');
-          await t.pumpAndSettle();
-        },
-      );
-    });
+        await expectMeetsTapTargetAndLabelGuidelinesForEachTheme(
+          tester,
+          (theme) {
+            fakeSupabase.setCurrentUser(createFakeUser(email));
+            return makeTestableWidget(
+              theme: theme,
+              child: SetNewPasswordPage(email: email),
+            );
+          },
+          find.text(l10n().setPasswordButton),
+          setupAfterPump: (t) async {
+            await enterNewPassword(t, '@Password123!');
+            await enterConfirmPassword(t, '@Password123!');
+            await t.pumpAndSettle();
+          },
+        );
+      },
+    );
 
-    testWidgets('meets a11y guidelines for new password label in both themes',
-        (tester) async {
+    testWidgets('meets a11y guidelines for new password label in both themes', (
+      tester,
+    ) async {
       await setupA11yTest(tester);
       await renderPage(tester);
 
@@ -161,20 +162,22 @@ void main() {
       );
     });
 
-    testWidgets('meets a11y guidelines for confirm password label in both themes',
-        (tester) async {
-      await setupA11yTest(tester);
-      await renderPage(tester);
+    testWidgets(
+      'meets a11y guidelines for confirm password label in both themes',
+      (tester) async {
+        await setupA11yTest(tester);
+        await renderPage(tester);
 
-      await expectMeetsTapTargetAndLabelGuidelinesForEachTheme(
-        tester,
-        (theme) => makeTestableWidget(
-          theme: theme,
-          child: SetNewPasswordPage(email: ''),
-        ),
-        find.text(l10n().confirmPasswordLabel),
-      );
-    });
+        await expectMeetsTapTargetAndLabelGuidelinesForEachTheme(
+          tester,
+          (theme) => makeTestableWidget(
+            theme: theme,
+            child: SetNewPasswordPage(email: ''),
+          ),
+          find.text(l10n().confirmPasswordLabel),
+        );
+      },
+    );
 
     testWidgets(
       'meets a11y guidelines when password too short error shown in both themes',

--- a/test/features/auth/widgets/pages/create_account_page_test.dart
+++ b/test/features/auth/widgets/pages/create_account_page_test.dart
@@ -3,8 +3,7 @@ import 'package:construculator/features/auth/auth_module.dart';
 import 'package:construculator/features/auth/presentation/bloc/create_account_bloc/create_account_bloc.dart';
 import 'package:construculator/features/auth/presentation/pages/create_account_page.dart';
 import 'package:construculator/l10n/generated/app_localizations.dart';
-import 'package:construculator/libraries/config/testing/fake_app_config.dart';
-import 'package:construculator/libraries/config/testing/fake_env_loader.dart';
+
 import 'package:construculator/libraries/router/interfaces/app_router.dart';
 import 'package:construculator/libraries/router/routes/dashboard_routes.dart';
 import 'package:construculator/libraries/router/testing/fake_router.dart';
@@ -21,6 +20,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_modular/flutter_modular.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:ripplearc_coreui/ripplearc_coreui.dart';
+import '../../../../utils/fake_app_bootstrap_factory.dart';
 import '../../../../utils/screenshot/font_loader.dart';
 
 class _CreateAccountPageTestModule extends Module {
@@ -56,9 +56,7 @@ void main() {
     fakeSupabase = FakeSupabaseWrapper(clock: FakeClockImpl());
     CoreToast.disableTimers();
 
-    final appBootstrap = AppBootstrap(
-      config: FakeAppConfig(),
-      envLoader: FakeEnvLoader(),
+    final appBootstrap = FakeAppBootstrapFactory.create(
       supabaseWrapper: fakeSupabase,
     );
 

--- a/test/features/auth/widgets/pages/enter_password_page_test.dart
+++ b/test/features/auth/widgets/pages/enter_password_page_test.dart
@@ -3,8 +3,7 @@ import 'package:construculator/features/auth/auth_module.dart';
 import 'package:construculator/features/auth/presentation/bloc/enter_password_bloc/enter_password_bloc.dart';
 import 'package:construculator/features/auth/presentation/pages/enter_password_page.dart';
 import 'package:construculator/l10n/generated/app_localizations.dart';
-import 'package:construculator/libraries/config/testing/fake_app_config.dart';
-import 'package:construculator/libraries/config/testing/fake_env_loader.dart';
+
 import 'package:construculator/libraries/router/interfaces/app_router.dart';
 import 'package:construculator/libraries/router/routes/auth_routes.dart';
 import 'package:construculator/libraries/router/testing/fake_router.dart';
@@ -19,6 +18,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_modular/flutter_modular.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:ripplearc_coreui/ripplearc_coreui.dart';
+import '../../../../utils/fake_app_bootstrap_factory.dart';
 import '../../../../utils/screenshot/font_loader.dart';
 
 class _EnterPasswordPageTestModule extends Module {
@@ -43,9 +43,7 @@ void main() {
     fakeSupabase = FakeSupabaseWrapper(clock: FakeClockImpl());
     CoreToast.disableTimers();
 
-    final appBootstrap = AppBootstrap(
-      config: FakeAppConfig(),
-      envLoader: FakeEnvLoader(),
+    final appBootstrap = FakeAppBootstrapFactory.create(
       supabaseWrapper: fakeSupabase,
     );
 

--- a/test/features/auth/widgets/pages/forgot_password_page_test.dart
+++ b/test/features/auth/widgets/pages/forgot_password_page_test.dart
@@ -4,8 +4,7 @@ import 'package:construculator/features/auth/presentation/bloc/forgot_password_b
 import 'package:construculator/features/auth/presentation/bloc/otp_verification_bloc/otp_verification_bloc.dart';
 import 'package:construculator/features/auth/presentation/pages/forgot_password_page.dart';
 import 'package:construculator/l10n/generated/app_localizations.dart';
-import 'package:construculator/libraries/config/testing/fake_app_config.dart';
-import 'package:construculator/libraries/config/testing/fake_env_loader.dart';
+
 import 'package:construculator/libraries/router/interfaces/app_router.dart';
 import 'package:construculator/libraries/router/routes/auth_routes.dart';
 import 'package:construculator/libraries/router/testing/fake_router.dart';
@@ -20,6 +19,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_modular/flutter_modular.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:ripplearc_coreui/ripplearc_coreui.dart';
+import '../../../../utils/fake_app_bootstrap_factory.dart';
 import '../../../../utils/screenshot/font_loader.dart';
 
 class _ForgotPasswordPageTestModule extends Module {
@@ -43,9 +43,7 @@ void main() {
     fakeSupabase = FakeSupabaseWrapper(clock: FakeClockImpl());
     CoreToast.disableTimers();
 
-    final appBootstrap = AppBootstrap(
-      config: FakeAppConfig(),
-      envLoader: FakeEnvLoader(),
+    final appBootstrap = FakeAppBootstrapFactory.create(
       supabaseWrapper: fakeSupabase,
     );
 

--- a/test/features/auth/widgets/pages/login_with_email_page_test.dart
+++ b/test/features/auth/widgets/pages/login_with_email_page_test.dart
@@ -5,8 +5,6 @@ import 'package:construculator/features/auth/auth_module.dart';
 import 'package:construculator/features/auth/presentation/bloc/login_with_email_bloc/login_with_email_bloc.dart';
 import 'package:construculator/features/auth/presentation/pages/login_with_email_page.dart';
 import 'package:construculator/l10n/generated/app_localizations.dart';
-import 'package:construculator/libraries/config/testing/fake_app_config.dart';
-import 'package:construculator/libraries/config/testing/fake_env_loader.dart';
 import 'package:construculator/libraries/router/interfaces/app_router.dart';
 import 'package:construculator/libraries/router/routes/auth_routes.dart';
 import 'package:construculator/libraries/router/testing/fake_router.dart';
@@ -24,6 +22,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:ripplearc_coreui/ripplearc_coreui.dart';
 
 import '../../../../utils/a11y/a11y_guidelines.dart';
+import '../../../../utils/fake_app_bootstrap_factory.dart';
 import '../../../../utils/screenshot/font_loader.dart';
 
 class _LoginWithEmailPageTestModule extends Module {
@@ -66,9 +65,7 @@ void main() {
     fakeSupabase = FakeSupabaseWrapper(clock: FakeClockImpl());
     CoreToast.disableTimers();
 
-    final appBootstrap = AppBootstrap(
-      config: FakeAppConfig(),
-      envLoader: FakeEnvLoader(),
+    final appBootstrap = FakeAppBootstrapFactory.create(
       supabaseWrapper: fakeSupabase,
     );
 
@@ -245,10 +242,10 @@ void main() {
     });
   });
 
-
   group('LoginWithEmailPage – accessibility', () {
-    testWidgets('meets a11y guidelines for continue button in both themes',
-        (tester) async {
+    testWidgets('meets a11y guidelines for continue button in both themes', (
+      tester,
+    ) async {
       fakeSupabase.setRpcResponse('check_email_exists', true);
       await setupA11yTest(tester);
 
@@ -264,8 +261,9 @@ void main() {
       );
     });
 
-    testWidgets('meets a11y guidelines for register link in both themes',
-        (tester) async {
+    testWidgets('meets a11y guidelines for register link in both themes', (
+      tester,
+    ) async {
       await setupA11yTest(tester);
 
       await renderPage(tester);
@@ -289,17 +287,15 @@ void main() {
         await enterEmail(tester, 'notregistered@example.com');
         await tester.pumpAndSettle();
 
-        await expectMeetsTapTargetAndLabelGuidelinesForEachTheme(
-          tester,
-          (theme) {
-            fakeSupabase.setRpcResponse('check_email_exists', false);
-            return makeTestableWidget(
-              theme: theme,
-              child: const LoginWithEmailPage(email: 'notregistered@example.com'),
-            );
-          },
-          find.byKey(const Key('Register')),
-        );
+        await expectMeetsTapTargetAndLabelGuidelinesForEachTheme(tester, (
+          theme,
+        ) {
+          fakeSupabase.setRpcResponse('check_email_exists', false);
+          return makeTestableWidget(
+            theme: theme,
+            child: const LoginWithEmailPage(email: 'notregistered@example.com'),
+          );
+        }, find.byKey(const Key('Register')));
       },
     );
 
@@ -350,17 +346,15 @@ void main() {
         await enterEmail(tester, 'error@example.com');
         await tester.pumpAndSettle();
 
-        await expectMeetsTapTargetAndLabelGuidelinesForEachTheme(
-          tester,
-          (theme) {
-            fakeSupabase.shouldThrowOnRpc = true;
-            return makeTestableWidget(
-              theme: theme,
-              child: const LoginWithEmailPage(email: 'error@example.com'),
-            );
-          },
-          find.text('Close'),
-        );
+        await expectMeetsTapTargetAndLabelGuidelinesForEachTheme(tester, (
+          theme,
+        ) {
+          fakeSupabase.shouldThrowOnRpc = true;
+          return makeTestableWidget(
+            theme: theme,
+            child: const LoginWithEmailPage(email: 'error@example.com'),
+          );
+        }, find.text('Close'));
       },
     );
   });

--- a/test/features/auth/widgets/pages/register_with_email_page_test.dart
+++ b/test/features/auth/widgets/pages/register_with_email_page_test.dart
@@ -7,8 +7,6 @@ import 'package:construculator/features/auth/presentation/bloc/register_with_ema
 import 'package:construculator/features/auth/presentation/pages/register_with_email_page.dart';
 import 'package:construculator/features/auth/presentation/widgets/otp_quick_sheet/otp_verification_sheet.dart';
 import 'package:construculator/l10n/generated/app_localizations.dart';
-import 'package:construculator/libraries/config/testing/fake_app_config.dart';
-import 'package:construculator/libraries/config/testing/fake_env_loader.dart';
 import 'package:construculator/libraries/router/interfaces/app_router.dart';
 import 'package:construculator/libraries/router/routes/auth_routes.dart';
 import 'package:construculator/libraries/router/testing/fake_router.dart';
@@ -23,6 +21,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_modular/flutter_modular.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:ripplearc_coreui/ripplearc_coreui.dart';
+import '../../../../utils/fake_app_bootstrap_factory.dart';
 import '../../../../utils/screenshot/font_loader.dart';
 
 class _RegisterWithEmailPageTestModule extends Module {
@@ -71,9 +70,7 @@ void main() {
     fakeSupabase = FakeSupabaseWrapper(clock: FakeClockImpl());
     CoreToast.disableTimers();
 
-    final appBootstrap = AppBootstrap(
-      config: FakeAppConfig(),
-      envLoader: FakeEnvLoader(),
+    final appBootstrap = FakeAppBootstrapFactory.create(
       supabaseWrapper: fakeSupabase,
     );
 

--- a/test/features/auth/widgets/pages/set_new_password_page_test.dart
+++ b/test/features/auth/widgets/pages/set_new_password_page_test.dart
@@ -3,8 +3,6 @@ import 'package:construculator/features/auth/auth_module.dart';
 import 'package:construculator/features/auth/presentation/bloc/set_new_password_bloc/set_new_password_bloc.dart';
 import 'package:construculator/features/auth/presentation/pages/set_new_password_page.dart';
 import 'package:construculator/l10n/generated/app_localizations.dart';
-import 'package:construculator/libraries/config/testing/fake_app_config.dart';
-import 'package:construculator/libraries/config/testing/fake_env_loader.dart';
 import 'package:construculator/libraries/router/interfaces/app_router.dart';
 import 'package:construculator/libraries/router/routes/dashboard_routes.dart';
 import 'package:construculator/libraries/router/testing/fake_router.dart';
@@ -19,6 +17,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_modular/flutter_modular.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:ripplearc_coreui/ripplearc_coreui.dart';
+import '../../../../utils/fake_app_bootstrap_factory.dart';
 import '../../../../utils/screenshot/font_loader.dart';
 
 class _SetNewPasswordPageTestModule extends Module {
@@ -50,9 +49,7 @@ void main() {
     fakeSupabase = FakeSupabaseWrapper(clock: FakeClockImpl());
     CoreToast.disableTimers();
 
-    final appBootstrap = AppBootstrap(
-      config: FakeAppConfig(),
-      envLoader: FakeEnvLoader(),
+    final appBootstrap = FakeAppBootstrapFactory.create(
       supabaseWrapper: fakeSupabase,
     );
 

--- a/test/features/dashboard/units/blocs/project_dropdown_bloc_test.dart
+++ b/test/features/dashboard/units/blocs/project_dropdown_bloc_test.dart
@@ -2,8 +2,6 @@ import 'package:bloc_test/bloc_test.dart';
 import 'package:construculator/app/app_bootstrap.dart';
 import 'package:construculator/features/dashboard/dashboard_module.dart';
 import 'package:construculator/features/dashboard/presentation/bloc/project_dropdown_bloc/project_dropdown_bloc.dart';
-import 'package:construculator/libraries/config/testing/fake_app_config.dart';
-import 'package:construculator/libraries/config/testing/fake_env_loader.dart';
 import 'package:construculator/libraries/supabase/data/supabase_types.dart';
 import 'package:construculator/libraries/supabase/database_constants.dart';
 import 'package:construculator/libraries/supabase/interfaces/supabase_wrapper.dart';
@@ -14,6 +12,8 @@ import 'package:construculator/libraries/time/testing/fake_clock_impl.dart';
 import 'package:flutter_modular/flutter_modular.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import '../../../../utils/fake_app_bootstrap_factory.dart';
+
 void main() {
   group('ProjectDropdownBloc', () {
     late FakeSupabaseWrapper fakeSupabaseWrapper;
@@ -22,10 +22,8 @@ void main() {
 
     setUpAll(() {
       clock = FakeClockImpl(DateTime(2025, 1, 1, 8, 0));
-      final bootstrap = AppBootstrap(
-        supabaseWrapper: FakeSupabaseWrapper(clock: clock),
-        config: FakeAppConfig(),
-        envLoader: FakeEnvLoader(),
+      final bootstrap = FakeAppBootstrapFactory.create(
+        clock: clock,
       );
       Modular.init(_ProjectDropdownBlocTestModule(bootstrap));
       fakeSupabaseWrapper =

--- a/test/features/dashboard/units/blocs/project_dropdown_bloc_test.dart
+++ b/test/features/dashboard/units/blocs/project_dropdown_bloc_test.dart
@@ -22,7 +22,9 @@ void main() {
 
     setUpAll(() {
       clock = FakeClockImpl(DateTime(2025, 1, 1, 8, 0));
-      final bootstrap = FakeAppBootstrapFactory.create(clock: clock);
+      final bootstrap = FakeAppBootstrapFactory.create(
+        supabaseWrapper: FakeSupabaseWrapper(clock: clock),
+      );
       Modular.init(_ProjectDropdownBlocTestModule(bootstrap));
       fakeSupabaseWrapper =
           Modular.get<SupabaseWrapper>() as FakeSupabaseWrapper;

--- a/test/features/dashboard/units/blocs/project_dropdown_bloc_test.dart
+++ b/test/features/dashboard/units/blocs/project_dropdown_bloc_test.dart
@@ -22,9 +22,7 @@ void main() {
 
     setUpAll(() {
       clock = FakeClockImpl(DateTime(2025, 1, 1, 8, 0));
-      final bootstrap = FakeAppBootstrapFactory.create(
-        clock: clock,
-      );
+      final bootstrap = FakeAppBootstrapFactory.create(clock: clock);
       Modular.init(_ProjectDropdownBlocTestModule(bootstrap));
       fakeSupabaseWrapper =
           Modular.get<SupabaseWrapper>() as FakeSupabaseWrapper;

--- a/test/features/estimations/helpers/log_test_data_factory.dart
+++ b/test/features/estimations/helpers/log_test_data_factory.dart
@@ -29,8 +29,7 @@ class LogTestDataFactory {
       DatabaseConstants.activityColumn: activity,
       DatabaseConstants.userColumn: userDto.toJson(),
       DatabaseConstants.activityDetailsColumn: activityDetails ?? const {},
-      DatabaseConstants.loggedAtColumn:
-          loggedAt ?? '2025-02-25T10:00:00.000Z',
+      DatabaseConstants.loggedAtColumn: loggedAt ?? '2025-02-25T10:00:00.000Z',
     };
   }
 

--- a/test/features/estimations/screenshots/cost_estimation_logs_list_screenshot_test.dart
+++ b/test/features/estimations/screenshots/cost_estimation_logs_list_screenshot_test.dart
@@ -4,8 +4,6 @@ import 'package:construculator/features/estimation/estimation_module.dart';
 import 'package:construculator/features/estimation/presentation/bloc/cost_estimation_log_bloc/cost_estimation_log_bloc.dart';
 import 'package:construculator/features/estimation/presentation/widgets/cost_estimation_logs_list.dart';
 import 'package:construculator/l10n/generated/app_localizations.dart';
-import 'package:construculator/libraries/config/testing/fake_app_config.dart';
-import 'package:construculator/libraries/config/testing/fake_env_loader.dart';
 import 'package:construculator/libraries/supabase/data/supabase_types.dart';
 import 'package:construculator/libraries/supabase/database_constants.dart';
 import 'package:construculator/libraries/supabase/testing/fake_supabase_wrapper.dart';
@@ -16,6 +14,7 @@ import 'package:flutter_modular/flutter_modular.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:ripplearc_coreui/ripplearc_coreui.dart';
 
+import '../../../utils/fake_app_bootstrap_factory.dart';
 import '../../../utils/screenshot/font_loader.dart';
 import '../helpers/log_test_data_factory.dart';
 
@@ -35,11 +34,7 @@ void main() {
 
     fakeClock = FakeClockImpl();
     fakeSupabase = FakeSupabaseWrapper(clock: fakeClock);
-    bootstrap = AppBootstrap(
-      supabaseWrapper: fakeSupabase,
-      config: FakeAppConfig(),
-      envLoader: FakeEnvLoader(),
-    );
+    bootstrap = FakeAppBootstrapFactory.create(supabaseWrapper: fakeSupabase);
 
     Modular.init(EstimationModule(bootstrap));
   });

--- a/test/features/estimations/screenshots/estimation_rename_sheet_screenshot_test.dart
+++ b/test/features/estimations/screenshots/estimation_rename_sheet_screenshot_test.dart
@@ -1,18 +1,14 @@
-import 'package:construculator/app/app_bootstrap.dart';
 import 'package:construculator/features/estimation/estimation_module.dart';
 import 'package:construculator/features/estimation/presentation/bloc/rename_estimation_bloc/rename_estimation_bloc.dart';
 import 'package:construculator/features/estimation/presentation/widgets/estimation_rename_sheet.dart';
 import 'package:construculator/l10n/generated/app_localizations.dart';
-import 'package:construculator/libraries/config/testing/fake_app_config.dart';
-import 'package:construculator/libraries/config/testing/fake_env_loader.dart';
-import 'package:construculator/libraries/supabase/testing/fake_supabase_wrapper.dart';
-import 'package:construculator/libraries/time/testing/fake_clock_impl.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_modular/flutter_modular.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:ripplearc_coreui/ripplearc_coreui.dart';
 
+import '../../../utils/fake_app_bootstrap_factory.dart';
 import '../../../utils/screenshot/font_loader.dart';
 
 void main() {
@@ -22,15 +18,7 @@ void main() {
 
   setUpAll(() async {
     await loadAppFonts();
-    Modular.init(
-      EstimationModule(
-        AppBootstrap(
-          config: FakeAppConfig(),
-          envLoader: FakeEnvLoader(),
-          supabaseWrapper: FakeSupabaseWrapper(clock: FakeClockImpl()),
-        ),
-      ),
-    );
+    Modular.init(EstimationModule(FakeAppBootstrapFactory.create()));
   });
 
   tearDownAll(() {

--- a/test/features/estimations/units/blocs/add_cost_estimation_bloc_test.dart
+++ b/test/features/estimations/units/blocs/add_cost_estimation_bloc_test.dart
@@ -1,11 +1,8 @@
 import 'package:bloc_test/bloc_test.dart';
-import 'package:construculator/app/app_bootstrap.dart';
 import 'package:construculator/features/estimation/domain/entities/enums.dart';
 import 'package:construculator/features/estimation/domain/entities/lock_status_entity.dart';
 import 'package:construculator/features/estimation/estimation_module.dart';
 import 'package:construculator/features/estimation/presentation/bloc/add_cost_estimation_bloc/add_cost_estimation_bloc.dart';
-import 'package:construculator/libraries/config/testing/fake_app_config.dart';
-import 'package:construculator/libraries/config/testing/fake_env_loader.dart';
 import 'package:construculator/libraries/errors/failures.dart';
 import 'package:construculator/libraries/estimation/domain/estimation_error_type.dart';
 import 'package:construculator/libraries/supabase/data/supabase_types.dart';
@@ -15,6 +12,8 @@ import 'package:construculator/libraries/supabase/testing/fake_supabase_wrapper.
 import 'package:construculator/libraries/time/testing/fake_clock_impl.dart';
 import 'package:flutter_modular/flutter_modular.dart';
 import 'package:flutter_test/flutter_test.dart';
+
+import '../../../../utils/fake_app_bootstrap_factory.dart';
 
 void main() {
   group('AddCostEstimationBloc', () {
@@ -66,11 +65,7 @@ void main() {
 
     setUpAll(() {
       fakeClock = FakeClockImpl();
-      final bootstrap = AppBootstrap(
-        supabaseWrapper: FakeSupabaseWrapper(clock: fakeClock),
-        config: FakeAppConfig(),
-        envLoader: FakeEnvLoader(),
-      );
+      final bootstrap = FakeAppBootstrapFactory.create(clock: fakeClock);
       Modular.init(EstimationModule(bootstrap));
 
       fakeSupabaseWrapper =

--- a/test/features/estimations/units/blocs/add_cost_estimation_bloc_test.dart
+++ b/test/features/estimations/units/blocs/add_cost_estimation_bloc_test.dart
@@ -65,7 +65,9 @@ void main() {
 
     setUpAll(() {
       fakeClock = FakeClockImpl();
-      final bootstrap = FakeAppBootstrapFactory.create(clock: fakeClock);
+      final bootstrap = FakeAppBootstrapFactory.create(
+        supabaseWrapper: FakeSupabaseWrapper(clock: fakeClock),
+      );
       Modular.init(EstimationModule(bootstrap));
 
       fakeSupabaseWrapper =

--- a/test/features/estimations/units/blocs/change_lock_status_bloc_test.dart
+++ b/test/features/estimations/units/blocs/change_lock_status_bloc_test.dart
@@ -26,7 +26,9 @@ void main() {
 
     setUpAll(() {
       fakeClock = FakeClockImpl();
-      final bootstrap = FakeAppBootstrapFactory.create(clock: fakeClock);
+      final bootstrap = FakeAppBootstrapFactory.create(
+        supabaseWrapper: FakeSupabaseWrapper(clock: fakeClock),
+      );
       Modular.init(EstimationModule(bootstrap));
 
       fakeSupabaseWrapper =

--- a/test/features/estimations/units/blocs/change_lock_status_bloc_test.dart
+++ b/test/features/estimations/units/blocs/change_lock_status_bloc_test.dart
@@ -1,9 +1,6 @@
 import 'package:bloc_test/bloc_test.dart';
-import 'package:construculator/app/app_bootstrap.dart';
 import 'package:construculator/features/estimation/estimation_module.dart';
 import 'package:construculator/features/estimation/presentation/bloc/change_lock_status_bloc/change_lock_status_bloc.dart';
-import 'package:construculator/libraries/config/testing/fake_app_config.dart';
-import 'package:construculator/libraries/config/testing/fake_env_loader.dart';
 import 'package:construculator/libraries/errors/failures.dart';
 import 'package:construculator/libraries/estimation/domain/estimation_error_type.dart';
 import 'package:construculator/libraries/supabase/data/supabase_types.dart';
@@ -14,6 +11,7 @@ import 'package:construculator/libraries/time/testing/fake_clock_impl.dart';
 import 'package:flutter_modular/flutter_modular.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import '../../../../utils/fake_app_bootstrap_factory.dart';
 import '../../helpers/estimation_test_data_map_factory.dart';
 
 void main() {
@@ -28,11 +26,7 @@ void main() {
 
     setUpAll(() {
       fakeClock = FakeClockImpl();
-      final bootstrap = AppBootstrap(
-        supabaseWrapper: FakeSupabaseWrapper(clock: fakeClock),
-        config: FakeAppConfig(),
-        envLoader: FakeEnvLoader(),
-      );
+      final bootstrap = FakeAppBootstrapFactory.create(clock: fakeClock);
       Modular.init(EstimationModule(bootstrap));
 
       fakeSupabaseWrapper =

--- a/test/features/estimations/units/blocs/cost_estimation_list_bloc_test.dart
+++ b/test/features/estimations/units/blocs/cost_estimation_list_bloc_test.dart
@@ -7,8 +7,7 @@ import 'package:construculator/features/estimation/data/repositories/cost_estima
 import 'package:construculator/features/estimation/domain/repositories/cost_estimation_repository.dart';
 import 'package:construculator/features/estimation/estimation_module.dart';
 import 'package:construculator/features/estimation/presentation/bloc/cost_estimation_list_bloc/cost_estimation_list_bloc.dart';
-import 'package:construculator/libraries/config/testing/fake_app_config.dart';
-import 'package:construculator/libraries/config/testing/fake_env_loader.dart';
+
 import 'package:construculator/libraries/errors/failures.dart';
 import 'package:construculator/libraries/estimation/domain/estimation_error_type.dart';
 import 'package:construculator/libraries/supabase/data/supabase_types.dart';
@@ -20,6 +19,7 @@ import 'package:construculator/libraries/time/testing/fake_clock_impl.dart';
 import 'package:flutter_modular/flutter_modular.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import '../../../../utils/fake_app_bootstrap_factory.dart';
 import '../../helpers/estimation_test_data_map_factory.dart';
 
 void main() {
@@ -33,11 +33,7 @@ void main() {
 
     setUpAll(() {
       fakeClock = FakeClockImpl();
-      final bootstrap = AppBootstrap(
-        supabaseWrapper: FakeSupabaseWrapper(clock: fakeClock),
-        config: FakeAppConfig(),
-        envLoader: FakeEnvLoader(),
-      );
+      final bootstrap = FakeAppBootstrapFactory.create(clock: fakeClock);
       Modular.init(_TestModule(bootstrap));
       fakeSupabaseWrapper =
           Modular.get<SupabaseWrapper>() as FakeSupabaseWrapper;

--- a/test/features/estimations/units/blocs/cost_estimation_list_bloc_test.dart
+++ b/test/features/estimations/units/blocs/cost_estimation_list_bloc_test.dart
@@ -7,7 +7,6 @@ import 'package:construculator/features/estimation/data/repositories/cost_estima
 import 'package:construculator/features/estimation/domain/repositories/cost_estimation_repository.dart';
 import 'package:construculator/features/estimation/estimation_module.dart';
 import 'package:construculator/features/estimation/presentation/bloc/cost_estimation_list_bloc/cost_estimation_list_bloc.dart';
-
 import 'package:construculator/libraries/errors/failures.dart';
 import 'package:construculator/libraries/estimation/domain/estimation_error_type.dart';
 import 'package:construculator/libraries/supabase/data/supabase_types.dart';
@@ -33,7 +32,9 @@ void main() {
 
     setUpAll(() {
       fakeClock = FakeClockImpl();
-      final bootstrap = FakeAppBootstrapFactory.create(clock: fakeClock);
+      final bootstrap = FakeAppBootstrapFactory.create(
+        supabaseWrapper: FakeSupabaseWrapper(clock: fakeClock),
+      );
       Modular.init(_TestModule(bootstrap));
       fakeSupabaseWrapper =
           Modular.get<SupabaseWrapper>() as FakeSupabaseWrapper;

--- a/test/features/estimations/units/blocs/cost_estimation_log_bloc_test.dart
+++ b/test/features/estimations/units/blocs/cost_estimation_log_bloc_test.dart
@@ -38,7 +38,9 @@ void main() {
 
     setUpAll(() {
       fakeClock = FakeClockImpl();
-      final bootstrap = FakeAppBootstrapFactory.create(clock: fakeClock);
+      final bootstrap = FakeAppBootstrapFactory.create(
+        supabaseWrapper: FakeSupabaseWrapper(clock: fakeClock),
+      );
       Modular.init(EstimationModule(bootstrap));
 
       fakeSupabaseWrapper =

--- a/test/features/estimations/units/blocs/cost_estimation_log_bloc_test.dart
+++ b/test/features/estimations/units/blocs/cost_estimation_log_bloc_test.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 
 import 'package:bloc_test/bloc_test.dart';
-import 'package:construculator/app/app_bootstrap.dart';
 import 'package:construculator/features/estimation/data/repositories/cost_estimation_log_repository_impl.dart';
 import 'package:construculator/features/estimation/domain/entities/cost_estimation_activity_type.dart';
 import 'package:construculator/features/estimation/domain/entities/cost_estimation_log_entity.dart';
@@ -9,8 +8,7 @@ import 'package:construculator/features/estimation/domain/repositories/cost_esti
 import 'package:construculator/features/estimation/estimation_module.dart';
 import 'package:construculator/features/estimation/presentation/bloc/cost_estimation_log_bloc/cost_estimation_log_bloc.dart';
 import 'package:construculator/libraries/auth/domain/entities/user_profile_entity.dart';
-import 'package:construculator/libraries/config/testing/fake_app_config.dart';
-import 'package:construculator/libraries/config/testing/fake_env_loader.dart';
+
 import 'package:construculator/libraries/errors/failures.dart';
 import 'package:construculator/libraries/estimation/domain/estimation_error_type.dart';
 import 'package:construculator/libraries/supabase/data/supabase_types.dart';
@@ -21,6 +19,7 @@ import 'package:construculator/libraries/time/testing/fake_clock_impl.dart';
 import 'package:flutter_modular/flutter_modular.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import '../../../../utils/fake_app_bootstrap_factory.dart';
 import '../../helpers/log_test_data_factory.dart';
 
 void main() {
@@ -39,11 +38,7 @@ void main() {
 
     setUpAll(() {
       fakeClock = FakeClockImpl();
-      final bootstrap = AppBootstrap(
-        supabaseWrapper: FakeSupabaseWrapper(clock: fakeClock),
-        config: FakeAppConfig(),
-        envLoader: FakeEnvLoader(),
-      );
+      final bootstrap = FakeAppBootstrapFactory.create(clock: fakeClock);
       Modular.init(EstimationModule(bootstrap));
 
       fakeSupabaseWrapper =

--- a/test/features/estimations/units/blocs/delete_cost_estimation_bloc_test.dart
+++ b/test/features/estimations/units/blocs/delete_cost_estimation_bloc_test.dart
@@ -1,7 +1,6 @@
 import 'package:bloc_test/bloc_test.dart';
 import 'package:construculator/features/estimation/estimation_module.dart';
 import 'package:construculator/features/estimation/presentation/bloc/delete_cost_estimation_bloc/delete_cost_estimation_bloc.dart';
-
 import 'package:construculator/libraries/errors/failures.dart';
 import 'package:construculator/libraries/estimation/domain/estimation_error_type.dart';
 import 'package:construculator/libraries/supabase/data/supabase_types.dart';
@@ -27,7 +26,9 @@ void main() {
 
     setUpAll(() {
       fakeClock = FakeClockImpl();
-      final bootstrap = FakeAppBootstrapFactory.create(clock: fakeClock);
+      final bootstrap = FakeAppBootstrapFactory.create(
+        supabaseWrapper: FakeSupabaseWrapper(clock: fakeClock),
+      );
       Modular.init(EstimationModule(bootstrap));
 
       fakeSupabaseWrapper =

--- a/test/features/estimations/units/blocs/delete_cost_estimation_bloc_test.dart
+++ b/test/features/estimations/units/blocs/delete_cost_estimation_bloc_test.dart
@@ -1,9 +1,7 @@
 import 'package:bloc_test/bloc_test.dart';
-import 'package:construculator/app/app_bootstrap.dart';
 import 'package:construculator/features/estimation/estimation_module.dart';
 import 'package:construculator/features/estimation/presentation/bloc/delete_cost_estimation_bloc/delete_cost_estimation_bloc.dart';
-import 'package:construculator/libraries/config/testing/fake_app_config.dart';
-import 'package:construculator/libraries/config/testing/fake_env_loader.dart';
+
 import 'package:construculator/libraries/errors/failures.dart';
 import 'package:construculator/libraries/estimation/domain/estimation_error_type.dart';
 import 'package:construculator/libraries/supabase/data/supabase_types.dart';
@@ -14,6 +12,7 @@ import 'package:construculator/libraries/time/testing/fake_clock_impl.dart';
 import 'package:flutter_modular/flutter_modular.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import '../../../../utils/fake_app_bootstrap_factory.dart';
 import '../../helpers/estimation_test_data_map_factory.dart';
 
 void main() {
@@ -28,11 +27,7 @@ void main() {
 
     setUpAll(() {
       fakeClock = FakeClockImpl();
-      final bootstrap = AppBootstrap(
-        supabaseWrapper: FakeSupabaseWrapper(clock: fakeClock),
-        config: FakeAppConfig(),
-        envLoader: FakeEnvLoader(),
-      );
+      final bootstrap = FakeAppBootstrapFactory.create(clock: fakeClock);
       Modular.init(EstimationModule(bootstrap));
 
       fakeSupabaseWrapper =

--- a/test/features/estimations/units/blocs/rename_estimation_bloc_test.dart
+++ b/test/features/estimations/units/blocs/rename_estimation_bloc_test.dart
@@ -1,7 +1,6 @@
 import 'package:bloc_test/bloc_test.dart';
 import 'package:construculator/features/estimation/estimation_module.dart';
 import 'package:construculator/features/estimation/presentation/bloc/rename_estimation_bloc/rename_estimation_bloc.dart';
-
 import 'package:construculator/libraries/errors/failures.dart';
 import 'package:construculator/libraries/estimation/domain/estimation_error_type.dart';
 import 'package:construculator/libraries/supabase/data/supabase_types.dart';
@@ -28,7 +27,9 @@ void main() {
 
     setUpAll(() {
       fakeClock = FakeClockImpl();
-      final bootstrap = FakeAppBootstrapFactory.create(clock: fakeClock);
+      final bootstrap = FakeAppBootstrapFactory.create(
+        supabaseWrapper: FakeSupabaseWrapper(clock: fakeClock),
+      );
       Modular.init(EstimationModule(bootstrap));
 
       fakeSupabaseWrapper =

--- a/test/features/estimations/units/blocs/rename_estimation_bloc_test.dart
+++ b/test/features/estimations/units/blocs/rename_estimation_bloc_test.dart
@@ -1,9 +1,7 @@
 import 'package:bloc_test/bloc_test.dart';
-import 'package:construculator/app/app_bootstrap.dart';
 import 'package:construculator/features/estimation/estimation_module.dart';
 import 'package:construculator/features/estimation/presentation/bloc/rename_estimation_bloc/rename_estimation_bloc.dart';
-import 'package:construculator/libraries/config/testing/fake_app_config.dart';
-import 'package:construculator/libraries/config/testing/fake_env_loader.dart';
+
 import 'package:construculator/libraries/errors/failures.dart';
 import 'package:construculator/libraries/estimation/domain/estimation_error_type.dart';
 import 'package:construculator/libraries/supabase/data/supabase_types.dart';
@@ -14,6 +12,7 @@ import 'package:construculator/libraries/time/testing/fake_clock_impl.dart';
 import 'package:flutter_modular/flutter_modular.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import '../../../../utils/fake_app_bootstrap_factory.dart';
 import '../../helpers/estimation_test_data_map_factory.dart';
 
 void main() {
@@ -29,11 +28,7 @@ void main() {
 
     setUpAll(() {
       fakeClock = FakeClockImpl();
-      final bootstrap = AppBootstrap(
-        supabaseWrapper: FakeSupabaseWrapper(clock: fakeClock),
-        config: FakeAppConfig(),
-        envLoader: FakeEnvLoader(),
-      );
+      final bootstrap = FakeAppBootstrapFactory.create(clock: fakeClock);
       Modular.init(EstimationModule(bootstrap));
 
       fakeSupabaseWrapper =

--- a/test/features/estimations/units/data/data_source/remote_cost_estimation_data_source_test.dart
+++ b/test/features/estimations/units/data/data_source/remote_cost_estimation_data_source_test.dart
@@ -1,12 +1,10 @@
 import 'dart:io';
 
-import 'package:construculator/app/app_bootstrap.dart';
 import 'package:construculator/features/estimation/data/data_source/interfaces/cost_estimation_data_source.dart';
 import 'package:construculator/features/estimation/data/data_source/remote_cost_estimation_data_source.dart';
 import 'package:construculator/features/estimation/data/models/cost_estimate_dto.dart';
 import 'package:construculator/features/estimation/estimation_module.dart';
-import 'package:construculator/libraries/config/testing/fake_app_config.dart';
-import 'package:construculator/libraries/config/testing/fake_env_loader.dart';
+
 import 'package:construculator/libraries/supabase/data/supabase_types.dart';
 import 'package:construculator/libraries/supabase/database_constants.dart';
 import 'package:construculator/libraries/supabase/testing/fake_supabase_wrapper.dart';
@@ -15,6 +13,7 @@ import 'package:flutter_modular/flutter_modular.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:supabase_flutter/supabase_flutter.dart' as supabase;
 
+import '../../../../../utils/fake_app_bootstrap_factory.dart';
 import '../../../helpers/estimation_test_data_map_factory.dart';
 
 void main() {
@@ -68,11 +67,7 @@ void main() {
       fakeSupabaseWrapper = FakeSupabaseWrapper(clock: fakeClock);
       Modular.init(
         EstimationModule(
-          AppBootstrap(
-            config: FakeAppConfig(),
-            envLoader: FakeEnvLoader(),
-            supabaseWrapper: fakeSupabaseWrapper,
-          ),
+          FakeAppBootstrapFactory.create(supabaseWrapper: fakeSupabaseWrapper),
         ),
       );
       dataSource =

--- a/test/features/estimations/units/data/data_source/remote_cost_estimation_log_data_source_test.dart
+++ b/test/features/estimations/units/data/data_source/remote_cost_estimation_log_data_source_test.dart
@@ -23,7 +23,11 @@ void main() {
     setUpAll(() {
       fakeClock = FakeClockImpl();
       Modular.init(
-        EstimationModule(FakeAppBootstrapFactory.create(clock: fakeClock)),
+        EstimationModule(
+          FakeAppBootstrapFactory.create(
+            supabaseWrapper: FakeSupabaseWrapper(clock: fakeClock),
+          ),
+        ),
       );
       fakeSupabaseWrapper =
           Modular.get<SupabaseWrapper>() as FakeSupabaseWrapper;

--- a/test/features/estimations/units/data/data_source/remote_cost_estimation_log_data_source_test.dart
+++ b/test/features/estimations/units/data/data_source/remote_cost_estimation_log_data_source_test.dart
@@ -1,9 +1,7 @@
-import 'package:construculator/app/app_bootstrap.dart';
 import 'package:construculator/features/estimation/data/data_source/interfaces/cost_estimation_log_data_source.dart';
 import 'package:construculator/features/estimation/data/models/cost_estimation_log_dto.dart';
 import 'package:construculator/features/estimation/estimation_module.dart';
-import 'package:construculator/libraries/config/testing/fake_app_config.dart';
-import 'package:construculator/libraries/config/testing/fake_env_loader.dart';
+
 import 'package:construculator/libraries/supabase/database_constants.dart';
 import 'package:construculator/libraries/supabase/interfaces/supabase_wrapper.dart';
 import 'package:construculator/libraries/supabase/testing/fake_supabase_wrapper.dart';
@@ -11,6 +9,7 @@ import 'package:construculator/libraries/time/testing/fake_clock_impl.dart';
 import 'package:flutter_modular/flutter_modular.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import '../../../../../utils/fake_app_bootstrap_factory.dart';
 import '../../../helpers/log_test_data_factory.dart';
 
 void main() {
@@ -24,13 +23,7 @@ void main() {
     setUpAll(() {
       fakeClock = FakeClockImpl();
       Modular.init(
-        EstimationModule(
-          AppBootstrap(
-            supabaseWrapper: FakeSupabaseWrapper(clock: fakeClock),
-            config: FakeAppConfig(),
-            envLoader: FakeEnvLoader(),
-          ),
-        ),
+        EstimationModule(FakeAppBootstrapFactory.create(clock: fakeClock)),
       );
       fakeSupabaseWrapper =
           Modular.get<SupabaseWrapper>() as FakeSupabaseWrapper;

--- a/test/features/estimations/units/data/repositories/cost_estimation_log_repository_impl_test.dart
+++ b/test/features/estimations/units/data/repositories/cost_estimation_log_repository_impl_test.dart
@@ -28,7 +28,11 @@ void main() {
     setUpAll(() {
       fakeClock = FakeClockImpl();
       Modular.init(
-        EstimationModule(FakeAppBootstrapFactory.create(clock: fakeClock)),
+        EstimationModule(
+          FakeAppBootstrapFactory.create(
+            supabaseWrapper: FakeSupabaseWrapper(clock: fakeClock),
+          ),
+        ),
       );
       fakeSupabaseWrapper =
           Modular.get<SupabaseWrapper>() as FakeSupabaseWrapper;

--- a/test/features/estimations/units/data/repositories/cost_estimation_log_repository_impl_test.dart
+++ b/test/features/estimations/units/data/repositories/cost_estimation_log_repository_impl_test.dart
@@ -1,10 +1,8 @@
-import 'package:construculator/app/app_bootstrap.dart';
 import 'package:construculator/features/estimation/data/models/cost_estimation_log_dto.dart';
 import 'package:construculator/features/estimation/data/repositories/cost_estimation_log_repository_impl.dart';
 import 'package:construculator/features/estimation/domain/repositories/cost_estimation_log_repository.dart';
 import 'package:construculator/features/estimation/estimation_module.dart';
-import 'package:construculator/libraries/config/testing/fake_app_config.dart';
-import 'package:construculator/libraries/config/testing/fake_env_loader.dart';
+
 import 'package:construculator/libraries/errors/failures.dart';
 import 'package:construculator/libraries/estimation/domain/estimation_error_type.dart';
 import 'package:construculator/libraries/supabase/data/supabase_types.dart';
@@ -15,6 +13,7 @@ import 'package:construculator/libraries/time/testing/fake_clock_impl.dart';
 import 'package:flutter_modular/flutter_modular.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import '../../../../../utils/fake_app_bootstrap_factory.dart';
 import '../../../helpers/log_test_data_factory.dart';
 
 void main() {
@@ -29,13 +28,7 @@ void main() {
     setUpAll(() {
       fakeClock = FakeClockImpl();
       Modular.init(
-        EstimationModule(
-          AppBootstrap(
-            supabaseWrapper: FakeSupabaseWrapper(clock: fakeClock),
-            config: FakeAppConfig(),
-            envLoader: FakeEnvLoader(),
-          ),
-        ),
+        EstimationModule(FakeAppBootstrapFactory.create(clock: fakeClock)),
       );
       fakeSupabaseWrapper =
           Modular.get<SupabaseWrapper>() as FakeSupabaseWrapper;

--- a/test/features/estimations/units/data/repositories/cost_estimation_repository_impl_test.dart
+++ b/test/features/estimations/units/data/repositories/cost_estimation_repository_impl_test.dart
@@ -1,11 +1,9 @@
-import 'package:construculator/app/app_bootstrap.dart';
 import 'package:construculator/features/estimation/data/models/cost_estimate_dto.dart';
 import 'package:construculator/features/estimation/data/repositories/cost_estimation_repository_impl.dart';
 import 'package:construculator/features/estimation/domain/entities/cost_estimate_entity.dart';
 import 'package:construculator/features/estimation/domain/repositories/cost_estimation_repository.dart';
 import 'package:construculator/features/estimation/estimation_module.dart';
-import 'package:construculator/libraries/config/testing/fake_app_config.dart';
-import 'package:construculator/libraries/config/testing/fake_env_loader.dart';
+
 import 'package:construculator/libraries/either/either.dart';
 import 'package:construculator/libraries/errors/failures.dart';
 import 'package:construculator/libraries/estimation/domain/estimation_error_type.dart';
@@ -17,6 +15,7 @@ import 'package:construculator/libraries/time/testing/fake_clock_impl.dart';
 import 'package:flutter_modular/flutter_modular.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import '../../../../../utils/fake_app_bootstrap_factory.dart';
 import '../../../helpers/estimation_test_data_map_factory.dart';
 
 void main() {
@@ -48,13 +47,7 @@ void main() {
     setUpAll(() {
       fakeClock = FakeClockImpl();
       Modular.init(
-        EstimationModule(
-          AppBootstrap(
-            supabaseWrapper: FakeSupabaseWrapper(clock: fakeClock),
-            config: FakeAppConfig(),
-            envLoader: FakeEnvLoader(),
-          ),
-        ),
+        EstimationModule(FakeAppBootstrapFactory.create(clock: fakeClock)),
       );
       fakeSupabaseWrapper =
           Modular.get<SupabaseWrapper>() as FakeSupabaseWrapper;

--- a/test/features/estimations/units/data/repositories/cost_estimation_repository_impl_test.dart
+++ b/test/features/estimations/units/data/repositories/cost_estimation_repository_impl_test.dart
@@ -47,7 +47,11 @@ void main() {
     setUpAll(() {
       fakeClock = FakeClockImpl();
       Modular.init(
-        EstimationModule(FakeAppBootstrapFactory.create(clock: fakeClock)),
+        EstimationModule(
+          FakeAppBootstrapFactory.create(
+            supabaseWrapper: FakeSupabaseWrapper(clock: fakeClock),
+          ),
+        ),
       );
       fakeSupabaseWrapper =
           Modular.get<SupabaseWrapper>() as FakeSupabaseWrapper;

--- a/test/features/estimations/units/domain/usecases/add_cost_estimation_usecase_test.dart
+++ b/test/features/estimations/units/domain/usecases/add_cost_estimation_usecase_test.dart
@@ -86,7 +86,11 @@ void main() {
       fakeClock = FakeClockImpl();
 
       Modular.init(
-        EstimationModule(FakeAppBootstrapFactory.create(clock: fakeClock)),
+        EstimationModule(
+          FakeAppBootstrapFactory.create(
+            supabaseWrapper: FakeSupabaseWrapper(clock: fakeClock),
+          ),
+        ),
       );
       fakeSupabaseWrapper =
           Modular.get<SupabaseWrapper>() as FakeSupabaseWrapper;

--- a/test/features/estimations/units/domain/usecases/add_cost_estimation_usecase_test.dart
+++ b/test/features/estimations/units/domain/usecases/add_cost_estimation_usecase_test.dart
@@ -1,12 +1,10 @@
-import 'package:construculator/app/app_bootstrap.dart';
 import 'package:construculator/features/estimation/domain/entities/cost_estimate_entity.dart';
 import 'package:construculator/features/estimation/domain/entities/enums.dart';
 import 'package:construculator/features/estimation/domain/entities/lock_status_entity.dart';
 import 'package:construculator/features/estimation/domain/entities/markup_configuration_entity.dart';
 import 'package:construculator/features/estimation/domain/usecases/add_cost_estimation_usecase.dart';
 import 'package:construculator/features/estimation/estimation_module.dart';
-import 'package:construculator/libraries/config/testing/fake_app_config.dart';
-import 'package:construculator/libraries/config/testing/fake_env_loader.dart';
+
 import 'package:construculator/libraries/either/interfaces/either.dart';
 import 'package:construculator/libraries/errors/failures.dart';
 import 'package:construculator/libraries/estimation/domain/estimation_error_type.dart';
@@ -18,6 +16,7 @@ import 'package:construculator/libraries/time/testing/fake_clock_impl.dart';
 import 'package:flutter_modular/flutter_modular.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import '../../../../../utils/fake_app_bootstrap_factory.dart';
 import '../../../helpers/estimation_test_data_map_factory.dart';
 
 void main() {
@@ -87,13 +86,7 @@ void main() {
       fakeClock = FakeClockImpl();
 
       Modular.init(
-        EstimationModule(
-          AppBootstrap(
-            supabaseWrapper: FakeSupabaseWrapper(clock: fakeClock),
-            config: FakeAppConfig(),
-            envLoader: FakeEnvLoader(),
-          ),
-        ),
+        EstimationModule(FakeAppBootstrapFactory.create(clock: fakeClock)),
       );
       fakeSupabaseWrapper =
           Modular.get<SupabaseWrapper>() as FakeSupabaseWrapper;

--- a/test/features/estimations/widgets/accessibility/cost_estimation_details_page_a11y_test.dart
+++ b/test/features/estimations/widgets/accessibility/cost_estimation_details_page_a11y_test.dart
@@ -3,8 +3,7 @@ import 'package:construculator/features/estimation/estimation_module.dart';
 import 'package:construculator/features/project/project_module.dart';
 import 'package:construculator/l10n/generated/app_localizations.dart';
 import 'package:construculator/libraries/auth/auth_library_module.dart';
-import 'package:construculator/libraries/config/testing/fake_app_config.dart';
-import 'package:construculator/libraries/config/testing/fake_env_loader.dart';
+
 import 'package:construculator/libraries/router/routes/estimation_routes.dart';
 import 'package:construculator/libraries/router/testing/router_test_module.dart';
 import 'package:construculator/libraries/supabase/testing/fake_supabase_user.dart';
@@ -18,6 +17,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:ripplearc_coreui/ripplearc_coreui.dart';
 
 import '../../../../utils/a11y/a11y_guidelines.dart';
+import '../../../../utils/fake_app_bootstrap_factory.dart';
 
 class _CostEstimationDetailsPageA11yTestModule extends Module {
   final AppBootstrap appBootstrap;
@@ -52,9 +52,7 @@ void main() {
     clock = FakeClockImpl();
     fakeSupabase = FakeSupabaseWrapper(clock: clock);
 
-    appBootstrap = AppBootstrap(
-      config: FakeAppConfig(),
-      envLoader: FakeEnvLoader(),
+    appBootstrap = FakeAppBootstrapFactory.create(
       supabaseWrapper: fakeSupabase,
     );
     Modular.init(_CostEstimationDetailsPageA11yTestModule(appBootstrap));
@@ -146,29 +144,28 @@ void main() {
       },
     );
 
-    testWidgets(
-      'meets a11y text contrast for app bar title in both themes',
-      (tester) async {
-        setUpAuthenticatedUser(
-          credentialId: 'test-credential-id',
-          email: 'test@example.com',
-        );
+    testWidgets('meets a11y text contrast for app bar title in both themes', (
+      tester,
+    ) async {
+      setUpAuthenticatedUser(
+        credentialId: 'test-credential-id',
+        email: 'test@example.com',
+      );
 
-        await setupA11yTest(tester);
-        await pumpAppAtRoute(tester, testEstimationRoute);
+      await setupA11yTest(tester);
+      await pumpAppAtRoute(tester, testEstimationRoute);
 
-        await expectMeetsTapTargetAndLabelGuidelinesForEachTheme(
-          tester,
-          (theme) => makeApp(theme: theme),
-          find.text('Estimation Details'),
-          checkTextContrast: false,
-          setupAfterPump: (t) async {
-            Modular.to.navigate(testEstimationRoute);
-            await t.pumpAndSettle();
-          },
-        );
-      },
-    );
+      await expectMeetsTapTargetAndLabelGuidelinesForEachTheme(
+        tester,
+        (theme) => makeApp(theme: theme),
+        find.text('Estimation Details'),
+        checkTextContrast: false,
+        setupAfterPump: (t) async {
+          Modular.to.navigate(testEstimationRoute);
+          await t.pumpAndSettle();
+        },
+      );
+    });
 
     testWidgets(
       'meets a11y text contrast for estimation ID text in both themes',

--- a/test/features/estimations/widgets/accessibility/cost_estimation_landing_page_a11y_test.dart
+++ b/test/features/estimations/widgets/accessibility/cost_estimation_landing_page_a11y_test.dart
@@ -4,8 +4,7 @@ import 'package:construculator/features/estimation/estimation_module.dart';
 import 'package:construculator/features/project/project_module.dart';
 import 'package:construculator/l10n/generated/app_localizations.dart';
 import 'package:construculator/libraries/auth/auth_library_module.dart';
-import 'package:construculator/libraries/config/testing/fake_app_config.dart';
-import 'package:construculator/libraries/config/testing/fake_env_loader.dart';
+
 import 'package:construculator/libraries/router/guards/auth_guard.dart';
 import 'package:construculator/libraries/router/interfaces/app_router.dart';
 import 'package:construculator/libraries/router/routes/estimation_routes.dart';
@@ -24,6 +23,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:ripplearc_coreui/ripplearc_coreui.dart';
 
 import '../../../../utils/a11y/a11y_guidelines.dart';
+import '../../../../utils/fake_app_bootstrap_factory.dart';
 import '../../helpers/estimation_test_data_map_factory.dart';
 
 class _CostEstimationLandingPageA11yTestModule extends Module {
@@ -69,9 +69,7 @@ void main() {
     clock = FakeClockImpl();
     fakeSupabase = FakeSupabaseWrapper(clock: clock);
 
-    appBootstrap = AppBootstrap(
-      config: FakeAppConfig(),
-      envLoader: FakeEnvLoader(),
+    appBootstrap = FakeAppBootstrapFactory.create(
       supabaseWrapper: fakeSupabase,
     );
     Modular.init(_CostEstimationLandingPageA11yTestModule(appBootstrap));

--- a/test/features/estimations/widgets/accessibility/cost_estimation_logs_list_a11y_test.dart
+++ b/test/features/estimations/widgets/accessibility/cost_estimation_logs_list_a11y_test.dart
@@ -4,8 +4,7 @@ import 'package:construculator/features/estimation/estimation_module.dart';
 import 'package:construculator/features/estimation/presentation/bloc/cost_estimation_log_bloc/cost_estimation_log_bloc.dart';
 import 'package:construculator/features/estimation/presentation/widgets/cost_estimation_logs_list.dart';
 import 'package:construculator/l10n/generated/app_localizations.dart';
-import 'package:construculator/libraries/config/testing/fake_app_config.dart';
-import 'package:construculator/libraries/config/testing/fake_env_loader.dart';
+
 import 'package:construculator/libraries/supabase/data/supabase_types.dart';
 import 'package:construculator/libraries/supabase/database_constants.dart';
 import 'package:construculator/libraries/supabase/testing/fake_supabase_wrapper.dart';
@@ -17,6 +16,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:ripplearc_coreui/ripplearc_coreui.dart';
 
 import '../../../../utils/a11y/a11y_guidelines.dart';
+import '../../../../utils/fake_app_bootstrap_factory.dart';
 import '../../../../utils/screenshot/font_loader.dart';
 import '../../helpers/log_test_data_factory.dart';
 
@@ -34,11 +34,7 @@ void main() {
 
     fakeClock = FakeClockImpl();
     fakeSupabase = FakeSupabaseWrapper(clock: fakeClock);
-    bootstrap = AppBootstrap(
-      supabaseWrapper: fakeSupabase,
-      config: FakeAppConfig(),
-      envLoader: FakeEnvLoader(),
-    );
+    bootstrap = FakeAppBootstrapFactory.create(supabaseWrapper: fakeSupabase);
 
     Modular.init(EstimationModule(bootstrap));
   });

--- a/test/features/estimations/widgets/accessibility/estimation_rename_sheet_a11y_test.dart
+++ b/test/features/estimations/widgets/accessibility/estimation_rename_sheet_a11y_test.dart
@@ -3,8 +3,7 @@ import 'package:construculator/features/estimation/estimation_module.dart';
 import 'package:construculator/features/estimation/presentation/bloc/rename_estimation_bloc/rename_estimation_bloc.dart';
 import 'package:construculator/features/estimation/presentation/widgets/estimation_rename_sheet.dart';
 import 'package:construculator/l10n/generated/app_localizations.dart';
-import 'package:construculator/libraries/config/testing/fake_app_config.dart';
-import 'package:construculator/libraries/config/testing/fake_env_loader.dart';
+
 import 'package:construculator/libraries/router/interfaces/app_router.dart';
 import 'package:construculator/libraries/router/testing/fake_router.dart';
 import 'package:construculator/libraries/router/testing/router_test_module.dart';
@@ -19,6 +18,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:ripplearc_coreui/ripplearc_coreui.dart';
 
 import '../../../../utils/a11y/a11y_guidelines.dart';
+import '../../../../utils/fake_app_bootstrap_factory.dart';
 import '../../../../utils/screenshot/font_loader.dart';
 import '../../helpers/estimation_test_data_map_factory.dart';
 
@@ -52,9 +52,7 @@ void main() {
     fakeSupabase = FakeSupabaseWrapper(clock: clock);
     CoreToast.disableTimers();
 
-    appBootstrap = AppBootstrap(
-      config: FakeAppConfig(),
-      envLoader: FakeEnvLoader(),
+    appBootstrap = FakeAppBootstrapFactory.create(
       supabaseWrapper: fakeSupabase,
     );
     Modular.init(_EstimationRenameSheetTestModule(appBootstrap));

--- a/test/features/estimations/widgets/pages/cost_estimation_details_page_test.dart
+++ b/test/features/estimations/widgets/pages/cost_estimation_details_page_test.dart
@@ -3,8 +3,7 @@ import 'package:construculator/features/estimation/estimation_module.dart';
 import 'package:construculator/features/project/project_module.dart';
 import 'package:construculator/l10n/generated/app_localizations.dart';
 import 'package:construculator/libraries/auth/auth_library_module.dart';
-import 'package:construculator/libraries/config/testing/fake_app_config.dart';
-import 'package:construculator/libraries/config/testing/fake_env_loader.dart';
+
 import 'package:construculator/libraries/router/routes/estimation_routes.dart';
 import 'package:construculator/libraries/router/testing/router_test_module.dart';
 import 'package:construculator/libraries/supabase/testing/fake_supabase_user.dart';
@@ -16,6 +15,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_modular/flutter_modular.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:ripplearc_coreui/ripplearc_coreui.dart';
+
+import '../../../../utils/fake_app_bootstrap_factory.dart';
 
 class _CostEstimationDetailsPageTestModule extends Module {
   final AppBootstrap appBootstrap;
@@ -49,9 +50,7 @@ void main() {
     clock = FakeClockImpl();
     fakeSupabase = FakeSupabaseWrapper(clock: clock);
 
-    appBootstrap = AppBootstrap(
-      config: FakeAppConfig(),
-      envLoader: FakeEnvLoader(),
+    appBootstrap = FakeAppBootstrapFactory.create(
       supabaseWrapper: fakeSupabase,
     );
     Modular.init(_CostEstimationDetailsPageTestModule(appBootstrap));

--- a/test/features/estimations/widgets/pages/cost_estimation_landing_page_test.dart
+++ b/test/features/estimations/widgets/pages/cost_estimation_landing_page_test.dart
@@ -13,8 +13,7 @@ import 'package:construculator/features/estimation/presentation/widgets/estimati
 import 'package:construculator/features/project/project_module.dart';
 import 'package:construculator/l10n/generated/app_localizations.dart';
 import 'package:construculator/libraries/auth/auth_library_module.dart';
-import 'package:construculator/libraries/config/testing/fake_app_config.dart';
-import 'package:construculator/libraries/config/testing/fake_env_loader.dart';
+
 import 'package:construculator/libraries/router/guards/auth_guard.dart';
 import 'package:construculator/libraries/router/interfaces/app_router.dart';
 import 'package:construculator/libraries/router/routes/estimation_routes.dart';
@@ -32,6 +31,7 @@ import 'package:flutter_modular/flutter_modular.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:ripplearc_coreui/ripplearc_coreui.dart';
 
+import '../../../../utils/fake_app_bootstrap_factory.dart';
 import '../../helpers/estimation_test_data_map_factory.dart';
 
 class _CostEstimationLandingPageTestModule extends Module {
@@ -76,9 +76,7 @@ void main() {
     CoreToast.disableTimers();
     clock = FakeClockImpl();
     fakeSupabase = FakeSupabaseWrapper(clock: clock);
-    appBootstrap = AppBootstrap(
-      config: FakeAppConfig(),
-      envLoader: FakeEnvLoader(),
+    appBootstrap = FakeAppBootstrapFactory.create(
       supabaseWrapper: fakeSupabase,
     );
     Modular.init(_CostEstimationLandingPageTestModule(appBootstrap));

--- a/test/features/estimations/widgets/widgets/cost_estimation_logs_list_test.dart
+++ b/test/features/estimations/widgets/widgets/cost_estimation_logs_list_test.dart
@@ -8,8 +8,7 @@ import 'package:construculator/features/estimation/presentation/widgets/cost_est
 import 'package:construculator/features/estimation/presentation/widgets/cost_estimation_logs_list.dart';
 import 'package:construculator/l10n/generated/app_localizations.dart';
 import 'package:construculator/libraries/auth/domain/entities/user_profile_entity.dart';
-import 'package:construculator/libraries/config/testing/fake_app_config.dart';
-import 'package:construculator/libraries/config/testing/fake_env_loader.dart';
+
 import 'package:construculator/libraries/supabase/data/supabase_types.dart';
 import 'package:construculator/libraries/supabase/database_constants.dart';
 import 'package:construculator/libraries/supabase/testing/fake_supabase_wrapper.dart';
@@ -20,6 +19,7 @@ import 'package:flutter_modular/flutter_modular.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:ripplearc_coreui/ripplearc_coreui.dart';
 
+import '../../../../utils/fake_app_bootstrap_factory.dart';
 import '../../helpers/log_test_data_factory.dart';
 
 void main() {
@@ -36,11 +36,7 @@ void main() {
 
     fakeClock = FakeClockImpl();
     fakeSupabase = FakeSupabaseWrapper(clock: fakeClock);
-    bootstrap = AppBootstrap(
-      supabaseWrapper: fakeSupabase,
-      config: FakeAppConfig(),
-      envLoader: FakeEnvLoader(),
-    );
+    bootstrap = FakeAppBootstrapFactory.create(supabaseWrapper: fakeSupabase);
 
     Modular.init(EstimationModule(bootstrap));
   });

--- a/test/features/estimations/widgets/widgets/estimation_rename_sheet_test.dart
+++ b/test/features/estimations/widgets/widgets/estimation_rename_sheet_test.dart
@@ -5,8 +5,7 @@ import 'package:construculator/features/estimation/estimation_module.dart';
 import 'package:construculator/features/estimation/presentation/bloc/rename_estimation_bloc/rename_estimation_bloc.dart';
 import 'package:construculator/features/estimation/presentation/widgets/estimation_rename_sheet.dart';
 import 'package:construculator/l10n/generated/app_localizations.dart';
-import 'package:construculator/libraries/config/testing/fake_app_config.dart';
-import 'package:construculator/libraries/config/testing/fake_env_loader.dart';
+
 import 'package:construculator/libraries/router/interfaces/app_router.dart';
 import 'package:construculator/libraries/router/testing/fake_router.dart';
 import 'package:construculator/libraries/router/testing/router_test_module.dart';
@@ -20,6 +19,7 @@ import 'package:flutter_modular/flutter_modular.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:ripplearc_coreui/ripplearc_coreui.dart';
 
+import '../../../../utils/fake_app_bootstrap_factory.dart';
 import '../../../../utils/screenshot/font_loader.dart';
 import '../../helpers/estimation_test_data_map_factory.dart';
 
@@ -53,9 +53,7 @@ void main() {
     fakeSupabase = FakeSupabaseWrapper(clock: clock);
     CoreToast.disableTimers();
 
-    appBootstrap = AppBootstrap(
-      config: FakeAppConfig(),
-      envLoader: FakeEnvLoader(),
+    appBootstrap = FakeAppBootstrapFactory.create(
       supabaseWrapper: fakeSupabase,
     );
     Modular.init(_EstimationRenameSheetTestModule(appBootstrap));

--- a/test/features/global_search/units/blocs/global_search_bloc_test.dart
+++ b/test/features/global_search/units/blocs/global_search_bloc_test.dart
@@ -78,7 +78,11 @@ void main() {
     setUpAll(() {
       fakeClock = FakeClockImpl();
       Modular.init(
-        GlobalSearchModule(FakeAppBootstrapFactory.create(clock: fakeClock)),
+        GlobalSearchModule(
+          FakeAppBootstrapFactory.create(
+            supabaseWrapper: FakeSupabaseWrapper(clock: fakeClock),
+          ),
+        ),
       );
       fakeSupabase = Modular.get<SupabaseWrapper>() as FakeSupabaseWrapper;
     });

--- a/test/features/global_search/units/blocs/global_search_bloc_test.dart
+++ b/test/features/global_search/units/blocs/global_search_bloc_test.dart
@@ -1,10 +1,8 @@
 import 'package:bloc_test/bloc_test.dart';
-import 'package:construculator/app/app_bootstrap.dart';
 import 'package:construculator/features/global_search/domain/entities/search_scope_entity.dart';
 import 'package:construculator/features/global_search/global_search_module.dart';
 import 'package:construculator/features/global_search/presentation/bloc/global_search_bloc/global_search_bloc.dart';
-import 'package:construculator/libraries/config/testing/fake_app_config.dart';
-import 'package:construculator/libraries/config/testing/fake_env_loader.dart';
+
 import 'package:construculator/libraries/errors/failures.dart';
 import 'package:construculator/libraries/global_search/domain/search_error_type.dart';
 import 'package:construculator/libraries/supabase/data/supabase_types.dart';
@@ -16,6 +14,7 @@ import 'package:construculator/libraries/time/testing/fake_clock_impl.dart';
 import 'package:flutter_modular/flutter_modular.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import '../../../../utils/fake_app_bootstrap_factory.dart';
 import '../../../estimations/helpers/estimation_test_data_map_factory.dart'
     as estimation_factory;
 
@@ -79,13 +78,7 @@ void main() {
     setUpAll(() {
       fakeClock = FakeClockImpl();
       Modular.init(
-        GlobalSearchModule(
-          AppBootstrap(
-            supabaseWrapper: FakeSupabaseWrapper(clock: fakeClock),
-            config: FakeAppConfig(),
-            envLoader: FakeEnvLoader(),
-          ),
-        ),
+        GlobalSearchModule(FakeAppBootstrapFactory.create(clock: fakeClock)),
       );
       fakeSupabase = Modular.get<SupabaseWrapper>() as FakeSupabaseWrapper;
     });

--- a/test/features/global_search/units/data/data_source/remote_global_search_data_source_test.dart
+++ b/test/features/global_search/units/data/data_source/remote_global_search_data_source_test.dart
@@ -76,7 +76,11 @@ void main() {
     setUpAll(() {
       fakeClock = FakeClockImpl();
       Modular.init(
-        GlobalSearchModule(FakeAppBootstrapFactory.create(clock: fakeClock)),
+        GlobalSearchModule(
+          FakeAppBootstrapFactory.create(
+            supabaseWrapper: FakeSupabaseWrapper(clock: fakeClock),
+          ),
+        ),
       );
       fakeSupabaseWrapper =
           Modular.get<SupabaseWrapper>() as FakeSupabaseWrapper;

--- a/test/features/global_search/units/data/data_source/remote_global_search_data_source_test.dart
+++ b/test/features/global_search/units/data/data_source/remote_global_search_data_source_test.dart
@@ -1,14 +1,12 @@
 import 'dart:io';
 
-import 'package:construculator/app/app_bootstrap.dart';
 import 'package:construculator/features/global_search/data/data_source/interfaces/global_search_data_source.dart';
 import 'package:construculator/features/global_search/data/data_source/remote_global_search_data_source.dart';
 import 'package:construculator/features/global_search/data/models/pagination_params_dto.dart';
 import 'package:construculator/features/global_search/data/models/search_params_dto.dart';
 import 'package:construculator/features/global_search/data/models/search_scope.dart';
 import 'package:construculator/features/global_search/global_search_module.dart';
-import 'package:construculator/libraries/config/testing/fake_app_config.dart';
-import 'package:construculator/libraries/config/testing/fake_env_loader.dart';
+
 import 'package:construculator/libraries/supabase/data/supabase_types.dart';
 import 'package:construculator/libraries/supabase/database_constants.dart';
 import 'package:construculator/libraries/supabase/interfaces/supabase_wrapper.dart';
@@ -19,6 +17,7 @@ import 'package:flutter_modular/flutter_modular.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:supabase_flutter/supabase_flutter.dart' as supabase;
 
+import '../../../../../utils/fake_app_bootstrap_factory.dart';
 import '../../../../estimations/helpers/estimation_test_data_map_factory.dart'
     as estimation_factory;
 
@@ -77,13 +76,7 @@ void main() {
     setUpAll(() {
       fakeClock = FakeClockImpl();
       Modular.init(
-        GlobalSearchModule(
-          AppBootstrap(
-            config: FakeAppConfig(),
-            envLoader: FakeEnvLoader(),
-            supabaseWrapper: FakeSupabaseWrapper(clock: fakeClock),
-          ),
-        ),
+        GlobalSearchModule(FakeAppBootstrapFactory.create(clock: fakeClock)),
       );
       fakeSupabaseWrapper =
           Modular.get<SupabaseWrapper>() as FakeSupabaseWrapper;

--- a/test/features/global_search/units/data/models/search_params_dto_test.dart
+++ b/test/features/global_search/units/data/models/search_params_dto_test.dart
@@ -129,8 +129,14 @@ void main() {
       });
 
       test('two instances with different scope are not equal', () {
-        const params1 = SearchParamsDto(query: 'bridge', scope: SearchScopeDto.estimation);
-        const params2 = SearchParamsDto(query: 'bridge', scope: SearchScopeDto.member);
+        const params1 = SearchParamsDto(
+          query: 'bridge',
+          scope: SearchScopeDto.estimation,
+        );
+        const params2 = SearchParamsDto(
+          query: 'bridge',
+          scope: SearchScopeDto.member,
+        );
 
         expect(params1, isNot(equals(params2)));
       });

--- a/test/features/global_search/units/data/models/search_results_dto_test.dart
+++ b/test/features/global_search/units/data/models/search_results_dto_test.dart
@@ -194,8 +194,8 @@ void main() {
 
       test('maps estimations to CostEstimate domain entities', () {
         final estimationDto = CostEstimateDto.fromJson(
-          estimation_factory.EstimationTestDataMapFactory
-              .createFakeEstimationData(),
+          estimation_factory
+              .EstimationTestDataMapFactory.createFakeEstimationData(),
         );
         final dto = SearchResultsDto(estimations: [estimationDto]);
 
@@ -215,8 +215,8 @@ void main() {
 
       test('lists are independent — items do not bleed across lists', () {
         final estimationDto = CostEstimateDto.fromJson(
-          estimation_factory.EstimationTestDataMapFactory
-              .createFakeEstimationData(),
+          estimation_factory
+              .EstimationTestDataMapFactory.createFakeEstimationData(),
         );
         final dto = SearchResultsDto(
           projects: [testProject],

--- a/test/features/global_search/units/data/repositories/global_search_repository_impl_test.dart
+++ b/test/features/global_search/units/data/repositories/global_search_repository_impl_test.dart
@@ -1,4 +1,3 @@
-import 'package:construculator/app/app_bootstrap.dart';
 import 'package:construculator/features/global_search/data/repositories/global_search_repository_impl.dart';
 import 'package:construculator/features/global_search/domain/entities/pagination_params.dart';
 import 'package:construculator/features/global_search/domain/entities/search_params_entity.dart';
@@ -6,8 +5,7 @@ import 'package:construculator/features/global_search/domain/entities/search_res
 import 'package:construculator/features/global_search/domain/entities/search_scope_entity.dart';
 import 'package:construculator/features/global_search/domain/repositories/global_search_repository.dart';
 import 'package:construculator/features/global_search/global_search_module.dart';
-import 'package:construculator/libraries/config/testing/fake_app_config.dart';
-import 'package:construculator/libraries/config/testing/fake_env_loader.dart';
+
 import 'package:construculator/libraries/either/either.dart';
 import 'package:construculator/libraries/errors/failures.dart';
 import 'package:construculator/libraries/global_search/domain/search_error_type.dart';
@@ -20,6 +18,7 @@ import 'package:construculator/libraries/time/testing/fake_clock_impl.dart';
 import 'package:flutter_modular/flutter_modular.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import '../../../../../utils/fake_app_bootstrap_factory.dart';
 import '../../../../estimations/helpers/estimation_test_data_map_factory.dart'
     as estimation_factory;
 
@@ -107,13 +106,7 @@ void main() {
     setUpAll(() {
       fakeClock = FakeClockImpl();
       Modular.init(
-        GlobalSearchModule(
-          AppBootstrap(
-            supabaseWrapper: FakeSupabaseWrapper(clock: fakeClock),
-            config: FakeAppConfig(),
-            envLoader: FakeEnvLoader(),
-          ),
-        ),
+        GlobalSearchModule(FakeAppBootstrapFactory.create(clock: fakeClock)),
       );
       fakeSupabaseWrapper =
           Modular.get<SupabaseWrapper>() as FakeSupabaseWrapper;

--- a/test/features/global_search/units/data/repositories/global_search_repository_impl_test.dart
+++ b/test/features/global_search/units/data/repositories/global_search_repository_impl_test.dart
@@ -106,7 +106,11 @@ void main() {
     setUpAll(() {
       fakeClock = FakeClockImpl();
       Modular.init(
-        GlobalSearchModule(FakeAppBootstrapFactory.create(clock: fakeClock)),
+        GlobalSearchModule(
+          FakeAppBootstrapFactory.create(
+            supabaseWrapper: FakeSupabaseWrapper(clock: fakeClock),
+          ),
+        ),
       );
       fakeSupabaseWrapper =
           Modular.get<SupabaseWrapper>() as FakeSupabaseWrapper;

--- a/test/features/project/screenshots/project_header_app_bar_screenshot_test.dart
+++ b/test/features/project/screenshots/project_header_app_bar_screenshot_test.dart
@@ -1,19 +1,15 @@
-import 'package:construculator/app/app_bootstrap.dart';
 import 'package:construculator/features/project/presentation/widgets/project_header_app_bar.dart';
 import 'package:construculator/features/project/project_module.dart';
-import 'package:construculator/libraries/config/testing/fake_app_config.dart';
-import 'package:construculator/libraries/config/testing/fake_env_loader.dart';
 import 'package:construculator/libraries/project/domain/entities/enums.dart';
 import 'package:construculator/libraries/project/domain/entities/project_entity.dart';
 import 'package:construculator/libraries/project/domain/repositories/project_repository.dart';
 import 'package:construculator/libraries/project/testing/fake_project_repository.dart';
-import 'package:construculator/libraries/supabase/testing/fake_supabase_wrapper.dart';
 import 'package:construculator/libraries/time/interfaces/clock.dart';
-import 'package:construculator/libraries/time/testing/fake_clock_impl.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_modular/flutter_modular.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import '../../../utils/fake_app_bootstrap_factory.dart';
 import '../../../utils/screenshot/await_images_extension.dart';
 import '../../../utils/screenshot/font_loader.dart';
 
@@ -26,11 +22,7 @@ void main() {
   late Clock clock;
 
   setUpAll(() async {
-    final appBootstrap = AppBootstrap(
-      config: FakeAppConfig(),
-      envLoader: FakeEnvLoader(),
-      supabaseWrapper: FakeSupabaseWrapper(clock: FakeClockImpl()),
-    );
+    final appBootstrap = FakeAppBootstrapFactory.create();
     Modular.init(ProjectModule(appBootstrap));
     Modular.replaceInstance<ProjectRepository>(FakeProjectRepository());
     fakeProjectRepository =

--- a/test/features/project/units/blocs/get_project_bloc_test.dart
+++ b/test/features/project/units/blocs/get_project_bloc_test.dart
@@ -10,6 +10,7 @@ import 'package:construculator/libraries/project/domain/entities/project_entity.
 import 'package:construculator/libraries/project/domain/repositories/project_repository.dart';
 import 'package:construculator/libraries/project/testing/fake_project_repository.dart';
 import 'package:construculator/libraries/supabase/data/supabase_types.dart';
+import 'package:construculator/libraries/supabase/testing/fake_supabase_wrapper.dart';
 import 'package:construculator/libraries/time/interfaces/clock.dart';
 import 'package:construculator/libraries/time/testing/fake_clock_impl.dart';
 import 'package:flutter_modular/flutter_modular.dart';
@@ -54,7 +55,9 @@ void main() {
 
     setUpAll(() {
       clock = FakeClockImpl();
-      final appBootstrap = FakeAppBootstrapFactory.create(clock: clock);
+      final appBootstrap = FakeAppBootstrapFactory.create(
+        supabaseWrapper: FakeSupabaseWrapper(clock: clock),
+      );
       Modular.init(ProjectModule(appBootstrap));
       Modular.replaceInstance<ProjectRepository>(FakeProjectRepository());
       Modular.replaceInstance<AuthRepository>(FakeAuthRepository(clock: clock));

--- a/test/features/project/units/blocs/get_project_bloc_test.dart
+++ b/test/features/project/units/blocs/get_project_bloc_test.dart
@@ -1,23 +1,20 @@
 import 'package:bloc_test/bloc_test.dart';
-import 'package:construculator/app/app_bootstrap.dart';
 import 'package:construculator/features/project/domain/entities/project_header_data.dart';
 import 'package:construculator/features/project/presentation/bloc/get_project_bloc/get_project_bloc.dart';
 import 'package:construculator/features/project/project_module.dart';
 import 'package:construculator/libraries/auth/interfaces/auth_repository.dart';
 import 'package:construculator/libraries/auth/testing/fake_auth_repository.dart';
-import 'package:construculator/libraries/config/testing/fake_app_config.dart';
-import 'package:construculator/libraries/config/testing/fake_env_loader.dart';
 import 'package:construculator/libraries/errors/failures.dart';
 import 'package:construculator/libraries/project/domain/entities/enums.dart';
 import 'package:construculator/libraries/project/domain/entities/project_entity.dart';
 import 'package:construculator/libraries/project/domain/repositories/project_repository.dart';
 import 'package:construculator/libraries/project/testing/fake_project_repository.dart';
 import 'package:construculator/libraries/supabase/data/supabase_types.dart';
-import 'package:construculator/libraries/supabase/testing/fake_supabase_wrapper.dart';
 import 'package:construculator/libraries/time/interfaces/clock.dart';
 import 'package:construculator/libraries/time/testing/fake_clock_impl.dart';
 import 'package:flutter_modular/flutter_modular.dart';
 import 'package:flutter_test/flutter_test.dart';
+import '../../../../utils/fake_app_bootstrap_factory.dart';
 
 void main() {
   late Clock clock;
@@ -57,11 +54,7 @@ void main() {
 
     setUpAll(() {
       clock = FakeClockImpl();
-      final appBootstrap = AppBootstrap(
-        config: FakeAppConfig(),
-        envLoader: FakeEnvLoader(),
-        supabaseWrapper: FakeSupabaseWrapper(clock: clock),
-      );
+      final appBootstrap = FakeAppBootstrapFactory.create(clock: clock);
       Modular.init(ProjectModule(appBootstrap));
       Modular.replaceInstance<ProjectRepository>(FakeProjectRepository());
       Modular.replaceInstance<AuthRepository>(FakeAuthRepository(clock: clock));

--- a/test/features/project/units/domain/entities/project_header_data_test.dart
+++ b/test/features/project/units/domain/entities/project_header_data_test.dart
@@ -76,7 +76,10 @@ void main() {
         final avatarImage = headerData.userAvatarImage;
         expect(avatarImage, isNotNull);
         expect(avatarImage, isA<NetworkImage>());
-        expect((avatarImage as NetworkImage).url, 'https://example.com/avatar.jpg');
+        expect(
+          (avatarImage as NetworkImage).url,
+          'https://example.com/avatar.jpg',
+        );
       });
 
       test('returns null when user profile is null', () {

--- a/test/features/project/units/domain/usecases/get_project_header_usecase_test.dart
+++ b/test/features/project/units/domain/usecases/get_project_header_usecase_test.dart
@@ -1,4 +1,3 @@
-import 'package:construculator/app/app_bootstrap.dart';
 import 'package:construculator/features/project/domain/usecases/get_project_header_usecase.dart';
 import 'package:construculator/features/project/project_module.dart';
 import 'package:construculator/libraries/auth/data/models/auth_credential.dart';
@@ -6,18 +5,18 @@ import 'package:construculator/libraries/auth/data/models/auth_user.dart';
 import 'package:construculator/libraries/auth/domain/types/auth_types.dart';
 import 'package:construculator/libraries/auth/interfaces/auth_repository.dart';
 import 'package:construculator/libraries/auth/testing/fake_auth_repository.dart';
-import 'package:construculator/libraries/config/testing/fake_app_config.dart';
-import 'package:construculator/libraries/config/testing/fake_env_loader.dart';
+
 import 'package:construculator/libraries/errors/failures.dart';
 import 'package:construculator/libraries/project/domain/entities/enums.dart';
 import 'package:construculator/libraries/project/domain/entities/project_entity.dart';
 import 'package:construculator/libraries/project/domain/repositories/project_repository.dart';
 import 'package:construculator/libraries/project/testing/fake_project_repository.dart';
 import 'package:construculator/libraries/supabase/data/supabase_types.dart';
-import 'package:construculator/libraries/supabase/testing/fake_supabase_wrapper.dart';
 import 'package:construculator/libraries/time/testing/fake_clock_impl.dart';
 import 'package:flutter_modular/flutter_modular.dart';
 import 'package:flutter_test/flutter_test.dart';
+
+import '../../../../../utils/fake_app_bootstrap_factory.dart';
 
 void main() {
   group('GetProjectHeaderUseCase', () {
@@ -40,15 +39,7 @@ void main() {
       fakeProjectRepository = FakeProjectRepository();
       fakeAuthRepository = FakeAuthRepository(clock: fakeClock);
 
-      Modular.init(
-        ProjectModule(
-          AppBootstrap(
-            envLoader: FakeEnvLoader(),
-            config: FakeAppConfig(),
-            supabaseWrapper: FakeSupabaseWrapper(clock: FakeClockImpl()),
-          ),
-        ),
-      );
+      Modular.init(ProjectModule(FakeAppBootstrapFactory.create()));
 
       Modular.replaceInstance<ProjectRepository>(fakeProjectRepository);
       Modular.replaceInstance<AuthRepository>(fakeAuthRepository);

--- a/test/features/project/units/presentation/project_ui_provider_impl_test.dart
+++ b/test/features/project/units/presentation/project_ui_provider_impl_test.dart
@@ -2,16 +2,15 @@ import 'package:construculator/app/app_bootstrap.dart';
 import 'package:construculator/features/project/presentation/project_ui_provider_impl.dart';
 import 'package:construculator/features/project/presentation/widgets/project_header_app_bar.dart';
 import 'package:construculator/features/project/project_module.dart';
-import 'package:construculator/libraries/config/testing/fake_app_config.dart';
-import 'package:construculator/libraries/config/testing/fake_env_loader.dart';
+
 import 'package:construculator/libraries/project/presentation/project_ui_provider.dart';
-import 'package:construculator/libraries/supabase/testing/fake_supabase_wrapper.dart';
 import 'package:construculator/libraries/time/testing/clock_test_module.dart';
-import 'package:construculator/libraries/time/testing/fake_clock_impl.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_modular/flutter_modular.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:ripplearc_coreui/ripplearc_coreui.dart';
+
+import '../../../../utils/fake_app_bootstrap_factory.dart';
 
 class _TestModule extends Module {
   final AppBootstrap appBootstrap;
@@ -26,11 +25,7 @@ void main() {
     late ProjectUIProviderImpl provider;
 
     setUpAll(() {
-      final appBootstrap = AppBootstrap(
-        envLoader: FakeEnvLoader(),
-        config: FakeAppConfig(),
-        supabaseWrapper: FakeSupabaseWrapper(clock: FakeClockImpl()),
-      );
+      final appBootstrap = FakeAppBootstrapFactory.create();
       Modular.init(_TestModule(appBootstrap));
     });
 

--- a/test/features/project/widgets/project_header_app_bar_test.dart
+++ b/test/features/project/widgets/project_header_app_bar_test.dart
@@ -1,20 +1,17 @@
-import 'package:construculator/app/app_bootstrap.dart';
 import 'package:construculator/features/project/presentation/widgets/project_header_app_bar.dart';
 import 'package:construculator/features/project/project_module.dart';
 import 'package:construculator/l10n/generated/app_localizations.dart';
-import 'package:construculator/libraries/config/testing/fake_app_config.dart';
-import 'package:construculator/libraries/config/testing/fake_env_loader.dart';
 import 'package:construculator/libraries/project/domain/entities/enums.dart';
 import 'package:construculator/libraries/project/domain/entities/project_entity.dart';
 import 'package:construculator/libraries/project/domain/repositories/project_repository.dart';
 import 'package:construculator/libraries/project/testing/fake_project_repository.dart';
-import 'package:construculator/libraries/supabase/testing/fake_supabase_wrapper.dart';
 import 'package:construculator/libraries/time/interfaces/clock.dart';
-import 'package:construculator/libraries/time/testing/fake_clock_impl.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_modular/flutter_modular.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:ripplearc_coreui/ripplearc_coreui.dart';
+
+import '../../../utils/fake_app_bootstrap_factory.dart';
 
 void main() {
   late FakeProjectRepository fakeProjectRepository;
@@ -22,11 +19,7 @@ void main() {
   BuildContext? buildContext;
 
   setUpAll(() async {
-    final appBootstrap = AppBootstrap(
-      config: FakeAppConfig(),
-      envLoader: FakeEnvLoader(),
-      supabaseWrapper: FakeSupabaseWrapper(clock: FakeClockImpl()),
-    );
+    final appBootstrap = FakeAppBootstrapFactory.create();
     Modular.init(ProjectModule(appBootstrap));
     Modular.replaceInstance<ProjectRepository>(FakeProjectRepository());
     fakeProjectRepository =

--- a/test/libraries/config/units/app_config_test.dart
+++ b/test/libraries/config/units/app_config_test.dart
@@ -87,7 +87,6 @@ void main() {
 
     group('Environment Name Tests', () {
       test('should return correct environment names', () {
-
         expect(
           appConfig.getEnvironmentName(Environment.dev),
           equals('Development'),
@@ -99,7 +98,6 @@ void main() {
         );
       });
       test('should return correct environment aliases', () {
-
         expect(
           appConfig.getEnvironmentName(Environment.dev, isAlias: true),
           equals('Fishfood'),
@@ -120,8 +118,8 @@ void main() {
         test('should successfully load environment files', () async {
           final createConfigWithEnvLoader =
               Modular.get<Config Function(EnvLoader)>(
-            key: 'createConfigWithEnvLoader',
-          );
+                key: 'createConfigWithEnvLoader',
+              );
 
           final environments = [
             Environment.dev,
@@ -131,7 +129,9 @@ void main() {
 
           for (final environment in environments) {
             final freshFakeDotEnvLoader = FakeEnvLoader();
-            final freshConfig = createConfigWithEnvLoader(freshFakeDotEnvLoader);
+            final freshConfig = createConfigWithEnvLoader(
+              freshFakeDotEnvLoader,
+            );
             freshFakeDotEnvLoader.setEnvVar(
               'SUPABASE_URL',
               'https://test.supabase.co',
@@ -181,8 +181,8 @@ void main() {
         test('should format app name correctly for each environment', () async {
           final createConfigWithEnvLoader =
               Modular.get<Config Function(EnvLoader)>(
-            key: 'createConfigWithEnvLoader',
-          );
+                key: 'createConfigWithEnvLoader',
+              );
 
           final testCases = [
             (Environment.dev, 'DevApp', 'DevApp (Fishfood)'),
@@ -192,7 +192,9 @@ void main() {
 
           for (final testCase in testCases) {
             final freshFakeDotEnvLoader = FakeEnvLoader();
-            final freshConfig = createConfigWithEnvLoader(freshFakeDotEnvLoader);
+            final freshConfig = createConfigWithEnvLoader(
+              freshFakeDotEnvLoader,
+            );
 
             freshFakeDotEnvLoader.setEnvVar('APP_NAME', testCase.$2);
             freshFakeDotEnvLoader.setEnvVar('API_URL', 'https://api.com');
@@ -216,8 +218,8 @@ void main() {
           () async {
             final createConfigWithEnvLoader =
                 Modular.get<Config Function(EnvLoader)>(
-              key: 'createConfigWithEnvLoader',
-            );
+                  key: 'createConfigWithEnvLoader',
+                );
 
             final testCases = [
               (Environment.dev, true),
@@ -227,7 +229,9 @@ void main() {
 
             for (final testCase in testCases) {
               final freshFakeDotEnvLoader = FakeEnvLoader();
-              final freshConfig = createConfigWithEnvLoader(freshFakeDotEnvLoader);
+              final freshConfig = createConfigWithEnvLoader(
+                freshFakeDotEnvLoader,
+              );
 
               freshFakeDotEnvLoader.setEnvVar('APP_NAME', 'TestApp');
               freshFakeDotEnvLoader.setEnvVar('API_URL', 'https://api.com');

--- a/test/libraries/formatting/units/formatting_helper_test.dart
+++ b/test/libraries/formatting/units/formatting_helper_test.dart
@@ -12,9 +12,15 @@ void main() {
   group('FormattingHelper', () {
     group('formatCurrency', () {
       test('should format currency with default parameters', () {
-        expect(FormattingHelper.formatCurrency(15000.50), equals('\$15,000.50'));
+        expect(
+          FormattingHelper.formatCurrency(15000.50),
+          equals('\$15,000.50'),
+        );
         expect(FormattingHelper.formatCurrency(0), equals('\$0.00'));
-        expect(FormattingHelper.formatCurrency(1000000), equals('\$1,000,000.00'));
+        expect(
+          FormattingHelper.formatCurrency(1000000),
+          equals('\$1,000,000.00'),
+        );
       });
 
       test('should return default null value when value is null', () {
@@ -22,32 +28,65 @@ void main() {
       });
 
       test('should return custom null value when provided', () {
-        expect(FormattingHelper.formatCurrency(null, nullValue: 'N/A'), equals('N/A'));
-        expect(FormattingHelper.formatCurrency(null, nullValue: '--'), equals('--'));
+        expect(
+          FormattingHelper.formatCurrency(null, nullValue: 'N/A'),
+          equals('N/A'),
+        );
+        expect(
+          FormattingHelper.formatCurrency(null, nullValue: '--'),
+          equals('--'),
+        );
       });
 
       test('should format currency with custom symbol', () {
-        expect(FormattingHelper.formatCurrency(1000, symbol: '€'), equals('€1,000.00'));
-        expect(FormattingHelper.formatCurrency(1000, symbol: '£'), equals('£1,000.00'));
-        expect(FormattingHelper.formatCurrency(1000, symbol: '¥'), equals('¥1,000.00'));
+        expect(
+          FormattingHelper.formatCurrency(1000, symbol: '€'),
+          equals('€1,000.00'),
+        );
+        expect(
+          FormattingHelper.formatCurrency(1000, symbol: '£'),
+          equals('£1,000.00'),
+        );
+        expect(
+          FormattingHelper.formatCurrency(1000, symbol: '¥'),
+          equals('¥1,000.00'),
+        );
       });
 
       test('should format currency with custom decimal digits', () {
-        expect(FormattingHelper.formatCurrency(1000.123, decimalDigits: 0), equals('\$1,000'));
-        expect(FormattingHelper.formatCurrency(1000.123, decimalDigits: 1), equals('\$1,000.1'));
-        expect(FormattingHelper.formatCurrency(1000.123, decimalDigits: 3), equals('\$1,000.123'));
+        expect(
+          FormattingHelper.formatCurrency(1000.123, decimalDigits: 0),
+          equals('\$1,000'),
+        );
+        expect(
+          FormattingHelper.formatCurrency(1000.123, decimalDigits: 1),
+          equals('\$1,000.1'),
+        );
+        expect(
+          FormattingHelper.formatCurrency(1000.123, decimalDigits: 3),
+          equals('\$1,000.123'),
+        );
       });
 
       test('should format currency with custom locale', () {
-        final deResult = FormattingHelper.formatCurrency(1000.50, locale: 'de_DE');
-        final frResult = FormattingHelper.formatCurrency(1000.50, locale: 'fr_FR');
-        
+        final deResult = FormattingHelper.formatCurrency(
+          1000.50,
+          locale: 'de_DE',
+        );
+        final frResult = FormattingHelper.formatCurrency(
+          1000.50,
+          locale: 'fr_FR',
+        );
+
         expect(deResult, contains('1.000,50'));
         expect(frResult, contains(RegExp(r'1\s*000,50')));
       });
 
       test('should handle negative values', () {
-        expect(FormattingHelper.formatCurrency(-1000.50), equals('-\$1,000.50'));
+        expect(
+          FormattingHelper.formatCurrency(-1000.50),
+          equals('-\$1,000.50'),
+        );
         expect(FormattingHelper.formatCurrency(-0.50), equals('-\$0.50'));
       });
 
@@ -71,17 +110,29 @@ void main() {
       });
 
       test('should format date with custom pattern', () {
-        expect(FormattingHelper.formatDate(testDate, pattern: 'yyyy-MM-dd'), equals('2024-03-15'));
-        expect(FormattingHelper.formatDate(testDate, pattern: 'dd/MM/yyyy'), equals('15/03/2024'));
-        expect(FormattingHelper.formatDate(testDate, pattern: 'EEEE, MMMM d, yyyy'), equals('Friday, March 15, 2024'));
-        expect(FormattingHelper.formatDate(testDate, pattern: 'MMM d'), equals('Mar 15'));
+        expect(
+          FormattingHelper.formatDate(testDate, pattern: 'yyyy-MM-dd'),
+          equals('2024-03-15'),
+        );
+        expect(
+          FormattingHelper.formatDate(testDate, pattern: 'dd/MM/yyyy'),
+          equals('15/03/2024'),
+        );
+        expect(
+          FormattingHelper.formatDate(testDate, pattern: 'EEEE, MMMM d, yyyy'),
+          equals('Friday, March 15, 2024'),
+        );
+        expect(
+          FormattingHelper.formatDate(testDate, pattern: 'MMM d'),
+          equals('Mar 15'),
+        );
       });
 
       test('should format date with custom locale', () {
         final deResult = FormattingHelper.formatDate(testDate, locale: 'de_DE');
         final frResult = FormattingHelper.formatDate(testDate, locale: 'fr_FR');
         final esResult = FormattingHelper.formatDate(testDate, locale: 'es_ES');
-        
+
         expect(deResult, contains('15'));
         expect(deResult, contains('2024'));
         expect(frResult, contains('15'));
@@ -91,7 +142,11 @@ void main() {
       });
 
       test('should combine custom pattern and locale', () {
-        final result = FormattingHelper.formatDate(testDate, pattern: 'EEEE, d MMMM yyyy', locale: 'de_DE');
+        final result = FormattingHelper.formatDate(
+          testDate,
+          pattern: 'EEEE, d MMMM yyyy',
+          locale: 'de_DE',
+        );
         expect(result, contains('15'));
         expect(result, contains('2024'));
       });
@@ -99,7 +154,7 @@ void main() {
       test('should handle edge cases', () {
         final newYear = DateTime(2024, 1, 1);
         expect(FormattingHelper.formatDate(newYear), equals('Jan 01, 2024'));
-        
+
         final leapYear = DateTime(2024, 2, 29);
         expect(FormattingHelper.formatDate(leapYear), equals('Feb 29, 2024'));
       });
@@ -119,22 +174,38 @@ void main() {
       });
 
       test('should format time with custom pattern', () {
-        expect(FormattingHelper.formatTime(testTime, pattern: 'HH:mm:ss'), equals('14:30:45'));
-        expect(FormattingHelper.formatTime(testTime, pattern: 'HH:mm'), equals('14:30'));
-        expect(FormattingHelper.formatTime(testTime, pattern: 'h:mm a'), equals('2:30 PM'));
-        expect(FormattingHelper.formatTime(testTime, pattern: 'HH:mm a'), equals('14:30 PM'));
+        expect(
+          FormattingHelper.formatTime(testTime, pattern: 'HH:mm:ss'),
+          equals('14:30:45'),
+        );
+        expect(
+          FormattingHelper.formatTime(testTime, pattern: 'HH:mm'),
+          equals('14:30'),
+        );
+        expect(
+          FormattingHelper.formatTime(testTime, pattern: 'h:mm a'),
+          equals('2:30 PM'),
+        );
+        expect(
+          FormattingHelper.formatTime(testTime, pattern: 'HH:mm a'),
+          equals('14:30 PM'),
+        );
       });
 
       test('should format time with custom locale', () {
         final deResult = FormattingHelper.formatTime(testTime, locale: 'de_DE');
         final frResult = FormattingHelper.formatTime(testTime, locale: 'fr_FR');
-        
+
         expect(deResult, contains('2:30'));
         expect(frResult, contains('2:30'));
       });
 
       test('should combine custom pattern and locale', () {
-        final result = FormattingHelper.formatTime(testTime, pattern: 'HH:mm', locale: 'de_DE');
+        final result = FormattingHelper.formatTime(
+          testTime,
+          pattern: 'HH:mm',
+          locale: 'de_DE',
+        );
         expect(result, equals('14:30'));
       });
     });
@@ -142,9 +213,9 @@ void main() {
     group('Static formatters', () {
       test('should have consistent static formatters', () {
         expect(FormattingHelper.currency.decimalDigits, equals(2));
-        
+
         expect(FormattingHelper.date.pattern, equals('MMM dd, yyyy'));
-        
+
         expect(FormattingHelper.time.pattern, equals('h:mm a'));
       });
     });

--- a/test/libraries/logging/units/app_logger_test.dart
+++ b/test/libraries/logging/units/app_logger_test.dart
@@ -185,23 +185,33 @@ void main() {
       final filter = AppLogFilter(config: prodConfig, debugMode: false);
 
       expect(
-        filter.shouldLog(LogEvent(Level.debug, 'test', error: null, stackTrace: null)),
+        filter.shouldLog(
+          LogEvent(Level.debug, 'test', error: null, stackTrace: null),
+        ),
         isFalse,
       );
       expect(
-        filter.shouldLog(LogEvent(Level.info, 'test', error: null, stackTrace: null)),
+        filter.shouldLog(
+          LogEvent(Level.info, 'test', error: null, stackTrace: null),
+        ),
         isFalse,
       );
       expect(
-        filter.shouldLog(LogEvent(Level.warning, 'test', error: null, stackTrace: null)),
+        filter.shouldLog(
+          LogEvent(Level.warning, 'test', error: null, stackTrace: null),
+        ),
         isTrue,
       );
       expect(
-        filter.shouldLog(LogEvent(Level.error, 'test', error: null, stackTrace: null)),
+        filter.shouldLog(
+          LogEvent(Level.error, 'test', error: null, stackTrace: null),
+        ),
         isTrue,
       );
       expect(
-        filter.shouldLog(LogEvent(Level.fatal, 'test', error: null, stackTrace: null)),
+        filter.shouldLog(
+          LogEvent(Level.fatal, 'test', error: null, stackTrace: null),
+        ),
         isTrue,
       );
     });
@@ -212,19 +222,27 @@ void main() {
       final filter = AppLogFilter(config: qaConfig, debugMode: false);
 
       expect(
-        filter.shouldLog(LogEvent(Level.debug, 'test', error: null, stackTrace: null)),
+        filter.shouldLog(
+          LogEvent(Level.debug, 'test', error: null, stackTrace: null),
+        ),
         isFalse,
       );
       expect(
-        filter.shouldLog(LogEvent(Level.info, 'test', error: null, stackTrace: null)),
+        filter.shouldLog(
+          LogEvent(Level.info, 'test', error: null, stackTrace: null),
+        ),
         isTrue,
       );
       expect(
-        filter.shouldLog(LogEvent(Level.warning, 'test', error: null, stackTrace: null)),
+        filter.shouldLog(
+          LogEvent(Level.warning, 'test', error: null, stackTrace: null),
+        ),
         isTrue,
       );
       expect(
-        filter.shouldLog(LogEvent(Level.error, 'test', error: null, stackTrace: null)),
+        filter.shouldLog(
+          LogEvent(Level.error, 'test', error: null, stackTrace: null),
+        ),
         isTrue,
       );
     });
@@ -235,15 +253,21 @@ void main() {
       final filter = AppLogFilter(config: devConfig, debugMode: false);
 
       expect(
-        filter.shouldLog(LogEvent(Level.debug, 'test', error: null, stackTrace: null)),
+        filter.shouldLog(
+          LogEvent(Level.debug, 'test', error: null, stackTrace: null),
+        ),
         isTrue,
       );
       expect(
-        filter.shouldLog(LogEvent(Level.info, 'test', error: null, stackTrace: null)),
+        filter.shouldLog(
+          LogEvent(Level.info, 'test', error: null, stackTrace: null),
+        ),
         isTrue,
       );
       expect(
-        filter.shouldLog(LogEvent(Level.warning, 'test', error: null, stackTrace: null)),
+        filter.shouldLog(
+          LogEvent(Level.warning, 'test', error: null, stackTrace: null),
+        ),
         isTrue,
       );
     });
@@ -254,11 +278,15 @@ void main() {
       final filter = AppLogFilter(config: prodConfig, debugMode: true);
 
       expect(
-        filter.shouldLog(LogEvent(Level.debug, 'test', error: null, stackTrace: null)),
+        filter.shouldLog(
+          LogEvent(Level.debug, 'test', error: null, stackTrace: null),
+        ),
         isTrue,
       );
       expect(
-        filter.shouldLog(LogEvent(Level.info, 'test', error: null, stackTrace: null)),
+        filter.shouldLog(
+          LogEvent(Level.info, 'test', error: null, stackTrace: null),
+        ),
         isTrue,
       );
     });
@@ -267,11 +295,15 @@ void main() {
       final filter = AppLogFilter(config: null);
 
       expect(
-        filter.shouldLog(LogEvent(Level.debug, 'test', error: null, stackTrace: null)),
+        filter.shouldLog(
+          LogEvent(Level.debug, 'test', error: null, stackTrace: null),
+        ),
         isTrue,
       );
       expect(
-        filter.shouldLog(LogEvent(Level.info, 'test', error: null, stackTrace: null)),
+        filter.shouldLog(
+          LogEvent(Level.info, 'test', error: null, stackTrace: null),
+        ),
         isTrue,
       );
     });

--- a/test/libraries/project/units/data/data_source/remote_project_data_source_test.dart
+++ b/test/libraries/project/units/data/data_source/remote_project_data_source_test.dart
@@ -72,12 +72,14 @@ void main() {
       },
     );
 
-    test('getSharedProjects returns empty list when user has no memberships',
-        () async {
-      final result = await dataSource.getSharedProjects('user-1');
+    test(
+      'getSharedProjects returns empty list when user has no memberships',
+      () async {
+        final result = await dataSource.getSharedProjects('user-1');
 
-      expect(result, isEmpty);
-    });
+        expect(result, isEmpty);
+      },
+    );
 
     test('getSharedProjects resolves project IDs from memberships', () async {
       supabaseWrapper.addTableData(DatabaseConstants.projectMembersTable, [
@@ -134,7 +136,9 @@ void main() {
       'watchProjectChanges emits when shared project data changes',
       () async {
         final completer = Completer<void>();
-        final subscription = dataSource.watchProjectChanges('user-1').listen((_) {
+        final subscription = dataSource.watchProjectChanges('user-1').listen((
+          _,
+        ) {
           if (!completer.isCompleted) completer.complete();
         });
 
@@ -168,7 +172,9 @@ void main() {
       'watchProjectChanges emits when owned projects data changes',
       () async {
         final completer = Completer<void>();
-        final subscription = dataSource.watchProjectChanges('user-1').listen((_) {
+        final subscription = dataSource.watchProjectChanges('user-1').listen((
+          _,
+        ) {
           if (!completer.isCompleted) completer.complete();
         });
 
@@ -194,14 +200,16 @@ void main() {
       'watchProjectChanges propagates stream error to subscriber onError',
       () async {
         final errorCompleter = Completer<Object>();
-        final subscription = dataSource.watchProjectChanges('user-1').listen(
-          (_) {},
-          onError: (Object error, StackTrace stackTrace) {
-            if (!errorCompleter.isCompleted) {
-              errorCompleter.complete(error);
-            }
-          },
-        );
+        final subscription = dataSource
+            .watchProjectChanges('user-1')
+            .listen(
+              (_) {},
+              onError: (Object error, StackTrace stackTrace) {
+                if (!errorCompleter.isCompleted) {
+                  errorCompleter.complete(error);
+                }
+              },
+            );
 
         await pumpEventQueue();
 

--- a/test/libraries/project/units/data/models/project_dto_test.dart
+++ b/test/libraries/project/units/data/models/project_dto_test.dart
@@ -134,10 +134,20 @@ void main() {
         DatabaseConstants.idColumn: 'project-123',
         DatabaseConstants.projectNameColumn: 'My Project',
         DatabaseConstants.creatorUserIdColumn: 'creator-1',
-        DatabaseConstants.createdAtColumn:
-            DateTime(2025, 1, 1, 10, 30).toIso8601String(),
-        DatabaseConstants.updatedAtColumn:
-            DateTime(2025, 1, 2, 11, 45).toIso8601String(),
+        DatabaseConstants.createdAtColumn: DateTime(
+          2025,
+          1,
+          1,
+          10,
+          30,
+        ).toIso8601String(),
+        DatabaseConstants.updatedAtColumn: DateTime(
+          2025,
+          1,
+          2,
+          11,
+          45,
+        ).toIso8601String(),
       };
 
       final archived = ProjectDto.fromJson({
@@ -168,10 +178,20 @@ void main() {
         DatabaseConstants.idColumn: 'project-123',
         DatabaseConstants.projectNameColumn: 'My Project',
         DatabaseConstants.creatorUserIdColumn: 'creator-1',
-        DatabaseConstants.createdAtColumn:
-            DateTime(2025, 1, 1, 10, 30).toIso8601String(),
-        DatabaseConstants.updatedAtColumn:
-            DateTime(2025, 1, 2, 11, 45).toIso8601String(),
+        DatabaseConstants.createdAtColumn: DateTime(
+          2025,
+          1,
+          1,
+          10,
+          30,
+        ).toIso8601String(),
+        DatabaseConstants.updatedAtColumn: DateTime(
+          2025,
+          1,
+          2,
+          11,
+          45,
+        ).toIso8601String(),
         DatabaseConstants.statusColumn: 'active',
       };
 
@@ -204,8 +224,14 @@ void main() {
         DatabaseConstants.exportStorageProviderColumn: null,
       }).toDomain();
 
-      expect(googleDriveSnake.exportStorageProvider, StorageProvider.googleDrive);
-      expect(googleDriveCamel.exportStorageProvider, StorageProvider.googleDrive);
+      expect(
+        googleDriveSnake.exportStorageProvider,
+        StorageProvider.googleDrive,
+      );
+      expect(
+        googleDriveCamel.exportStorageProvider,
+        StorageProvider.googleDrive,
+      );
       expect(oneDriveSnake.exportStorageProvider, StorageProvider.oneDrive);
       expect(oneDriveCamel.exportStorageProvider, StorageProvider.oneDrive);
       expect(dropbox.exportStorageProvider, StorageProvider.dropbox);
@@ -245,4 +271,3 @@ void main() {
     });
   });
 }
-

--- a/test/libraries/project/units/data/repositories/project_reposiotory_test.dart
+++ b/test/libraries/project/units/data/repositories/project_reposiotory_test.dart
@@ -157,14 +157,12 @@ void main() {
       test('emits empty list when userId is empty', () async {
         final emittedBatches = <List<Project>>[];
         final emissionReceived = Completer<void>();
-        final subscription = repository.watchProjects('').listen(
-          (batch) {
-            emittedBatches.add(batch);
-            if (!emissionReceived.isCompleted) {
-              emissionReceived.complete();
-            }
-          },
-        );
+        final subscription = repository.watchProjects('').listen((batch) {
+          emittedBatches.add(batch);
+          if (!emissionReceived.isCompleted) {
+            emissionReceived.complete();
+          }
+        });
 
         await emissionReceived.future;
         await subscription.cancel();
@@ -199,17 +197,16 @@ void main() {
           final firstEmissionReceived = Completer<void>();
           final secondEmissionReceived = Completer<void>();
           var emissionCount = 0;
-          final subscription = repository.watchProjects(userId).listen(
-            (batch) {
-              emittedBatches.add(batch);
-              emissionCount++;
-              if (emissionCount == 1) {
-                firstEmissionReceived.complete();
-              } else if (emissionCount >= 2 && !secondEmissionReceived.isCompleted) {
-                secondEmissionReceived.complete();
-              }
-            },
-          );
+          final subscription = repository.watchProjects(userId).listen((batch) {
+            emittedBatches.add(batch);
+            emissionCount++;
+            if (emissionCount == 1) {
+              firstEmissionReceived.complete();
+            } else if (emissionCount >= 2 &&
+                !secondEmissionReceived.isCompleted) {
+              secondEmissionReceived.complete();
+            }
+          });
 
           await firstEmissionReceived.future;
 
@@ -243,15 +240,17 @@ void main() {
 
         final firstEmission = Completer<void>();
         final errorReceived = Completer<void>();
-        final subscription = repository.watchProjects(userId).listen(
-          (_) {
-            if (!firstEmission.isCompleted) firstEmission.complete();
-          },
-          onError: (error, _) {
-            expect(error, isA<Exception>());
-            if (!errorReceived.isCompleted) errorReceived.complete();
-          },
-        );
+        final subscription = repository
+            .watchProjects(userId)
+            .listen(
+              (_) {
+                if (!firstEmission.isCompleted) firstEmission.complete();
+              },
+              onError: (error, _) {
+                expect(error, isA<Exception>());
+                if (!errorReceived.isCompleted) errorReceived.complete();
+              },
+            );
         await firstEmission.future;
 
         projectDataSource.emitError(Exception('realtime failure'));
@@ -277,20 +276,19 @@ void main() {
           projectDataSource.firstGetOwnedProjectsStartedCompleter =
               Completer<void>();
           final firstRefreshCompleter = Completer<void>();
-          projectDataSource.nextGetOwnedProjectsCompleter = firstRefreshCompleter;
+          projectDataSource.nextGetOwnedProjectsCompleter =
+              firstRefreshCompleter;
 
           final emittedBatches = <List<Project>>[];
           final secondEmissionReceived = Completer<void>();
           var emissionCount = 0;
-          final subscription = repository.watchProjects(userId).listen(
-            (batch) {
-              emittedBatches.add(batch);
-              emissionCount++;
-              if (emissionCount >= 2 && !secondEmissionReceived.isCompleted) {
-                secondEmissionReceived.complete();
-              }
-            },
-          );
+          final subscription = repository.watchProjects(userId).listen((batch) {
+            emittedBatches.add(batch);
+            emissionCount++;
+            if (emissionCount >= 2 && !secondEmissionReceived.isCompleted) {
+              secondEmissionReceived.complete();
+            }
+          });
 
           await projectDataSource.firstGetOwnedProjectsStartedCompleter!.future;
 
@@ -310,14 +308,21 @@ void main() {
 
           await subscription.cancel();
 
-          expect(projectDataSource.getOwnedProjectsCalls, greaterThanOrEqualTo(2));
+          expect(
+            projectDataSource.getOwnedProjectsCalls,
+            greaterThanOrEqualTo(2),
+          );
           expect(emittedBatches.length, greaterThanOrEqualTo(2));
           expect(
-            emittedBatches.first.firstWhere((project) => project.id == 'owned-project').projectName,
+            emittedBatches.first
+                .firstWhere((project) => project.id == 'owned-project')
+                .projectName,
             'Owned V1',
           );
           expect(
-            emittedBatches.last.firstWhere((project) => project.id == 'owned-project').projectName,
+            emittedBatches.last
+                .firstWhere((project) => project.id == 'owned-project')
+                .projectName,
             'Owned V2',
           );
         },

--- a/test/libraries/supabase/units/fakes/fake_supabase_wrapper_test.dart
+++ b/test/libraries/supabase/units/fakes/fake_supabase_wrapper_test.dart
@@ -1070,52 +1070,44 @@ void main() {
           expect(remaining.single['id'], equals('2'));
         });
 
-        test(
-          'throws exception independently of shouldThrowOnDelete',
-          () async {
-            fakeWrapper.shouldThrowOnDeleteMatch = true;
-            fakeWrapper.deleteMatchErrorMessage = 'Delete match failed';
+        test('throws exception independently of shouldThrowOnDelete', () async {
+          fakeWrapper.shouldThrowOnDeleteMatch = true;
+          fakeWrapper.deleteMatchErrorMessage = 'Delete match failed';
 
-            await expectLater(
-              () async => fakeWrapper.deleteMatch(
-                table: 'items',
-                filters: {'id': '1'},
+          await expectLater(
+            () async =>
+                fakeWrapper.deleteMatch(table: 'items', filters: {'id': '1'}),
+            throwsA(
+              isA<ServerException>().having(
+                (e) => e.toString(),
+                'message',
+                contains('Delete match failed'),
               ),
-              throwsA(
-                isA<ServerException>().having(
-                  (e) => e.toString(),
-                  'message',
-                  contains('Delete match failed'),
-                ),
-              ),
-            );
-          },
-        );
+            ),
+          );
+        });
 
-        test(
-          'shouldThrowOnDelete does not affect deleteMatch',
-          () async {
-            fakeWrapper.addTableData('items', [
-              {'id': '1', 'project_id': 'p1'},
-            ]);
-            fakeWrapper.shouldThrowOnDelete = true;
+        test('shouldThrowOnDelete does not affect deleteMatch', () async {
+          fakeWrapper.addTableData('items', [
+            {'id': '1', 'project_id': 'p1'},
+          ]);
+          fakeWrapper.shouldThrowOnDelete = true;
 
-            await fakeWrapper.deleteMatch(
-              table: 'items',
-              filters: {'project_id': 'p1'},
-            );
+          await fakeWrapper.deleteMatch(
+            table: 'items',
+            filters: {'project_id': 'p1'},
+          );
 
-            final result = await fakeWrapper.selectMatch(
-              table: 'items',
-              filters: {'project_id': 'p1'},
-            );
-            expect(
-              result,
-              isEmpty,
-              reason: 'deleteMatch must not be affected by shouldThrowOnDelete',
-            );
-          },
-        );
+          final result = await fakeWrapper.selectMatch(
+            table: 'items',
+            filters: {'project_id': 'p1'},
+          );
+          expect(
+            result,
+            isEmpty,
+            reason: 'deleteMatch must not be affected by shouldThrowOnDelete',
+          );
+        });
 
         test('records call before delay completes', () async {
           fakeWrapper.shouldDelayOperations = true;
@@ -1303,10 +1295,8 @@ void main() {
           fakeWrapper.selectMatchErrorMessage = 'Select match failed';
 
           await expectLater(
-            () async => fakeWrapper.selectMatch(
-              table: 'items',
-              filters: {'id': '1'},
-            ),
+            () async =>
+                fakeWrapper.selectMatch(table: 'items', filters: {'id': '1'}),
             throwsA(
               isA<ServerException>().having(
                 (e) => e.toString(),
@@ -1317,50 +1307,46 @@ void main() {
           );
         });
 
-        test('returns empty list when shouldReturnEmptyOnSelectMatch is true',
-            () async {
-          fakeWrapper.addTableData('items', [
-            {'id': '1', 'project_id': 'p1'},
-          ]);
-          fakeWrapper.shouldReturnEmptyOnSelectMatch = true;
-
-          final result = await fakeWrapper.selectMatch(
-            table: 'items',
-            filters: {'project_id': 'p1'},
-          );
-
-          expect(result, isEmpty);
-        });
-
         test(
-          'shouldThrowOnSelectMultiple does not affect selectMatch',
+          'returns empty list when shouldReturnEmptyOnSelectMatch is true',
           () async {
             fakeWrapper.addTableData('items', [
               {'id': '1', 'project_id': 'p1'},
             ]);
-            fakeWrapper.shouldThrowOnSelectMultiple = true;
+            fakeWrapper.shouldReturnEmptyOnSelectMatch = true;
 
             final result = await fakeWrapper.selectMatch(
               table: 'items',
               filters: {'project_id': 'p1'},
             );
 
-            expect(
-              result,
-              hasLength(1),
-              reason:
-                  'selectMatch must not be affected by shouldThrowOnSelectMultiple',
-            );
+            expect(result, isEmpty);
           },
         );
+
+        test('shouldThrowOnSelectMultiple does not affect selectMatch', () async {
+          fakeWrapper.addTableData('items', [
+            {'id': '1', 'project_id': 'p1'},
+          ]);
+          fakeWrapper.shouldThrowOnSelectMultiple = true;
+
+          final result = await fakeWrapper.selectMatch(
+            table: 'items',
+            filters: {'project_id': 'p1'},
+          );
+
+          expect(
+            result,
+            hasLength(1),
+            reason:
+                'selectMatch must not be affected by shouldThrowOnSelectMultiple',
+          );
+        });
 
         test('defaults to all columns when columns not specified', () async {
           fakeWrapper.addTableData('items', []);
 
-          await fakeWrapper.selectMatch(
-            table: 'items',
-            filters: {'id': '1'},
-          );
+          await fakeWrapper.selectMatch(table: 'items', filters: {'id': '1'});
 
           final call = fakeWrapper.getMethodCallsFor('selectMatch').first;
           expect(call['columns'], equals('*'));
@@ -1413,42 +1399,44 @@ void main() {
           expect(result!['bio'], equals('New bio'));
         });
 
-        test('preserves created_at on update and only sets it on insert',
-            () async {
-          const originalCreatedAt = '2024-01-01T00:00:00Z';
-          fakeWrapper.addTableData('profiles', [
-            {
-              'id': '1',
-              'user_id': 'u1',
-              'bio': 'Old bio',
-              'created_at': originalCreatedAt,
-              'updated_at': originalCreatedAt,
-            },
-          ]);
+        test(
+          'preserves created_at on update and only sets it on insert',
+          () async {
+            const originalCreatedAt = '2024-01-01T00:00:00Z';
+            fakeWrapper.addTableData('profiles', [
+              {
+                'id': '1',
+                'user_id': 'u1',
+                'bio': 'Old bio',
+                'created_at': originalCreatedAt,
+                'updated_at': originalCreatedAt,
+              },
+            ]);
 
-          await fakeWrapper.upsert(
-            table: 'profiles',
-            data: {'user_id': 'u1', 'bio': 'Updated bio'},
-            onConflict: 'user_id',
-          );
+            await fakeWrapper.upsert(
+              table: 'profiles',
+              data: {'user_id': 'u1', 'bio': 'Updated bio'},
+              onConflict: 'user_id',
+            );
 
-          final result = await fakeWrapper.selectSingle(
-            table: 'profiles',
-            filterColumn: 'user_id',
-            filterValue: 'u1',
-          );
+            final result = await fakeWrapper.selectSingle(
+              table: 'profiles',
+              filterColumn: 'user_id',
+              filterValue: 'u1',
+            );
 
-          expect(
-            result!['created_at'],
-            equals(originalCreatedAt),
-            reason: 'created_at must not change on upsert update path',
-          );
-          expect(
-            result['updated_at'],
-            isNot(equals(originalCreatedAt)),
-            reason: 'updated_at must be refreshed on upsert update path',
-          );
-        });
+            expect(
+              result!['created_at'],
+              equals(originalCreatedAt),
+              reason: 'created_at must not change on upsert update path',
+            );
+            expect(
+              result['updated_at'],
+              isNot(equals(originalCreatedAt)),
+              reason: 'updated_at must be refreshed on upsert update path',
+            );
+          },
+        );
 
         test('does not mutate other rows when upserting on conflict', () async {
           fakeWrapper.addTableData('profiles', [
@@ -1529,9 +1517,7 @@ void main() {
 
           await expectLater(
             stream,
-            emitsThrough(
-              contains(containsPair('bio', 'Hello')),
-            ),
+            emitsThrough(contains(containsPair('bio', 'Hello'))),
           );
         });
 
@@ -2136,27 +2122,30 @@ void main() {
     });
 
     group('reset', () {
-      test('clears addTableData state so tables are empty after reset', () async {
-        fakeWrapper.addTableData('projects', [
-          {'id': 'p1', 'name': 'Project 1'},
-          {'id': 'p2', 'name': 'Project 2'},
-        ]);
-        final beforeReset = await fakeWrapper.selectWhereIn(
-          table: 'projects',
-          filterColumn: 'id',
-          filterValues: ['p1', 'p2'],
-        );
-        expect(beforeReset, hasLength(2));
+      test(
+        'clears addTableData state so tables are empty after reset',
+        () async {
+          fakeWrapper.addTableData('projects', [
+            {'id': 'p1', 'name': 'Project 1'},
+            {'id': 'p2', 'name': 'Project 2'},
+          ]);
+          final beforeReset = await fakeWrapper.selectWhereIn(
+            table: 'projects',
+            filterColumn: 'id',
+            filterValues: ['p1', 'p2'],
+          );
+          expect(beforeReset, hasLength(2));
 
-        fakeWrapper.reset();
+          fakeWrapper.reset();
 
-        final afterReset = await fakeWrapper.selectWhereIn(
-          table: 'projects',
-          filterColumn: 'id',
-          filterValues: ['p1', 'p2'],
-        );
-        expect(afterReset, isEmpty);
-      });
+          final afterReset = await fakeWrapper.selectWhereIn(
+            table: 'projects',
+            filterColumn: 'id',
+            filterValues: ['p1', 'p2'],
+          );
+          expect(afterReset, isEmpty);
+        },
+      );
 
       test('clears all configurations and data', () async {
         fakeWrapper.addTableData('users', [

--- a/test/utils/fake_app_bootstrap_factory.dart
+++ b/test/utils/fake_app_bootstrap_factory.dart
@@ -1,4 +1,6 @@
 import 'package:construculator/app/app_bootstrap.dart';
+import 'package:construculator/libraries/config/interfaces/config.dart';
+import 'package:construculator/libraries/config/interfaces/env_loader.dart';
 import 'package:construculator/libraries/config/testing/fake_app_config.dart';
 import 'package:construculator/libraries/config/testing/fake_env_loader.dart';
 import 'package:construculator/libraries/supabase/testing/fake_supabase_wrapper.dart';
@@ -15,8 +17,9 @@ class FakeAppBootstrapFactory {
   /// All parameters are optional:
   /// - [supabaseWrapper]: Provide a specific FakeSupabaseWrapper to control
   ///   database state and assertions
-  /// - [clock]: Provide a Clock to control time in tests. Will be used for
-  ///   supabaseWrapper if not provided separately
+  /// - [clock]: Provide a Clock to control time in tests. Note: [clock] is only
+  ///   used when [supabaseWrapper] is omitted. If you supply your own
+  ///   [supabaseWrapper], wire the clock into it directly.
   /// - [config]: Provide custom app configuration for the test
   /// - [envLoader]: Provide custom environment loading behavior
   ///
@@ -34,8 +37,8 @@ class FakeAppBootstrapFactory {
   static AppBootstrap create({
     FakeSupabaseWrapper? supabaseWrapper,
     Clock? clock,
-    FakeAppConfig? config,
-    FakeEnvLoader? envLoader,
+    Config? config,
+    EnvLoader? envLoader,
   }) {
     final fakeClock = clock ?? FakeClockImpl();
     return AppBootstrap(

--- a/test/utils/fake_app_bootstrap_factory.dart
+++ b/test/utils/fake_app_bootstrap_factory.dart
@@ -4,7 +4,6 @@ import 'package:construculator/libraries/config/interfaces/env_loader.dart';
 import 'package:construculator/libraries/config/testing/fake_app_config.dart';
 import 'package:construculator/libraries/config/testing/fake_env_loader.dart';
 import 'package:construculator/libraries/supabase/testing/fake_supabase_wrapper.dart';
-import 'package:construculator/libraries/time/interfaces/clock.dart';
 import 'package:construculator/libraries/time/testing/fake_clock_impl.dart';
 
 /// Factory for creating test AppBootstrap instances with fake dependencies.
@@ -17,9 +16,6 @@ class FakeAppBootstrapFactory {
   /// All parameters are optional:
   /// - [supabaseWrapper]: Provide a specific FakeSupabaseWrapper to control
   ///   database state and assertions
-  /// - [clock]: Provide a Clock to control time in tests. Note: [clock] is only
-  ///   used when [supabaseWrapper] is omitted. If you supply your own
-  ///   [supabaseWrapper], wire the clock into it directly.
   /// - [config]: Provide custom app configuration for the test
   /// - [envLoader]: Provide custom environment loading behavior
   ///
@@ -31,18 +27,19 @@ class FakeAppBootstrapFactory {
   /// final bootstrap = FakeAppBootstrapFactory.create();
   ///
   /// // With custom clock for time-dependent tests
-  /// final clock = FakeClockImpl(DateTime(2025, 1, 1));
-  /// final bootstrap = FakeAppBootstrapFactory.create(clock: clock);
+  /// final fakeClock = FakeClockImpl(DateTime(2025, 1, 1));
+  /// final bootstrap = FakeAppBootstrapFactory.create(
+  ///   supabaseWrapper: FakeSupabaseWrapper(clock: fakeClock),
+  /// );
   /// ```
   static AppBootstrap create({
     FakeSupabaseWrapper? supabaseWrapper,
-    Clock? clock,
     Config? config,
     EnvLoader? envLoader,
   }) {
-    final fakeClock = clock ?? FakeClockImpl();
     return AppBootstrap(
-      supabaseWrapper: supabaseWrapper ?? FakeSupabaseWrapper(clock: fakeClock),
+      supabaseWrapper:
+          supabaseWrapper ?? FakeSupabaseWrapper(clock: FakeClockImpl()),
       config: config ?? FakeAppConfig(),
       envLoader: envLoader ?? FakeEnvLoader(),
     );

--- a/test/utils/fake_app_bootstrap_factory.dart
+++ b/test/utils/fake_app_bootstrap_factory.dart
@@ -1,0 +1,47 @@
+import 'package:construculator/app/app_bootstrap.dart';
+import 'package:construculator/libraries/config/testing/fake_app_config.dart';
+import 'package:construculator/libraries/config/testing/fake_env_loader.dart';
+import 'package:construculator/libraries/supabase/testing/fake_supabase_wrapper.dart';
+import 'package:construculator/libraries/time/interfaces/clock.dart';
+import 'package:construculator/libraries/time/testing/fake_clock_impl.dart';
+
+/// Factory for creating test AppBootstrap instances with fake dependencies.
+///
+/// Provides convenient methods to create AppBootstrap with sensible test
+/// defaults, reducing boilerplate in test setup.
+class FakeAppBootstrapFactory {
+  /// Creates an AppBootstrap with fake dependencies for testing.
+  ///
+  /// All parameters are optional:
+  /// - [supabaseWrapper]: Provide a specific FakeSupabaseWrapper to control
+  ///   database state and assertions
+  /// - [clock]: Provide a Clock to control time in tests. Will be used for
+  ///   supabaseWrapper if not provided separately
+  /// - [config]: Provide custom app configuration for the test
+  /// - [envLoader]: Provide custom environment loading behavior
+  ///
+  /// When parameters are omitted, sensible test defaults are provided.
+  ///
+  /// Example:
+  /// ```dart
+  /// // Basic usage with all defaults
+  /// final bootstrap = FakeAppBootstrapFactory.create();
+  ///
+  /// // With custom clock for time-dependent tests
+  /// final clock = FakeClockImpl(DateTime(2025, 1, 1));
+  /// final bootstrap = FakeAppBootstrapFactory.create(clock: clock);
+  /// ```
+  static AppBootstrap create({
+    FakeSupabaseWrapper? supabaseWrapper,
+    Clock? clock,
+    FakeAppConfig? config,
+    FakeEnvLoader? envLoader,
+  }) {
+    final fakeClock = clock ?? FakeClockImpl();
+    return AppBootstrap(
+      supabaseWrapper: supabaseWrapper ?? FakeSupabaseWrapper(clock: fakeClock),
+      config: config ?? FakeAppConfig(),
+      envLoader: envLoader ?? FakeEnvLoader(),
+    );
+  }
+}


### PR DESCRIPTION
# PR Review: feat/create-centralized-fake-app-bootstrap → main
**Reviewed:** Sat Apr 11 2026

## Summary

Introduces FakeAppBootstrapFactory to centralize test AppBootstrap creation, eliminating repetitive boilerplate across 42+ test files.

### Changes

New:
  - test/utils/fake_app_bootstrap_factory.dart - Factory with two static methods:
  - create() - Creates bootstrap with optional overrides (clock, config, etc.)
  
### Benefits
 - ✅ Reduced boilerplate - 4 lines → 1 line per test
  - ✅ Single source of truth - Consistent test defaults across all tests
  - ✅ Easier maintenance - Update defaults in one place
  - ✅ Clearer intent - Method names express purpose (withSupabase, create)
  - ✅ Flexible - Can still override any dependency for specific test needs


---

## REVIEW SUMMARY

| Issue Name | Description | Status | Notes |
|---|---|---|---|
| `withSupabase` duplicates `create` logic | `withSupabase` constructs `AppBootstrap` independently instead of delegating to `create`, creating two maintenance points for the same construction | ✅ | |
| Silent `clock` / `supabaseWrapper` precedence | When both `clock` and `supabaseWrapper` are passed to `create()`, `clock` is silently ignored. The parameter is also typed as the concrete `FakeClockImpl` rather than `Clock` | ✅ | |
| Unnecessary downcast in `get_project_bloc_test` | `clock as FakeClockImpl` downcast is required only because of the tightly-typed factory parameter; removing or widening the `clock` param eliminates it | ✅ | |
| Stray blank lines after import removal | Double blank lines remain in several test files after the two import lines were removed; `dart format` would resolve all instances | ✅ | |
| Docstrings describe implementation, not contract | Parameter docs in `create()` explain internal defaulting logic rather than the observable contract the caller can rely on | ✅ | |