### PR TITLE
CA-595: feat: implement permission data source and integrate it

### DIFF
--- a/lib/libraries/project/data/data_source/interfaces/permission_data_source.dart
+++ b/lib/libraries/project/data/data_source/interfaces/permission_data_source.dart
@@ -1,0 +1,27 @@
+/// Data source for accessing user permission data.
+///
+/// This abstraction provides access to permission information stored in JWT claims
+/// or other authentication/authorization sources.
+abstract class ProjectPermissionDataSource {
+  /// Get all permissions for a specific project.
+  ///
+  /// Returns a list of permission keys (e.g., ['edit_cost_estimation', 'get_cost_estimations'])
+  /// that the current user has for the specified project.
+  ///
+  /// Returns an empty list if:
+  /// - User is not authenticated
+  /// - User has no permissions for the project
+  /// - Project ID not found in the permission source
+  ///
+  /// [projectId] The UUID of the project
+  List<String> getProjectPermissions(String projectId);
+
+  /// Check if user has a specific permission for a project.
+  ///
+  /// Convenience method that checks if [permissionKey] exists in the
+  /// permissions list for [projectId].
+  ///
+  /// [projectId] The UUID of the project
+  /// [permissionKey] The permission key to check (e.g., 'edit_cost_estimation')
+  bool hasProjectPermission(String projectId, String permissionKey);
+}

--- a/lib/libraries/project/data/data_source/interfaces/permission_data_source.dart
+++ b/lib/libraries/project/data/data_source/interfaces/permission_data_source.dart
@@ -1,7 +1,4 @@
-/// Data source for accessing user permission data.
-///
-/// This abstraction provides access to permission information stored in JWT claims
-/// or other authentication/authorization sources.
+/// Provides access to project-scoped permission data for the current user.
 abstract class ProjectPermissionDataSource {
   /// Get all permissions for a specific project.
   ///

--- a/lib/libraries/project/data/data_source/local_jwt_project_permission_data_source.dart
+++ b/lib/libraries/project/data/data_source/local_jwt_project_permission_data_source.dart
@@ -1,0 +1,25 @@
+import 'package:construculator/libraries/project/data/data_source/interfaces/permission_data_source.dart';
+import 'package:construculator/libraries/supabase/interfaces/supabase_wrapper.dart';
+
+/// JWT-backed implementation of [ProjectPermissionDataSource].
+///
+/// Reads project permissions from the claims embedded in the current
+/// Supabase auth session's JWT — no network calls, no on-device persistence.
+class LocalJwtProjectPermissionDataSource
+    implements ProjectPermissionDataSource {
+  final SupabaseWrapper _supabaseWrapper;
+
+  LocalJwtProjectPermissionDataSource({
+    required SupabaseWrapper supabaseWrapper,
+  }) : _supabaseWrapper = supabaseWrapper;
+
+  @override
+  List<String> getProjectPermissions(String projectId) {
+    return _supabaseWrapper.getProjectPermissions(projectId);
+  }
+
+  @override
+  bool hasProjectPermission(String projectId, String permissionKey) {
+    return _supabaseWrapper.hasProjectPermission(projectId, permissionKey);
+  }
+}

--- a/lib/libraries/project/domain/permission_constants.dart
+++ b/lib/libraries/project/domain/permission_constants.dart
@@ -1,0 +1,24 @@
+// coverage:ignore-file
+/// Centralized permission key constants.
+///
+/// This file contains all permission keys used across the application for
+/// authorization checks. These keys must match the permission keys defined
+/// in the database.
+///
+/// When adding new permissions, add them here first, then reference them
+/// in your repositories, data sources, and UI components.
+class PermissionConstants {
+  PermissionConstants._();
+
+  // Cost Estimation permissions
+  static const String getCostEstimations = 'get_cost_estimations';
+  static const String addCostEstimation = 'add_cost_estimation';
+  static const String deleteCostEstimation = 'delete_cost_estimation';
+  static const String editCostEstimation = 'edit_cost_estimation';
+  static const String lockCostEstimation = 'lock_cost_estimation';
+
+  // Project permissions
+  static const String viewProject = 'view_project';
+  static const String editProject = 'edit_project';
+  static const String deleteProject = 'delete_project';
+}

--- a/lib/libraries/project/project_library_module.dart
+++ b/lib/libraries/project/project_library_module.dart
@@ -1,6 +1,8 @@
 import 'package:construculator/app/app_bootstrap.dart';
 import 'package:construculator/libraries/project/data/current_project_notifier_impl.dart';
+import 'package:construculator/libraries/project/data/data_source/interfaces/permission_data_source.dart';
 import 'package:construculator/libraries/project/data/data_source/interfaces/project_data_source.dart';
+import 'package:construculator/libraries/project/data/data_source/local_jwt_project_permission_data_source.dart';
 import 'package:construculator/libraries/project/data/data_source/remote_project_data_source.dart';
 import 'package:construculator/libraries/project/data/repositories/project_repository_impl.dart';
 import 'package:construculator/libraries/project/domain/repositories/project_repository.dart';
@@ -33,6 +35,12 @@ void _registerDependencies(Injector i) {
 
   i.addLazySingleton<ProjectDataSource>(
     () => RemoteProjectDataSource(
+      supabaseWrapper: Modular.get<SupabaseWrapper>(),
+    ),
+  );
+
+  i.addLazySingleton<ProjectPermissionDataSource>(
+    () => LocalJwtProjectPermissionDataSource(
       supabaseWrapper: Modular.get<SupabaseWrapper>(),
     ),
   );

--- a/lib/libraries/supabase/interfaces/supabase_wrapper.dart
+++ b/lib/libraries/supabase/interfaces/supabase_wrapper.dart
@@ -286,8 +286,8 @@ abstract class SupabaseWrapper {
 
   /// Get the internal user ID from JWT claims
   ///
-  /// Returns the internal application user ID (users.id) from app_metadata,
-  /// which is different from the credential_id (auth.users.id).
+  /// Returns the application-layer user ID stored in JWT app_metadata,
+  /// which differs from the authentication provider's user identifier.
   ///
   /// Returns null if user is not authenticated or internal_user_id is not set
   String? getInternalUserId();

--- a/lib/libraries/supabase/interfaces/supabase_wrapper.dart
+++ b/lib/libraries/supabase/interfaces/supabase_wrapper.dart
@@ -243,4 +243,52 @@ abstract class SupabaseWrapper {
   /// [functionName] The name of the RPC function to call
   /// [params] The parameters to pass to the function
   Future<T> rpc<T>(String functionName, {Map<String, dynamic>? params});
+
+  /// Get all permissions for a specific project from JWT claims
+  ///
+  /// Returns a list of permission keys (e.g., ['edit_cost_estimation', 'get_cost_estimations'])
+  /// that the current user has for the specified project.
+  ///
+  /// Returns an empty list if:
+  /// - User is not authenticated
+  /// - User has no permissions for the project
+  /// - Project ID not found in JWT claims
+  ///
+  /// [projectId] The UUID of the project
+  List<String> getProjectPermissions(String projectId);
+
+  /// Check if user has a specific permission for a project
+  ///
+  /// Convenience method that checks if [permissionKey] exists in the
+  /// permissions list for [projectId] in the current user's JWT claims.
+  ///
+  /// [projectId] The UUID of the project
+  /// [permissionKey] The permission key to check (e.g., 'edit_cost_estimation')
+  bool hasProjectPermission(String projectId, String permissionKey);
+
+  /// Refresh the current session to get updated JWT claims from the server
+  ///
+  /// **Important:** While Supabase automatically refreshes tokens before expiry,
+  /// automatic refresh only extends token validity - it does NOT fetch updated
+  /// claims from the server. This method forces a server-side refresh to get
+  /// the latest JWT claims including updated permissions.
+  ///
+  /// Call this after operations that change user permissions:
+  /// - Accepting project invitations
+  /// - Role changes
+  /// - Permission updates by admins
+  ///
+  /// Without manual refresh, permission changes remain invisible until the
+  /// next natural token expiry (up to 1 hour).
+  ///
+  /// Throws [AuthException] if the refresh token has expired
+  Future<void> refreshSession();
+
+  /// Get the internal user ID from JWT claims
+  ///
+  /// Returns the internal application user ID (users.id) from app_metadata,
+  /// which is different from the credential_id (auth.users.id).
+  ///
+  /// Returns null if user is not authenticated or internal_user_id is not set
+  String? getInternalUserId();
 }

--- a/lib/libraries/supabase/supabase_wrapper_impl.dart
+++ b/lib/libraries/supabase/supabase_wrapper_impl.dart
@@ -2,6 +2,7 @@
 import 'dart:async';
 import 'package:construculator/libraries/config/interfaces/env_loader.dart';
 import 'package:construculator/libraries/errors/exceptions.dart';
+import 'package:construculator/libraries/logging/app_logger.dart';
 import 'package:construculator/libraries/supabase/interfaces/supabase_wrapper.dart';
 import 'package:stack_trace/stack_trace.dart';
 import 'package:supabase_flutter/supabase_flutter.dart' as supabase;
@@ -9,6 +10,7 @@ import 'package:supabase_flutter/supabase_flutter.dart' as supabase;
 class SupabaseWrapperImpl implements SupabaseWrapper {
   late supabase.SupabaseClient _supabaseClient;
   final EnvLoader _envLoader;
+  static final _logger = AppLogger().tag('SupabaseWrapperImpl');
 
   SupabaseWrapperImpl({required EnvLoader envLoader}) : _envLoader = envLoader;
 
@@ -268,5 +270,72 @@ class SupabaseWrapperImpl implements SupabaseWrapper {
   @override
   Future<T> rpc<T>(String functionName, {Map<String, dynamic>? params}) async {
     return await _supabaseClient.rpc(functionName, params: params);
+  }
+
+  @override
+  List<String> getProjectPermissions(String projectId) {
+    final user = currentUser;
+    if (user == null) return [];
+
+    final appMetadata = user.appMetadata;
+    final projectsRaw = appMetadata['projects'];
+
+    if (projectsRaw is! Map<String, dynamic>) {
+      if (projectsRaw != null) {
+        _logger.warning(
+          'Invalid JWT structure: projects is not a Map, got ${projectsRaw.runtimeType}',
+        );
+      }
+      return [];
+    }
+
+    final permissionsRaw = projectsRaw[projectId];
+    if (permissionsRaw is! List) {
+      if (permissionsRaw != null) {
+        _logger.warning(
+          'Invalid JWT structure: permissions for project $projectId is not a List, got ${permissionsRaw.runtimeType}',
+        );
+      }
+      return [];
+    }
+
+    final permissions = permissionsRaw.whereType<String>().toList();
+    final droppedCount = permissionsRaw.length - permissions.length;
+    if (droppedCount > 0) {
+      _logger.warning(
+        'Dropped $droppedCount non-String permission entries from JWT for project $projectId',
+      );
+    }
+
+    return permissions;
+  }
+
+  @override
+  bool hasProjectPermission(String projectId, String permissionKey) {
+    return getProjectPermissions(projectId).contains(permissionKey);
+  }
+
+  @override
+  Future<void> refreshSession() async {
+    await _supabaseClient.auth.refreshSession();
+  }
+
+  @override
+  String? getInternalUserId() {
+    final user = currentUser;
+    if (user == null) return null;
+
+    final appMetadata = user.appMetadata;
+    final userId = appMetadata['internal_user_id'];
+
+    if (userId is String) return userId;
+
+    if (userId != null) {
+      _logger.warning(
+        'Invalid JWT structure: internal_user_id is not a String, got ${userId.runtimeType}',
+      );
+    }
+
+    return null;
   }
 }

--- a/lib/libraries/supabase/supabase_wrapper_impl.dart
+++ b/lib/libraries/supabase/supabase_wrapper_impl.dart
@@ -4,6 +4,7 @@ import 'package:construculator/libraries/config/interfaces/env_loader.dart';
 import 'package:construculator/libraries/errors/exceptions.dart';
 import 'package:construculator/libraries/logging/app_logger.dart';
 import 'package:construculator/libraries/supabase/interfaces/supabase_wrapper.dart';
+import 'package:construculator/libraries/supabase/utils/jwt_parser.dart';
 import 'package:stack_trace/stack_trace.dart';
 import 'package:supabase_flutter/supabase_flutter.dart' as supabase;
 
@@ -274,12 +275,28 @@ class SupabaseWrapperImpl implements SupabaseWrapper {
 
   @override
   List<String> getProjectPermissions(String projectId) {
-    final user = currentUser;
-    if (user == null) return [];
+    final session = _supabaseClient.auth.currentSession;
+    if (session == null) return [];
 
-    final appMetadata = user.appMetadata;
+    final payload = JwtParser.parsePayload(session.accessToken);
+    if (payload == null) {
+      _logger.warning(
+        'Failed to get project permissions for $projectId: JWT parsing failed',
+      );
+      return [];
+    }
+
+    final appMetadata = payload['app_metadata'];
+    if (appMetadata is! Map<String, dynamic>) {
+      if (appMetadata != null) {
+        _logger.warning(
+          'Invalid JWT structure: app_metadata is not a Map, got ${appMetadata.runtimeType}',
+        );
+      }
+      return [];
+    }
+
     final projectsRaw = appMetadata['projects'];
-
     if (projectsRaw is! Map<String, dynamic>) {
       if (projectsRaw != null) {
         _logger.warning(
@@ -322,12 +339,26 @@ class SupabaseWrapperImpl implements SupabaseWrapper {
 
   @override
   String? getInternalUserId() {
-    final user = currentUser;
-    if (user == null) return null;
+    final session = _supabaseClient.auth.currentSession;
+    if (session == null) return null;
 
-    final appMetadata = user.appMetadata;
+    final payload = JwtParser.parsePayload(session.accessToken);
+    if (payload == null) {
+      _logger.warning('Failed to get internal user ID: JWT parsing failed');
+      return null;
+    }
+
+    final appMetadata = payload['app_metadata'];
+    if (appMetadata is! Map<String, dynamic>) {
+      if (appMetadata != null) {
+        _logger.warning(
+          'Invalid JWT structure: app_metadata is not a Map, got ${appMetadata.runtimeType}',
+        );
+      }
+      return null;
+    }
+
     final userId = appMetadata['internal_user_id'];
-
     if (userId is String) return userId;
 
     if (userId != null) {

--- a/lib/libraries/supabase/testing/fake_supabase_wrapper.dart
+++ b/lib/libraries/supabase/testing/fake_supabase_wrapper.dart
@@ -1235,6 +1235,9 @@ class FakeSupabaseWrapper implements SupabaseWrapper {
     shouldThrowOnGetUserProfile = false;
     _nextId = 1;
 
+    _projectPermissions.clear();
+    _internalUserId = null;
+
     clearAllData();
     clearMethodCalls();
     clearRpcResponses();

--- a/lib/libraries/supabase/testing/fake_supabase_wrapper.dart
+++ b/lib/libraries/supabase/testing/fake_supabase_wrapper.dart
@@ -34,6 +34,12 @@ class FakeSupabaseWrapper implements SupabaseWrapper {
   /// Tracks RPC responses for different function names
   final Map<String, dynamic> _rpcResponses = {};
 
+  /// Tracks permissions by project ID for testing
+  final Map<String, List<String>> _projectPermissions = {};
+
+  /// Tracks internal user ID for testing
+  String? _internalUserId;
+
   /// Controls whether [signInWithPassword] throws an exception
   bool shouldThrowOnSignIn = false;
 
@@ -81,6 +87,9 @@ class FakeSupabaseWrapper implements SupabaseWrapper {
 
   /// Controls whether [rpc] throws an exception
   bool shouldThrowOnRpc = false;
+
+  /// Controls whether [refreshSession] throws an exception
+  bool shouldThrowOnRefreshSession = false;
 
   /// Error message for sign in.
   /// Used to specify the error message thrown when [signInWithPassword] is attempted
@@ -146,6 +155,10 @@ class FakeSupabaseWrapper implements SupabaseWrapper {
   /// Used to specify the error message thrown when [rpc] is attempted
   String? rpcErrorMessage;
 
+  /// Error message for refresh session.
+  /// Used to specify the error message thrown when [refreshSession] is attempted
+  String? refreshSessionErrorMessage;
+
   /// Error message for select.
   /// Used to specify the error message thrown when [select] is attempted
   SupabaseExceptionType? selectMultipleExceptionType;
@@ -176,6 +189,9 @@ class FakeSupabaseWrapper implements SupabaseWrapper {
 
   /// Used to specify the type of exception thrown when [rpc] is attempted
   SupabaseExceptionType? rpcExceptionType;
+
+  /// Used to specify the type of exception thrown when [refreshSession] is attempted
+  SupabaseExceptionType? refreshSessionExceptionType;
 
   /// Used to specify the error code thrown when [signInWithPassword] is attempted
   SupabaseAuthErrorCode? authErrorCode;
@@ -944,6 +960,47 @@ class FakeSupabaseWrapper implements SupabaseWrapper {
   }
 
   @override
+  List<String> getProjectPermissions(String projectId) {
+    _methodCalls.add({
+      'method': 'getProjectPermissions',
+      'projectId': projectId,
+    });
+    return List<String>.from(_projectPermissions[projectId] ?? []);
+  }
+
+  @override
+  bool hasProjectPermission(String projectId, String permissionKey) {
+    _methodCalls.add({
+      'method': 'hasProjectPermission',
+      'projectId': projectId,
+      'permissionKey': permissionKey,
+    });
+    return _projectPermissions[projectId]?.contains(permissionKey) ?? false;
+  }
+
+  @override
+  Future<void> refreshSession() async {
+    if (shouldDelayOperations) {
+      await completer?.future;
+    }
+
+    _methodCalls.add({'method': 'refreshSession'});
+
+    if (shouldThrowOnRefreshSession) {
+      _throwConfiguredException(
+        refreshSessionExceptionType,
+        refreshSessionErrorMessage ?? 'Refresh session failed',
+      );
+    }
+  }
+
+  @override
+  String? getInternalUserId() {
+    _methodCalls.add({'method': 'getInternalUserId'});
+    return _internalUserId;
+  }
+
+  @override
   Future<void> initialize() {
     // No need to implement this method, fake supabase wrapper does not need
     // to initialize any dependencies
@@ -1082,6 +1139,21 @@ class FakeSupabaseWrapper implements SupabaseWrapper {
     _rpcResponses.clear();
   }
 
+  /// Sets permissions for a specific project (for testing)
+  void setProjectPermissions(String projectId, List<String> permissions) {
+    _projectPermissions[projectId] = List<String>.from(permissions);
+  }
+
+  /// Clears permissions for a specific project (for testing)
+  void clearProjectPermissions(String projectId) {
+    _projectPermissions.remove(projectId);
+  }
+
+  /// Sets the internal user ID (for testing)
+  void setInternalUserId(String? userId) {
+    _internalUserId = userId;
+  }
+
   /// Closes the auth state controller
   void dispose() {
     _authStateController.close();
@@ -1120,6 +1192,7 @@ class FakeSupabaseWrapper implements SupabaseWrapper {
     shouldThrowOnDeleteMatch = false;
     shouldThrowOnUpsert = false;
     shouldThrowOnRpc = false;
+    shouldThrowOnRefreshSession = false;
 
     signInErrorMessage = null;
     signUpErrorMessage = null;
@@ -1136,6 +1209,7 @@ class FakeSupabaseWrapper implements SupabaseWrapper {
     deleteMatchErrorMessage = null;
     upsertErrorMessage = null;
     rpcErrorMessage = null;
+    refreshSessionErrorMessage = null;
 
     selectExceptionType = null;
     selectPaginatedExceptionType = null;
@@ -1147,6 +1221,7 @@ class FakeSupabaseWrapper implements SupabaseWrapper {
     deleteMatchExceptionType = null;
     upsertExceptionType = null;
     rpcExceptionType = null;
+    refreshSessionExceptionType = null;
     postgrestErrorCode = null;
 
     shouldReturnNullUser = false;

--- a/lib/libraries/supabase/utils/jwt_parser.dart
+++ b/lib/libraries/supabase/utils/jwt_parser.dart
@@ -1,0 +1,40 @@
+import 'dart:convert';
+
+import 'package:construculator/libraries/logging/app_logger.dart';
+
+/// Utility class for parsing JWT tokens
+class JwtParser {
+  static final _logger = AppLogger().tag('JwtParser');
+
+  /// Parse JWT token and extract payload
+  ///
+  /// Returns the decoded payload as a Map, or null if parsing fails.
+  /// Handles base64 URL decoding with proper padding normalization.
+  ///
+  /// Example:
+  /// ```dart
+  /// final payload = JwtParser.parsePayload(token);
+  /// if (payload != null) {
+  ///   final userId = payload['user_id'];
+  /// }
+  /// ```
+  static Map<String, dynamic>? parsePayload(String token) {
+    try {
+      final parts = token.split('.');
+      if (parts.length != 3) {
+        _logger.warning(
+          'Invalid JWT format: expected 3 parts, got ${parts.length}',
+        );
+        return null;
+      }
+
+      final payload = parts[1];
+      var normalized = base64Url.normalize(payload);
+      final decoded = utf8.decode(base64Url.decode(normalized));
+      return json.decode(decoded) as Map<String, dynamic>;
+    } catch (e) {
+      _logger.warning('Failed to parse JWT: $e');
+      return null;
+    }
+  }
+}

--- a/test/features/estimations/units/blocs/cost_estimation_list_bloc_test.dart
+++ b/test/features/estimations/units/blocs/cost_estimation_list_bloc_test.dart
@@ -28,7 +28,7 @@ void main() {
     late CostEstimationRepository repository;
     late FakeClockImpl fakeClock;
     const String testProjectId = 'test-project-123';
-    const Duration streamDebounceWaitDuration = Duration(milliseconds: 400);
+    const Duration streamDebounceWaitDuration = Duration(milliseconds: 500);
 
     setUpAll(() {
       fakeClock = FakeClockImpl();
@@ -134,10 +134,13 @@ void main() {
           seedEstimationTable([]);
           return bloc;
         },
-        act: (bloc) => bloc.add(
-          const CostEstimationListStartWatching(projectId: testProjectId),
-        ),
-        wait: streamDebounceWaitDuration,
+        act: (bloc) async {
+          bloc.add(
+            const CostEstimationListStartWatching(projectId: testProjectId),
+          );
+          // Wait for the empty state to ensure the async operation and debounce complete
+          await bloc.stream.firstWhere((s) => s is CostEstimationListEmpty);
+        },
         expect: () => [
           isA<CostEstimationListLoading>(),
           isA<CostEstimationListEmpty>(),

--- a/test/libraries/project/units/data/data_source/local_jwt_project_permission_data_source_test.dart
+++ b/test/libraries/project/units/data/data_source/local_jwt_project_permission_data_source_test.dart
@@ -1,0 +1,110 @@
+import 'package:construculator/libraries/project/data/data_source/interfaces/permission_data_source.dart';
+import 'package:construculator/libraries/project/data/data_source/local_jwt_project_permission_data_source.dart';
+import 'package:construculator/libraries/project/project_library_module.dart';
+import 'package:construculator/libraries/supabase/testing/fake_supabase_wrapper.dart';
+import 'package:construculator/libraries/time/testing/fake_clock_impl.dart';
+import 'package:flutter_modular/flutter_modular.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../../../../../utils/fake_app_bootstrap_factory.dart';
+
+class _TestModule extends Module {
+  final FakeSupabaseWrapper supabaseWrapper;
+
+  _TestModule({required this.supabaseWrapper});
+
+  @override
+  List<Module> get imports => [
+    ProjectLibraryModule(
+      FakeAppBootstrapFactory.create(supabaseWrapper: supabaseWrapper),
+    ),
+  ];
+}
+
+void main() {
+  group('LocalJwtProjectPermissionDataSource', () {
+    late FakeClockImpl clock;
+    late FakeSupabaseWrapper supabaseWrapper;
+    late LocalJwtProjectPermissionDataSource dataSource;
+
+    setUpAll(() {
+      clock = FakeClockImpl(DateTime(2025, 1, 1, 8, 0));
+      supabaseWrapper = FakeSupabaseWrapper(clock: clock);
+      Modular.init(_TestModule(supabaseWrapper: supabaseWrapper));
+      dataSource =
+          Modular.get<ProjectPermissionDataSource>()
+              as LocalJwtProjectPermissionDataSource;
+    });
+
+    setUp(() {
+      supabaseWrapper.reset();
+    });
+
+    tearDownAll(() {
+      Modular.dispose();
+    });
+
+    group('getProjectPermissions', () {
+      test('returns permissions from supabase wrapper', () {
+        supabaseWrapper.setProjectPermissions('project-1', [
+          'read',
+          'write',
+          'delete',
+        ]);
+
+        final result = dataSource.getProjectPermissions('project-1');
+
+        expect(result, ['read', 'write', 'delete']);
+      });
+
+      test('returns empty list when no permissions set', () {
+        final result = dataSource.getProjectPermissions('project-1');
+
+        expect(result, isEmpty);
+      });
+
+      test('returns permissions for specific project only', () {
+        supabaseWrapper.setProjectPermissions('project-1', ['read', 'write']);
+        supabaseWrapper.setProjectPermissions('project-2', ['admin']);
+
+        final result = dataSource.getProjectPermissions('project-1');
+
+        expect(result, ['read', 'write']);
+        expect(result, isNot(contains('admin')));
+      });
+    });
+
+    group('hasProjectPermission', () {
+      test('returns true when permission exists', () {
+        supabaseWrapper.setProjectPermissions('project-1', ['read', 'write']);
+
+        final result = dataSource.hasProjectPermission('project-1', 'read');
+
+        expect(result, isTrue);
+      });
+
+      test('returns false when permission does not exist', () {
+        supabaseWrapper.setProjectPermissions('project-1', ['read']);
+
+        final result = dataSource.hasProjectPermission('project-1', 'write');
+
+        expect(result, isFalse);
+      });
+
+      test('returns false when no permissions set for project', () {
+        final result = dataSource.hasProjectPermission('project-1', 'read');
+
+        expect(result, isFalse);
+      });
+
+      test('returns false for permission in different project', () {
+        supabaseWrapper.setProjectPermissions('project-1', ['read']);
+        supabaseWrapper.setProjectPermissions('project-2', ['write']);
+
+        final result = dataSource.hasProjectPermission('project-1', 'write');
+
+        expect(result, isFalse);
+      });
+    });
+  });
+}

--- a/test/libraries/supabase/units/fakes/fake_supabase_wrapper_test.dart
+++ b/test/libraries/supabase/units/fakes/fake_supabase_wrapper_test.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:construculator/libraries/errors/exceptions.dart';
+import 'package:construculator/libraries/project/domain/permission_constants.dart';
 import 'package:construculator/libraries/supabase/data/supabase_types.dart';
 import 'package:construculator/libraries/supabase/interfaces/supabase_wrapper.dart';
 import 'package:construculator/libraries/supabase/testing/fake_supabase_auth_response.dart';
@@ -2121,6 +2122,290 @@ void main() {
       });
     });
 
+    group('Permission Methods', () {
+      const projectId = 'project-123';
+      const otherProjectId = 'project-456';
+
+      group('getProjectPermissions', () {
+        test('returns empty list when user has no permissions', () {
+          final permissions = fakeWrapper.getProjectPermissions(projectId);
+
+          expect(permissions, isEmpty);
+          expect(
+            fakeWrapper.getMethodCallsFor('getProjectPermissions'),
+            hasLength(1),
+          );
+        });
+
+        test('returns permissions for specific project', () {
+          fakeWrapper.setProjectPermissions(projectId, [
+            PermissionConstants.editCostEstimation,
+            PermissionConstants.getCostEstimations,
+            PermissionConstants.lockCostEstimation,
+          ]);
+
+          final permissions = fakeWrapper.getProjectPermissions(projectId);
+
+          expect(permissions, hasLength(3));
+          expect(permissions, contains(PermissionConstants.editCostEstimation));
+          expect(permissions, contains(PermissionConstants.getCostEstimations));
+          expect(permissions, contains(PermissionConstants.lockCostEstimation));
+        });
+
+        test('does not return permissions from other projects', () {
+          fakeWrapper.setProjectPermissions(projectId, ['permission_a']);
+          fakeWrapper.setProjectPermissions(otherProjectId, ['permission_b']);
+
+          final permissions = fakeWrapper.getProjectPermissions(projectId);
+
+          expect(permissions, hasLength(1));
+          expect(permissions, contains('permission_a'));
+          expect(permissions, isNot(contains('permission_b')));
+        });
+
+        test('records method call with project ID', () {
+          fakeWrapper.getProjectPermissions(projectId);
+
+          final calls = fakeWrapper.getMethodCallsFor('getProjectPermissions');
+          expect(calls, hasLength(1));
+          expect(calls.first['projectId'], equals(projectId));
+        });
+      });
+
+      group('hasProjectPermission', () {
+        test('returns false when user has no permissions', () {
+          final hasPermission = fakeWrapper.hasProjectPermission(
+            projectId,
+            PermissionConstants.editCostEstimation,
+          );
+
+          expect(hasPermission, isFalse);
+        });
+
+        test('returns true when user has specific permission', () {
+          fakeWrapper.setProjectPermissions(projectId, [
+            PermissionConstants.editCostEstimation,
+            PermissionConstants.getCostEstimations,
+          ]);
+
+          final hasEdit = fakeWrapper.hasProjectPermission(
+            projectId,
+            PermissionConstants.editCostEstimation,
+          );
+          final hasGet = fakeWrapper.hasProjectPermission(
+            projectId,
+            PermissionConstants.getCostEstimations,
+          );
+
+          expect(hasEdit, isTrue);
+          expect(hasGet, isTrue);
+        });
+
+        test('returns false when user lacks specific permission', () {
+          fakeWrapper.setProjectPermissions(projectId, [
+            PermissionConstants.getCostEstimations,
+          ]);
+
+          final hasPermission = fakeWrapper.hasProjectPermission(
+            projectId,
+            PermissionConstants.editCostEstimation,
+          );
+
+          expect(hasPermission, isFalse);
+        });
+
+        test('returns false for permissions from other projects', () {
+          fakeWrapper.setProjectPermissions(otherProjectId, [
+            PermissionConstants.editCostEstimation,
+          ]);
+
+          final hasPermission = fakeWrapper.hasProjectPermission(
+            projectId,
+            PermissionConstants.editCostEstimation,
+          );
+
+          expect(hasPermission, isFalse);
+        });
+
+        test('records method call with all parameters', () {
+          fakeWrapper.hasProjectPermission(
+            projectId,
+            PermissionConstants.editCostEstimation,
+          );
+
+          final calls = fakeWrapper.getMethodCallsFor('hasProjectPermission');
+          expect(calls, hasLength(1));
+          expect(
+            calls,
+            equals([
+              {
+                'method': 'hasProjectPermission',
+                'projectId': projectId,
+                'permissionKey': PermissionConstants.editCostEstimation,
+              },
+            ]),
+          );
+        });
+      });
+
+      group('refreshSession', () {
+        test('completes successfully by default', () async {
+          await fakeWrapper.refreshSession();
+
+          final calls = fakeWrapper.getMethodCallsFor('refreshSession');
+          expect(calls, hasLength(1));
+        });
+
+        test('throws exception when configured to fail', () async {
+          fakeWrapper.shouldThrowOnRefreshSession = true;
+          fakeWrapper.refreshSessionErrorMessage = 'Token expired';
+
+          await expectLater(
+            fakeWrapper.refreshSession(),
+            throwsA(
+              isA<ServerException>().having(
+                (e) => e.toString(),
+                'message',
+                contains('Token expired'),
+              ),
+            ),
+          );
+        });
+
+        test(
+          'throws AuthException when configured with auth error type',
+          () async {
+            fakeWrapper.shouldThrowOnRefreshSession = true;
+            fakeWrapper.refreshSessionErrorMessage = 'Invalid refresh token';
+            fakeWrapper.refreshSessionExceptionType =
+                SupabaseExceptionType.auth;
+
+            await expectLater(
+              fakeWrapper.refreshSession(),
+              throwsA(
+                isA<supabase.AuthException>().having(
+                  (e) => e.message,
+                  'message',
+                  contains('Invalid refresh token'),
+                ),
+              ),
+            );
+          },
+        );
+
+        test('supports delayed operations', () async {
+          fakeWrapper.shouldDelayOperations = true;
+          fakeWrapper.completer = Completer();
+
+          final future = fakeWrapper.refreshSession();
+
+          expect(fakeWrapper.getMethodCallsFor('refreshSession'), isEmpty);
+
+          fakeWrapper.completer!.complete();
+          await future;
+
+          expect(fakeWrapper.getMethodCallsFor('refreshSession'), hasLength(1));
+        });
+
+        test('records method call even when throwing', () async {
+          fakeWrapper.shouldThrowOnRefreshSession = true;
+
+          try {
+            await fakeWrapper.refreshSession();
+          } catch (_) {}
+
+          expect(fakeWrapper.getMethodCallsFor('refreshSession'), hasLength(1));
+        });
+      });
+
+      group('getInternalUserId', () {
+        test('returns null by default', () {
+          final userId = fakeWrapper.getInternalUserId();
+
+          expect(userId, isNull);
+        });
+
+        test('returns configured user ID', () {
+          const userId = 'user-internal-123';
+          fakeWrapper.setInternalUserId(userId);
+
+          final result = fakeWrapper.getInternalUserId();
+
+          expect(result, equals(userId));
+        });
+
+        test('can be set to null', () {
+          fakeWrapper.setInternalUserId('user-123');
+          fakeWrapper.setInternalUserId(null);
+
+          final result = fakeWrapper.getInternalUserId();
+
+          expect(result, isNull);
+        });
+
+        test('records method call', () {
+          fakeWrapper.getInternalUserId();
+
+          final calls = fakeWrapper.getMethodCallsFor('getInternalUserId');
+          expect(calls, hasLength(1));
+        });
+      });
+
+      group('Permission Test Utilities', () {
+        test('setProjectPermissions sets permissions correctly', () {
+          fakeWrapper.setProjectPermissions(projectId, ['perm1', 'perm2']);
+
+          final permissions = fakeWrapper.getProjectPermissions(projectId);
+
+          expect(permissions, hasLength(2));
+          expect(permissions, containsAll(['perm1', 'perm2']));
+        });
+
+        test('setProjectPermissions replaces existing permissions', () {
+          fakeWrapper.setProjectPermissions(projectId, ['perm1']);
+          fakeWrapper.setProjectPermissions(projectId, ['perm2', 'perm3']);
+
+          final permissions = fakeWrapper.getProjectPermissions(projectId);
+
+          expect(permissions, hasLength(2));
+          expect(permissions, containsAll(['perm2', 'perm3']));
+          expect(permissions, isNot(contains('perm1')));
+        });
+
+        test('clearProjectPermissions removes all permissions', () {
+          fakeWrapper.setProjectPermissions(projectId, [
+            'perm1',
+            'perm2',
+            'perm3',
+          ]);
+          fakeWrapper.clearProjectPermissions(projectId);
+
+          final permissions = fakeWrapper.getProjectPermissions(projectId);
+
+          expect(permissions, isEmpty);
+        });
+
+        test('clearProjectPermissions only affects specified project', () {
+          fakeWrapper.setProjectPermissions(projectId, ['perm1']);
+          fakeWrapper.setProjectPermissions(otherProjectId, ['perm2']);
+
+          fakeWrapper.clearProjectPermissions(projectId);
+
+          expect(fakeWrapper.getProjectPermissions(projectId), isEmpty);
+          expect(
+            fakeWrapper.getProjectPermissions(otherProjectId),
+            contains('perm2'),
+          );
+        });
+
+        test('setInternalUserId updates user ID', () {
+          fakeWrapper.setInternalUserId('user-123');
+
+          expect(fakeWrapper.getInternalUserId(), equals('user-123'));
+        });
+      });
+    });
+
     group('reset', () {
       test(
         'clears addTableData state so tables are empty after reset',
@@ -2170,6 +2455,7 @@ void main() {
         fakeWrapper.shouldThrowOnDeleteMatch = true;
         fakeWrapper.shouldThrowOnUpsert = true;
         fakeWrapper.shouldThrowOnRpc = true;
+        fakeWrapper.shouldThrowOnRefreshSession = true;
         fakeWrapper.shouldReturnEmptyOnSelectMatch = true;
         fakeWrapper.signInErrorMessage = 'Sign in failed';
         fakeWrapper.signUpErrorMessage = 'Sign up failed';
@@ -2185,6 +2471,7 @@ void main() {
         fakeWrapper.deleteErrorMessage = 'Delete failed';
         fakeWrapper.deleteMatchErrorMessage = 'Delete match failed';
         fakeWrapper.rpcErrorMessage = 'RPC failed';
+        fakeWrapper.refreshSessionErrorMessage = 'Refresh session failed';
         fakeWrapper.selectExceptionType = SupabaseExceptionType.postgrest;
         fakeWrapper.selectMultipleExceptionType = SupabaseExceptionType.socket;
         fakeWrapper.selectMatchExceptionType = SupabaseExceptionType.socket;
@@ -2194,6 +2481,7 @@ void main() {
         fakeWrapper.deleteExceptionType = SupabaseExceptionType.type;
         fakeWrapper.deleteMatchExceptionType = SupabaseExceptionType.type;
         fakeWrapper.rpcExceptionType = SupabaseExceptionType.postgrest;
+        fakeWrapper.refreshSessionExceptionType = SupabaseExceptionType.auth;
         fakeWrapper.postgrestErrorCode = PostgresErrorCode.uniqueViolation;
         fakeWrapper.shouldReturnNullUser = true;
         fakeWrapper.shouldReturnNullOnSelect = true;
@@ -2231,6 +2519,7 @@ void main() {
         expect(fakeWrapper.shouldThrowOnDeleteMatch, isFalse);
         expect(fakeWrapper.shouldThrowOnUpsert, isFalse);
         expect(fakeWrapper.shouldThrowOnRpc, isFalse);
+        expect(fakeWrapper.shouldThrowOnRefreshSession, isFalse);
         expect(fakeWrapper.shouldReturnEmptyOnSelectMatch, isFalse);
         expect(fakeWrapper.signInErrorMessage, isNull);
         expect(fakeWrapper.signUpErrorMessage, isNull);
@@ -2246,6 +2535,7 @@ void main() {
         expect(fakeWrapper.deleteErrorMessage, isNull);
         expect(fakeWrapper.deleteMatchErrorMessage, isNull);
         expect(fakeWrapper.rpcErrorMessage, isNull);
+        expect(fakeWrapper.refreshSessionErrorMessage, isNull);
         expect(fakeWrapper.selectExceptionType, isNull);
         expect(fakeWrapper.selectMultipleExceptionType, isNull);
         expect(fakeWrapper.selectMatchExceptionType, isNull);
@@ -2255,6 +2545,7 @@ void main() {
         expect(fakeWrapper.deleteExceptionType, isNull);
         expect(fakeWrapper.deleteMatchExceptionType, isNull);
         expect(fakeWrapper.rpcExceptionType, isNull);
+        expect(fakeWrapper.refreshSessionExceptionType, isNull);
         expect(fakeWrapper.postgrestErrorCode, isNull);
         expect(fakeWrapper.shouldReturnNullUser, isFalse);
         expect(fakeWrapper.shouldReturnNullOnSelect, isFalse);

--- a/test/libraries/supabase/units/jwt_parser_test.dart
+++ b/test/libraries/supabase/units/jwt_parser_test.dart
@@ -1,0 +1,249 @@
+import 'dart:convert';
+
+import 'package:construculator/libraries/supabase/utils/jwt_parser.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('JwtParser', () {
+    group('parsePayload', () {
+      test('successfully parses valid JWT token', () {
+        final payload = {
+          'user_id': '123',
+          'email': 'test@example.com',
+          'app_metadata': {
+            'projects': {
+              'project-1': ['read', 'write']
+            }
+          }
+        };
+        final encodedPayload = base64Url.encode(utf8.encode(json.encode(payload)));
+        final token = 'header.$encodedPayload.signature';
+
+        final result = JwtParser.parsePayload(token);
+
+        expect(result, isNotNull);
+        expect(result!['user_id'], equals('123'));
+        expect(result['email'], equals('test@example.com'));
+        expect(result['app_metadata'], isA<Map>());
+      });
+
+      test('successfully parses JWT token with base64 padding', () {
+        final payload = {'sub': '1234567890', 'name': 'John Doe', 'iat': 1516239022};
+        final encodedPayload = base64Url.encode(utf8.encode(json.encode(payload)));
+        final token = 'header.$encodedPayload.signature';
+
+        final result = JwtParser.parsePayload(token);
+
+        expect(result, isNotNull);
+        expect(result!['sub'], equals('1234567890'));
+        expect(result['name'], equals('John Doe'));
+        expect(result['iat'], equals(1516239022));
+      });
+
+      test('successfully parses JWT token without base64 padding', () {
+        final payload = {'test': 'value'};
+        var encodedPayload = base64Url.encode(utf8.encode(json.encode(payload)));
+
+        encodedPayload = encodedPayload.replaceAll('=', '');
+        final token = 'header.$encodedPayload.signature';
+
+        final result = JwtParser.parsePayload(token);
+
+        expect(result, isNotNull);
+        expect(result!['test'], equals('value'));
+      });
+
+      test('parses JWT token with complex nested structure', () {
+        final payload = {
+          'app_metadata': {
+            'projects': {
+              'project-1': ['read', 'write', 'delete'],
+              'project-2': ['read']
+            },
+            'internal_user_id': 'user-123'
+          },
+          'user_metadata': {
+            'name': 'Test User',
+            'preferences': {'theme': 'dark', 'language': 'en'}
+          }
+        };
+        final encodedPayload = base64Url.encode(utf8.encode(json.encode(payload)));
+        final token = 'header.$encodedPayload.signature';
+
+        final result = JwtParser.parsePayload(token);
+
+        expect(result, isNotNull);
+        expect(result!['app_metadata']['projects']['project-1'], hasLength(3));
+        expect(result['app_metadata']['internal_user_id'], equals('user-123'));
+        expect(result['user_metadata']['preferences']['theme'], equals('dark'));
+      });
+
+      test('parses JWT token with special characters in payload', () {
+        final payload = {
+          'email': 'user+test@example.com',
+          'name': 'Test User™',
+          'description': 'Line 1\nLine 2\tTabbed'
+        };
+        final encodedPayload = base64Url.encode(utf8.encode(json.encode(payload)));
+        final token = 'header.$encodedPayload.signature';
+
+        final result = JwtParser.parsePayload(token);
+
+        expect(result, isNotNull);
+        expect(result!['email'], equals('user+test@example.com'));
+        expect(result['name'], equals('Test User™'));
+        expect(result['description'], equals('Line 1\nLine 2\tTabbed'));
+      });
+
+      test('returns null for empty string', () {
+        final result = JwtParser.parsePayload('');
+
+        expect(result, isNull);
+      });
+
+      test('returns null for token with only 1 part', () {
+        const token = 'onlyonepart';
+
+        final result = JwtParser.parsePayload(token);
+
+        expect(result, isNull);
+      });
+
+      test('returns null for token with only 2 parts', () {
+        const token = 'header.payload';
+
+        final result = JwtParser.parsePayload(token);
+
+        expect(result, isNull);
+      });
+
+      test('returns null for token with 4 parts', () {
+        const token = 'header.payload.signature.extra';
+
+        final result = JwtParser.parsePayload(token);
+
+        expect(result, isNull);
+      });
+
+      test('returns null for token with invalid base64 encoding', () {
+        const token = 'header.invalid@#\$%base64!.signature';
+
+        final result = JwtParser.parsePayload(token);
+
+        expect(result, isNull);
+      });
+
+      test('returns null for token with valid base64 but invalid JSON', () {
+        final invalidJson = 'not-valid-json{]';
+        final encodedPayload = base64Url.encode(utf8.encode(invalidJson));
+        final token = 'header.$encodedPayload.signature';
+
+        final result = JwtParser.parsePayload(token);
+
+        expect(result, isNull);
+      });
+
+      test('returns null for token with valid base64 but non-object JSON', () {
+        final jsonArray = ['item1', 'item2'];
+        final encodedPayload = base64Url.encode(utf8.encode(json.encode(jsonArray)));
+        final token = 'header.$encodedPayload.signature';
+
+        final result = JwtParser.parsePayload(token);
+
+        expect(result, isNull);
+      });
+
+      test('returns null for token with valid base64 but primitive JSON value', () {
+        const primitiveValue = '"just a string"';
+        final encodedPayload = base64Url.encode(utf8.encode(primitiveValue));
+        final token = 'header.$encodedPayload.signature';
+
+        final result = JwtParser.parsePayload(token);
+
+        expect(result, isNull);
+      });
+
+      test('returns null for token with empty payload section', () {
+        const token = 'header..signature';
+
+        final result = JwtParser.parsePayload(token);
+
+        expect(result, isNull);
+      });
+
+      test('parses JWT token with empty object payload', () {
+        final payload = <String, dynamic>{};
+        final encodedPayload = base64Url.encode(utf8.encode(json.encode(payload)));
+        final token = 'header.$encodedPayload.signature';
+
+        final result = JwtParser.parsePayload(token);
+
+        expect(result, isNotNull);
+        expect(result, isEmpty);
+      });
+
+      test('parses JWT token with null values in payload', () {
+        final payload = {'key1': null, 'key2': 'value', 'key3': null};
+        final encodedPayload = base64Url.encode(utf8.encode(json.encode(payload)));
+        final token = 'header.$encodedPayload.signature';
+
+        final result = JwtParser.parsePayload(token);
+
+        expect(result, isNotNull);
+        expect(result!['key1'], isNull);
+        expect(result['key2'], equals('value'));
+        expect(result['key3'], isNull);
+      });
+
+      test('parses JWT token with numeric values', () {
+        final payload = {
+          'int_value': 42,
+          'double_value': 3.14,
+          'negative': -100,
+          'exp_notation': 1.5e10
+        };
+        final encodedPayload = base64Url.encode(utf8.encode(json.encode(payload)));
+        final token = 'header.$encodedPayload.signature';
+
+        final result = JwtParser.parsePayload(token);
+
+        expect(result, isNotNull);
+        expect(result!['int_value'], equals(42));
+        expect(result['double_value'], equals(3.14));
+        expect(result['negative'], equals(-100));
+        expect(result['exp_notation'], equals(1.5e10));
+      });
+
+      test('parses JWT token with boolean values', () {
+        final payload = {'is_admin': true, 'is_active': false, 'verified': true};
+        final encodedPayload = base64Url.encode(utf8.encode(json.encode(payload)));
+        final token = 'header.$encodedPayload.signature';
+
+        final result = JwtParser.parsePayload(token);
+
+        expect(result, isNotNull);
+        expect(result!['is_admin'], isTrue);
+        expect(result['is_active'], isFalse);
+        expect(result['verified'], isTrue);
+      });
+
+      test('parses JWT token with array values', () {
+        final payload = {
+          'roles': ['admin', 'user', 'moderator'],
+          'numbers': [1, 2, 3, 4, 5],
+          'mixed': ['string', 123, true, null]
+        };
+        final encodedPayload = base64Url.encode(utf8.encode(json.encode(payload)));
+        final token = 'header.$encodedPayload.signature';
+
+        final result = JwtParser.parsePayload(token);
+
+        expect(result, isNotNull);
+        expect(result!['roles'], hasLength(3));
+        expect(result['roles'][0], equals('admin'));
+        expect(result['numbers'], equals([1, 2, 3, 4, 5]));
+        expect(result['mixed'], equals(['string', 123, true, null]));
+      });
+    });
+  });
+}


### PR DESCRIPTION
### 1. PR Summary

This PR introduces a JWT-based permission system into the app. It adds a `ProjectPermissionDataSource` interface and a `JwtPermissionDataSource` implementation that reads project-scoped permissions from the current Supabase session's JWT claims — no network calls required. It also extends `SupabaseWrapper` with `getProjectPermissions`, `hasProjectPermission`, `refreshSession`, and `getInternalUserId`. The fake wrapper and its test suite are updated accordingly. **PR size is M — acceptable.**


---

### 2. Review Summary Table

| Issue Name | Description | Status | Notes |
|------------|-------------|--------|-------|
| Missing unit tests for impl & data source | `JwtPermissionDataSource` has no tests. `SupabaseWrapperImpl`'s new parsing logic (type guards, warning branches, `whereType` fallback) is also untested. | ✅ | |
| Silent permission entry drop | Non-String items in the JWT permissions list are silently ignored with no log warning, potentially masking malformed JWT data. | ✅ | |
| Implementation comment in fake | The `// Successfully refreshed...` comment in `FakeSupabaseWrapper.refreshSession` is an AI residual that explains internal intent rather than defining a contract. Should be removed. | ✅ | |