### PR TITLE
CA-103: feat: integrate project permissions in estimation module and 

### DIFF
--- a/lib/features/estimation/estimation_module.dart
+++ b/lib/features/estimation/estimation_module.dart
@@ -14,6 +14,7 @@ import 'package:construculator/features/estimation/presentation/pages/cost_estim
 import 'package:construculator/libraries/auth/auth_library_module.dart';
 import 'package:construculator/libraries/estimation/estimation_library_module.dart';
 import 'package:construculator/libraries/project/interfaces/current_project_notifier.dart';
+import 'package:construculator/libraries/project/project_library_module.dart';
 import 'package:construculator/libraries/time/clock_module.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -30,8 +31,9 @@ class EstimationModule extends Module {
     return MultiBlocProvider(
       providers: [
         BlocProvider<CostEstimationListBloc>(
-          create: (context) => Modular.get<CostEstimationListBloc>()
-            ..add(CostEstimationListStartWatching(projectId: projectId)),
+          create: (context) =>
+              Modular.get<CostEstimationListBloc>()
+                ..add(CostEstimationListStartWatching(projectId: projectId)),
         ),
         BlocProvider<AddCostEstimationBloc>(
           create: (context) => Modular.get<AddCostEstimationBloc>(),
@@ -54,6 +56,7 @@ class EstimationModule extends Module {
   List<Module> get imports => [
     AuthLibraryModule(appBootstrap),
     EstimationLibraryModule(appBootstrap),
+    ProjectLibraryModule(appBootstrap),
     ClockModule(),
   ];
 
@@ -86,10 +89,12 @@ class EstimationModule extends Module {
       () => DeleteCostEstimationBloc(costEstimationRepository: i.get()),
     );
     i.add<ChangeLockStatusBloc>(
-      () => ChangeLockStatusBloc(repository: i.get()),
+      () =>
+          ChangeLockStatusBloc(repository: i.get(), projectRepository: i.get()),
     );
     i.add<RenameEstimationBloc>(
-      () => RenameEstimationBloc(repository: i.get()),
+      () =>
+          RenameEstimationBloc(repository: i.get(), projectRepository: i.get()),
     );
     i.add<CostEstimationLogBloc>(
       () => CostEstimationLogBloc(repository: i.get()),

--- a/lib/features/estimation/presentation/bloc/change_lock_status_bloc/change_lock_status_bloc.dart
+++ b/lib/features/estimation/presentation/bloc/change_lock_status_bloc/change_lock_status_bloc.dart
@@ -1,5 +1,8 @@
 import 'package:construculator/libraries/errors/failures.dart';
+import 'package:construculator/libraries/estimation/domain/estimation_error_type.dart';
 import 'package:construculator/libraries/estimation/domain/repositories/cost_estimation_repository.dart';
+import 'package:construculator/libraries/project/domain/permission_constants.dart';
+import 'package:construculator/libraries/project/domain/repositories/project_repository.dart';
 import 'package:equatable/equatable.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
@@ -9,10 +12,14 @@ part 'change_lock_status_state.dart';
 class ChangeLockStatusBloc
     extends Bloc<ChangeLockStatusEvent, ChangeLockStatusState> {
   final CostEstimationRepository _repository;
+  final ProjectRepository _projectRepository;
 
-  ChangeLockStatusBloc({required CostEstimationRepository repository})
-    : _repository = repository,
-      super(const ChangeLockStatusInitial()) {
+  ChangeLockStatusBloc({
+    required CostEstimationRepository repository,
+    required ProjectRepository projectRepository,
+  }) : _repository = repository,
+       _projectRepository = projectRepository,
+       super(const ChangeLockStatusInitial()) {
     on<ChangeLockStatusRequested>(_onChangeLockStatusRequested);
   }
 
@@ -23,6 +30,23 @@ class ChangeLockStatusBloc
     if (state is ChangeLockStatusInProgress) return;
 
     final originalValue = !event.isLocked;
+
+    final hasPermission = _projectRepository.hasProjectPermission(
+      event.projectId,
+      PermissionConstants.lockCostEstimation,
+    );
+
+    if (!hasPermission) {
+      emit(
+        ChangeLockStatusFailure(
+          failure: const EstimationFailure(
+            errorType: EstimationErrorType.permissionDenied,
+          ),
+          originalValue: originalValue,
+        ),
+      );
+      return;
+    }
 
     emit(const ChangeLockStatusInProgress());
 

--- a/lib/features/estimation/presentation/bloc/rename_estimation_bloc/rename_estimation_bloc.dart
+++ b/lib/features/estimation/presentation/bloc/rename_estimation_bloc/rename_estimation_bloc.dart
@@ -1,5 +1,8 @@
 import 'package:construculator/libraries/errors/failures.dart';
+import 'package:construculator/libraries/estimation/domain/estimation_error_type.dart';
 import 'package:construculator/libraries/estimation/domain/repositories/cost_estimation_repository.dart';
+import 'package:construculator/libraries/project/domain/permission_constants.dart';
+import 'package:construculator/libraries/project/domain/repositories/project_repository.dart';
 import 'package:equatable/equatable.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
@@ -9,10 +12,14 @@ part 'rename_estimation_state.dart';
 class RenameEstimationBloc
     extends Bloc<RenameEstimationEvent, RenameEstimationState> {
   final CostEstimationRepository _repository;
+  final ProjectRepository _projectRepository;
 
-  RenameEstimationBloc({required CostEstimationRepository repository})
-    : _repository = repository,
-      super(const RenameEstimationInitial()) {
+  RenameEstimationBloc({
+    required CostEstimationRepository repository,
+    required ProjectRepository projectRepository,
+  }) : _repository = repository,
+       _projectRepository = projectRepository,
+       super(const RenameEstimationInitial()) {
     on<RenameEstimationReset>(_onReset);
     on<RenameEstimationTextChanged>(_onTextChanged);
     on<RenameEstimationRequested>(_onRenameEstimationRequested);
@@ -37,9 +44,25 @@ class RenameEstimationBloc
     RenameEstimationRequested event,
     Emitter<RenameEstimationState> emit,
   ) async {
-    // TODO: https://github.com/Flutterando/modular/issues/331 (Handle permission checks and other edgecases as well)s
     final trimmedName = event.newName.trim();
     final isSaveEnabled = trimmedName.isNotEmpty;
+
+    final hasPermission = _projectRepository.hasProjectPermission(
+      event.projectId,
+      PermissionConstants.editCostEstimation,
+    );
+
+    if (!hasPermission) {
+      emit(
+        RenameEstimationFailure(
+          const EstimationFailure(
+            errorType: EstimationErrorType.permissionDenied,
+          ),
+          isSaveEnabled: isSaveEnabled,
+        ),
+      );
+      return;
+    }
 
     emit(RenameEstimationInProgress(isSaveEnabled: isSaveEnabled));
 

--- a/lib/features/estimation/presentation/pages/cost_estimation_landing_page.dart
+++ b/lib/features/estimation/presentation/pages/cost_estimation_landing_page.dart
@@ -474,6 +474,8 @@ class _CostEstimationLandingPageState extends State<CostEstimationLandingPage> {
         return l10n.connectionError;
       case EstimationErrorType.authenticationError:
         return l10n.userIdNotAvailable;
+      case EstimationErrorType.permissionDenied:
+        return l10n.permissionDenied;
       default:
         return l10n.unexpectedErrorMessage;
     }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1096,5 +1096,10 @@
   "@membersTab": {
     "description": "Label for members tab in bottom navigation",
     "context": "AppShellPage"
+  },
+  "permissionDenied": "You don't have permission to perform this action",
+  "@permissionDenied": {
+    "description": "Error message shown when user lacks permission for an operation",
+    "context": "N/A"
   }
 }

--- a/lib/l10n/generated/app_localizations.dart
+++ b/lib/l10n/generated/app_localizations.dart
@@ -1329,6 +1329,12 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Members'**
   String get membersTab;
+
+  /// Error message shown when user lacks permission for an operation
+  ///
+  /// In en, this message translates to:
+  /// **'You don\'t have permission to perform this action'**
+  String get permissionDenied;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/generated/app_localizations_en.dart
+++ b/lib/l10n/generated/app_localizations_en.dart
@@ -694,4 +694,8 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get membersTab => 'Members';
+
+  @override
+  String get permissionDenied =>
+      'You don\'t have permission to perform this action';
 }

--- a/lib/libraries/estimation/domain/estimation_error_type.dart
+++ b/lib/libraries/estimation/domain/estimation_error_type.dart
@@ -7,6 +7,7 @@
 /// - [timeoutError]: the operation timed out
 /// - [unexpectedDatabaseError]: database query or operation failed
 /// - [authenticationError]: user authentication failed or user not found
+/// - [permissionDenied]: user lacks required permission for the operation
 enum EstimationErrorType {
   connectionError,
   parsingError,
@@ -15,4 +16,5 @@ enum EstimationErrorType {
   unexpectedError,
   authenticationError,
   notFoundError,
+  permissionDenied,
 }

--- a/test/features/estimations/units/blocs/change_lock_status_bloc_test.dart
+++ b/test/features/estimations/units/blocs/change_lock_status_bloc_test.dart
@@ -3,6 +3,9 @@ import 'package:construculator/features/estimation/estimation_module.dart';
 import 'package:construculator/features/estimation/presentation/bloc/change_lock_status_bloc/change_lock_status_bloc.dart';
 import 'package:construculator/libraries/errors/failures.dart';
 import 'package:construculator/libraries/estimation/domain/estimation_error_type.dart';
+import 'package:construculator/libraries/project/domain/permission_constants.dart';
+import 'package:construculator/libraries/project/domain/repositories/project_repository.dart';
+import 'package:construculator/libraries/project/testing/fake_project_repository.dart';
 import 'package:construculator/libraries/supabase/data/supabase_types.dart';
 import 'package:construculator/libraries/supabase/database_constants.dart';
 import 'package:construculator/libraries/supabase/interfaces/supabase_wrapper.dart';
@@ -18,6 +21,7 @@ void main() {
   group('ChangeLockStatusBloc', () {
     late ChangeLockStatusBloc bloc;
     late FakeSupabaseWrapper fakeSupabaseWrapper;
+    late FakeProjectRepository fakeProjectRepository;
     late FakeClockImpl fakeClock;
 
     const testProjectId = 'test-project-123';
@@ -33,6 +37,9 @@ void main() {
 
       fakeSupabaseWrapper =
           Modular.get<SupabaseWrapper>() as FakeSupabaseWrapper;
+      Modular.replaceInstance<ProjectRepository>(FakeProjectRepository());
+      fakeProjectRepository =
+          Modular.get<ProjectRepository>() as FakeProjectRepository;
     });
 
     tearDownAll(() {
@@ -41,6 +48,9 @@ void main() {
 
     setUp(() {
       fakeSupabaseWrapper.reset();
+      fakeProjectRepository.setProjectPermissions(testProjectId, [
+        PermissionConstants.lockCostEstimation,
+      ]);
       bloc = Modular.get<ChangeLockStatusBloc>();
     });
 
@@ -264,6 +274,101 @@ void main() {
           expect(calls.first['filterColumn'], equals('id'));
           expect(calls.first['filterValue'], testEstimationId);
           expect(calls.first['data'], containsPair('is_locked', true));
+        },
+      );
+    });
+
+    group('Permission checks', () {
+      blocTest<ChangeLockStatusBloc, ChangeLockStatusState>(
+        'should emit permission denied failure when user lacks lock permission',
+        build: () {
+          fakeProjectRepository.setProjectPermissions(testProjectId, []);
+          final estimationMap = buildEstimationMap(
+            id: testEstimationId,
+            projectId: testProjectId,
+            estimateName: testEstimationName,
+            isLocked: false,
+          );
+          seedEstimationTable([estimationMap]);
+          return bloc;
+        },
+        act: (bloc) => bloc.add(
+          const ChangeLockStatusRequested(
+            estimationId: testEstimationId,
+            isLocked: true,
+            projectId: testProjectId,
+          ),
+        ),
+        expect: () => [
+          isA<ChangeLockStatusFailure>()
+              .having(
+                (s) => s.failure,
+                'failure',
+                isA<EstimationFailure>().having(
+                  (f) => f.errorType,
+                  'errorType',
+                  EstimationErrorType.permissionDenied,
+                ),
+              )
+              .having((s) => s.originalValue, 'originalValue', isFalse),
+        ],
+      );
+
+      blocTest<ChangeLockStatusBloc, ChangeLockStatusState>(
+        'should succeed when user has lock permission',
+        build: () {
+          fakeProjectRepository.setProjectPermissions(testProjectId, [
+            PermissionConstants.lockCostEstimation,
+          ]);
+          final estimationMap = buildEstimationMap(
+            id: testEstimationId,
+            projectId: testProjectId,
+            estimateName: testEstimationName,
+            isLocked: false,
+          );
+          seedEstimationTable([estimationMap]);
+          return bloc;
+        },
+        act: (bloc) => bloc.add(
+          const ChangeLockStatusRequested(
+            estimationId: testEstimationId,
+            isLocked: true,
+            projectId: testProjectId,
+          ),
+        ),
+        expect: () => [
+          isA<ChangeLockStatusInProgress>(),
+          isA<ChangeLockStatusSuccess>().having(
+            (s) => s.isLocked,
+            'isLocked',
+            isTrue,
+          ),
+        ],
+      );
+
+      blocTest<ChangeLockStatusBloc, ChangeLockStatusState>(
+        'should not proceed to change lock status when permission denied',
+        build: () {
+          fakeProjectRepository.setProjectPermissions(testProjectId, []);
+          final estimationMap = buildEstimationMap(
+            id: testEstimationId,
+            projectId: testProjectId,
+            estimateName: testEstimationName,
+            isLocked: false,
+          );
+          seedEstimationTable([estimationMap]);
+          return bloc;
+        },
+        act: (bloc) => bloc.add(
+          const ChangeLockStatusRequested(
+            estimationId: testEstimationId,
+            isLocked: true,
+            projectId: testProjectId,
+          ),
+        ),
+        verify: (_) {
+          final updateCalls = fakeSupabaseWrapper.getMethodCallsFor('update');
+          expect(updateCalls, isEmpty);
         },
       );
     });

--- a/test/features/estimations/units/blocs/rename_estimation_bloc_test.dart
+++ b/test/features/estimations/units/blocs/rename_estimation_bloc_test.dart
@@ -3,6 +3,9 @@ import 'package:construculator/features/estimation/estimation_module.dart';
 import 'package:construculator/features/estimation/presentation/bloc/rename_estimation_bloc/rename_estimation_bloc.dart';
 import 'package:construculator/libraries/errors/failures.dart';
 import 'package:construculator/libraries/estimation/domain/estimation_error_type.dart';
+import 'package:construculator/libraries/project/domain/permission_constants.dart';
+import 'package:construculator/libraries/project/domain/repositories/project_repository.dart';
+import 'package:construculator/libraries/project/testing/fake_project_repository.dart';
 import 'package:construculator/libraries/supabase/data/supabase_types.dart';
 import 'package:construculator/libraries/supabase/database_constants.dart';
 import 'package:construculator/libraries/supabase/interfaces/supabase_wrapper.dart';
@@ -18,6 +21,7 @@ void main() {
   group('RenameEstimationBloc', () {
     late RenameEstimationBloc bloc;
     late FakeSupabaseWrapper fakeSupabaseWrapper;
+    late FakeProjectRepository fakeProjectRepository;
     late FakeClockImpl fakeClock;
 
     const testProjectId = 'test-project-123';
@@ -34,6 +38,10 @@ void main() {
 
       fakeSupabaseWrapper =
           Modular.get<SupabaseWrapper>() as FakeSupabaseWrapper;
+
+      Modular.replaceInstance<ProjectRepository>(FakeProjectRepository());
+      fakeProjectRepository =
+          Modular.get<ProjectRepository>() as FakeProjectRepository;
     });
 
     tearDownAll(() {
@@ -42,6 +50,9 @@ void main() {
 
     setUp(() {
       fakeSupabaseWrapper.reset();
+      fakeProjectRepository.setProjectPermissions(testProjectId, [
+        PermissionConstants.editCostEstimation,
+      ]);
       bloc = Modular.get<RenameEstimationBloc>();
     });
 
@@ -352,6 +363,101 @@ void main() {
             equals('Retried Name'),
           ),
         ],
+      );
+    });
+
+    group('Permission checks', () {
+      blocTest<RenameEstimationBloc, RenameEstimationState>(
+        'should emit permission denied failure when user lacks edit permission',
+        build: () {
+          fakeProjectRepository.setProjectPermissions(testProjectId, []);
+          final estimationMap =
+              EstimationTestDataMapFactory.createFakeEstimationData(
+                id: testEstimationId,
+                projectId: testProjectId,
+                estimateName: testEstimationName,
+              );
+          seedEstimationTable([estimationMap]);
+          return bloc;
+        },
+        act: (bloc) => bloc.add(
+          const RenameEstimationRequested(
+            estimationId: testEstimationId,
+            newName: testNewName,
+            projectId: testProjectId,
+          ),
+        ),
+        expect: () => [
+          isA<RenameEstimationFailure>()
+              .having(
+                (s) => s.failure,
+                'failure',
+                isA<EstimationFailure>().having(
+                  (f) => f.errorType,
+                  'errorType',
+                  EstimationErrorType.permissionDenied,
+                ),
+              )
+              .having((s) => s.isSaveEnabled, 'isSaveEnabled', isTrue),
+        ],
+      );
+
+      blocTest<RenameEstimationBloc, RenameEstimationState>(
+        'should succeed when user has edit permission',
+        build: () {
+          fakeProjectRepository.setProjectPermissions(testProjectId, [
+            PermissionConstants.editCostEstimation,
+          ]);
+          final estimationMap =
+              EstimationTestDataMapFactory.createFakeEstimationData(
+                id: testEstimationId,
+                projectId: testProjectId,
+                estimateName: testEstimationName,
+              );
+          seedEstimationTable([estimationMap]);
+          return bloc;
+        },
+        act: (bloc) => bloc.add(
+          const RenameEstimationRequested(
+            estimationId: testEstimationId,
+            newName: testNewName,
+            projectId: testProjectId,
+          ),
+        ),
+        expect: () => [
+          isA<RenameEstimationInProgress>(),
+          isA<RenameEstimationSuccess>().having(
+            (s) => s.newName,
+            'newName',
+            equals(testNewName),
+          ),
+        ],
+      );
+
+      blocTest<RenameEstimationBloc, RenameEstimationState>(
+        'should not proceed to rename when permission denied',
+        build: () {
+          fakeProjectRepository.setProjectPermissions(testProjectId, []);
+          final estimationMap =
+              EstimationTestDataMapFactory.createFakeEstimationData(
+                id: testEstimationId,
+                projectId: testProjectId,
+                estimateName: testEstimationName,
+              );
+          seedEstimationTable([estimationMap]);
+          return bloc;
+        },
+        act: (bloc) => bloc.add(
+          const RenameEstimationRequested(
+            estimationId: testEstimationId,
+            newName: testNewName,
+            projectId: testProjectId,
+          ),
+        ),
+        verify: (_) {
+          final updateCalls = fakeSupabaseWrapper.getMethodCallsFor('update');
+          expect(updateCalls, isEmpty);
+        },
       );
     });
   });

--- a/test/features/estimations/widgets/pages/cost_estimation_landing_page_test.dart
+++ b/test/features/estimations/widgets/pages/cost_estimation_landing_page_test.dart
@@ -13,8 +13,11 @@ import 'package:construculator/features/project/project_module.dart';
 import 'package:construculator/l10n/generated/app_localizations.dart';
 import 'package:construculator/libraries/auth/auth_library_module.dart';
 import 'package:construculator/libraries/estimation/data/repositories/cost_estimation_repository_impl.dart';
+import 'package:construculator/libraries/project/domain/permission_constants.dart';
+import 'package:construculator/libraries/project/domain/repositories/project_repository.dart';
 import 'package:construculator/libraries/project/interfaces/current_project_notifier.dart';
 import 'package:construculator/libraries/project/presentation/project_ui_provider.dart';
+import 'package:construculator/libraries/project/testing/fake_project_repository.dart';
 import 'package:construculator/libraries/router/guards/auth_guard.dart';
 import 'package:construculator/libraries/router/interfaces/app_router.dart';
 import 'package:construculator/libraries/router/routes/estimation_routes.dart';
@@ -66,6 +69,7 @@ void main() {
   late Clock clock;
   late AppBootstrap appBootstrap;
   late FakeAppRouter fakeAppRouter;
+  late FakeProjectRepository fakeProjectRepository;
 
   const debounceWaitTime = Duration(milliseconds: 400);
   const testEstimationRoute = '/test-landing/$testProjectId';
@@ -81,6 +85,10 @@ void main() {
     Modular.init(_CostEstimationLandingPageTestModule(appBootstrap));
     fakeAppRouter = Modular.get<AppRouter>() as FakeAppRouter;
     Modular.setInitialRoute(testEstimationRoute);
+
+    fakeProjectRepository = FakeProjectRepository();
+    Modular.replaceInstance<ProjectRepository>(fakeProjectRepository);
+    Modular.get<CurrentProjectNotifier>().setCurrentProjectId(testProjectId);
   });
 
   tearDownAll(() {
@@ -89,9 +97,15 @@ void main() {
   });
 
   setUp(() {
+    fakeProjectRepository.setProjectPermissions(testProjectId, [
+      PermissionConstants.getCostEstimations,
+      PermissionConstants.addCostEstimation,
+      PermissionConstants.editCostEstimation,
+      PermissionConstants.deleteCostEstimation,
+      PermissionConstants.lockCostEstimation,
+    ]);
     fakeSupabase.reset();
     fakeAppRouter.reset();
-    Modular.get<CurrentProjectNotifier>().setCurrentProjectId(testProjectId);
   });
 
   Widget makeApp() {
@@ -273,6 +287,9 @@ void main() {
             estimateName: 'Existing Estimation',
           ),
         );
+        fakeProjectRepository.setProjectPermissions(testProjectId, [
+          PermissionConstants.addCostEstimation,
+        ]);
 
         await pumpAppAtRoute(tester, testEstimationRoute);
         await tester.pumpAndSettle();
@@ -1180,6 +1197,37 @@ void main() {
         expect(find.text(l10n().connectionError), findsOneWidget);
 
         expect(fakeSupabase.getMethodCallsFor('update').length, 1);
+      },
+    );
+    testWidgets(
+      'shows permission denied error message when permission error occurs',
+      (tester) async {
+        setUpAuthenticatedUser(
+          credentialId: 'test-credential-id',
+          email: 'test@example.com',
+        );
+
+        addCostEstimationData(
+          EstimationTestDataMapFactory.createFakeEstimationData(
+            id: 'estimation-1',
+            projectId: testProjectId,
+            estimateName: 'Kitchen Remodel',
+            isLocked: false,
+          ),
+        );
+
+        await pumpAppAtRoute(tester, testEstimationRoute);
+
+        fakeProjectRepository.setProjectPermissions(testProjectId, []);
+
+        await tester.tap(find.byKey(const Key('menuIcon')));
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.byType(CoreSwitch));
+        await tester.pumpAndSettle();
+
+        expect(find.text(l10n().permissionDenied), findsOneWidget);
+        expect(find.byKey(const Key('toast_close_button')), findsOneWidget);
       },
     );
   });

--- a/test/features/estimations/widgets/widgets/estimation_rename_sheet_test.dart
+++ b/test/features/estimations/widgets/widgets/estimation_rename_sheet_test.dart
@@ -5,6 +5,9 @@ import 'package:construculator/features/estimation/estimation_module.dart';
 import 'package:construculator/features/estimation/presentation/bloc/rename_estimation_bloc/rename_estimation_bloc.dart';
 import 'package:construculator/features/estimation/presentation/widgets/estimation_rename_sheet.dart';
 import 'package:construculator/l10n/generated/app_localizations.dart';
+import 'package:construculator/libraries/project/domain/permission_constants.dart';
+import 'package:construculator/libraries/project/domain/repositories/project_repository.dart';
+import 'package:construculator/libraries/project/testing/fake_project_repository.dart';
 
 import 'package:construculator/libraries/router/interfaces/app_router.dart';
 import 'package:construculator/libraries/router/testing/fake_router.dart';
@@ -57,6 +60,12 @@ void main() {
       supabaseWrapper: fakeSupabase,
     );
     Modular.init(_EstimationRenameSheetTestModule(appBootstrap));
+    Modular.replaceInstance<ProjectRepository>(FakeProjectRepository());
+    final projectRepository =
+        Modular.get<ProjectRepository>() as FakeProjectRepository;
+    projectRepository.setProjectPermissions(testProjectId, [
+      PermissionConstants.editCostEstimation,
+    ]);
     fakeAppRouter = Modular.get<AppRouter>() as FakeAppRouter;
   });
 


### PR DESCRIPTION
### 1. PR Summary

This PR enforces permission checks for the lock and rename cost estimation operations. Both `ChangeLockStatusBloc` and `RenameEstimationBloc` are injected with `ProjectRepository`, perform an upfront `hasProjectPermission` guard before proceeding, and emit a `permissionDenied` failure state if the check fails. `EstimationErrorType` gains a `permissionDenied` variant, and both BLoC test suites gain a dedicated permission group. **PR size is S — well within bounds.**

---

---

### Review Summary Table

| Issue Name | Description | Status | Notes |
|------------|-------------|--------|-------|
| `FakeProjectRepository` in BLoC tests violates Rule 3 | BLoC tests replace `ProjectRepository` with a fake instead of using the real impl backed by `FakeSupabaseWrapper`, skipping the actual permission delegation chain. | ✅ | |
| Narrative `// Check permission first` comment | Step-by-step comment in both BLoC handlers explains what the next line does — should be removed. | ✅ | |