### PR TITLE
Feat/update rename feature not to rely on project

### DIFF
--- a/lib/features/estimation/estimation_module.dart
+++ b/lib/features/estimation/estimation_module.dart
@@ -63,9 +63,6 @@ class EstimationModule extends Module {
   ];
 
   @override
-  void exportedBinds(Injector i) {}
-
-  @override
   void binds(Injector i) {
     i.addLazySingleton<CostEstimationLogDataSource>(
       () => RemoteCostEstimationLogDataSource(
@@ -98,8 +95,11 @@ class EstimationModule extends Module {
       ),
     );
     i.add<RenameEstimationBloc>(
-      () =>
-          RenameEstimationBloc(repository: i.get(), projectRepository: i.get()),
+      () => RenameEstimationBloc(
+        repository: i.get(),
+        projectRepository: i.get(),
+        currentProjectNotifier: i.get(),
+      ),
     );
     i.add<CostEstimationLogBloc>(
       () => CostEstimationLogBloc(repository: i.get()),

--- a/lib/features/estimation/estimation_module.dart
+++ b/lib/features/estimation/estimation_module.dart
@@ -12,6 +12,7 @@ import 'package:construculator/features/estimation/presentation/bloc/delete_cost
 import 'package:construculator/features/estimation/presentation/bloc/rename_estimation_bloc/rename_estimation_bloc.dart';
 import 'package:construculator/features/estimation/presentation/pages/cost_estimation_landing_page.dart';
 import 'package:construculator/libraries/auth/auth_library_module.dart';
+import 'package:construculator/libraries/project/project_library_module.dart';
 import 'package:construculator/libraries/estimation/estimation_library_module.dart';
 import 'package:construculator/libraries/project/interfaces/current_project_notifier.dart';
 import 'package:construculator/libraries/project/project_library_module.dart';
@@ -61,7 +62,7 @@ class EstimationModule extends Module {
   ];
 
   @override
-  void exportedBinds(Injector i) {}
+  List<Module> get imports => [AuthLibraryModule(appBootstrap), ClockModule()];
 
   @override
   void binds(Injector i) {
@@ -93,8 +94,11 @@ class EstimationModule extends Module {
           ChangeLockStatusBloc(repository: i.get(), projectRepository: i.get()),
     );
     i.add<RenameEstimationBloc>(
-      () =>
-          RenameEstimationBloc(repository: i.get(), projectRepository: i.get()),
+      () => RenameEstimationBloc(
+        repository: i.get(),
+        projectRepository: i.get(),
+        currentProjectNotifier: i.get(),
+      ),
     );
     i.add<CostEstimationLogBloc>(
       () => CostEstimationLogBloc(repository: i.get()),

--- a/lib/features/estimation/presentation/bloc/rename_estimation_bloc/rename_estimation_bloc.dart
+++ b/lib/features/estimation/presentation/bloc/rename_estimation_bloc/rename_estimation_bloc.dart
@@ -3,6 +3,7 @@ import 'package:construculator/libraries/estimation/domain/estimation_error_type
 import 'package:construculator/libraries/estimation/domain/repositories/cost_estimation_repository.dart';
 import 'package:construculator/libraries/project/domain/permission_constants.dart';
 import 'package:construculator/libraries/project/domain/repositories/project_repository.dart';
+import 'package:construculator/libraries/project/interfaces/current_project_notifier.dart';
 import 'package:equatable/equatable.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
@@ -13,12 +14,15 @@ class RenameEstimationBloc
     extends Bloc<RenameEstimationEvent, RenameEstimationState> {
   final CostEstimationRepository _repository;
   final ProjectRepository _projectRepository;
+  final CurrentProjectNotifier _currentProjectNotifier;
 
   RenameEstimationBloc({
     required CostEstimationRepository repository,
     required ProjectRepository projectRepository,
+    required CurrentProjectNotifier currentProjectNotifier,
   }) : _repository = repository,
        _projectRepository = projectRepository,
+       _currentProjectNotifier = currentProjectNotifier,
        super(const RenameEstimationInitial()) {
     on<RenameEstimationReset>(_onReset);
     on<RenameEstimationTextChanged>(_onTextChanged);
@@ -44,11 +48,24 @@ class RenameEstimationBloc
     RenameEstimationRequested event,
     Emitter<RenameEstimationState> emit,
   ) async {
+    final projectId = _currentProjectNotifier.currentProjectId;
     final trimmedName = event.newName.trim();
     final isSaveEnabled = trimmedName.isNotEmpty;
 
+    if (projectId == null) {
+      emit(
+        RenameEstimationFailure(
+          const EstimationFailure(
+            errorType: EstimationErrorType.unexpectedError,
+          ),
+          isSaveEnabled: isSaveEnabled,
+        ),
+      );
+      return;
+    }
+
     final hasPermission = _projectRepository.hasProjectPermission(
-      event.projectId,
+      projectId,
       PermissionConstants.editCostEstimation,
     );
 
@@ -69,7 +86,7 @@ class RenameEstimationBloc
     final result = await _repository.renameEstimation(
       estimationId: event.estimationId,
       newName: trimmedName,
-      projectId: event.projectId,
+      projectId: projectId,
     );
 
     result.fold(

--- a/lib/features/estimation/presentation/bloc/rename_estimation_bloc/rename_estimation_event.dart
+++ b/lib/features/estimation/presentation/bloc/rename_estimation_bloc/rename_estimation_event.dart
@@ -29,14 +29,12 @@ class RenameEstimationTextChanged extends RenameEstimationEvent {
 class RenameEstimationRequested extends RenameEstimationEvent {
   final String estimationId;
   final String newName;
-  final String projectId;
 
   const RenameEstimationRequested({
     required this.estimationId,
     required this.newName,
-    required this.projectId,
   });
 
   @override
-  List<Object> get props => [estimationId, newName, projectId];
+  List<Object> get props => [estimationId, newName];
 }

--- a/lib/features/estimation/presentation/pages/cost_estimation_landing_page.dart
+++ b/lib/features/estimation/presentation/pages/cost_estimation_landing_page.dart
@@ -183,7 +183,6 @@ class _CostEstimationLandingPageState extends State<CostEstimationLandingPage> {
           value: renameEstimationBloc,
           child: EstimationRenameSheet(
             estimationId: estimation.id,
-            projectId: widget.projectId,
             currentName: estimation.estimateName,
           ),
         );

--- a/lib/features/estimation/presentation/pages/cost_estimation_landing_page.dart
+++ b/lib/features/estimation/presentation/pages/cost_estimation_landing_page.dart
@@ -181,7 +181,6 @@ class _CostEstimationLandingPageState extends State<CostEstimationLandingPage> {
           value: renameEstimationBloc,
           child: EstimationRenameSheet(
             estimationId: estimation.id,
-            projectId: widget.projectId,
             currentName: estimation.estimateName,
           ),
         );

--- a/lib/features/estimation/presentation/widgets/estimation_rename_sheet.dart
+++ b/lib/features/estimation/presentation/widgets/estimation_rename_sheet.dart
@@ -10,12 +10,10 @@ class EstimationRenameSheet extends StatefulWidget {
   const EstimationRenameSheet({
     super.key,
     required this.estimationId,
-    required this.projectId,
     required this.currentName,
   });
 
   final String estimationId;
-  final String projectId;
   final String currentName;
 
   @override
@@ -50,7 +48,6 @@ class _EstimationRenameSheetState extends State<EstimationRenameSheet> {
       RenameEstimationRequested(
         estimationId: widget.estimationId,
         newName: _nameController.text,
-        projectId: widget.projectId,
       ),
     );
   }

--- a/test/features/estimations/screenshots/estimation_rename_sheet_screenshot_test.dart
+++ b/test/features/estimations/screenshots/estimation_rename_sheet_screenshot_test.dart
@@ -2,6 +2,8 @@ import 'package:construculator/features/estimation/estimation_module.dart';
 import 'package:construculator/features/estimation/presentation/bloc/rename_estimation_bloc/rename_estimation_bloc.dart';
 import 'package:construculator/features/estimation/presentation/widgets/estimation_rename_sheet.dart';
 import 'package:construculator/l10n/generated/app_localizations.dart';
+import 'package:construculator/libraries/project/interfaces/current_project_notifier.dart';
+import 'package:construculator/libraries/project/testing/fake_current_project_notifier.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_modular/flutter_modular.dart';
@@ -14,11 +16,17 @@ import '../../../utils/screenshot/font_loader.dart';
 void main() {
   const size = Size(390, 300);
   const ratio = 1.0;
+  const testProjectId = 'test-project-123';
+  late FakeCurrentProjectNotifier fakeCurrentProjectNotifier;
+
   TestWidgetsFlutterBinding.ensureInitialized();
 
   setUpAll(() async {
     await loadAppFonts();
     Modular.init(EstimationModule(FakeAppBootstrapFactory.create()));
+
+    fakeCurrentProjectNotifier = FakeCurrentProjectNotifier(initialProjectId: testProjectId);
+    Modular.replaceInstance<CurrentProjectNotifier>(fakeCurrentProjectNotifier);
   });
 
   tearDownAll(() {
@@ -29,7 +37,6 @@ void main() {
     Future<void> pumpRenameSheet({
       required WidgetTester tester,
       required String estimationId,
-      required String projectId,
       required String initialName,
     }) async {
       await tester.pumpWidget(
@@ -43,7 +50,6 @@ void main() {
               value: Modular.get<RenameEstimationBloc>(),
               child: EstimationRenameSheet(
                 estimationId: estimationId,
-                projectId: projectId,
                 currentName: initialName,
               ),
             ),
@@ -62,7 +68,6 @@ void main() {
       await pumpRenameSheet(
         tester: tester,
         estimationId: 'test-estimation-123',
-        projectId: 'test-project-123',
         initialName: 'Existing Estimation Name',
       );
 
@@ -83,7 +88,6 @@ void main() {
         await pumpRenameSheet(
           tester: tester,
           estimationId: 'test-estimation-123',
-          projectId: 'test-project-123',
           initialName: 'Old Name',
         );
 

--- a/test/features/estimations/units/blocs/rename_estimation_bloc_test.dart
+++ b/test/features/estimations/units/blocs/rename_estimation_bloc_test.dart
@@ -5,6 +5,8 @@ import 'package:construculator/libraries/errors/failures.dart';
 import 'package:construculator/libraries/estimation/domain/estimation_error_type.dart';
 import 'package:construculator/libraries/project/domain/permission_constants.dart';
 import 'package:construculator/libraries/project/domain/repositories/project_repository.dart';
+import 'package:construculator/libraries/project/interfaces/current_project_notifier.dart';
+import 'package:construculator/libraries/project/testing/fake_current_project_notifier.dart';
 import 'package:construculator/libraries/project/testing/fake_project_repository.dart';
 import 'package:construculator/libraries/supabase/data/supabase_types.dart';
 import 'package:construculator/libraries/supabase/database_constants.dart';
@@ -23,6 +25,7 @@ void main() {
     late FakeSupabaseWrapper fakeSupabaseWrapper;
     late FakeProjectRepository fakeProjectRepository;
     late FakeClockImpl fakeClock;
+    late FakeCurrentProjectNotifier fakeCurrentProjectNotifier;
 
     const testProjectId = 'test-project-123';
     const testEstimationId = 'test-estimation-123';
@@ -42,6 +45,13 @@ void main() {
       Modular.replaceInstance<ProjectRepository>(FakeProjectRepository());
       fakeProjectRepository =
           Modular.get<ProjectRepository>() as FakeProjectRepository;
+
+      fakeCurrentProjectNotifier = FakeCurrentProjectNotifier(
+        initialProjectId: testProjectId,
+      );
+      Modular.replaceInstance<CurrentProjectNotifier>(
+        fakeCurrentProjectNotifier,
+      );
     });
 
     tearDownAll(() {
@@ -50,6 +60,7 @@ void main() {
 
     setUp(() {
       fakeSupabaseWrapper.reset();
+      fakeCurrentProjectNotifier.reset(projectId: testProjectId);
       fakeProjectRepository.setProjectPermissions(testProjectId, [
         PermissionConstants.editCostEstimation,
       ]);
@@ -165,6 +176,37 @@ void main() {
 
     group('RenameEstimationRequested', () {
       blocTest<RenameEstimationBloc, RenameEstimationState>(
+        'should emit unexpected failure when current project is unavailable',
+        build: () {
+          fakeCurrentProjectNotifier.reset(projectId: null);
+          return bloc;
+        },
+        act: (bloc) => bloc.add(
+          const RenameEstimationRequested(
+            estimationId: testEstimationId,
+            newName: testNewName,
+          ),
+        ),
+        expect: () => [
+          isA<RenameEstimationFailure>()
+              .having(
+                (s) => s.failure,
+                'failure',
+                isA<EstimationFailure>().having(
+                  (f) => f.errorType,
+                  'errorType',
+                  EstimationErrorType.unexpectedError,
+                ),
+              )
+              .having((s) => s.isSaveEnabled, 'isSaveEnabled', isTrue),
+        ],
+        verify: (_) {
+          final updateCalls = fakeSupabaseWrapper.getMethodCallsFor('update');
+          expect(updateCalls, isEmpty);
+        },
+      );
+
+      blocTest<RenameEstimationBloc, RenameEstimationState>(
         'should emit in progress then success with new name when renaming succeeds',
         build: () {
           final estimationMap =
@@ -180,7 +222,6 @@ void main() {
           const RenameEstimationRequested(
             estimationId: testEstimationId,
             newName: testNewName,
-            projectId: testProjectId,
           ),
         ),
         expect: () => [
@@ -209,7 +250,6 @@ void main() {
           const RenameEstimationRequested(
             estimationId: testEstimationId,
             newName: '  $testNewName  ',
-            projectId: testProjectId,
           ),
         ),
         expect: () => [
@@ -234,7 +274,6 @@ void main() {
           const RenameEstimationRequested(
             estimationId: testEstimationId,
             newName: testNewName,
-            projectId: testProjectId,
           ),
         ),
         expect: () => [
@@ -265,7 +304,6 @@ void main() {
           const RenameEstimationRequested(
             estimationId: testEstimationId,
             newName: testNewName,
-            projectId: testProjectId,
           ),
         ),
         expect: () => [
@@ -298,7 +336,6 @@ void main() {
           const RenameEstimationRequested(
             estimationId: testEstimationId,
             newName: testNewName,
-            projectId: testProjectId,
           ),
         ),
         expect: () => [
@@ -338,7 +375,6 @@ void main() {
             const RenameEstimationRequested(
               estimationId: testEstimationId,
               newName: testNewName,
-              projectId: testProjectId,
             ),
           );
           await bloc.stream.firstWhere(
@@ -349,7 +385,6 @@ void main() {
             const RenameEstimationRequested(
               estimationId: testEstimationId,
               newName: 'Retried Name',
-              projectId: testProjectId,
             ),
           );
         },
@@ -384,7 +419,6 @@ void main() {
           const RenameEstimationRequested(
             estimationId: testEstimationId,
             newName: testNewName,
-            projectId: testProjectId,
           ),
         ),
         expect: () => [
@@ -421,7 +455,6 @@ void main() {
           const RenameEstimationRequested(
             estimationId: testEstimationId,
             newName: testNewName,
-            projectId: testProjectId,
           ),
         ),
         expect: () => [
@@ -451,7 +484,6 @@ void main() {
           const RenameEstimationRequested(
             estimationId: testEstimationId,
             newName: testNewName,
-            projectId: testProjectId,
           ),
         ),
         verify: (_) {

--- a/test/features/estimations/widgets/accessibility/estimation_rename_sheet_a11y_test.dart
+++ b/test/features/estimations/widgets/accessibility/estimation_rename_sheet_a11y_test.dart
@@ -3,6 +3,8 @@ import 'package:construculator/features/estimation/estimation_module.dart';
 import 'package:construculator/features/estimation/presentation/bloc/rename_estimation_bloc/rename_estimation_bloc.dart';
 import 'package:construculator/features/estimation/presentation/widgets/estimation_rename_sheet.dart';
 import 'package:construculator/l10n/generated/app_localizations.dart';
+import 'package:construculator/libraries/project/interfaces/current_project_notifier.dart';
+import 'package:construculator/libraries/project/testing/fake_current_project_notifier.dart';
 
 import 'package:construculator/libraries/router/interfaces/app_router.dart';
 import 'package:construculator/libraries/router/testing/fake_router.dart';
@@ -40,6 +42,7 @@ void main() {
   late Clock clock;
   late AppBootstrap appBootstrap;
   late FakeAppRouter fakeAppRouter;
+  late FakeCurrentProjectNotifier fakeCurrentProjectNotifier;
 
   const testEstimationId = 'estimation-123';
   const testProjectId = 'project-123';
@@ -57,6 +60,9 @@ void main() {
     );
     Modular.init(_EstimationRenameSheetTestModule(appBootstrap));
     fakeAppRouter = Modular.get<AppRouter>() as FakeAppRouter;
+
+    fakeCurrentProjectNotifier = FakeCurrentProjectNotifier(initialProjectId: testProjectId);
+    Modular.replaceInstance<CurrentProjectNotifier>(fakeCurrentProjectNotifier);
   });
 
   tearDownAll(() {
@@ -67,6 +73,7 @@ void main() {
   setUp(() {
     fakeSupabase.reset();
     fakeAppRouter.reset();
+    fakeCurrentProjectNotifier.reset(projectId: testProjectId);
 
     fakeSupabase.addTableData('cost_estimates', [
       EstimationTestDataMapFactory.createFakeEstimationData(
@@ -79,7 +86,6 @@ void main() {
 
   Widget createWidget({
     String estimationId = testEstimationId,
-    String projectId = testProjectId,
     String initialName = testCurrentName,
     ThemeData? theme,
   }) {
@@ -97,7 +103,6 @@ void main() {
               create: (_) => Modular.get<RenameEstimationBloc>(),
               child: EstimationRenameSheet(
                 estimationId: estimationId,
-                projectId: projectId,
                 currentName: initialName,
               ),
             ),

--- a/test/features/estimations/widgets/pages/cost_estimation_landing_page_test.dart
+++ b/test/features/estimations/widgets/pages/cost_estimation_landing_page_test.dart
@@ -104,7 +104,6 @@ void main() {
       PermissionConstants.deleteCostEstimation,
       PermissionConstants.lockCostEstimation,
     ]);
-    fakeCurrentProjectNotifier.reset(projectId: testProjectId);
     fakeSupabase.reset();
     fakeAppRouter.reset();
   });

--- a/test/features/estimations/widgets/pages/cost_estimation_landing_page_test.dart
+++ b/test/features/estimations/widgets/pages/cost_estimation_landing_page_test.dart
@@ -17,6 +17,8 @@ import 'package:construculator/libraries/project/domain/permission_constants.dar
 import 'package:construculator/libraries/project/domain/repositories/project_repository.dart';
 import 'package:construculator/libraries/project/interfaces/current_project_notifier.dart';
 import 'package:construculator/libraries/project/presentation/project_ui_provider.dart';
+import 'package:construculator/libraries/project/interfaces/current_project_notifier.dart';
+import 'package:construculator/libraries/project/testing/fake_current_project_notifier.dart';
 import 'package:construculator/libraries/project/testing/fake_project_repository.dart';
 import 'package:construculator/libraries/router/guards/auth_guard.dart';
 import 'package:construculator/libraries/router/interfaces/app_router.dart';
@@ -70,6 +72,7 @@ void main() {
   late AppBootstrap appBootstrap;
   late FakeAppRouter fakeAppRouter;
   late FakeProjectRepository fakeProjectRepository;
+  late FakeCurrentProjectNotifier fakeCurrentProjectNotifier;
 
   const debounceWaitTime = Duration(milliseconds: 400);
   const testEstimationRoute = '/test-landing/$testProjectId';
@@ -88,7 +91,11 @@ void main() {
 
     fakeProjectRepository = FakeProjectRepository();
     Modular.replaceInstance<ProjectRepository>(fakeProjectRepository);
-    Modular.get<CurrentProjectNotifier>().setCurrentProjectId(testProjectId);
+
+    fakeCurrentProjectNotifier = FakeCurrentProjectNotifier(
+      initialProjectId: testProjectId,
+    );
+    Modular.replaceInstance<CurrentProjectNotifier>(fakeCurrentProjectNotifier);
   });
 
   tearDownAll(() {

--- a/test/features/estimations/widgets/widgets/estimation_rename_sheet_test.dart
+++ b/test/features/estimations/widgets/widgets/estimation_rename_sheet_test.dart
@@ -7,6 +7,8 @@ import 'package:construculator/features/estimation/presentation/widgets/estimati
 import 'package:construculator/l10n/generated/app_localizations.dart';
 import 'package:construculator/libraries/project/domain/permission_constants.dart';
 import 'package:construculator/libraries/project/domain/repositories/project_repository.dart';
+import 'package:construculator/libraries/project/interfaces/current_project_notifier.dart';
+import 'package:construculator/libraries/project/testing/fake_current_project_notifier.dart';
 import 'package:construculator/libraries/project/testing/fake_project_repository.dart';
 
 import 'package:construculator/libraries/router/interfaces/app_router.dart';
@@ -44,6 +46,7 @@ void main() {
   late Clock clock;
   late AppBootstrap appBootstrap;
   late FakeAppRouter fakeAppRouter;
+  late FakeCurrentProjectNotifier fakeCurrentProjectNotifier;
 
   const testEstimationId = 'estimation-123';
   const testProjectId = 'project-123';
@@ -67,6 +70,9 @@ void main() {
       PermissionConstants.editCostEstimation,
     ]);
     fakeAppRouter = Modular.get<AppRouter>() as FakeAppRouter;
+
+    fakeCurrentProjectNotifier = FakeCurrentProjectNotifier(initialProjectId: testProjectId);
+    Modular.replaceInstance<CurrentProjectNotifier>(fakeCurrentProjectNotifier);
   });
 
   tearDownAll(() {
@@ -77,6 +83,7 @@ void main() {
   setUp(() {
     fakeSupabase.reset();
     fakeAppRouter.reset();
+    fakeCurrentProjectNotifier.reset(projectId: testProjectId);
 
     fakeSupabase.addTableData('cost_estimates', [
       EstimationTestDataMapFactory.createFakeEstimationData(
@@ -89,7 +96,6 @@ void main() {
 
   Widget createWidget({
     String estimationId = testEstimationId,
-    String projectId = testProjectId,
     String initialName = testCurrentName,
   }) {
     return MaterialApp(
@@ -105,7 +111,6 @@ void main() {
               create: (_) => Modular.get<RenameEstimationBloc>(),
               child: EstimationRenameSheet(
                 estimationId: estimationId,
-                projectId: projectId,
                 currentName: initialName,
               ),
             ),


### PR DESCRIPTION
### 1. PR Summary

This PR removes `projectId` from `RenameEstimationRequested` and `EstimationRenameSheet`, replacing the prop-drilling approach with a `CurrentProjectNotifier` injection into `RenameEstimationBloc`. The BLoC now reads the current project ID internally before executing the permission check and rename operation. All downstream tests and screenshot/a11y suites are updated accordingly. **PR size is XS — clean and focused.**

---

---

### Review Summary Table

| Issue Name | Description | Status | Notes |
|------------|-------------|--------|-------|
| Silent `return` on null project ID | `if (projectId == null) return` emits no state, leaving the user with no feedback when the current project is unavailable. Should emit a failure state. |✅| |
| No test for null project ID branch | The new null guard path is entirely untested. Needs a `blocTest` that sets `projectId` to null and asserts a failure state is emitted. | ✅ | |