### PR TITLE
feat: update test file paths to include app unit tests in CI workflows

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -51,8 +51,8 @@ workflows:
           BASE_COMMIT=$(git merge-base HEAD origin/$CM_PULL_REQUEST_DEST)
 
           # Find changed test files
-          CHANGED_UNIT_TESTS=$(git diff --name-only --diff-filter=d $BASE_COMMIT HEAD -- "test/features/**/units/*.dart" "test/libraries/**/units/*.dart" "test/app/units/*.dart")
-          CHANGED_WIDGET_TESTS=$(git diff --name-only --diff-filter=d $BASE_COMMIT HEAD -- "test/features/**/widgets/*.dart")
+          CHANGED_UNIT_TESTS=$(git diff --name-only --diff-filter=d $BASE_COMMIT HEAD -- "test/features/**/units/*.dart" "test/libraries/**/units/*.dart" "test/app/**/units/*.dart")
+          CHANGED_WIDGET_TESTS=$(git diff --name-only --diff-filter=d $BASE_COMMIT HEAD -- "test/features/**/widgets/*.dart" "test/app/**/widgets/*.dart")
 
           # Combine all changed tests
           CHANGED_TESTS="$CHANGED_UNIT_TESTS $CHANGED_WIDGET_TESTS"
@@ -125,8 +125,8 @@ workflows:
           BASE_COMMIT=$(git merge-base HEAD origin/$CM_PULL_REQUEST_DEST)
 
           # Find changed test files
-          CHANGED_UNIT_TESTS=$(git diff --name-only --diff-filter=d $BASE_COMMIT HEAD -- "test/features/**/units/*.dart" "test/libraries/**/units/*.dart" "test/app/units/*.dart")
-          CHANGED_WIDGET_TESTS=$(git diff --name-only --diff-filter=d $BASE_COMMIT HEAD -- "test/features/**/widgets/*.dart")
+          CHANGED_UNIT_TESTS=$(git diff --name-only --diff-filter=d $BASE_COMMIT HEAD -- "test/features/**/units/*.dart" "test/libraries/**/units/*.dart" "test/app/**/units/*.dart")
+          CHANGED_WIDGET_TESTS=$(git diff --name-only --diff-filter=d $BASE_COMMIT HEAD -- "test/features/**/widgets/*.dart" "test/app/**/widgets/*.dart")
 
           # Combine all changed tests
           CHANGED_TESTS="$CHANGED_UNIT_TESTS $CHANGED_WIDGET_TESTS"
@@ -203,7 +203,7 @@ workflows:
           fi
           sudo apt-get install -y lcov
           mkdir -p test-results
-          fvm flutter test test/features/**/units test/features/**/widgets test/libraries/**/units test/app/units --coverage --machine > test-results/flutter.json
+          fvm flutter test test/features/**/units test/features/**/widgets test/libraries/**/units test/app/**/units test/app/**/widgets --coverage --machine > test-results/flutter.json
           lcov --remove coverage/lcov.info '**/*.g.dart' '**/*.freezed.dart' '**/l10n/**' -o coverage/lcov.info
           # Compute coverage
           if [ ! -f "coverage/lcov.info" ] || [ ! -s "coverage/lcov.info" ]; then
@@ -375,7 +375,7 @@ workflows:
           fi
           HOMEBREW_NO_AUTO_UPDATE=1 brew install lcov
           mkdir -p test-results
-          fvm flutter test test/features/**/units test/app/units test/features/**/widgets test/libraries/**/units --coverage --machine > test-results/flutter.json
+          fvm flutter test test/features/**/units test/features/**/widgets test/libraries/**/units test/app/**/units test/app/**/widgets --coverage --machine > test-results/flutter.json
           lcov --remove coverage/lcov.info '**/*.g.dart' '**/*.freezed.dart' '**/l10n/**' -o coverage/lcov.info
           # Compute coverage
           if [ ! -f "coverage/lcov.info" ] || [ ! -s "coverage/lcov.info" ]; then

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -51,7 +51,7 @@ workflows:
           BASE_COMMIT=$(git merge-base HEAD origin/$CM_PULL_REQUEST_DEST)
 
           # Find changed test files
-          CHANGED_UNIT_TESTS=$(git diff --name-only --diff-filter=d $BASE_COMMIT HEAD -- "test/features/**/units/*.dart" "test/libraries/**/units/*.dart")
+          CHANGED_UNIT_TESTS=$(git diff --name-only --diff-filter=d $BASE_COMMIT HEAD -- "test/features/**/units/*.dart" "test/libraries/**/units/*.dart" "test/app/units/*.dart")
           CHANGED_WIDGET_TESTS=$(git diff --name-only --diff-filter=d $BASE_COMMIT HEAD -- "test/features/**/widgets/*.dart")
 
           # Combine all changed tests
@@ -125,7 +125,7 @@ workflows:
           BASE_COMMIT=$(git merge-base HEAD origin/$CM_PULL_REQUEST_DEST)
 
           # Find changed test files
-          CHANGED_UNIT_TESTS=$(git diff --name-only --diff-filter=d $BASE_COMMIT HEAD -- "test/features/**/units/*.dart" "test/libraries/**/units/*.dart")
+          CHANGED_UNIT_TESTS=$(git diff --name-only --diff-filter=d $BASE_COMMIT HEAD -- "test/features/**/units/*.dart" "test/libraries/**/units/*.dart" "test/app/units/*.dart")
           CHANGED_WIDGET_TESTS=$(git diff --name-only --diff-filter=d $BASE_COMMIT HEAD -- "test/features/**/widgets/*.dart")
 
           # Combine all changed tests
@@ -203,7 +203,7 @@ workflows:
           fi
           sudo apt-get install -y lcov
           mkdir -p test-results
-          fvm flutter test test/features/**/units test/features/**/widgets test/libraries/**/units --coverage --machine > test-results/flutter.json
+          fvm flutter test test/features/**/units test/features/**/widgets test/libraries/**/units test/app/units --coverage --machine > test-results/flutter.json
           lcov --remove coverage/lcov.info '**/*.g.dart' '**/*.freezed.dart' '**/l10n/**' -o coverage/lcov.info
           # Compute coverage
           if [ ! -f "coverage/lcov.info" ] || [ ! -s "coverage/lcov.info" ]; then
@@ -375,7 +375,7 @@ workflows:
           fi
           HOMEBREW_NO_AUTO_UPDATE=1 brew install lcov
           mkdir -p test-results
-          fvm flutter test test/features/**/units test/features/**/widgets test/libraries/**/units --coverage --machine > test-results/flutter.json
+          fvm flutter test test/features/**/units test/app/units test/features/**/widgets test/libraries/**/units --coverage --machine > test-results/flutter.json
           lcov --remove coverage/lcov.info '**/*.g.dart' '**/*.freezed.dart' '**/l10n/**' -o coverage/lcov.info
           # Compute coverage
           if [ ! -f "coverage/lcov.info" ] || [ ! -s "coverage/lcov.info" ]; then

--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -1,3 +1,4 @@
+// coverage:ignore-file
 import 'package:construculator/l10n/generated/app_localizations.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_modular/flutter_modular.dart';

--- a/lib/app/app_bootstrap.dart
+++ b/lib/app/app_bootstrap.dart
@@ -1,3 +1,4 @@
+// coverage:ignore-file
 import 'package:construculator/libraries/config/interfaces/config.dart';
 import 'package:construculator/libraries/config/interfaces/env_loader.dart';
 import 'package:construculator/libraries/sentry/interfaces/sentry_wrapper.dart';

--- a/lib/app/app_module.dart
+++ b/lib/app/app_module.dart
@@ -1,3 +1,4 @@
+// coverage:ignore-file
 import 'package:construculator/app/app_bootstrap.dart';
 import 'package:construculator/features/auth/auth_module.dart';
 import 'package:construculator/features/dashboard/dashboard_module.dart';

--- a/scripts/run_check.sh
+++ b/scripts/run_check.sh
@@ -105,6 +105,7 @@ pre_check() {
   # Changed tests
   local changed_tests=$(git diff --name-only --diff-filter=d "$base_commit" -- \
     "test/features/**/units/*.dart" \
+    "test/app/**/units test/app/**/widgets/*.dart" \
     "test/features/**/widgets/*.dart" \
     "test/libraries/**/units/*.dart")
 
@@ -195,6 +196,7 @@ comprehensive_check() {
     fvm flutter test \
     test/libraries/**/units \
     test/features/**/units \
+    test/app/**/units test/app/**/widgets \
     test/features/**/widgets \
     --coverage --machine > test-results/flutter.json
 

--- a/scripts/run_check.sh
+++ b/scripts/run_check.sh
@@ -105,9 +105,10 @@ pre_check() {
   # Changed tests
   local changed_tests=$(git diff --name-only --diff-filter=d "$base_commit" -- \
     "test/features/**/units/*.dart" \
-    "test/app/**/units test/app/**/widgets/*.dart" \
     "test/features/**/widgets/*.dart" \
-    "test/libraries/**/units/*.dart")
+    "test/libraries/**/units/*.dart" \
+    "test/app/**/units/*.dart" \
+    "test/app/**/widgets/*.dart")
 
   if [[ -z "$changed_tests" ]]; then
     echo "✅ No tests changed"
@@ -196,7 +197,8 @@ comprehensive_check() {
     fvm flutter test \
     test/libraries/**/units \
     test/features/**/units \
-    test/app/**/units test/app/**/widgets \
+    test/app/**/units \
+    test/app/**/widgets \
     test/features/**/widgets \
     --coverage --machine > test-results/flutter.json
 


### PR DESCRIPTION
1. PR SUMMARY
This PR updates the CI/CD pipeline and local check scripts to include the test/app/units directory in the test coverage reports. It also excludes core application configuration files (app.dart, app_bootstrap.dart, and app_module.dart) from coverage tracking, as these files primarily handle dependency injection and framework setup.