### PR TITLE
CA-151: feat: create cost item entity

### DIFF
--- a/lib/features/estimation/domain/entities/cost_item_entity.dart
+++ b/lib/features/estimation/domain/entities/cost_item_entity.dart
@@ -1,0 +1,548 @@
+import 'package:equatable/equatable.dart';
+
+/// Sentinel value used in copyWith methods to explicitly clear nullable fields.
+///
+/// Usage:
+/// ```dart
+/// item.copyWith(productLink: clearField())
+/// ```
+/// This will set productLink to null, as opposed to omitting the parameter
+/// which preserves the current value.
+const _ClearField _clearField = _ClearField();
+
+/// Sentinel class for clearing nullable fields in copyWith methods.
+class _ClearField {
+  const _ClearField();
+}
+
+/// Helper function to create a clear field sentinel.
+///
+/// Returns a special sentinel value that can be passed to copyWith methods
+/// to explicitly set nullable fields to null.
+Object clearField() => _clearField;
+
+/// Type of cost item stored in an estimation.
+enum CostItemType {
+  /// A physical or consumable item priced by unit and quantity.
+  material,
+
+  /// Labor work tracked by hours, days, or per-unit pricing.
+  labor,
+
+  /// Equipment or rented assets priced by unit and quantity.
+  equipment;
+
+  String toJson() => name;
+
+  /// Deserializes a [CostItemType] from JSON string.
+  ///
+  /// Falls back to [CostItemType.material] for unknown values to ensure
+  /// forward compatibility with new item types added in future versions.
+  /// This allows older clients to gracefully handle unknown types by treating
+  /// them as materials, which is the most common and safest default.
+  ///
+  /// Note: This fallback behavior means validation errors are silent.
+  /// Consider logging unknown values if strict validation is required.
+  static CostItemType fromJson(String value) {
+    return CostItemType.values.firstWhere(
+      (e) => e.name.toLowerCase() == value.toLowerCase(),
+      orElse: () => CostItemType.material,
+    );
+  }
+}
+
+/// Units supported for material and equipment quantities.
+enum Unit {
+  /// Individual countable items.
+  pieces,
+
+  /// Linear length measured in meters.
+  meters,
+
+  /// Area measured in square meters.
+  squareMeters,
+
+  /// Volume measured in cubic meters.
+  cubicMeters,
+
+  /// Mass measured in kilograms.
+  kilograms,
+
+  /// Heavy mass measured in metric tons.
+  tons,
+
+  /// Volume measured in liters.
+  liters,
+
+  /// Time measured in hours.
+  hours,
+
+  /// Time measured in days.
+  days,
+
+  /// Bundled items counted as boxes.
+  boxes,
+
+  /// Bundled items counted as bags.
+  bags,
+
+  /// Rolled material counted as rolls.
+  rolls,
+
+  /// Sheet-based material counted as sheets.
+  sheets;
+
+  String toJson() => name;
+
+  /// Deserializes a [Unit] from JSON string.
+  ///
+  /// Falls back to [Unit.pieces] for unknown values to ensure forward
+  /// compatibility with new units added in future versions. Pieces is chosen
+  /// as the default because it is the most generic unit and can represent
+  /// discrete countable items without requiring specific measurements.
+  ///
+  /// Note: This fallback behavior means validation errors are silent.
+  /// Consider logging unknown values if strict validation is required.
+  static Unit fromJson(String value) {
+    return Unit.values.firstWhere(
+      (e) => e.name.toLowerCase() == value.toLowerCase(),
+      orElse: () => Unit.pieces,
+    );
+  }
+}
+
+/// Labor pricing strategies supported by the estimation model.
+enum LaborCalculationMethodType {
+  /// Labor is priced per hour of work.
+  hourly,
+
+  /// Labor is priced per day of work.
+  daily,
+
+  /// Labor is priced per unit of completed work.
+  perUnit;
+
+  String toJson() => name;
+
+  /// Deserializes a [LaborCalculationMethodType] from JSON string.
+  ///
+  /// Falls back to [LaborCalculationMethodType.hourly] for unknown values to
+  /// ensure forward compatibility with new calculation methods added in future
+  /// versions. Hourly is chosen as the default because it is the most common
+  /// labor pricing strategy and provides a conservative fallback that requires
+  /// explicit time tracking.
+  ///
+  /// Note: This fallback behavior means validation errors are silent.
+  /// Consider logging unknown values if strict validation is required.
+  static LaborCalculationMethodType fromJson(String value) {
+    return LaborCalculationMethodType.values.firstWhere(
+      (e) => e.name.toLowerCase() == value.toLowerCase(),
+      orElse: () => LaborCalculationMethodType.hourly,
+    );
+  }
+}
+
+/// Value object representing a monetary amount
+class Money extends Equatable {
+  final double amount;
+  final String currency;
+
+  const Money({required this.amount, this.currency = 'USD'});
+
+  @override
+  List<Object?> get props => [amount, currency];
+
+  Money copyWith({double? amount, String? currency}) {
+    return Money(
+      amount: amount ?? this.amount,
+      currency: currency ?? this.currency,
+    );
+  }
+}
+
+/// Value object representing a quantity with unit
+class Quantity extends Equatable {
+  final double value;
+  final Unit unit;
+
+  const Quantity({required this.value, required this.unit});
+
+  @override
+  List<Object?> get props => [value, unit];
+
+  Quantity copyWith({double? value, Unit? unit}) {
+    return Quantity(value: value ?? this.value, unit: unit ?? this.unit);
+  }
+}
+
+/// Value object representing labor calculation values.
+///
+/// Stores the computed or input values used for labor cost calculations.
+/// Different fields are populated based on the [LaborCalculationMethodType]:
+/// - For hourly: [laborHours] contains total hours
+/// - For daily: [laborDays] contains total days
+/// - For perUnit: [laborUnitValue] contains the calculated labor cost per unit,
+///   and [laborUnitType] describes the unit (e.g., "per_sqm", "per_door")
+///
+/// Note: [laborUnitType] is a free-form String representing the specific unit
+/// of work (e.g., "per_square_meter", "per_window") distinct from the
+/// [LaborCalculationMethodType] enum which defines the pricing strategy.
+class LaborValue extends Equatable {
+  /// Total number of days for daily labor calculations.
+  final double? laborDays;
+
+  /// Total number of hours for hourly labor calculations.
+  final double? laborHours;
+
+  /// Free-form description of the work unit for per-unit calculations.
+  /// Examples: "per_sqm", "per_door", "per_installation".
+  /// This is distinct from [LaborCalculationMethodType] which defines
+  /// the pricing strategy (hourly/daily/perUnit).
+  final String? laborUnitType;
+
+  /// Calculated labor cost per unit for per-unit calculations.
+  final double? laborUnitValue;
+
+  const LaborValue({
+    this.laborDays,
+    this.laborHours,
+    this.laborUnitType,
+    this.laborUnitValue,
+  });
+
+  @override
+  List<Object?> get props => [
+    laborDays,
+    laborHours,
+    laborUnitType,
+    laborUnitValue,
+  ];
+
+  /// Creates a copy of this [LaborValue] with the given fields replaced.
+  ///
+  /// To explicitly clear a nullable field, pass [clearField()] as the value.
+  /// Omitting a parameter preserves the current value.
+  ///
+  /// Example:
+  /// ```dart
+  /// final updated = value.copyWith(
+  ///   laborDays: 5.0,           // Update to 5.0
+  ///   laborHours: clearField(), // Clear to null
+  /// );                          // laborUnitType unchanged
+  /// ```
+  LaborValue copyWith({
+    Object? laborDays,
+    Object? laborHours,
+    Object? laborUnitType,
+    Object? laborUnitValue,
+  }) {
+    return LaborValue(
+      laborDays: laborDays == _clearField
+          ? null
+          : (laborDays as double?) ?? this.laborDays,
+      laborHours: laborHours == _clearField
+          ? null
+          : (laborHours as double?) ?? this.laborHours,
+      laborUnitType: laborUnitType == _clearField
+          ? null
+          : (laborUnitType as String?) ?? this.laborUnitType,
+      laborUnitValue: laborUnitValue == _clearField
+          ? null
+          : (laborUnitValue as double?) ?? this.laborUnitValue,
+    );
+  }
+}
+
+/// Sealed class representing a cost item in an estimation
+sealed class CostItem extends Equatable {
+  final String id;
+  final String estimateId;
+  final String itemName;
+  final CostItemType itemType;
+
+  /// Breakdown of cost calculation components as key-value pairs.
+  ///
+  /// This map stores intermediate calculation values for transparency and auditing.
+  /// Common keys include:
+  /// - "unitPrice": The price per unit (for materials/equipment)
+  /// - "quantity": The quantity purchased/used
+  /// - "subtotal": Subtotal before adjustments
+  /// - "taxRate": Applied tax rate (if applicable)
+  /// - "taxAmount": Calculated tax amount
+  /// - "discountRate": Applied discount rate (if applicable)
+  /// - "discountAmount": Calculated discount amount
+  /// - "laborRate": Rate per hour/day (for labor items)
+  /// - "hours" or "days": Time worked
+  /// - "markup": Markup percentage or amount
+  ///
+  /// The exact keys present depend on the [CostItemType] and calculation method.
+  /// Consumer code should handle missing keys gracefully.
+  final Map<String, double> calculation;
+
+  final double itemTotalCost;
+  final DateTime createdAt;
+  final DateTime updatedAt;
+  final String? productLink;
+  final String? description;
+
+  const CostItem({
+    required this.id,
+    required this.estimateId,
+    required this.itemName,
+    required this.itemType,
+    required this.calculation,
+    required this.itemTotalCost,
+    required this.createdAt,
+    required this.updatedAt,
+    this.productLink,
+    this.description,
+  });
+
+  @override
+  List<Object?> get props => [
+    id,
+    estimateId,
+    itemName,
+    itemType,
+    calculation,
+    itemTotalCost,
+    createdAt,
+    updatedAt,
+    productLink,
+    description,
+  ];
+}
+
+/// Material cost item with unit price and quantity.
+///
+/// Although structurally identical to [EquipmentCostItem], this class is kept
+/// separate to maintain type safety and domain semantics. Materials and equipment
+/// represent distinct business concepts with different:
+/// - Accounting categories and tax treatment
+/// - Procurement workflows and suppliers
+/// - Storage and inventory management requirements
+/// - Regulatory compliance and tracking needs
+///
+/// This separation allows the domain model to evolve independently for each
+/// concept and prevents accidental conflation of semantically different items.
+class MaterialCostItem extends CostItem {
+  final Money unitPrice;
+  final Quantity quantity;
+
+  const MaterialCostItem({
+    required super.id,
+    required super.estimateId,
+    required super.itemName,
+    required super.calculation,
+    required super.itemTotalCost,
+    required super.createdAt,
+    required super.updatedAt,
+    required this.unitPrice,
+    required this.quantity,
+    super.productLink,
+    super.description,
+  }) : super(itemType: CostItemType.material);
+
+  @override
+  List<Object?> get props => [...super.props, unitPrice, quantity];
+
+  /// Creates a copy of this [MaterialCostItem] with the given fields replaced.
+  ///
+  /// To explicitly clear a nullable field, pass [clearField()] as the value.
+  /// Omitting a parameter preserves the current value.
+  ///
+  /// Example:
+  /// ```dart
+  /// final updated = item.copyWith(
+  ///   itemName: 'New Name',
+  ///   productLink: clearField(), // Clear to null
+  /// );
+  /// ```
+  MaterialCostItem copyWith({
+    String? id,
+    String? estimateId,
+    String? itemName,
+    Map<String, double>? calculation,
+    double? itemTotalCost,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+    Money? unitPrice,
+    Quantity? quantity,
+    Object? productLink,
+    Object? description,
+  }) {
+    return MaterialCostItem(
+      id: id ?? this.id,
+      estimateId: estimateId ?? this.estimateId,
+      itemName: itemName ?? this.itemName,
+      calculation: calculation ?? this.calculation,
+      itemTotalCost: itemTotalCost ?? this.itemTotalCost,
+      createdAt: createdAt ?? this.createdAt,
+      updatedAt: updatedAt ?? this.updatedAt,
+      unitPrice: unitPrice ?? this.unitPrice,
+      quantity: quantity ?? this.quantity,
+      productLink: productLink == _clearField
+          ? null
+          : (productLink as String?) ?? this.productLink,
+      description: description == _clearField
+          ? null
+          : (description as String?) ?? this.description,
+    );
+  }
+}
+
+/// Labor cost item with calculation method and labor values
+class LaborCostItem extends CostItem {
+  final LaborCalculationMethodType laborCalcMethod;
+  final LaborValue laborValue;
+  final int? crewSize;
+
+  const LaborCostItem({
+    required super.id,
+    required super.estimateId,
+    required super.itemName,
+    required super.calculation,
+    required super.itemTotalCost,
+    required super.createdAt,
+    required super.updatedAt,
+    required this.laborCalcMethod,
+    required this.laborValue,
+    this.crewSize,
+    super.productLink,
+    super.description,
+  }) : super(itemType: CostItemType.labor);
+
+  @override
+  List<Object?> get props => [
+    ...super.props,
+    laborCalcMethod,
+    laborValue,
+    crewSize,
+  ];
+
+  /// Creates a copy of this [LaborCostItem] with the given fields replaced.
+  ///
+  /// To explicitly clear a nullable field, pass [clearField()] as the value.
+  /// Omitting a parameter preserves the current value.
+  ///
+  /// Example:
+  /// ```dart
+  /// final updated = item.copyWith(
+  ///   itemName: 'New Name',
+  ///   crewSize: clearField(),    // Clear to null
+  ///   productLink: clearField(), // Clear to null
+  /// );
+  /// ```
+  LaborCostItem copyWith({
+    String? id,
+    String? estimateId,
+    String? itemName,
+    Map<String, double>? calculation,
+    double? itemTotalCost,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+    LaborCalculationMethodType? laborCalcMethod,
+    LaborValue? laborValue,
+    Object? crewSize,
+    Object? productLink,
+    Object? description,
+  }) {
+    return LaborCostItem(
+      id: id ?? this.id,
+      estimateId: estimateId ?? this.estimateId,
+      itemName: itemName ?? this.itemName,
+      calculation: calculation ?? this.calculation,
+      itemTotalCost: itemTotalCost ?? this.itemTotalCost,
+      createdAt: createdAt ?? this.createdAt,
+      updatedAt: updatedAt ?? this.updatedAt,
+      laborCalcMethod: laborCalcMethod ?? this.laborCalcMethod,
+      laborValue: laborValue ?? this.laborValue,
+      crewSize:
+          crewSize == _clearField ? null : (crewSize as int?) ?? this.crewSize,
+      productLink: productLink == _clearField
+          ? null
+          : (productLink as String?) ?? this.productLink,
+      description: description == _clearField
+          ? null
+          : (description as String?) ?? this.description,
+    );
+  }
+}
+
+/// Equipment cost item with unit price and quantity.
+///
+/// Although structurally identical to [MaterialCostItem], this class is kept
+/// separate to maintain type safety and domain semantics. Equipment and materials
+/// represent distinct business concepts with different:
+/// - Depreciation schedules and asset management
+/// - Rental vs. purchase considerations
+/// - Maintenance and operational tracking
+/// - Capital expenditure vs. operational expense classification
+///
+/// This separation allows the domain model to evolve independently for each
+/// concept and prevents accidental conflation of semantically different items.
+class EquipmentCostItem extends CostItem {
+  final Money unitPrice;
+  final Quantity quantity;
+
+  const EquipmentCostItem({
+    required super.id,
+    required super.estimateId,
+    required super.itemName,
+    required super.calculation,
+    required super.itemTotalCost,
+    required super.createdAt,
+    required super.updatedAt,
+    required this.unitPrice,
+    required this.quantity,
+    super.productLink,
+    super.description,
+  }) : super(itemType: CostItemType.equipment);
+
+  @override
+  List<Object?> get props => [...super.props, unitPrice, quantity];
+
+  /// Creates a copy of this [EquipmentCostItem] with the given fields replaced.
+  ///
+  /// To explicitly clear a nullable field, pass [clearField()] as the value.
+  /// Omitting a parameter preserves the current value.
+  ///
+  /// Example:
+  /// ```dart
+  /// final updated = item.copyWith(
+  ///   itemName: 'New Name',
+  ///   productLink: clearField(), // Clear to null
+  /// );
+  /// ```
+  EquipmentCostItem copyWith({
+    String? id,
+    String? estimateId,
+    String? itemName,
+    Map<String, double>? calculation,
+    double? itemTotalCost,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+    Money? unitPrice,
+    Quantity? quantity,
+    Object? productLink,
+    Object? description,
+  }) {
+    return EquipmentCostItem(
+      id: id ?? this.id,
+      estimateId: estimateId ?? this.estimateId,
+      itemName: itemName ?? this.itemName,
+      calculation: calculation ?? this.calculation,
+      itemTotalCost: itemTotalCost ?? this.itemTotalCost,
+      createdAt: createdAt ?? this.createdAt,
+      updatedAt: updatedAt ?? this.updatedAt,
+      unitPrice: unitPrice ?? this.unitPrice,
+      quantity: quantity ?? this.quantity,
+      productLink: productLink == _clearField
+          ? null
+          : (productLink as String?) ?? this.productLink,
+      description: description == _clearField
+          ? null
+          : (description as String?) ?? this.description,
+    );
+  }
+}

--- a/lib/features/estimation/domain/entities/cost_item_entity.dart
+++ b/lib/features/estimation/domain/entities/cost_item_entity.dart
@@ -114,21 +114,24 @@ enum Unit {
 /// Labor pricing strategies supported by the estimation model.
 enum LaborCalculationMethodType {
   /// Labor is priced per hour of work.
-  hourly,
+  perHour('per_hour'),
 
   /// Labor is priced per day of work.
-  daily,
+  perDay('per_day'),
 
   /// Labor is priced per unit of completed work.
-  perUnit;
+  perUnit('per_unit');
 
-  String toJson() => name;
+  final String value;
+  const LaborCalculationMethodType(this.value);
+
+  String toJson() => value;
 
   /// Deserializes a [LaborCalculationMethodType] from JSON string.
   ///
-  /// Falls back to [LaborCalculationMethodType.hourly] for unknown values to
+  /// Falls back to [LaborCalculationMethodType.perHour] for unknown values to
   /// ensure forward compatibility with new calculation methods added in future
-  /// versions. Hourly is chosen as the default because it is the most common
+  /// versions. Per hour is chosen as the default because it is the most common
   /// labor pricing strategy and provides a conservative fallback that requires
   /// explicit time tracking.
   ///
@@ -136,8 +139,8 @@ enum LaborCalculationMethodType {
   /// Consider logging unknown values if strict validation is required.
   static LaborCalculationMethodType fromJson(String value) {
     return LaborCalculationMethodType.values.firstWhere(
-      (e) => e.name.toLowerCase() == value.toLowerCase(),
-      orElse: () => LaborCalculationMethodType.hourly,
+      (e) => e.value == value,
+      orElse: () => LaborCalculationMethodType.perHour,
     );
   }
 }

--- a/lib/features/estimation/domain/entities/cost_item_entity.dart
+++ b/lib/features/estimation/domain/entities/cost_item_entity.dart
@@ -114,21 +114,24 @@ enum Unit {
 /// Labor pricing strategies supported by the estimation model.
 enum LaborCalculationMethodType {
   /// Labor is priced per hour of work.
-  hourly,
+  perHour('per_hour'),
 
   /// Labor is priced per day of work.
-  daily,
+  perDay('per_day'),
 
   /// Labor is priced per unit of completed work.
-  perUnit;
+  perUnit('per_unit');
 
-  String toJson() => name;
+  final String value;
+  const LaborCalculationMethodType(this.value);
+
+  String toJson() => value;
 
   /// Deserializes a [LaborCalculationMethodType] from JSON string.
   ///
-  /// Falls back to [LaborCalculationMethodType.hourly] for unknown values to
+  /// Falls back to [LaborCalculationMethodType.perHour] for unknown values to
   /// ensure forward compatibility with new calculation methods added in future
-  /// versions. Hourly is chosen as the default because it is the most common
+  /// versions. Per hour is chosen as the default because it is the most common
   /// labor pricing strategy and provides a conservative fallback that requires
   /// explicit time tracking.
   ///
@@ -136,15 +139,18 @@ enum LaborCalculationMethodType {
   /// Consider logging unknown values if strict validation is required.
   static LaborCalculationMethodType fromJson(String value) {
     return LaborCalculationMethodType.values.firstWhere(
-      (e) => e.name.toLowerCase() == value.toLowerCase(),
-      orElse: () => LaborCalculationMethodType.hourly,
+      (e) => e.value == value,
+      orElse: () => LaborCalculationMethodType.perHour,
     );
   }
 }
 
 /// Value object representing a monetary amount
 class Money extends Equatable {
+  /// The monetary amount in the given [currency].
   final double amount;
+
+  /// ISO 4217 currency code; defaults to `'USD'`.
   final String currency;
 
   const Money({required this.amount, this.currency = 'USD'});
@@ -152,6 +158,7 @@ class Money extends Equatable {
   @override
   List<Object?> get props => [amount, currency];
 
+  /// Creates a copy of this [Money] with the given fields replaced.
   Money copyWith({double? amount, String? currency}) {
     return Money(
       amount: amount ?? this.amount,
@@ -162,7 +169,10 @@ class Money extends Equatable {
 
 /// Value object representing a quantity with unit
 class Quantity extends Equatable {
+  /// The numeric quantity of units.
   final double value;
+
+  /// The unit of measurement for this quantity.
   final Unit unit;
 
   const Quantity({required this.value, required this.unit});
@@ -170,6 +180,7 @@ class Quantity extends Equatable {
   @override
   List<Object?> get props => [value, unit];
 
+  /// Creates a copy of this [Quantity] with the given fields replaced.
   Quantity copyWith({double? value, Unit? unit}) {
     return Quantity(value: value ?? this.value, unit: unit ?? this.unit);
   }
@@ -282,6 +293,13 @@ sealed class CostItem extends Equatable {
   final double itemTotalCost;
   final DateTime createdAt;
   final DateTime updatedAt;
+
+  /// ISO 4217 currency code for this cost item's monetary values.
+  final String currency;
+
+  /// Optional brand or manufacturer name for this cost item.
+  final String? brand;
+
   final String? productLink;
   final String? description;
 
@@ -294,6 +312,8 @@ sealed class CostItem extends Equatable {
     required this.itemTotalCost,
     required this.createdAt,
     required this.updatedAt,
+    required this.currency,
+    this.brand,
     this.productLink,
     this.description,
   });
@@ -308,6 +328,8 @@ sealed class CostItem extends Equatable {
     itemTotalCost,
     createdAt,
     updatedAt,
+    currency,
+    brand,
     productLink,
     description,
   ];
@@ -337,8 +359,10 @@ class MaterialCostItem extends CostItem {
     required super.itemTotalCost,
     required super.createdAt,
     required super.updatedAt,
+    required super.currency,
     required this.unitPrice,
     required this.quantity,
+    super.brand,
     super.productLink,
     super.description,
   }) : super(itemType: CostItemType.material);
@@ -366,8 +390,10 @@ class MaterialCostItem extends CostItem {
     double? itemTotalCost,
     DateTime? createdAt,
     DateTime? updatedAt,
+    String? currency,
     Money? unitPrice,
     Quantity? quantity,
+    Object? brand,
     Object? productLink,
     Object? description,
   }) {
@@ -379,8 +405,10 @@ class MaterialCostItem extends CostItem {
       itemTotalCost: itemTotalCost ?? this.itemTotalCost,
       createdAt: createdAt ?? this.createdAt,
       updatedAt: updatedAt ?? this.updatedAt,
+      currency: currency ?? this.currency,
       unitPrice: unitPrice ?? this.unitPrice,
       quantity: quantity ?? this.quantity,
+      brand: brand == _clearField ? null : (brand as String?) ?? this.brand,
       productLink: productLink == _clearField
           ? null
           : (productLink as String?) ?? this.productLink,
@@ -405,9 +433,11 @@ class LaborCostItem extends CostItem {
     required super.itemTotalCost,
     required super.createdAt,
     required super.updatedAt,
+    required super.currency,
     required this.laborCalcMethod,
     required this.laborValue,
     this.crewSize,
+    super.brand,
     super.productLink,
     super.description,
   }) : super(itemType: CostItemType.labor);
@@ -441,9 +471,11 @@ class LaborCostItem extends CostItem {
     double? itemTotalCost,
     DateTime? createdAt,
     DateTime? updatedAt,
+    String? currency,
     LaborCalculationMethodType? laborCalcMethod,
     LaborValue? laborValue,
     Object? crewSize,
+    Object? brand,
     Object? productLink,
     Object? description,
   }) {
@@ -455,10 +487,12 @@ class LaborCostItem extends CostItem {
       itemTotalCost: itemTotalCost ?? this.itemTotalCost,
       createdAt: createdAt ?? this.createdAt,
       updatedAt: updatedAt ?? this.updatedAt,
+      currency: currency ?? this.currency,
       laborCalcMethod: laborCalcMethod ?? this.laborCalcMethod,
       laborValue: laborValue ?? this.laborValue,
       crewSize:
           crewSize == _clearField ? null : (crewSize as int?) ?? this.crewSize,
+      brand: brand == _clearField ? null : (brand as String?) ?? this.brand,
       productLink: productLink == _clearField
           ? null
           : (productLink as String?) ?? this.productLink,
@@ -493,8 +527,10 @@ class EquipmentCostItem extends CostItem {
     required super.itemTotalCost,
     required super.createdAt,
     required super.updatedAt,
+    required super.currency,
     required this.unitPrice,
     required this.quantity,
+    super.brand,
     super.productLink,
     super.description,
   }) : super(itemType: CostItemType.equipment);
@@ -522,8 +558,10 @@ class EquipmentCostItem extends CostItem {
     double? itemTotalCost,
     DateTime? createdAt,
     DateTime? updatedAt,
+    String? currency,
     Money? unitPrice,
     Quantity? quantity,
+    Object? brand,
     Object? productLink,
     Object? description,
   }) {
@@ -535,8 +573,10 @@ class EquipmentCostItem extends CostItem {
       itemTotalCost: itemTotalCost ?? this.itemTotalCost,
       createdAt: createdAt ?? this.createdAt,
       updatedAt: updatedAt ?? this.updatedAt,
+      currency: currency ?? this.currency,
       unitPrice: unitPrice ?? this.unitPrice,
       quantity: quantity ?? this.quantity,
+      brand: brand == _clearField ? null : (brand as String?) ?? this.brand,
       productLink: productLink == _clearField
           ? null
           : (productLink as String?) ?? this.productLink,

--- a/lib/features/estimation/domain/entities/cost_item_entity.dart
+++ b/lib/features/estimation/domain/entities/cost_item_entity.dart
@@ -1,25 +1,18 @@
 import 'package:equatable/equatable.dart';
 
-/// Sentinel value used in copyWith methods to explicitly clear nullable fields.
-///
-/// Usage:
-/// ```dart
-/// item.copyWith(productLink: clearField())
-/// ```
-/// This will set productLink to null, as opposed to omitting the parameter
-/// which preserves the current value.
-const _ClearField _clearField = _ClearField();
-
-/// Sentinel class for clearing nullable fields in copyWith methods.
+// Sentinel class for clearing nullable fields in copyWith methods.
 class _ClearField {
   const _ClearField();
 }
 
-/// Helper function to create a clear field sentinel.
+/// Sentinel value to explicitly clear a nullable field in [copyWith].
 ///
-/// Returns a special sentinel value that can be passed to copyWith methods
-/// to explicitly set nullable fields to null.
-Object clearField() => _clearField;
+/// Pass this constant to set a nullable field to null instead of omitting
+/// the parameter (which preserves the current value):
+/// ```dart
+/// item.copyWith(productLink: clearField) // sets productLink to null
+/// ```
+const Object clearField = _ClearField();
 
 /// Type of cost item stored in an estimation.
 enum CostItemType {
@@ -31,8 +24,6 @@ enum CostItemType {
 
   /// Equipment or rented assets priced by unit and quantity.
   equipment;
-
-  String toJson() => name;
 
   /// Deserializes a [CostItemType] from JSON string.
   ///
@@ -92,8 +83,6 @@ enum Unit {
   /// Sheet-based material counted as sheets.
   sheets;
 
-  String toJson() => name;
-
   /// Deserializes a [Unit] from JSON string.
   ///
   /// Falls back to [Unit.pieces] for unknown values to ensure forward
@@ -128,6 +117,12 @@ enum LaborCalculationMethodType {
   String toJson() => value;
 
   /// Deserializes a [LaborCalculationMethodType] from JSON string.
+  ///
+  /// Uses exact, case-sensitive matching against the snake_case [value]
+  /// property (e.g., `"per_hour"`). This is intentional: the backend contract
+  /// guarantees lowercase snake_case values for labor methods, unlike
+  /// [CostItemType] and [Unit] which match against the Dart enum name and
+  /// accept mixed-case input.
   ///
   /// Falls back to [LaborCalculationMethodType.perHour] for unknown values to
   /// ensure forward compatibility with new calculation methods added in future
@@ -231,15 +226,15 @@ class LaborValue extends Equatable {
 
   /// Creates a copy of this [LaborValue] with the given fields replaced.
   ///
-  /// To explicitly clear a nullable field, pass [clearField()] as the value.
+  /// To explicitly clear a nullable field, pass [clearField] as the value.
   /// Omitting a parameter preserves the current value.
   ///
   /// Example:
   /// ```dart
   /// final updated = value.copyWith(
-  ///   laborDays: 5.0,           // Update to 5.0
-  ///   laborHours: clearField(), // Clear to null
-  /// );                          // laborUnitType unchanged
+  ///   laborDays: 5.0,          // Update to 5.0
+  ///   laborHours: clearField,  // Clear to null
+  /// );                         // laborUnitType unchanged
   /// ```
   LaborValue copyWith({
     Object? laborDays,
@@ -248,16 +243,16 @@ class LaborValue extends Equatable {
     Object? laborUnitValue,
   }) {
     return LaborValue(
-      laborDays: laborDays == _clearField
+      laborDays: laborDays == clearField
           ? null
           : (laborDays as double?) ?? this.laborDays,
-      laborHours: laborHours == _clearField
+      laborHours: laborHours == clearField
           ? null
           : (laborHours as double?) ?? this.laborHours,
-      laborUnitType: laborUnitType == _clearField
+      laborUnitType: laborUnitType == clearField
           ? null
           : (laborUnitType as String?) ?? this.laborUnitType,
-      laborUnitValue: laborUnitValue == _clearField
+      laborUnitValue: laborUnitValue == clearField
           ? null
           : (laborUnitValue as double?) ?? this.laborUnitValue,
     );
@@ -266,9 +261,16 @@ class LaborValue extends Equatable {
 
 /// Sealed class representing a cost item in an estimation
 sealed class CostItem extends Equatable {
+  /// Unique identifier for this cost item.
   final String id;
+
+  /// The estimation this cost item belongs to.
   final String estimateId;
+
+  /// Display name of this cost item.
   final String itemName;
+
+  /// The type category of this cost item.
   final CostItemType itemType;
 
   /// Breakdown of cost calculation components as key-value pairs.
@@ -290,8 +292,13 @@ sealed class CostItem extends Equatable {
   /// Consumer code should handle missing keys gracefully.
   final Map<String, double> calculation;
 
+  /// The total computed cost for this item in [currency].
   final double itemTotalCost;
+
+  /// Timestamp when this cost item was created.
   final DateTime createdAt;
+
+  /// Timestamp when this cost item was last updated.
   final DateTime updatedAt;
 
   /// ISO 4217 currency code for this cost item's monetary values.
@@ -300,7 +307,10 @@ sealed class CostItem extends Equatable {
   /// Optional brand or manufacturer name for this cost item.
   final String? brand;
 
+  /// Optional URL linking to the product or resource for this item.
   final String? productLink;
+
+  /// Optional freeform notes or description for this item.
   final String? description;
 
   const CostItem({
@@ -348,7 +358,10 @@ sealed class CostItem extends Equatable {
 /// This separation allows the domain model to evolve independently for each
 /// concept and prevents accidental conflation of semantically different items.
 class MaterialCostItem extends CostItem {
+  /// Price per single unit of this material.
   final Money unitPrice;
+
+  /// Total quantity of this material with its unit of measurement.
   final Quantity quantity;
 
   const MaterialCostItem({
@@ -372,14 +385,14 @@ class MaterialCostItem extends CostItem {
 
   /// Creates a copy of this [MaterialCostItem] with the given fields replaced.
   ///
-  /// To explicitly clear a nullable field, pass [clearField()] as the value.
+  /// To explicitly clear a nullable field, pass [clearField] as the value.
   /// Omitting a parameter preserves the current value.
   ///
   /// Example:
   /// ```dart
   /// final updated = item.copyWith(
   ///   itemName: 'New Name',
-  ///   productLink: clearField(), // Clear to null
+  ///   productLink: clearField, // Clear to null
   /// );
   /// ```
   MaterialCostItem copyWith({
@@ -408,11 +421,11 @@ class MaterialCostItem extends CostItem {
       currency: currency ?? this.currency,
       unitPrice: unitPrice ?? this.unitPrice,
       quantity: quantity ?? this.quantity,
-      brand: brand == _clearField ? null : (brand as String?) ?? this.brand,
-      productLink: productLink == _clearField
+      brand: brand == clearField ? null : (brand as String?) ?? this.brand,
+      productLink: productLink == clearField
           ? null
           : (productLink as String?) ?? this.productLink,
-      description: description == _clearField
+      description: description == clearField
           ? null
           : (description as String?) ?? this.description,
     );
@@ -421,8 +434,14 @@ class MaterialCostItem extends CostItem {
 
 /// Labor cost item with calculation method and labor values
 class LaborCostItem extends CostItem {
+  /// Pricing strategy used to calculate this labor cost (hourly, daily, or per-unit).
   final LaborCalculationMethodType laborCalcMethod;
+
+  /// Computed or input values backing the calculation; populated fields depend
+  /// on [laborCalcMethod]. See [LaborValue] for details.
   final LaborValue laborValue;
+
+  /// Optional number of workers assigned to this labor item.
   final int? crewSize;
 
   const LaborCostItem({
@@ -452,15 +471,15 @@ class LaborCostItem extends CostItem {
 
   /// Creates a copy of this [LaborCostItem] with the given fields replaced.
   ///
-  /// To explicitly clear a nullable field, pass [clearField()] as the value.
+  /// To explicitly clear a nullable field, pass [clearField] as the value.
   /// Omitting a parameter preserves the current value.
   ///
   /// Example:
   /// ```dart
   /// final updated = item.copyWith(
   ///   itemName: 'New Name',
-  ///   crewSize: clearField(),    // Clear to null
-  ///   productLink: clearField(), // Clear to null
+  ///   crewSize: clearField,   // Clear to null
+  ///   productLink: clearField, // Clear to null
   /// );
   /// ```
   LaborCostItem copyWith({
@@ -491,12 +510,12 @@ class LaborCostItem extends CostItem {
       laborCalcMethod: laborCalcMethod ?? this.laborCalcMethod,
       laborValue: laborValue ?? this.laborValue,
       crewSize:
-          crewSize == _clearField ? null : (crewSize as int?) ?? this.crewSize,
-      brand: brand == _clearField ? null : (brand as String?) ?? this.brand,
-      productLink: productLink == _clearField
+          crewSize == clearField ? null : (crewSize as int?) ?? this.crewSize,
+      brand: brand == clearField ? null : (brand as String?) ?? this.brand,
+      productLink: productLink == clearField
           ? null
           : (productLink as String?) ?? this.productLink,
-      description: description == _clearField
+      description: description == clearField
           ? null
           : (description as String?) ?? this.description,
     );
@@ -516,7 +535,10 @@ class LaborCostItem extends CostItem {
 /// This separation allows the domain model to evolve independently for each
 /// concept and prevents accidental conflation of semantically different items.
 class EquipmentCostItem extends CostItem {
+  /// Price per single unit of this equipment.
   final Money unitPrice;
+
+  /// Total quantity of this equipment with its unit of measurement.
   final Quantity quantity;
 
   const EquipmentCostItem({
@@ -540,14 +562,14 @@ class EquipmentCostItem extends CostItem {
 
   /// Creates a copy of this [EquipmentCostItem] with the given fields replaced.
   ///
-  /// To explicitly clear a nullable field, pass [clearField()] as the value.
+  /// To explicitly clear a nullable field, pass [clearField] as the value.
   /// Omitting a parameter preserves the current value.
   ///
   /// Example:
   /// ```dart
   /// final updated = item.copyWith(
   ///   itemName: 'New Name',
-  ///   productLink: clearField(), // Clear to null
+  ///   productLink: clearField, // Clear to null
   /// );
   /// ```
   EquipmentCostItem copyWith({
@@ -576,11 +598,11 @@ class EquipmentCostItem extends CostItem {
       currency: currency ?? this.currency,
       unitPrice: unitPrice ?? this.unitPrice,
       quantity: quantity ?? this.quantity,
-      brand: brand == _clearField ? null : (brand as String?) ?? this.brand,
-      productLink: productLink == _clearField
+      brand: brand == clearField ? null : (brand as String?) ?? this.brand,
+      productLink: productLink == clearField
           ? null
           : (productLink as String?) ?? this.productLink,
-      description: description == _clearField
+      description: description == clearField
           ? null
           : (description as String?) ?? this.description,
     );

--- a/test/features/estimations/units/domain/entities/cost_item_entity_test.dart
+++ b/test/features/estimations/units/domain/entities/cost_item_entity_test.dart
@@ -65,45 +65,55 @@ void main() {
 
   group('LaborCalculationMethodType enum', () {
     test('toJson returns correct string values', () {
-      expect(LaborCalculationMethodType.hourly.toJson(), 'hourly');
-      expect(LaborCalculationMethodType.daily.toJson(), 'daily');
-      expect(LaborCalculationMethodType.perUnit.toJson(), 'perUnit');
+      expect(LaborCalculationMethodType.perHour.toJson(), 'per_hour');
+      expect(LaborCalculationMethodType.perDay.toJson(), 'per_day');
+      expect(LaborCalculationMethodType.perUnit.toJson(), 'per_unit');
     });
 
     test('fromJson creates correct enum from string', () {
       expect(
-        LaborCalculationMethodType.fromJson('hourly'),
-        LaborCalculationMethodType.hourly,
+        LaborCalculationMethodType.fromJson('per_hour'),
+        LaborCalculationMethodType.perHour,
       );
       expect(
-        LaborCalculationMethodType.fromJson('daily'),
-        LaborCalculationMethodType.daily,
+        LaborCalculationMethodType.fromJson('per_day'),
+        LaborCalculationMethodType.perDay,
       );
       expect(
-        LaborCalculationMethodType.fromJson('perUnit'),
+        LaborCalculationMethodType.fromJson('per_unit'),
         LaborCalculationMethodType.perUnit,
       );
     });
 
-    test('fromJson is case-insensitive', () {
+    test('fromJson is case-sensitive and exact match', () {
+      // These should fall back to perHour as they don't match exactly
       expect(
-        LaborCalculationMethodType.fromJson('HOURLY'),
-        LaborCalculationMethodType.hourly,
+        LaborCalculationMethodType.fromJson('PER_HOUR'),
+        LaborCalculationMethodType.perHour,
       );
       expect(
-        LaborCalculationMethodType.fromJson('Daily'),
-        LaborCalculationMethodType.daily,
+        LaborCalculationMethodType.fromJson('Per_Day'),
+        LaborCalculationMethodType.perHour,
       );
     });
 
-    test('fromJson returns hourly for invalid value', () {
+    test('fromJson returns perHour for invalid value', () {
       expect(
         LaborCalculationMethodType.fromJson('invalid'),
-        LaborCalculationMethodType.hourly,
+        LaborCalculationMethodType.perHour,
       );
       expect(
         LaborCalculationMethodType.fromJson(''),
-        LaborCalculationMethodType.hourly,
+        LaborCalculationMethodType.perHour,
+      );
+      // Old format should also fall back
+      expect(
+        LaborCalculationMethodType.fromJson('hourly'),
+        LaborCalculationMethodType.perHour,
+      );
+      expect(
+        LaborCalculationMethodType.fromJson('daily'),
+        LaborCalculationMethodType.perHour,
       );
     });
   });
@@ -397,7 +407,7 @@ void main() {
       itemTotalCost: 2000.0,
       createdAt: DateTime(2024, 1, 1),
       updatedAt: DateTime(2024, 1, 1),
-      laborCalcMethod: LaborCalculationMethodType.hourly,
+      laborCalcMethod: LaborCalculationMethodType.perHour,
       laborValue: const LaborValue(
         laborHours: 40.0,
         laborUnitType: 'hourly',
@@ -412,7 +422,7 @@ void main() {
       expect(testItem.estimateId, 'estimate-1');
       expect(testItem.itemName, 'Electrician Work');
       expect(testItem.itemType, CostItemType.labor);
-      expect(testItem.laborCalcMethod, LaborCalculationMethodType.hourly);
+      expect(testItem.laborCalcMethod, LaborCalculationMethodType.perHour);
       expect(testItem.laborValue.laborHours, 40.0);
       expect(testItem.crewSize, 2);
       expect(testItem.description, 'Electrical installation');
@@ -424,10 +434,10 @@ void main() {
 
     test('copyWith creates new instance with updated values', () {
       final updated = testItem.copyWith(
-        laborCalcMethod: LaborCalculationMethodType.daily,
+        laborCalcMethod: LaborCalculationMethodType.perDay,
       );
 
-      expect(updated.laborCalcMethod, LaborCalculationMethodType.daily);
+      expect(updated.laborCalcMethod, LaborCalculationMethodType.perDay);
       expect(updated.id, testItem.id);
       expect(updated.itemName, testItem.itemName);
     });
@@ -470,7 +480,7 @@ void main() {
         itemTotalCost: 2000.0,
         createdAt: DateTime(2024, 1, 1),
         updatedAt: DateTime(2024, 1, 1),
-        laborCalcMethod: LaborCalculationMethodType.hourly,
+        laborCalcMethod: LaborCalculationMethodType.perHour,
         laborValue: const LaborValue(laborHours: 40.0),
       );
 
@@ -482,7 +492,7 @@ void main() {
         itemTotalCost: 2000.0,
         createdAt: DateTime(2024, 1, 1),
         updatedAt: DateTime(2024, 1, 1),
-        laborCalcMethod: LaborCalculationMethodType.hourly,
+        laborCalcMethod: LaborCalculationMethodType.perHour,
         laborValue: const LaborValue(laborHours: 40.0),
       );
 
@@ -624,7 +634,7 @@ void main() {
           itemTotalCost: 2000.0,
           createdAt: DateTime(2024, 1, 1),
           updatedAt: DateTime(2024, 1, 1),
-          laborCalcMethod: LaborCalculationMethodType.hourly,
+          laborCalcMethod: LaborCalculationMethodType.perHour,
           laborValue: const LaborValue(laborHours: 40.0),
         ),
         EquipmentCostItem(
@@ -667,7 +677,7 @@ void main() {
           itemTotalCost: 2000.0,
           createdAt: DateTime(2024, 1, 1),
           updatedAt: DateTime(2024, 1, 1),
-          laborCalcMethod: LaborCalculationMethodType.hourly,
+          laborCalcMethod: LaborCalculationMethodType.perHour,
           laborValue: const LaborValue(laborHours: 40.0),
         ),
       ];

--- a/test/features/estimations/units/domain/entities/cost_item_entity_test.dart
+++ b/test/features/estimations/units/domain/entities/cost_item_entity_test.dart
@@ -1,0 +1,682 @@
+import 'package:construculator/features/estimation/domain/entities/cost_item_entity.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('CostItemType enum', () {
+    test('toJson returns correct string values', () {
+      expect(CostItemType.material.toJson(), 'material');
+      expect(CostItemType.labor.toJson(), 'labor');
+      expect(CostItemType.equipment.toJson(), 'equipment');
+    });
+
+    test('fromJson creates correct enum from string', () {
+      expect(CostItemType.fromJson('material'), CostItemType.material);
+      expect(CostItemType.fromJson('labor'), CostItemType.labor);
+      expect(CostItemType.fromJson('equipment'), CostItemType.equipment);
+    });
+
+    test('fromJson is case-insensitive', () {
+      expect(CostItemType.fromJson('MATERIAL'), CostItemType.material);
+      expect(CostItemType.fromJson('Labor'), CostItemType.labor);
+      expect(CostItemType.fromJson('EQUIPMENT'), CostItemType.equipment);
+    });
+
+    test('fromJson returns material for invalid value', () {
+      expect(CostItemType.fromJson('invalid'), CostItemType.material);
+      expect(CostItemType.fromJson(''), CostItemType.material);
+    });
+  });
+
+  group('Unit enum', () {
+    test('toJson returns correct string values', () {
+      expect(Unit.pieces.toJson(), 'pieces');
+      expect(Unit.meters.toJson(), 'meters');
+      expect(Unit.squareMeters.toJson(), 'squareMeters');
+      expect(Unit.cubicMeters.toJson(), 'cubicMeters');
+      expect(Unit.kilograms.toJson(), 'kilograms');
+      expect(Unit.tons.toJson(), 'tons');
+      expect(Unit.liters.toJson(), 'liters');
+      expect(Unit.hours.toJson(), 'hours');
+      expect(Unit.days.toJson(), 'days');
+      expect(Unit.boxes.toJson(), 'boxes');
+      expect(Unit.bags.toJson(), 'bags');
+      expect(Unit.rolls.toJson(), 'rolls');
+      expect(Unit.sheets.toJson(), 'sheets');
+    });
+
+    test('fromJson creates correct enum from string', () {
+      expect(Unit.fromJson('pieces'), Unit.pieces);
+      expect(Unit.fromJson('meters'), Unit.meters);
+      expect(Unit.fromJson('squareMeters'), Unit.squareMeters);
+      expect(Unit.fromJson('hours'), Unit.hours);
+    });
+
+    test('fromJson is case-insensitive', () {
+      expect(Unit.fromJson('PIECES'), Unit.pieces);
+      expect(Unit.fromJson('Meters'), Unit.meters);
+      expect(Unit.fromJson('HOURS'), Unit.hours);
+    });
+
+    test('fromJson returns pieces for invalid value', () {
+      expect(Unit.fromJson('invalid'), Unit.pieces);
+      expect(Unit.fromJson(''), Unit.pieces);
+    });
+  });
+
+  group('LaborCalculationMethodType enum', () {
+    test('toJson returns correct string values', () {
+      expect(LaborCalculationMethodType.hourly.toJson(), 'hourly');
+      expect(LaborCalculationMethodType.daily.toJson(), 'daily');
+      expect(LaborCalculationMethodType.perUnit.toJson(), 'perUnit');
+    });
+
+    test('fromJson creates correct enum from string', () {
+      expect(
+        LaborCalculationMethodType.fromJson('hourly'),
+        LaborCalculationMethodType.hourly,
+      );
+      expect(
+        LaborCalculationMethodType.fromJson('daily'),
+        LaborCalculationMethodType.daily,
+      );
+      expect(
+        LaborCalculationMethodType.fromJson('perUnit'),
+        LaborCalculationMethodType.perUnit,
+      );
+    });
+
+    test('fromJson is case-insensitive', () {
+      expect(
+        LaborCalculationMethodType.fromJson('HOURLY'),
+        LaborCalculationMethodType.hourly,
+      );
+      expect(
+        LaborCalculationMethodType.fromJson('Daily'),
+        LaborCalculationMethodType.daily,
+      );
+    });
+
+    test('fromJson returns hourly for invalid value', () {
+      expect(
+        LaborCalculationMethodType.fromJson('invalid'),
+        LaborCalculationMethodType.hourly,
+      );
+      expect(
+        LaborCalculationMethodType.fromJson(''),
+        LaborCalculationMethodType.hourly,
+      );
+    });
+  });
+
+  group('Money value object', () {
+    test('creates Money with amount and currency', () {
+      const money = Money(amount: 100.50, currency: 'USD');
+
+      expect(money.amount, 100.50);
+      expect(money.currency, 'USD');
+    });
+
+    test('defaults currency to USD when not specified', () {
+      const money = Money(amount: 100.50);
+
+      expect(money.currency, 'USD');
+    });
+
+    test('copyWith creates new instance with updated values', () {
+      const money = Money(amount: 100.50, currency: 'USD');
+      final updated = money.copyWith(amount: 200.75);
+
+      expect(updated.amount, 200.75);
+      expect(updated.currency, 'USD');
+    });
+
+    test('copyWith preserves original values when not specified', () {
+      const money = Money(amount: 100.50, currency: 'EUR');
+      final updated = money.copyWith(amount: 200.75);
+
+      expect(updated.currency, 'EUR');
+    });
+
+    test('two Money objects with same values are equal', () {
+      const money1 = Money(amount: 100.50, currency: 'USD');
+      const money2 = Money(amount: 100.50, currency: 'USD');
+
+      expect(money1, money2);
+    });
+
+    test('two Money objects with different values are not equal', () {
+      const money1 = Money(amount: 100.50, currency: 'USD');
+      const money2 = Money(amount: 200.75, currency: 'USD');
+
+      expect(money1, isNot(money2));
+    });
+
+    test('two Money objects with different currencies are not equal', () {
+      const money1 = Money(amount: 100.50, currency: 'USD');
+      const money2 = Money(amount: 100.50, currency: 'EUR');
+
+      expect(money1, isNot(money2));
+    });
+  });
+
+  group('Quantity value object', () {
+    test('creates Quantity with value and unit', () {
+      const quantity = Quantity(value: 50.0, unit: Unit.meters);
+
+      expect(quantity.value, 50.0);
+      expect(quantity.unit, Unit.meters);
+    });
+
+    test('copyWith creates new instance with updated values', () {
+      const quantity = Quantity(value: 50.0, unit: Unit.meters);
+      final updated = quantity.copyWith(value: 100.0);
+
+      expect(updated.value, 100.0);
+      expect(updated.unit, Unit.meters);
+    });
+
+    test('copyWith can update unit', () {
+      const quantity = Quantity(value: 50.0, unit: Unit.meters);
+      final updated = quantity.copyWith(unit: Unit.squareMeters);
+
+      expect(updated.value, 50.0);
+      expect(updated.unit, Unit.squareMeters);
+    });
+
+    test('two Quantity objects with same values are equal', () {
+      const quantity1 = Quantity(value: 50.0, unit: Unit.meters);
+      const quantity2 = Quantity(value: 50.0, unit: Unit.meters);
+
+      expect(quantity1, quantity2);
+    });
+
+    test('two Quantity objects with different values are not equal', () {
+      const quantity1 = Quantity(value: 50.0, unit: Unit.meters);
+      const quantity2 = Quantity(value: 100.0, unit: Unit.meters);
+
+      expect(quantity1, isNot(quantity2));
+    });
+
+    test('two Quantity objects with different units are not equal', () {
+      const quantity1 = Quantity(value: 50.0, unit: Unit.meters);
+      const quantity2 = Quantity(value: 50.0, unit: Unit.squareMeters);
+
+      expect(quantity1, isNot(quantity2));
+    });
+  });
+
+  group('LaborValue value object', () {
+    test('creates LaborValue with all fields', () {
+      const laborValue = LaborValue(
+        laborDays: 5.0,
+        laborHours: 40.0,
+        laborUnitType: 'hourly',
+        laborUnitValue: 25.0,
+      );
+
+      expect(laborValue.laborDays, 5.0);
+      expect(laborValue.laborHours, 40.0);
+      expect(laborValue.laborUnitType, 'hourly');
+      expect(laborValue.laborUnitValue, 25.0);
+    });
+
+    test('creates LaborValue with null fields', () {
+      const laborValue = LaborValue();
+
+      expect(laborValue.laborDays, isNull);
+      expect(laborValue.laborHours, isNull);
+      expect(laborValue.laborUnitType, isNull);
+      expect(laborValue.laborUnitValue, isNull);
+    });
+
+    test('copyWith updates specified fields', () {
+      const laborValue = LaborValue(laborDays: 5.0, laborHours: 40.0);
+      final updated = laborValue.copyWith(laborDays: 10.0);
+
+      expect(updated.laborDays, 10.0);
+      expect(updated.laborHours, 40.0);
+    });
+
+    test('copyWith can clear nullable fields using clearField', () {
+      const laborValue = LaborValue(
+        laborDays: 5.0,
+        laborHours: 40.0,
+        laborUnitType: 'hourly',
+        laborUnitValue: 25.0,
+      );
+
+      final updated = laborValue.copyWith(
+        laborDays: clearField(),
+        laborUnitType: clearField(),
+      );
+
+      expect(updated.laborDays, isNull);
+      expect(updated.laborHours, 40.0); // Preserved
+      expect(updated.laborUnitType, isNull);
+      expect(updated.laborUnitValue, 25.0); // Preserved
+    });
+
+    test('copyWith preserves null when parameter omitted', () {
+      const laborValue = LaborValue(laborDays: 5.0);
+      final updated = laborValue.copyWith(laborHours: 40.0);
+
+      expect(updated.laborDays, 5.0);
+      expect(updated.laborHours, 40.0);
+      expect(updated.laborUnitType, isNull); // Still null
+      expect(updated.laborUnitValue, isNull); // Still null
+    });
+
+    test('two LaborValue objects with same values are equal', () {
+      const laborValue1 = LaborValue(laborDays: 5.0, laborHours: 40.0);
+      const laborValue2 = LaborValue(laborDays: 5.0, laborHours: 40.0);
+
+      expect(laborValue1, laborValue2);
+    });
+
+    test('two LaborValue objects with different values are not equal', () {
+      const laborValue1 = LaborValue(laborDays: 5.0, laborHours: 40.0);
+      const laborValue2 = LaborValue(laborDays: 10.0, laborHours: 40.0);
+
+      expect(laborValue1, isNot(laborValue2));
+    });
+  });
+
+  group('MaterialCostItem', () {
+    final testItem = MaterialCostItem(
+      id: 'item-1',
+      estimateId: 'estimate-1',
+      itemName: 'Concrete',
+      calculation: const {'base': 100.0},
+      itemTotalCost: 5000.0,
+      createdAt: DateTime(2024, 1, 1),
+      updatedAt: DateTime(2024, 1, 1),
+      unitPrice: const Money(amount: 100.0, currency: 'USD'),
+      quantity: const Quantity(value: 50.0, unit: Unit.cubicMeters),
+      productLink: 'https://example.com/concrete',
+      description: 'High quality concrete',
+    );
+
+    test('creates MaterialCostItem with all fields', () {
+      expect(testItem.id, 'item-1');
+      expect(testItem.estimateId, 'estimate-1');
+      expect(testItem.itemName, 'Concrete');
+      expect(testItem.itemType, CostItemType.material);
+      expect(testItem.calculation, const {'base': 100.0});
+      expect(testItem.itemTotalCost, 5000.0);
+      expect(testItem.unitPrice.amount, 100.0);
+      expect(testItem.quantity.value, 50.0);
+      expect(testItem.quantity.unit, Unit.cubicMeters);
+      expect(testItem.productLink, 'https://example.com/concrete');
+      expect(testItem.description, 'High quality concrete');
+    });
+
+    test('itemType is always material', () {
+      expect(testItem.itemType, CostItemType.material);
+    });
+
+    test('copyWith creates new instance with updated values', () {
+      final updated = testItem.copyWith(itemName: 'Updated Concrete');
+
+      expect(updated.itemName, 'Updated Concrete');
+      expect(updated.id, testItem.id);
+      expect(updated.estimateId, testItem.estimateId);
+    });
+
+    test('copyWith preserves original values when not specified', () {
+      final updated = testItem.copyWith(itemTotalCost: 6000.0);
+
+      expect(updated.itemName, testItem.itemName);
+      expect(updated.unitPrice, testItem.unitPrice);
+      expect(updated.quantity, testItem.quantity);
+    });
+
+    test('copyWith can clear nullable fields using clearField', () {
+      final updated = testItem.copyWith(
+        productLink: clearField(),
+        description: clearField(),
+      );
+
+      expect(updated.productLink, isNull);
+      expect(updated.description, isNull);
+      expect(updated.itemName, testItem.itemName); // Preserved
+      expect(updated.unitPrice, testItem.unitPrice); // Preserved
+    });
+
+    test('copyWith preserves nullable fields when not specified', () {
+      final updated = testItem.copyWith(itemName: 'Updated Name');
+
+      expect(updated.itemName, 'Updated Name');
+      expect(updated.productLink, testItem.productLink); // Preserved
+      expect(updated.description, testItem.description); // Preserved
+    });
+
+    test('two MaterialCostItem objects with same values are equal', () {
+      final item1 = MaterialCostItem(
+        id: 'item-1',
+        estimateId: 'estimate-1',
+        itemName: 'Concrete',
+        calculation: const {'base': 100.0},
+        itemTotalCost: 5000.0,
+        createdAt: DateTime(2024, 1, 1),
+        updatedAt: DateTime(2024, 1, 1),
+        unitPrice: const Money(amount: 100.0),
+        quantity: const Quantity(value: 50.0, unit: Unit.cubicMeters),
+      );
+
+      final item2 = MaterialCostItem(
+        id: 'item-1',
+        estimateId: 'estimate-1',
+        itemName: 'Concrete',
+        calculation: const {'base': 100.0},
+        itemTotalCost: 5000.0,
+        createdAt: DateTime(2024, 1, 1),
+        updatedAt: DateTime(2024, 1, 1),
+        unitPrice: const Money(amount: 100.0),
+        quantity: const Quantity(value: 50.0, unit: Unit.cubicMeters),
+      );
+
+      expect(item1, item2);
+    });
+
+    test(
+      'two MaterialCostItem objects with different values are not equal',
+      () {
+        final item2 = testItem.copyWith(itemName: 'Different Material');
+
+        expect(testItem, isNot(item2));
+      },
+    );
+  });
+
+  group('LaborCostItem', () {
+    final testItem = LaborCostItem(
+      id: 'item-2',
+      estimateId: 'estimate-1',
+      itemName: 'Electrician Work',
+      calculation: const {'hours': 40.0, 'rate': 50.0},
+      itemTotalCost: 2000.0,
+      createdAt: DateTime(2024, 1, 1),
+      updatedAt: DateTime(2024, 1, 1),
+      laborCalcMethod: LaborCalculationMethodType.hourly,
+      laborValue: const LaborValue(
+        laborHours: 40.0,
+        laborUnitType: 'hourly',
+        laborUnitValue: 50.0,
+      ),
+      crewSize: 2,
+      description: 'Electrical installation',
+    );
+
+    test('creates LaborCostItem with all fields', () {
+      expect(testItem.id, 'item-2');
+      expect(testItem.estimateId, 'estimate-1');
+      expect(testItem.itemName, 'Electrician Work');
+      expect(testItem.itemType, CostItemType.labor);
+      expect(testItem.laborCalcMethod, LaborCalculationMethodType.hourly);
+      expect(testItem.laborValue.laborHours, 40.0);
+      expect(testItem.crewSize, 2);
+      expect(testItem.description, 'Electrical installation');
+    });
+
+    test('itemType is always labor', () {
+      expect(testItem.itemType, CostItemType.labor);
+    });
+
+    test('copyWith creates new instance with updated values', () {
+      final updated = testItem.copyWith(
+        laborCalcMethod: LaborCalculationMethodType.daily,
+      );
+
+      expect(updated.laborCalcMethod, LaborCalculationMethodType.daily);
+      expect(updated.id, testItem.id);
+      expect(updated.itemName, testItem.itemName);
+    });
+
+    test('copyWith can update crew size', () {
+      final updated = testItem.copyWith(crewSize: 5);
+
+      expect(updated.crewSize, 5);
+      expect(updated.laborCalcMethod, testItem.laborCalcMethod);
+    });
+
+    test('copyWith can clear nullable fields using clearField', () {
+      final updated = testItem.copyWith(
+        crewSize: clearField(),
+        productLink: clearField(),
+        description: clearField(),
+      );
+
+      expect(updated.crewSize, isNull);
+      expect(updated.productLink, isNull);
+      expect(updated.description, isNull);
+      expect(updated.itemName, testItem.itemName); // Preserved
+      expect(updated.laborCalcMethod, testItem.laborCalcMethod); // Preserved
+    });
+
+    test('copyWith preserves nullable fields when not specified', () {
+      final updated = testItem.copyWith(itemName: 'Updated Labor');
+
+      expect(updated.itemName, 'Updated Labor');
+      expect(updated.crewSize, testItem.crewSize); // Preserved
+      expect(updated.description, testItem.description); // Preserved
+    });
+
+    test('two LaborCostItem objects with same values are equal', () {
+      final item1 = LaborCostItem(
+        id: 'item-2',
+        estimateId: 'estimate-1',
+        itemName: 'Electrician Work',
+        calculation: const {'hours': 40.0},
+        itemTotalCost: 2000.0,
+        createdAt: DateTime(2024, 1, 1),
+        updatedAt: DateTime(2024, 1, 1),
+        laborCalcMethod: LaborCalculationMethodType.hourly,
+        laborValue: const LaborValue(laborHours: 40.0),
+      );
+
+      final item2 = LaborCostItem(
+        id: 'item-2',
+        estimateId: 'estimate-1',
+        itemName: 'Electrician Work',
+        calculation: const {'hours': 40.0},
+        itemTotalCost: 2000.0,
+        createdAt: DateTime(2024, 1, 1),
+        updatedAt: DateTime(2024, 1, 1),
+        laborCalcMethod: LaborCalculationMethodType.hourly,
+        laborValue: const LaborValue(laborHours: 40.0),
+      );
+
+      expect(item1, item2);
+    });
+
+    test('two LaborCostItem objects with different values are not equal', () {
+      final item2 = testItem.copyWith(crewSize: 5);
+
+      expect(testItem, isNot(item2));
+    });
+  });
+
+  group('EquipmentCostItem', () {
+    final testItem = EquipmentCostItem(
+      id: 'item-3',
+      estimateId: 'estimate-1',
+      itemName: 'Excavator Rental',
+      calculation: const {'days': 5.0, 'rate': 500.0},
+      itemTotalCost: 2500.0,
+      createdAt: DateTime(2024, 1, 1),
+      updatedAt: DateTime(2024, 1, 1),
+      unitPrice: const Money(amount: 500.0, currency: 'USD'),
+      quantity: const Quantity(value: 5.0, unit: Unit.days),
+      productLink: 'https://example.com/excavator',
+      description: 'Heavy equipment rental',
+    );
+
+    test('creates EquipmentCostItem with all fields', () {
+      expect(testItem.id, 'item-3');
+      expect(testItem.estimateId, 'estimate-1');
+      expect(testItem.itemName, 'Excavator Rental');
+      expect(testItem.itemType, CostItemType.equipment);
+      expect(testItem.unitPrice.amount, 500.0);
+      expect(testItem.quantity.value, 5.0);
+      expect(testItem.quantity.unit, Unit.days);
+      expect(testItem.productLink, 'https://example.com/excavator');
+      expect(testItem.description, 'Heavy equipment rental');
+    });
+
+    test('itemType is always equipment', () {
+      expect(testItem.itemType, CostItemType.equipment);
+    });
+
+    test('copyWith creates new instance with updated values', () {
+      final updated = testItem.copyWith(itemName: 'Updated Equipment');
+
+      expect(updated.itemName, 'Updated Equipment');
+      expect(updated.id, testItem.id);
+      expect(updated.estimateId, testItem.estimateId);
+    });
+
+    test('copyWith can update quantity', () {
+      final updated = testItem.copyWith(
+        quantity: const Quantity(value: 10.0, unit: Unit.days),
+      );
+
+      expect(updated.quantity.value, 10.0);
+      expect(updated.quantity.unit, Unit.days);
+    });
+
+    test('copyWith can clear nullable fields using clearField', () {
+      final updated = testItem.copyWith(
+        productLink: clearField(),
+        description: clearField(),
+      );
+
+      expect(updated.productLink, isNull);
+      expect(updated.description, isNull);
+      expect(updated.itemName, testItem.itemName); // Preserved
+      expect(updated.unitPrice, testItem.unitPrice); // Preserved
+    });
+
+    test('copyWith preserves nullable fields when not specified', () {
+      final updated = testItem.copyWith(itemName: 'Updated Equipment');
+
+      expect(updated.itemName, 'Updated Equipment');
+      expect(updated.productLink, testItem.productLink); // Preserved
+      expect(updated.description, testItem.description); // Preserved
+    });
+
+    test('two EquipmentCostItem objects with same values are equal', () {
+      final item1 = EquipmentCostItem(
+        id: 'item-3',
+        estimateId: 'estimate-1',
+        itemName: 'Excavator Rental',
+        calculation: const {'days': 5.0},
+        itemTotalCost: 2500.0,
+        createdAt: DateTime(2024, 1, 1),
+        updatedAt: DateTime(2024, 1, 1),
+        unitPrice: const Money(amount: 500.0),
+        quantity: const Quantity(value: 5.0, unit: Unit.days),
+      );
+
+      final item2 = EquipmentCostItem(
+        id: 'item-3',
+        estimateId: 'estimate-1',
+        itemName: 'Excavator Rental',
+        calculation: const {'days': 5.0},
+        itemTotalCost: 2500.0,
+        createdAt: DateTime(2024, 1, 1),
+        updatedAt: DateTime(2024, 1, 1),
+        unitPrice: const Money(amount: 500.0),
+        quantity: const Quantity(value: 5.0, unit: Unit.days),
+      );
+
+      expect(item1, item2);
+    });
+
+    test(
+      'two EquipmentCostItem objects with different values are not equal',
+      () {
+        final item2 = testItem.copyWith(itemName: 'Different Equipment');
+
+        expect(testItem, isNot(item2));
+      },
+    );
+  });
+
+  group('CostItem polymorphism', () {
+    test('can store different cost item types in same list', () {
+      final items = <CostItem>[
+        MaterialCostItem(
+          id: 'item-1',
+          estimateId: 'estimate-1',
+          itemName: 'Concrete',
+          calculation: const {},
+          itemTotalCost: 5000.0,
+          createdAt: DateTime(2024, 1, 1),
+          updatedAt: DateTime(2024, 1, 1),
+          unitPrice: const Money(amount: 100.0),
+          quantity: const Quantity(value: 50.0, unit: Unit.cubicMeters),
+        ),
+        LaborCostItem(
+          id: 'item-2',
+          estimateId: 'estimate-1',
+          itemName: 'Electrician Work',
+          calculation: const {},
+          itemTotalCost: 2000.0,
+          createdAt: DateTime(2024, 1, 1),
+          updatedAt: DateTime(2024, 1, 1),
+          laborCalcMethod: LaborCalculationMethodType.hourly,
+          laborValue: const LaborValue(laborHours: 40.0),
+        ),
+        EquipmentCostItem(
+          id: 'item-3',
+          estimateId: 'estimate-1',
+          itemName: 'Excavator Rental',
+          calculation: const {},
+          itemTotalCost: 2500.0,
+          createdAt: DateTime(2024, 1, 1),
+          updatedAt: DateTime(2024, 1, 1),
+          unitPrice: const Money(amount: 500.0),
+          quantity: const Quantity(value: 5.0, unit: Unit.days),
+        ),
+      ];
+
+      expect(items.length, 3);
+      expect(items[0].itemType, CostItemType.material);
+      expect(items[1].itemType, CostItemType.labor);
+      expect(items[2].itemType, CostItemType.equipment);
+    });
+
+    test('can filter items by type using pattern matching', () {
+      final items = <CostItem>[
+        MaterialCostItem(
+          id: 'item-1',
+          estimateId: 'estimate-1',
+          itemName: 'Concrete',
+          calculation: const {},
+          itemTotalCost: 5000.0,
+          createdAt: DateTime(2024, 1, 1),
+          updatedAt: DateTime(2024, 1, 1),
+          unitPrice: const Money(amount: 100.0),
+          quantity: const Quantity(value: 50.0, unit: Unit.cubicMeters),
+        ),
+        LaborCostItem(
+          id: 'item-2',
+          estimateId: 'estimate-1',
+          itemName: 'Electrician Work',
+          calculation: const {},
+          itemTotalCost: 2000.0,
+          createdAt: DateTime(2024, 1, 1),
+          updatedAt: DateTime(2024, 1, 1),
+          laborCalcMethod: LaborCalculationMethodType.hourly,
+          laborValue: const LaborValue(laborHours: 40.0),
+        ),
+      ];
+
+      final materialItems = items.whereType<MaterialCostItem>().toList();
+      final laborItems = items.whereType<LaborCostItem>().toList();
+
+      expect(materialItems.length, 1);
+      expect(laborItems.length, 1);
+    });
+  });
+}

--- a/test/features/estimations/units/domain/entities/cost_item_entity_test.dart
+++ b/test/features/estimations/units/domain/entities/cost_item_entity_test.dart
@@ -3,10 +3,10 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   group('CostItemType enum', () {
-    test('toJson returns correct string values', () {
-      expect(CostItemType.material.toJson(), 'material');
-      expect(CostItemType.labor.toJson(), 'labor');
-      expect(CostItemType.equipment.toJson(), 'equipment');
+    test('name returns correct string values', () {
+      expect(CostItemType.material.name, 'material');
+      expect(CostItemType.labor.name, 'labor');
+      expect(CostItemType.equipment.name, 'equipment');
     });
 
     test('fromJson creates correct enum from string', () {
@@ -25,23 +25,29 @@ void main() {
       expect(CostItemType.fromJson('invalid'), CostItemType.material);
       expect(CostItemType.fromJson(''), CostItemType.material);
     });
+
+    test('round-trip serialization preserves all values', () {
+      for (final type in CostItemType.values) {
+        expect(CostItemType.fromJson(type.name), type);
+      }
+    });
   });
 
   group('Unit enum', () {
-    test('toJson returns correct string values', () {
-      expect(Unit.pieces.toJson(), 'pieces');
-      expect(Unit.meters.toJson(), 'meters');
-      expect(Unit.squareMeters.toJson(), 'squareMeters');
-      expect(Unit.cubicMeters.toJson(), 'cubicMeters');
-      expect(Unit.kilograms.toJson(), 'kilograms');
-      expect(Unit.tons.toJson(), 'tons');
-      expect(Unit.liters.toJson(), 'liters');
-      expect(Unit.hours.toJson(), 'hours');
-      expect(Unit.days.toJson(), 'days');
-      expect(Unit.boxes.toJson(), 'boxes');
-      expect(Unit.bags.toJson(), 'bags');
-      expect(Unit.rolls.toJson(), 'rolls');
-      expect(Unit.sheets.toJson(), 'sheets');
+    test('name returns correct string values', () {
+      expect(Unit.pieces.name, 'pieces');
+      expect(Unit.meters.name, 'meters');
+      expect(Unit.squareMeters.name, 'squareMeters');
+      expect(Unit.cubicMeters.name, 'cubicMeters');
+      expect(Unit.kilograms.name, 'kilograms');
+      expect(Unit.tons.name, 'tons');
+      expect(Unit.liters.name, 'liters');
+      expect(Unit.hours.name, 'hours');
+      expect(Unit.days.name, 'days');
+      expect(Unit.boxes.name, 'boxes');
+      expect(Unit.bags.name, 'bags');
+      expect(Unit.rolls.name, 'rolls');
+      expect(Unit.sheets.name, 'sheets');
     });
 
     test('fromJson creates correct enum from string', () {
@@ -60,6 +66,12 @@ void main() {
     test('fromJson returns pieces for invalid value', () {
       expect(Unit.fromJson('invalid'), Unit.pieces);
       expect(Unit.fromJson(''), Unit.pieces);
+    });
+
+    test('round-trip serialization preserves all values', () {
+      for (final unit in Unit.values) {
+        expect(Unit.fromJson(unit.name), unit);
+      }
     });
   });
 
@@ -115,6 +127,12 @@ void main() {
         LaborCalculationMethodType.fromJson('daily'),
         LaborCalculationMethodType.perHour,
       );
+    });
+
+    test('round-trip serialization preserves all values', () {
+      for (final method in LaborCalculationMethodType.values) {
+        expect(LaborCalculationMethodType.fromJson(method.toJson()), method);
+      }
     });
   });
 
@@ -256,8 +274,8 @@ void main() {
       );
 
       final updated = laborValue.copyWith(
-        laborDays: clearField(),
-        laborUnitType: clearField(),
+        laborDays: clearField,
+        laborUnitType: clearField,
       );
 
       expect(updated.laborDays, isNull);
@@ -343,8 +361,8 @@ void main() {
 
     test('copyWith can clear nullable fields using clearField', () {
       final updated = testItem.copyWith(
-        productLink: clearField(),
-        description: clearField(),
+        productLink: clearField,
+        description: clearField,
       );
 
       expect(updated.productLink, isNull);
@@ -455,9 +473,9 @@ void main() {
 
     test('copyWith can clear nullable fields using clearField', () {
       final updated = testItem.copyWith(
-        crewSize: clearField(),
-        productLink: clearField(),
-        description: clearField(),
+        crewSize: clearField,
+        productLink: clearField,
+        description: clearField,
       );
 
       expect(updated.crewSize, isNull);
@@ -563,8 +581,8 @@ void main() {
 
     test('copyWith can clear nullable fields using clearField', () {
       final updated = testItem.copyWith(
-        productLink: clearField(),
-        description: clearField(),
+        productLink: clearField,
+        description: clearField,
       );
 
       expect(updated.productLink, isNull);

--- a/test/features/estimations/units/domain/entities/cost_item_entity_test.dart
+++ b/test/features/estimations/units/domain/entities/cost_item_entity_test.dart
@@ -65,45 +65,55 @@ void main() {
 
   group('LaborCalculationMethodType enum', () {
     test('toJson returns correct string values', () {
-      expect(LaborCalculationMethodType.hourly.toJson(), 'hourly');
-      expect(LaborCalculationMethodType.daily.toJson(), 'daily');
-      expect(LaborCalculationMethodType.perUnit.toJson(), 'perUnit');
+      expect(LaborCalculationMethodType.perHour.toJson(), 'per_hour');
+      expect(LaborCalculationMethodType.perDay.toJson(), 'per_day');
+      expect(LaborCalculationMethodType.perUnit.toJson(), 'per_unit');
     });
 
     test('fromJson creates correct enum from string', () {
       expect(
-        LaborCalculationMethodType.fromJson('hourly'),
-        LaborCalculationMethodType.hourly,
+        LaborCalculationMethodType.fromJson('per_hour'),
+        LaborCalculationMethodType.perHour,
       );
       expect(
-        LaborCalculationMethodType.fromJson('daily'),
-        LaborCalculationMethodType.daily,
+        LaborCalculationMethodType.fromJson('per_day'),
+        LaborCalculationMethodType.perDay,
       );
       expect(
-        LaborCalculationMethodType.fromJson('perUnit'),
+        LaborCalculationMethodType.fromJson('per_unit'),
         LaborCalculationMethodType.perUnit,
       );
     });
 
-    test('fromJson is case-insensitive', () {
+    test('fromJson is case-sensitive and exact match', () {
+      // These should fall back to perHour as they don't match exactly
       expect(
-        LaborCalculationMethodType.fromJson('HOURLY'),
-        LaborCalculationMethodType.hourly,
+        LaborCalculationMethodType.fromJson('PER_HOUR'),
+        LaborCalculationMethodType.perHour,
       );
       expect(
-        LaborCalculationMethodType.fromJson('Daily'),
-        LaborCalculationMethodType.daily,
+        LaborCalculationMethodType.fromJson('Per_Day'),
+        LaborCalculationMethodType.perHour,
       );
     });
 
-    test('fromJson returns hourly for invalid value', () {
+    test('fromJson returns perHour for invalid value', () {
       expect(
         LaborCalculationMethodType.fromJson('invalid'),
-        LaborCalculationMethodType.hourly,
+        LaborCalculationMethodType.perHour,
       );
       expect(
         LaborCalculationMethodType.fromJson(''),
-        LaborCalculationMethodType.hourly,
+        LaborCalculationMethodType.perHour,
+      );
+      // Old format should also fall back
+      expect(
+        LaborCalculationMethodType.fromJson('hourly'),
+        LaborCalculationMethodType.perHour,
+      );
+      expect(
+        LaborCalculationMethodType.fromJson('daily'),
+        LaborCalculationMethodType.perHour,
       );
     });
   });
@@ -256,7 +266,7 @@ void main() {
       expect(updated.laborUnitValue, 25.0); // Preserved
     });
 
-    test('copyWith preserves null when parameter omitted', () {
+    test('copyWith preserves existing value when parameter omitted', () {
       const laborValue = LaborValue(laborDays: 5.0);
       final updated = laborValue.copyWith(laborHours: 40.0);
 
@@ -290,6 +300,7 @@ void main() {
       itemTotalCost: 5000.0,
       createdAt: DateTime(2024, 1, 1),
       updatedAt: DateTime(2024, 1, 1),
+      currency: 'USD',
       unitPrice: const Money(amount: 100.0, currency: 'USD'),
       quantity: const Quantity(value: 50.0, unit: Unit.cubicMeters),
       productLink: 'https://example.com/concrete',
@@ -359,6 +370,7 @@ void main() {
         itemTotalCost: 5000.0,
         createdAt: DateTime(2024, 1, 1),
         updatedAt: DateTime(2024, 1, 1),
+        currency: 'USD',
         unitPrice: const Money(amount: 100.0),
         quantity: const Quantity(value: 50.0, unit: Unit.cubicMeters),
       );
@@ -371,6 +383,7 @@ void main() {
         itemTotalCost: 5000.0,
         createdAt: DateTime(2024, 1, 1),
         updatedAt: DateTime(2024, 1, 1),
+        currency: 'USD',
         unitPrice: const Money(amount: 100.0),
         quantity: const Quantity(value: 50.0, unit: Unit.cubicMeters),
       );
@@ -397,7 +410,8 @@ void main() {
       itemTotalCost: 2000.0,
       createdAt: DateTime(2024, 1, 1),
       updatedAt: DateTime(2024, 1, 1),
-      laborCalcMethod: LaborCalculationMethodType.hourly,
+      currency: 'USD',
+      laborCalcMethod: LaborCalculationMethodType.perHour,
       laborValue: const LaborValue(
         laborHours: 40.0,
         laborUnitType: 'hourly',
@@ -412,7 +426,7 @@ void main() {
       expect(testItem.estimateId, 'estimate-1');
       expect(testItem.itemName, 'Electrician Work');
       expect(testItem.itemType, CostItemType.labor);
-      expect(testItem.laborCalcMethod, LaborCalculationMethodType.hourly);
+      expect(testItem.laborCalcMethod, LaborCalculationMethodType.perHour);
       expect(testItem.laborValue.laborHours, 40.0);
       expect(testItem.crewSize, 2);
       expect(testItem.description, 'Electrical installation');
@@ -424,10 +438,10 @@ void main() {
 
     test('copyWith creates new instance with updated values', () {
       final updated = testItem.copyWith(
-        laborCalcMethod: LaborCalculationMethodType.daily,
+        laborCalcMethod: LaborCalculationMethodType.perDay,
       );
 
-      expect(updated.laborCalcMethod, LaborCalculationMethodType.daily);
+      expect(updated.laborCalcMethod, LaborCalculationMethodType.perDay);
       expect(updated.id, testItem.id);
       expect(updated.itemName, testItem.itemName);
     });
@@ -470,7 +484,8 @@ void main() {
         itemTotalCost: 2000.0,
         createdAt: DateTime(2024, 1, 1),
         updatedAt: DateTime(2024, 1, 1),
-        laborCalcMethod: LaborCalculationMethodType.hourly,
+        currency: 'USD',
+        laborCalcMethod: LaborCalculationMethodType.perHour,
         laborValue: const LaborValue(laborHours: 40.0),
       );
 
@@ -482,7 +497,8 @@ void main() {
         itemTotalCost: 2000.0,
         createdAt: DateTime(2024, 1, 1),
         updatedAt: DateTime(2024, 1, 1),
-        laborCalcMethod: LaborCalculationMethodType.hourly,
+        currency: 'USD',
+        laborCalcMethod: LaborCalculationMethodType.perHour,
         laborValue: const LaborValue(laborHours: 40.0),
       );
 
@@ -505,6 +521,7 @@ void main() {
       itemTotalCost: 2500.0,
       createdAt: DateTime(2024, 1, 1),
       updatedAt: DateTime(2024, 1, 1),
+      currency: 'USD',
       unitPrice: const Money(amount: 500.0, currency: 'USD'),
       quantity: const Quantity(value: 5.0, unit: Unit.days),
       productLink: 'https://example.com/excavator',
@@ -573,6 +590,7 @@ void main() {
         itemTotalCost: 2500.0,
         createdAt: DateTime(2024, 1, 1),
         updatedAt: DateTime(2024, 1, 1),
+        currency: 'USD',
         unitPrice: const Money(amount: 500.0),
         quantity: const Quantity(value: 5.0, unit: Unit.days),
       );
@@ -585,6 +603,7 @@ void main() {
         itemTotalCost: 2500.0,
         createdAt: DateTime(2024, 1, 1),
         updatedAt: DateTime(2024, 1, 1),
+        currency: 'USD',
         unitPrice: const Money(amount: 500.0),
         quantity: const Quantity(value: 5.0, unit: Unit.days),
       );
@@ -613,6 +632,7 @@ void main() {
           itemTotalCost: 5000.0,
           createdAt: DateTime(2024, 1, 1),
           updatedAt: DateTime(2024, 1, 1),
+          currency: 'USD',
           unitPrice: const Money(amount: 100.0),
           quantity: const Quantity(value: 50.0, unit: Unit.cubicMeters),
         ),
@@ -624,7 +644,8 @@ void main() {
           itemTotalCost: 2000.0,
           createdAt: DateTime(2024, 1, 1),
           updatedAt: DateTime(2024, 1, 1),
-          laborCalcMethod: LaborCalculationMethodType.hourly,
+          currency: 'USD',
+          laborCalcMethod: LaborCalculationMethodType.perHour,
           laborValue: const LaborValue(laborHours: 40.0),
         ),
         EquipmentCostItem(
@@ -635,6 +656,7 @@ void main() {
           itemTotalCost: 2500.0,
           createdAt: DateTime(2024, 1, 1),
           updatedAt: DateTime(2024, 1, 1),
+          currency: 'USD',
           unitPrice: const Money(amount: 500.0),
           quantity: const Quantity(value: 5.0, unit: Unit.days),
         ),
@@ -656,6 +678,7 @@ void main() {
           itemTotalCost: 5000.0,
           createdAt: DateTime(2024, 1, 1),
           updatedAt: DateTime(2024, 1, 1),
+          currency: 'USD',
           unitPrice: const Money(amount: 100.0),
           quantity: const Quantity(value: 50.0, unit: Unit.cubicMeters),
         ),
@@ -667,7 +690,8 @@ void main() {
           itemTotalCost: 2000.0,
           createdAt: DateTime(2024, 1, 1),
           updatedAt: DateTime(2024, 1, 1),
-          laborCalcMethod: LaborCalculationMethodType.hourly,
+          currency: 'USD',
+          laborCalcMethod: LaborCalculationMethodType.perHour,
           laborValue: const LaborValue(laborHours: 40.0),
         ),
       ];


### PR DESCRIPTION
### 1. PR Summary

This PR introduces the domain entity layer for cost items. It adds a `CostItem` sealed class hierarchy (`MaterialCostItem`, `LaborCostItem`, `EquipmentCostItem`), three supporting value objects (`Money`, `Quantity`, `LaborValue`), and three enums (`CostItemType`, `Unit`, `LaborCalculationMethodType`), all with serialization support. The test file covers equality, `copyWith`, serialization, and polymorphism. **PR size is L — all production code is a single new domain entity file, which justifies the size.**

---

---

### Review Summary Table

| Issue Name | Description | Status | Notes |
|------------|-------------|--------|-------|
| `MaterialCostItem` / `EquipmentCostItem` structural duplication undocumented | The two classes are field-for-field identical. The semantic reason for keeping them separate should be documented in the class docstring to prevent future consolidation. | ✅ | |
| `LaborValue.laborUnitType` is untyped `String?` | The relationship between `laborUnitType: String?` and `LaborCalculationMethodType` is ambiguous. Should be typed or clearly documented as a distinct concept. | ✅ | |
| `calculation` field is undocumented opaque map | `Map<String, double> calculation` has no docstring explaining its shape, key semantics, or intended consumer. Will become a maintenance hazard. | ✅ | |
| `fromJson` fallback behaviour undocumented | All three enums silently fall back to a default for unknown values. The fallback and its implications should be documented. | ✅ | |
| `copyWith` cannot clear nullable fields to null | `??`-based `copyWith` on `LaborValue` and `LaborCostItem` makes it impossible to explicitly set nullable fields (`laborDays`, `crewSize`, etc.) back to `null`. No test covers this; production code needs a sentinel pattern. | ✅ | |