### PR TITLE
fix: enhance coverage reporting and filtering in CI scripts

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -80,7 +80,7 @@ workflows:
             exit 0
           fi
 
-          COVERED_SOURCES=$(grep '^SF:' coverage/lcov.info | cut -d: -f2- || true)
+          COVERED_SOURCES=$(grep '^SF:' coverage/lcov.info | cut -d: -f2-)
           EXTRACT_PATTERNS=()
           while IFS= read -r file; do
             [ -z "$file" ] && continue
@@ -94,7 +94,7 @@ workflows:
             exit 0
           fi
 
-          lcov --quiet --extract coverage/lcov.info "${EXTRACT_PATTERNS[@]}" -o coverage/changed.lcov.info --ignore-errors unused,empty 2>/dev/null || true
+          lcov --quiet --extract coverage/lcov.info "${EXTRACT_PATTERNS[@]}" -o coverage/changed.lcov.info --ignore-errors unused,empty || true
 
           # Compute coverage
           LF_RAW=""
@@ -226,8 +226,19 @@ workflows:
           fi
           sudo apt-get install -y lcov
           mkdir -p test-results
-          fvm flutter test test/features/**/units test/features/**/widgets test/libraries/**/units test/app/**/units test/app/**/widgets --coverage --machine > test-results/flutter.json
-          lcov --quiet --remove coverage/lcov.info '**/*.g.dart' '**/*.freezed.dart' '**/l10n/**' -o coverage/lcov.info --ignore-errors unused 2>/dev/null
+          
+          UNIT_TEST_DIRS=()
+          while IFS= read -r dir; do
+            [[ -n "$dir" ]] && UNIT_TEST_DIRS+=("$dir")
+          done < <(find test/features test/libraries test/app -type d \( -name "units" -o -name "widgets" \) 2>/dev/null | sort)
+          
+          if [ ${#UNIT_TEST_DIRS[@]} -gt 0 ]; then
+            fvm flutter test "${UNIT_TEST_DIRS[@]}" --coverage --machine > test-results/flutter.json
+          else
+            echo "No test directories found."
+            echo "{\"success\":true}" > test-results/flutter.json
+          fi
+          lcov --quiet --remove coverage/lcov.info '**/*.g.dart' '**/*.freezed.dart' '**/l10n/**' -o coverage/lcov.info --ignore-errors unused
           # Compute coverage
           if [ ! -f "coverage/lcov.info" ] || [ ! -s "coverage/lcov.info" ]; then
             echo "❌ Coverage file coverage/lcov.info is missing or empty."
@@ -275,18 +286,15 @@ workflows:
           fi
         test_report: test-results/flutter.json
 
-      - name: Run Widget Tests
-        script: |
-          if find test/features -type f -path "*/widgets/*.dart" 2>/dev/null | grep -q .; then
-            fvm flutter test test/features/**/widgets
-          else
-            echo "No widget tests found. Skipping."
-          fi
-
       - name: Run Screenshot Tests
         script: |
-          if find test/features -type f -path "*/screenshots/*.dart" 2>/dev/null | grep -q .; then
-            fvm flutter test test/features/**/screenshots
+          SCREENSHOT_TEST_DIRS=()
+          while IFS= read -r dir; do
+            [[ -n "$dir" ]] && SCREENSHOT_TEST_DIRS+=("$dir")
+          done < <(find test/features -type d -name "screenshots" 2>/dev/null | sort)
+          
+          if [ ${#SCREENSHOT_TEST_DIRS[@]} -gt 0 ]; then
+            fvm flutter test "${SCREENSHOT_TEST_DIRS[@]}"
           else
             echo "No screenshot tests found. Skipping."
           fi
@@ -398,8 +406,19 @@ workflows:
           fi
           HOMEBREW_NO_AUTO_UPDATE=1 brew install lcov
           mkdir -p test-results
-          fvm flutter test test/features/**/units test/features/**/widgets test/libraries/**/units test/app/**/units test/app/**/widgets --coverage --machine > test-results/flutter.json
-          lcov --quiet --remove coverage/lcov.info '**/*.g.dart' '**/*.freezed.dart' '**/l10n/**' -o coverage/lcov.info --ignore-errors unused 2>/dev/null
+          
+          UNIT_TEST_DIRS=()
+          while IFS= read -r dir; do
+            [[ -n "$dir" ]] && UNIT_TEST_DIRS+=("$dir")
+          done < <(find test/features test/libraries test/app -type d \( -name "units" -o -name "widgets" \) 2>/dev/null | sort)
+          
+          if [ ${#UNIT_TEST_DIRS[@]} -gt 0 ]; then
+            fvm flutter test "${UNIT_TEST_DIRS[@]}" --coverage --machine > test-results/flutter.json
+          else
+            echo "No test directories found."
+            echo "{\"success\":true}" > test-results/flutter.json
+          fi
+          lcov --quiet --remove coverage/lcov.info '**/*.g.dart' '**/*.freezed.dart' '**/l10n/**' -o coverage/lcov.info --ignore-errors unused
           # Compute coverage
           if [ ! -f "coverage/lcov.info" ] || [ ! -s "coverage/lcov.info" ]; then
             echo "❌ Coverage file coverage/lcov.info is missing or empty."
@@ -447,18 +466,15 @@ workflows:
           fi
         test_report: test-results/flutter.json
 
-      - name: Run Widget Tests
-        script: |
-          if find test/features -type f -path "*/widgets/*.dart" 2>/dev/null | grep -q .; then
-            fvm flutter test test/features/**/widgets
-          else
-            echo "No widget tests found. Skipping."
-          fi
-
       - name: Run Screenshot Tests
         script: |
-          if find test/features -type f -path "*/screenshots/*.dart" 2>/dev/null | grep -q .; then
-            fvm flutter test test/features/**/screenshots
+          SCREENSHOT_TEST_DIRS=()
+          while IFS= read -r dir; do
+            [[ -n "$dir" ]] && SCREENSHOT_TEST_DIRS+=("$dir")
+          done < <(find test/features -type d -name "screenshots" 2>/dev/null | sort)
+          
+          if [ ${#SCREENSHOT_TEST_DIRS[@]} -gt 0 ]; then
+            fvm flutter test "${SCREENSHOT_TEST_DIRS[@]}"
           else
             echo "No screenshot tests found. Skipping."
           fi

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -71,15 +71,38 @@ workflows:
           HOMEBREW_NO_AUTO_UPDATE=1 brew install lcov
           mkdir -p test-results
           fvm flutter test $CHANGED_TESTS --coverage --machine > test-results/flutter.json
-          lcov --remove coverage/lcov.info '**/*.g.dart' '**/*.freezed.dart' '**/l10n/**' -o coverage/lcov.info
-          # Compute coverage
-          if [ ! -f "coverage/lcov.info" ] || [ ! -s "coverage/lcov.info" ]; then
-            echo "❌ Coverage file coverage/lcov.info is missing or empty."
-            exit 1
+          lcov --quiet --remove coverage/lcov.info '**/*.g.dart' '**/*.freezed.dart' '**/l10n/**' -o coverage/lcov.info --ignore-errors unused 2>/dev/null
+
+          CHANGED_SOURCE_FILES=$(git diff --name-only --diff-filter=d $BASE_COMMIT HEAD -- 'lib/**/*.dart' | grep -v -E '(\.g\.dart$|\.freezed\.dart$|/generated/|/l10n/)' || true)
+
+          if [ -z "$CHANGED_SOURCE_FILES" ]; then
+            echo "✅ No changed source files in lib/. Skipping coverage threshold check."
+            exit 0
           fi
 
-          LF_RAW=$(grep '^LF:' coverage/lcov.info | cut -d: -f2 || true)
-          LH_RAW=$(grep '^LH:' coverage/lcov.info | cut -d: -f2 || true)
+          COVERED_SOURCES=$(grep '^SF:' coverage/lcov.info | cut -d: -f2- || true)
+          EXTRACT_PATTERNS=()
+          while IFS= read -r file; do
+            [ -z "$file" ] && continue
+            if printf '%s\n' "$COVERED_SOURCES" | grep -Fxq "$file" || printf '%s\n' "$COVERED_SOURCES" | grep -Fxq "$FCI_BUILD_DIR/$file"; then
+              EXTRACT_PATTERNS+=("*/$file")
+            fi
+          done <<< "$CHANGED_SOURCE_FILES"
+
+          if [ ${#EXTRACT_PATTERNS[@]} -eq 0 ]; then
+            echo "✅ No changed source files with coverage records. Skipping coverage threshold check."
+            exit 0
+          fi
+
+          lcov --quiet --extract coverage/lcov.info "${EXTRACT_PATTERNS[@]}" -o coverage/changed.lcov.info --ignore-errors unused,empty 2>/dev/null || true
+
+          # Compute coverage
+          LF_RAW=""
+          LH_RAW=""
+          if [ -f "coverage/changed.lcov.info" ] && [ -s "coverage/changed.lcov.info" ]; then
+            LF_RAW=$(grep '^LF:' coverage/changed.lcov.info | cut -d: -f2 || true)
+            LH_RAW=$(grep '^LH:' coverage/changed.lcov.info | cut -d: -f2 || true)
+          fi
 
           if [ -z "$LF_RAW" ]; then
               LF_SUM=0
@@ -103,13 +126,13 @@ workflows:
           fi
 
           if [ "$LF_SUM" -eq 0 ]; then
-            COVERAGE_PERCENT="0.00"
-            echo "⚠️ LF (total lines found) is 0. Setting coverage to 0.00%."
+            echo "⚠️ No valid coverage records found for changed source files. Skipping coverage threshold check."
+            exit 0
           else
             COVERAGE_PERCENT=$(echo "scale=2; $LH_SUM*100/$LF_SUM" | bc)
           fi
 
-          echo "Code Coverage: ${COVERAGE_PERCENT}%"
+          echo "Changed source coverage: ${COVERAGE_PERCENT}%"
 
           if (( $(echo "$COVERAGE_PERCENT < $TARGET" | bc -l) )); then
             echo "❌ Coverage is $COVERAGE_PERCENT%, below $TARGET%"
@@ -204,7 +227,7 @@ workflows:
           sudo apt-get install -y lcov
           mkdir -p test-results
           fvm flutter test test/features/**/units test/features/**/widgets test/libraries/**/units test/app/**/units test/app/**/widgets --coverage --machine > test-results/flutter.json
-          lcov --remove coverage/lcov.info '**/*.g.dart' '**/*.freezed.dart' '**/l10n/**' -o coverage/lcov.info
+          lcov --quiet --remove coverage/lcov.info '**/*.g.dart' '**/*.freezed.dart' '**/l10n/**' -o coverage/lcov.info --ignore-errors unused 2>/dev/null
           # Compute coverage
           if [ ! -f "coverage/lcov.info" ] || [ ! -s "coverage/lcov.info" ]; then
             echo "❌ Coverage file coverage/lcov.info is missing or empty."
@@ -376,7 +399,7 @@ workflows:
           HOMEBREW_NO_AUTO_UPDATE=1 brew install lcov
           mkdir -p test-results
           fvm flutter test test/features/**/units test/features/**/widgets test/libraries/**/units test/app/**/units test/app/**/widgets --coverage --machine > test-results/flutter.json
-          lcov --remove coverage/lcov.info '**/*.g.dart' '**/*.freezed.dart' '**/l10n/**' -o coverage/lcov.info
+          lcov --quiet --remove coverage/lcov.info '**/*.g.dart' '**/*.freezed.dart' '**/l10n/**' -o coverage/lcov.info --ignore-errors unused 2>/dev/null
           # Compute coverage
           if [ ! -f "coverage/lcov.info" ] || [ ! -s "coverage/lcov.info" ]; then
             echo "❌ Coverage file coverage/lcov.info is missing or empty."

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -50,12 +50,19 @@ workflows:
           # Find the common ancestor commit between source and target branches
           BASE_COMMIT=$(git merge-base HEAD origin/$CM_PULL_REQUEST_DEST)
 
-          # Find changed test files
-          CHANGED_UNIT_TESTS=$(git diff --name-only --diff-filter=d $BASE_COMMIT HEAD -- "test/features/**/units/*.dart" "test/libraries/**/units/*.dart" "test/app/**/units/*.dart")
-          CHANGED_WIDGET_TESTS=$(git diff --name-only --diff-filter=d $BASE_COMMIT HEAD -- "test/features/**/widgets/*.dart" "test/app/**/widgets/*.dart")
+          # Find changed test files using find to avoid ** globbing issues
+          TEST_DIRS=$(find test/features test/libraries test/app -type d \
+            \( -name "units" -o -name "widgets" \) 2>/dev/null | sort)
 
-          # Combine all changed tests
-          CHANGED_TESTS="$CHANGED_UNIT_TESTS $CHANGED_WIDGET_TESTS"
+          CHANGED_TESTS=""
+          if [ -n "$TEST_DIRS" ]; then
+            PATTERNS=()
+            while IFS= read -r dir; do
+              [ -n "$dir" ] && PATTERNS+=("$dir/*.dart")
+            done <<< "$TEST_DIRS"
+            CHANGED_TESTS=$(git diff --name-only --diff-filter=d $BASE_COMMIT HEAD -- "${PATTERNS[@]}")
+          fi
+
 
           if [ -z "$CHANGED_TESTS" ]; then
             echo "✅ No test files modified. Skipping tests..."
@@ -147,12 +154,19 @@ workflows:
           # Find the common ancestor commit between source and target branches
           BASE_COMMIT=$(git merge-base HEAD origin/$CM_PULL_REQUEST_DEST)
 
-          # Find changed test files
-          CHANGED_UNIT_TESTS=$(git diff --name-only --diff-filter=d $BASE_COMMIT HEAD -- "test/features/**/units/*.dart" "test/libraries/**/units/*.dart" "test/app/**/units/*.dart")
-          CHANGED_WIDGET_TESTS=$(git diff --name-only --diff-filter=d $BASE_COMMIT HEAD -- "test/features/**/widgets/*.dart" "test/app/**/widgets/*.dart")
+          # Find changed test files using find to avoid ** globbing issues
+          TEST_DIRS=$(find test/features test/libraries test/app -type d \
+            \( -name "units" -o -name "widgets" \) 2>/dev/null | sort)
 
-          # Combine all changed tests
-          CHANGED_TESTS="$CHANGED_UNIT_TESTS $CHANGED_WIDGET_TESTS"
+          CHANGED_TESTS=""
+          if [ -n "$TEST_DIRS" ]; then
+            PATTERNS=()
+            while IFS= read -r dir; do
+              [ -n "$dir" ] && PATTERNS+=("$dir/*.dart")
+            done <<< "$TEST_DIRS"
+            CHANGED_TESTS=$(git diff --name-only --diff-filter=d $BASE_COMMIT HEAD -- "${PATTERNS[@]}")
+          fi
+
 
           if [ -z "$CHANGED_TESTS" ]; then
             echo "✅ No test files modified. Skipping tests..."

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -78,7 +78,7 @@ workflows:
           HOMEBREW_NO_AUTO_UPDATE=1 brew install lcov
           mkdir -p test-results
           fvm flutter test $CHANGED_TESTS --coverage --machine > test-results/flutter.json
-          lcov --quiet --remove coverage/lcov.info '**/*.g.dart' '**/*.freezed.dart' '**/l10n/**' -o coverage/lcov.info --ignore-errors unused 2>/dev/null
+          lcov --quiet --remove coverage/lcov.info '**/*.g.dart' '**/*.freezed.dart' '**/l10n/**' -o coverage/lcov.info --ignore-errors unused
 
           CHANGED_SOURCE_FILES=$(git diff --name-only --diff-filter=d $BASE_COMMIT HEAD -- 'lib/**/*.dart' | grep -v -E '(\.g\.dart$|\.freezed\.dart$|/generated/|/l10n/)' || true)
 
@@ -101,7 +101,7 @@ workflows:
             exit 0
           fi
 
-          lcov --quiet --extract coverage/lcov.info "${EXTRACT_PATTERNS[@]}" -o coverage/changed.lcov.info --ignore-errors unused,empty || true
+          lcov --quiet --extract coverage/lcov.info "${EXTRACT_PATTERNS[@]}" -o coverage/changed.lcov.info --ignore-errors unused,empty
 
           # Compute coverage
           LF_RAW=""

--- a/scripts/run_check.sh
+++ b/scripts/run_check.sh
@@ -74,7 +74,7 @@ filter_coverage_tracefile() {
     '**/*.freezed.dart' \
     '**/l10n/**' \
     -o "$tracefile" \
-    --ignore-errors unused 2>/dev/null
+    --ignore-errors unused
 }
 
 build_extract_patterns_from_tracefile() {
@@ -170,7 +170,7 @@ pre_check() {
         if [[ ${#extract_patterns[@]} -eq 0 ]]; then
           echo "✅ No changed source files with coverage records. Skipping coverage threshold check."
         else
-          lcov --quiet --extract coverage/lcov.info "${extract_patterns[@]}" -o coverage/changed.lcov.info --ignore-errors unused,empty 2>/dev/null || true
+          lcov --quiet --extract coverage/lcov.info "${extract_patterns[@]}" -o coverage/changed.lcov.info --ignore-errors unused,empty
 
           local lf=0
           local lh=0

--- a/scripts/run_check.sh
+++ b/scripts/run_check.sh
@@ -252,7 +252,9 @@ comprehensive_check() {
   run_custom_linter "$filtered_files"
 
   local unit_test_dirs=()
-  mapfile -t unit_test_dirs < <(
+  while IFS= read -r dir; do
+    [[ -n "$dir" ]] && unit_test_dirs+=("$dir")
+  done < <(
     find test/features test/libraries test/app -type d \
       \( -name "units" -o -name "widgets" \) 2>/dev/null | sort
   )

--- a/scripts/run_check.sh
+++ b/scripts/run_check.sh
@@ -131,12 +131,20 @@ pre_check() {
   fi
 
   # Changed tests
-  local changed_tests=$(git diff --name-only --diff-filter=d "$base_commit" -- \
-    "test/features/**/units/*.dart" \
-    "test/features/**/widgets/*.dart" \
-    "test/libraries/**/units/*.dart" \
-    "test/app/**/units/*.dart" \
-    "test/app/**/widgets/*.dart")
+  local test_dirs=()
+  while IFS= read -r dir; do
+    [[ -n "$dir" ]] && test_dirs+=("$dir")
+  done < <(find test/features test/libraries test/app -type d \
+    \( -name "units" -o -name "widgets" \) 2>/dev/null | sort)
+
+  local changed_tests=""
+  if [[ ${#test_dirs[@]} -gt 0 ]]; then
+    local patterns=()
+    for dir in "${test_dirs[@]}"; do
+      patterns+=("$dir/*.dart")
+    done
+    changed_tests=$(git diff --name-only --diff-filter=d "$base_commit" -- "${patterns[@]}")
+  fi
 
   if [[ -z "$changed_tests" ]]; then
     echo "✅ No tests changed"

--- a/scripts/run_check.sh
+++ b/scripts/run_check.sh
@@ -65,6 +65,41 @@ check_dependencies() {
   fi
 }
 
+filter_coverage_tracefile() {
+  local tracefile="$1"
+
+  lcov --quiet --remove \
+    "$tracefile" \
+    '**/*.g.dart' \
+    '**/*.freezed.dart' \
+    '**/l10n/**' \
+    -o "$tracefile" \
+    --ignore-errors unused 2>/dev/null
+}
+
+build_extract_patterns_from_tracefile() {
+  local tracefile="$1"
+  local changed_files="$2"
+
+  declare -A covered_sources=()
+  local source_file
+
+  while IFS= read -r source_file; do
+    [[ -z "$source_file" ]] && continue
+    covered_sources["$source_file"]=1
+
+    if [[ "$source_file" == "$PWD/"* ]]; then
+      covered_sources["${source_file#"$PWD"/}"]=1
+    fi
+  done < <(grep '^SF:' "$tracefile" | cut -d: -f2-)
+
+  local file
+  while IFS= read -r file; do
+    [[ -z "$file" ]] && continue
+    [[ -n "${covered_sources[$file]:-}" ]] && printf '*/%s\n' "$file"
+  done <<< "$changed_files"
+}
+
 pre_check() {
   echo "🚀 Running Pre-check..."
 
@@ -115,19 +150,46 @@ pre_check() {
   else
     echo "🧪 Running changed tests..."
     fvm flutter test $changed_tests --update-goldens --coverage
-    lcov --remove coverage/lcov.info '**/*.g.dart' '**/*.freezed.dart' -o coverage/lcov.info --ignore-errors unused
 
     # Process coverage
     if [[ -s "coverage/lcov.info" ]]; then
-      lcov --remove coverage/lcov.info '**/*.g.dart' '**/l10n/**' -o coverage/lcov.info --ignore-errors unused
-      local lf=$(grep '^LF:' coverage/lcov.info | cut -d: -f2 | awk '{sum+=$1} END {print sum}')
-      local lh=$(grep '^LH:' coverage/lcov.info | cut -d: -f2 | awk '{sum+=$1} END {print sum}')
-      local coverage=$(echo "scale=2; $lh*100/$lf" | bc)
+      filter_coverage_tracefile "coverage/lcov.info"
 
-      echo "📊 Coverage: $coverage% (Target: ${ARC_CODE_COVERAGE_TARGET}%)"
-      if (( $(echo "$coverage < $ARC_CODE_COVERAGE_TARGET" | bc -l) )); then
-        echo "❌ Low coverage"
-        exit 1
+      local changed_source_files
+      changed_source_files=$(git diff --name-only --diff-filter=d "$base_commit" HEAD -- 'lib/**/*.dart' | grep -v -E '(\.g\.dart$|\.freezed\.dart$|/generated/|/l10n/)' || true)
+
+      if [[ -z "$changed_source_files" ]]; then
+        echo "✅ No changed source files in lib/. Skipping coverage threshold check for --pre."
+      else
+        local extract_patterns=()
+        while IFS= read -r file; do
+          [[ -n "$file" ]] && extract_patterns+=("$file")
+        done < <(build_extract_patterns_from_tracefile "coverage/lcov.info" "$changed_source_files")
+
+        if [[ ${#extract_patterns[@]} -eq 0 ]]; then
+          echo "✅ No changed source files with coverage records. Skipping coverage threshold check."
+        else
+          lcov --quiet --extract coverage/lcov.info "${extract_patterns[@]}" -o coverage/changed.lcov.info --ignore-errors unused,empty 2>/dev/null || true
+
+          local lf=0
+          local lh=0
+          if [[ -s "coverage/changed.lcov.info" ]]; then
+            lf=$(grep '^LF:' coverage/changed.lcov.info | cut -d: -f2 | awk '{sum+=$1} END {print sum+0}')
+            lh=$(grep '^LH:' coverage/changed.lcov.info | cut -d: -f2 | awk '{sum+=$1} END {print sum+0}')
+          fi
+
+          if [[ "$lf" -eq 0 ]]; then
+            echo "⚠️ No valid coverage records found for changed source files. Skipping coverage threshold check."
+          else
+            local coverage
+            coverage=$(echo "scale=2; $lh*100/$lf" | bc)
+            echo "📊 Changed source coverage: $coverage% (Target: ${ARC_CODE_COVERAGE_TARGET}%)"
+            if (( $(echo "$coverage < $ARC_CODE_COVERAGE_TARGET" | bc -l) )); then
+              echo "❌ Low coverage"
+              exit 1
+            fi
+          fi
+        fi
       fi
     else
       echo "❌ Coverage file missing"
@@ -189,22 +251,20 @@ comprehensive_check() {
   local filtered_files=$(echo "$changed_dart_files" | grep -v -E "(lib/generated/|\.g\.dart$|\.freezed\.dart$|lib/l10n/generated/)")
   run_custom_linter "$filtered_files"
 
-  if find test/features -type d -name "units" 2>/dev/null | grep -q . || \
-     find test/features -type d -name "widgets" 2>/dev/null | grep -q . || \
-     find test/libraries -type d -name "units" 2>/dev/null | grep -q .; then
+  local unit_test_dirs=()
+  mapfile -t unit_test_dirs < <(
+    find test/features test/libraries test/app -type d \
+      \( -name "units" -o -name "widgets" \) 2>/dev/null | sort
+  )
+
+  if [[ ${#unit_test_dirs[@]} -gt 0 ]]; then
     echo "🧪 Unit tests with coverage..."
     mkdir -p test-results
-    fvm flutter test \
-    test/libraries/**/units \
-    test/features/**/units \
-    test/app/**/units \
-    test/app/**/widgets \
-    test/features/**/widgets \
-    --coverage --machine > test-results/flutter.json
+    fvm flutter test "${unit_test_dirs[@]}" --coverage --machine > test-results/flutter.json
 
     # Process coverage
     if [[ -s "coverage/lcov.info" ]]; then
-      lcov --remove coverage/lcov.info '**/*.g.dart' '**/l10n/**' -o coverage/lcov.info --ignore-errors unused
+      filter_coverage_tracefile "coverage/lcov.info"
       
       # Show individual file coverage
       echo "📊 Individual file coverage:"

--- a/scripts/run_check.sh
+++ b/scripts/run_check.sh
@@ -81,22 +81,15 @@ build_extract_patterns_from_tracefile() {
   local tracefile="$1"
   local changed_files="$2"
 
-  declare -A covered_sources=()
-  local source_file
-
-  while IFS= read -r source_file; do
-    [[ -z "$source_file" ]] && continue
-    covered_sources["$source_file"]=1
-
-    if [[ "$source_file" == "$PWD/"* ]]; then
-      covered_sources["${source_file#"$PWD"/}"]=1
-    fi
-  done < <(grep '^SF:' "$tracefile" | cut -d: -f2-)
+  local covered_sources
+  covered_sources=$(grep '^SF:' "$tracefile" | cut -d: -f2- || true)
 
   local file
   while IFS= read -r file; do
     [[ -z "$file" ]] && continue
-    [[ -n "${covered_sources[$file]:-}" ]] && printf '*/%s\n' "$file"
+    if printf '%s\n' "$covered_sources" | grep -Fxq "$file" || printf '%s\n' "$covered_sources" | grep -Fxq "$PWD/$file"; then
+      printf '*/%s\n' "$file"
+    fi
   done <<< "$changed_files"
 }
 
@@ -305,11 +298,14 @@ comprehensive_check() {
   fi
 
   # Screenshot tests
-  if find test/features -type f -path "*/screenshots/*.dart" 2>/dev/null | grep -q .; then
+  local screenshot_test_dirs=()
+  while IFS= read -r dir; do
+    [[ -n "$dir" ]] && screenshot_test_dirs+=("$dir")
+  done < <(find test/features -type d -name "screenshots" 2>/dev/null | sort)
+
+  if [[ ${#screenshot_test_dirs[@]} -gt 0 ]]; then
     echo "🖼️ Screenshot tests..."
-    fvm flutter test \
-    test/features/**/screenshots \
-    --update-goldens
+    fvm flutter test "${screenshot_test_dirs[@]}" --update-goldens
   else
     echo "⏩ Skipping screenshot tests: no screenshot test files found."
   fi


### PR DESCRIPTION
## Summary

This updates the changed-file coverage flow so it only extracts coverage for changed source files that still exist in coverage/lcov.info after filtering. It also reduces lcov noise and keeps the Codemagic coverage logic aligned with the local
scripts/run_check.sh behavior.

## Problem

The previous flow could:

- filter files out of coverage/lcov.info
- then try to lcov --extract those same files for changed-source coverage

When that happened, lcov produced:

- unused include pattern warnings
- empty coverage/changed.lcov.info
- skipped changed-source coverage checks with No valid coverage records found for changed source files

This made the logs noisy and the changed-source coverage check unreliable.

Additionally, new source files introduced without tests bypass the changed-source check entirely. This pre-existing coverage gap has been documented in [CA-658](https://ripplearc.youtrack.cloud/issue/CA-658/Coverage-gap-New-files-without-tests-are-skipped-entirely-by-changed-source-coverage-check).

## What Changed

- Added a single coverage tracefile cleanup step for generated and l10n files.
- Updated changed-source coverage extraction to intersect changed lib/**/*.dart files with actual SF: entries still present in coverage/lcov.info.
- Kept extraction limited to files with valid coverage records.
- Reduced noisy lcov output with quiet/error-tolerant filtering.
- Updated Codemagic to follow the same changed-source coverage behavior as the local script.
- Made Codemagic tolerant of both relative and absolute SF: paths.

## Result

- Changed-source coverage is now calculated from coverage/changed.lcov.info only when valid records exist.
- False empty extractions and related lcov warnings are avoided.
- CI and local coverage behavior are aligned more closely.

## Validation

- Validated scripts/run_check.sh syntax with bash -n.
- Did not run the full Codemagic pipeline locally.
