### PR TITLE
CA-151: feat: create dtos and their tests

### DIFF
--- a/lib/features/estimation/data/models/cost_item_dto.dart
+++ b/lib/features/estimation/data/models/cost_item_dto.dart
@@ -1,0 +1,330 @@
+import 'package:construculator/features/estimation/domain/entities/cost_item_entity.dart';
+import 'package:construculator/libraries/logging/app_logger.dart';
+import 'package:equatable/equatable.dart';
+
+/// Data Transfer Object for CostItem entity.
+///
+/// This DTO represents the serialized form of a cost item as it appears
+/// in the database or API responses. It handles the conversion between the
+/// flat database structure and the domain entity's nested object structure.
+///
+/// The DTO contains all possible fields for material, labor, and equipment cost items.
+/// The specific fields populated depend on the item_type value.
+class CostItemDto extends Equatable {
+  static final _logger = AppLogger().tag('CostItemDto');
+
+  /// Unique identifier for the cost item.
+  final String id;
+
+  /// ID of the estimate this cost item belongs to.
+  final String estimateId;
+
+  /// Name of the cost item.
+  final String itemName;
+
+  /// Type of cost item: 'material', 'labor', or 'equipment'.
+  final String itemType;
+
+  /// Calculation breakdown for the cost item.
+  final Map<String, dynamic> calculation;
+
+  /// Total calculated cost for this item.
+  final double itemTotalCost;
+
+  /// ISO 8601 timestamp when the cost item was created.
+  final String createdAt;
+
+  /// ISO 8601 timestamp when the cost item was last updated.
+  final String updatedAt;
+
+  /// Optional URL link to product information.
+  final String? productLink;
+
+  /// Optional description of the cost item.
+  final String? description;
+
+  // Material and Equipment specific fields
+
+  /// Unit price for material or equipment items.
+  final double? unitPrice;
+
+  /// Quantity value for material or equipment items.
+  final double? quantity;
+
+  /// Unit of measurement for material or equipment items.
+  final String? unitMeasurement;
+
+  // Labor specific fields
+
+  /// Labor calculation method: 'per_hour', 'per_day', or 'per_unit'.
+  final String? laborCalcMethod;
+
+  /// Number of labor days.
+  final double? laborDays;
+
+  /// Number of labor hours.
+  final double? laborHours;
+
+  /// Type of labor unit.
+  final String? laborUnitType;
+
+  /// Value per labor unit.
+  final double? laborUnitValue;
+
+  /// Size of the crew for labor items.
+  final int? crewSize;
+
+  /// Creates a new [CostItemDto] instance.
+  const CostItemDto({
+    required this.id,
+    required this.estimateId,
+    required this.itemName,
+    required this.itemType,
+    required this.calculation,
+    required this.itemTotalCost,
+    required this.createdAt,
+    required this.updatedAt,
+    this.productLink,
+    this.description,
+    this.unitPrice,
+    this.quantity,
+    this.unitMeasurement,
+    this.laborCalcMethod,
+    this.laborDays,
+    this.laborHours,
+    this.laborUnitType,
+    this.laborUnitValue,
+    this.crewSize,
+  });
+
+  /// Creates a [CostItemDto] from a JSON map.
+  ///
+  /// This factory method handles the conversion from the database/API JSON format
+  /// to the DTO structure. It performs type conversion for numeric values and
+  /// maps snake_case JSON keys to camelCase Dart properties.
+  factory CostItemDto.fromJson(Map<String, dynamic> json) {
+    return CostItemDto(
+      id: json['id'] as String,
+      estimateId: json['estimate_id'] as String,
+      itemName: json['item_name'] as String,
+      itemType: json['item_type'] as String,
+      calculation: Map<String, dynamic>.from(json['calculation'] as Map? ?? {}),
+      itemTotalCost: (json['item_total_cost'] as num).toDouble(),
+      createdAt: json['created_at'] as String,
+      updatedAt: json['updated_at'] as String,
+      productLink: json['product_link'] as String?,
+      description: json['description'] as String?,
+      unitPrice: json['unit_price'] != null
+          ? (json['unit_price'] as num).toDouble()
+          : null,
+      quantity: json['quantity'] != null
+          ? (json['quantity'] as num).toDouble()
+          : null,
+      unitMeasurement: json['unit_measurement'] as String?,
+      laborCalcMethod: json['labor_calc_method'] as String?,
+      laborDays: json['labor_days'] != null
+          ? (json['labor_days'] as num).toDouble()
+          : null,
+      laborHours: json['labor_hours'] != null
+          ? (json['labor_hours'] as num).toDouble()
+          : null,
+      laborUnitType: json['labor_unit_type'] as String?,
+      laborUnitValue: json['labor_unit_value'] != null
+          ? (json['labor_unit_value'] as num).toDouble()
+          : null,
+      crewSize: json['crew_size'] as int?,
+    );
+  }
+
+  /// Converts this DTO to a JSON map.
+  ///
+  /// This method converts the DTO back to the database/API JSON format,
+  /// mapping camelCase Dart properties to snake_case JSON keys.
+  Map<String, dynamic> toJson() => {
+    'id': id,
+    'estimate_id': estimateId,
+    'item_name': itemName,
+    'item_type': itemType,
+    'calculation': calculation,
+    'item_total_cost': itemTotalCost,
+    'created_at': createdAt,
+    'updated_at': updatedAt,
+    'product_link': productLink,
+    'description': description,
+    'unit_price': unitPrice,
+    'quantity': quantity,
+    'unit_measurement': unitMeasurement,
+    'labor_calc_method': laborCalcMethod,
+    'labor_days': laborDays,
+    'labor_hours': laborHours,
+    'labor_unit_type': laborUnitType,
+    'labor_unit_value': laborUnitValue,
+    'crew_size': crewSize,
+  };
+
+  /// Converts this DTO to a domain [CostItem] entity.
+  ///
+  /// This method performs the transformation from the flat DTO structure
+  /// to the appropriate domain entity subtype based on the item_type.
+  /// It creates MaterialCostItem, LaborCostItem, or EquipmentCostItem
+  /// with the relevant fields populated.
+  CostItem toEntity() {
+    final type = CostItemType.fromJson(itemType);
+    final calculationMap = <String, double>{};
+    for (final entry in calculation.entries) {
+      final value = entry.value;
+      if (value is num) {
+        calculationMap[entry.key] = value.toDouble();
+      } else {
+        _logger.warning(
+          'Skipping non-numeric calculation entry: ${entry.key}=$value',
+        );
+      }
+    }
+
+    switch (type) {
+      case CostItemType.material:
+        final unit = Unit.fromJson(unitMeasurement ?? 'pieces');
+        return MaterialCostItem(
+          id: id,
+          estimateId: estimateId,
+          itemName: itemName,
+          calculation: calculationMap,
+          itemTotalCost: itemTotalCost,
+          createdAt: DateTime.parse(createdAt),
+          updatedAt: DateTime.parse(updatedAt),
+          unitPrice: Money(amount: unitPrice ?? 0.0, currency: 'USD'),
+          quantity: Quantity(value: quantity ?? 0.0, unit: unit),
+          productLink: productLink,
+          description: description,
+        );
+
+      case CostItemType.labor:
+        final method = LaborCalculationMethodType.fromJson(
+          laborCalcMethod ?? 'per_hour',
+        );
+        return LaborCostItem(
+          id: id,
+          estimateId: estimateId,
+          itemName: itemName,
+          calculation: calculationMap,
+          itemTotalCost: itemTotalCost,
+          createdAt: DateTime.parse(createdAt),
+          updatedAt: DateTime.parse(updatedAt),
+          laborCalcMethod: method,
+          laborValue: LaborValue(
+            laborDays: laborDays,
+            laborHours: laborHours,
+            laborUnitType: laborUnitType,
+            laborUnitValue: laborUnitValue,
+          ),
+          crewSize: crewSize,
+          productLink: productLink,
+          description: description,
+        );
+
+      case CostItemType.equipment:
+        final unit = Unit.fromJson(unitMeasurement ?? 'pieces');
+        return EquipmentCostItem(
+          id: id,
+          estimateId: estimateId,
+          itemName: itemName,
+          calculation: calculationMap,
+          itemTotalCost: itemTotalCost,
+          createdAt: DateTime.parse(createdAt),
+          updatedAt: DateTime.parse(updatedAt),
+          unitPrice: Money(amount: unitPrice ?? 0.0, currency: 'USD'),
+          quantity: Quantity(value: quantity ?? 0.0, unit: unit),
+          productLink: productLink,
+          description: description,
+        );
+    }
+  }
+
+  /// Creates a [CostItemDto] from a domain [CostItem] entity.
+  ///
+  /// This factory method performs the transformation from the domain entity
+  /// to the flat DTO structure, extracting type-specific fields.
+  factory CostItemDto.fromEntity(CostItem item) {
+    return CostItemDto(
+      id: item.id,
+      estimateId: item.estimateId,
+      itemName: item.itemName,
+      itemType: item.itemType.toJson(),
+      calculation: item.calculation,
+      itemTotalCost: item.itemTotalCost,
+      createdAt: item.createdAt.toIso8601String(),
+      updatedAt: item.updatedAt.toIso8601String(),
+      productLink: item.productLink,
+      description: item.description,
+      unitPrice: switch (item) {
+        MaterialCostItem() => item.unitPrice.amount,
+        EquipmentCostItem() => item.unitPrice.amount,
+        LaborCostItem() => null,
+      },
+      quantity: switch (item) {
+        MaterialCostItem() => item.quantity.value,
+        EquipmentCostItem() => item.quantity.value,
+        LaborCostItem() => null,
+      },
+      unitMeasurement: switch (item) {
+        MaterialCostItem() => item.quantity.unit.toJson(),
+        EquipmentCostItem() => item.quantity.unit.toJson(),
+        LaborCostItem() => null,
+      },
+      laborCalcMethod: switch (item) {
+        LaborCostItem() => item.laborCalcMethod.toJson(),
+        MaterialCostItem() => null,
+        EquipmentCostItem() => null,
+      },
+      laborDays: switch (item) {
+        LaborCostItem() => item.laborValue.laborDays,
+        MaterialCostItem() => null,
+        EquipmentCostItem() => null,
+      },
+      laborHours: switch (item) {
+        LaborCostItem() => item.laborValue.laborHours,
+        MaterialCostItem() => null,
+        EquipmentCostItem() => null,
+      },
+      laborUnitType: switch (item) {
+        LaborCostItem() => item.laborValue.laborUnitType,
+        MaterialCostItem() => null,
+        EquipmentCostItem() => null,
+      },
+      laborUnitValue: switch (item) {
+        LaborCostItem() => item.laborValue.laborUnitValue,
+        MaterialCostItem() => null,
+        EquipmentCostItem() => null,
+      },
+      crewSize: switch (item) {
+        LaborCostItem() => item.crewSize,
+        MaterialCostItem() => null,
+        EquipmentCostItem() => null,
+      },
+    );
+  }
+
+  @override
+  List<Object?> get props => [
+    id,
+    estimateId,
+    itemName,
+    itemType,
+    calculation,
+    itemTotalCost,
+    createdAt,
+    updatedAt,
+    productLink,
+    description,
+    unitPrice,
+    quantity,
+    unitMeasurement,
+    laborCalcMethod,
+    laborDays,
+    laborHours,
+    laborUnitType,
+    laborUnitValue,
+    crewSize,
+  ];
+}

--- a/lib/features/estimation/data/models/cost_item_dto.dart
+++ b/lib/features/estimation/data/models/cost_item_dto.dart
@@ -43,8 +43,6 @@ class CostItemDto extends Equatable {
   /// Optional description of the cost item.
   final String? description;
 
-  // Material and Equipment specific fields
-
   /// Unit price for material or equipment items.
   final double? unitPrice;
 
@@ -53,8 +51,6 @@ class CostItemDto extends Equatable {
 
   /// Unit of measurement for material or equipment items.
   final String? unitMeasurement;
-
-  // Labor specific fields
 
   /// Labor calculation method: 'per_hour', 'per_day', or 'per_unit'.
   final String? laborCalcMethod;
@@ -74,6 +70,12 @@ class CostItemDto extends Equatable {
   /// Size of the crew for labor items.
   final int? crewSize;
 
+  /// ISO 4217 currency code for this cost item's monetary values.
+  final String currency;
+
+  /// Optional brand or manufacturer name for this cost item.
+  final String? brand;
+
   /// Creates a new [CostItemDto] instance.
   const CostItemDto({
     required this.id,
@@ -84,6 +86,7 @@ class CostItemDto extends Equatable {
     required this.itemTotalCost,
     required this.createdAt,
     required this.updatedAt,
+    required this.currency,
     this.productLink,
     this.description,
     this.unitPrice,
@@ -95,6 +98,7 @@ class CostItemDto extends Equatable {
     this.laborUnitType,
     this.laborUnitValue,
     this.crewSize,
+    this.brand,
   });
 
   /// Creates a [CostItemDto] from a JSON map.
@@ -133,6 +137,8 @@ class CostItemDto extends Equatable {
           ? (json['labor_unit_value'] as num).toDouble()
           : null,
       crewSize: json['crew_size'] as int?,
+      currency: json['currency'] as String,
+      brand: json['brand'] as String?,
     );
   }
 
@@ -160,6 +166,8 @@ class CostItemDto extends Equatable {
     'labor_unit_type': laborUnitType,
     'labor_unit_value': laborUnitValue,
     'crew_size': crewSize,
+    'currency': currency,
+    'brand': brand,
   };
 
   /// Converts this DTO to a domain [CostItem] entity.
@@ -193,8 +201,10 @@ class CostItemDto extends Equatable {
           itemTotalCost: itemTotalCost,
           createdAt: DateTime.parse(createdAt),
           updatedAt: DateTime.parse(updatedAt),
-          unitPrice: Money(amount: unitPrice ?? 0.0, currency: 'USD'),
+          currency: currency,
+          unitPrice: Money(amount: unitPrice ?? 0.0, currency: currency),
           quantity: Quantity(value: quantity ?? 0.0, unit: unit),
+          brand: brand,
           productLink: productLink,
           description: description,
         );
@@ -211,6 +221,7 @@ class CostItemDto extends Equatable {
           itemTotalCost: itemTotalCost,
           createdAt: DateTime.parse(createdAt),
           updatedAt: DateTime.parse(updatedAt),
+          currency: currency,
           laborCalcMethod: method,
           laborValue: LaborValue(
             laborDays: laborDays,
@@ -219,6 +230,7 @@ class CostItemDto extends Equatable {
             laborUnitValue: laborUnitValue,
           ),
           crewSize: crewSize,
+          brand: brand,
           productLink: productLink,
           description: description,
         );
@@ -233,8 +245,10 @@ class CostItemDto extends Equatable {
           itemTotalCost: itemTotalCost,
           createdAt: DateTime.parse(createdAt),
           updatedAt: DateTime.parse(updatedAt),
-          unitPrice: Money(amount: unitPrice ?? 0.0, currency: 'USD'),
+          currency: currency,
+          unitPrice: Money(amount: unitPrice ?? 0.0, currency: currency),
           quantity: Quantity(value: quantity ?? 0.0, unit: unit),
+          brand: brand,
           productLink: productLink,
           description: description,
         );
@@ -255,6 +269,8 @@ class CostItemDto extends Equatable {
       itemTotalCost: item.itemTotalCost,
       createdAt: item.createdAt.toIso8601String(),
       updatedAt: item.updatedAt.toIso8601String(),
+      currency: item.currency,
+      brand: item.brand,
       productLink: item.productLink,
       description: item.description,
       unitPrice: switch (item) {
@@ -274,33 +290,27 @@ class CostItemDto extends Equatable {
       },
       laborCalcMethod: switch (item) {
         LaborCostItem() => item.laborCalcMethod.toJson(),
-        MaterialCostItem() => null,
-        EquipmentCostItem() => null,
+        MaterialCostItem() || EquipmentCostItem() => null,
       },
       laborDays: switch (item) {
         LaborCostItem() => item.laborValue.laborDays,
-        MaterialCostItem() => null,
-        EquipmentCostItem() => null,
+        MaterialCostItem() || EquipmentCostItem() => null,
       },
       laborHours: switch (item) {
         LaborCostItem() => item.laborValue.laborHours,
-        MaterialCostItem() => null,
-        EquipmentCostItem() => null,
+        MaterialCostItem() || EquipmentCostItem() => null,
       },
       laborUnitType: switch (item) {
         LaborCostItem() => item.laborValue.laborUnitType,
-        MaterialCostItem() => null,
-        EquipmentCostItem() => null,
+        MaterialCostItem() || EquipmentCostItem() => null,
       },
       laborUnitValue: switch (item) {
         LaborCostItem() => item.laborValue.laborUnitValue,
-        MaterialCostItem() => null,
-        EquipmentCostItem() => null,
+        MaterialCostItem() || EquipmentCostItem() => null,
       },
       crewSize: switch (item) {
         LaborCostItem() => item.crewSize,
-        MaterialCostItem() => null,
-        EquipmentCostItem() => null,
+        MaterialCostItem() || EquipmentCostItem() => null,
       },
     );
   }
@@ -326,5 +336,7 @@ class CostItemDto extends Equatable {
     laborUnitType,
     laborUnitValue,
     crewSize,
+    currency,
+    brand,
   ];
 }

--- a/lib/features/estimation/domain/entities/cost_item_entity.dart
+++ b/lib/features/estimation/domain/entities/cost_item_entity.dart
@@ -40,6 +40,9 @@ enum CostItemType {
       orElse: () => CostItemType.material,
     );
   }
+
+  /// Serializes this [CostItemType] to its JSON string representation.
+  String toJson() => name;
 }
 
 /// Units supported for material and equipment quantities.
@@ -98,6 +101,9 @@ enum Unit {
       orElse: () => Unit.pieces,
     );
   }
+
+  /// Serializes this [Unit] to its JSON string representation.
+  String toJson() => name;
 }
 
 /// Labor pricing strategies supported by the estimation model.

--- a/test/features/estimations/helpers/cost_item_test_data_map_factory.dart
+++ b/test/features/estimations/helpers/cost_item_test_data_map_factory.dart
@@ -1,0 +1,163 @@
+/// Factory for creating test data for cost items.
+class CostItemTestDataMapFactory {
+  static Map<String, dynamic> createMaterialItemData({
+    String? id,
+    String? estimateId,
+    String? itemName,
+    String? description,
+    double? unitPrice,
+    String? unit,
+    double? quantity,
+    String? productLink,
+    String? createdAt,
+    String? updatedAt,
+    Map<String, dynamic>? calculation,
+    double? itemTotalCost,
+  }) {
+    final price = unitPrice ?? 100.0;
+    final qty = quantity ?? 5.0;
+
+    return {
+      'id': id ?? 'item-material-1',
+      'estimate_id': estimateId ?? 'estimate-123',
+      'item_name': itemName ?? 'Test Material',
+      'description': description ?? 'Test description',
+      'item_type': 'material',
+      'unit_price': price,
+      'unit_measurement': unit ?? 'pieces',
+      'quantity': qty,
+      'product_link': productLink,
+      'labor_calc_method': null,
+      'labor_days': null,
+      'labor_hours': null,
+      'labor_unit_type': null,
+      'labor_unit_value': null,
+      'crew_size': null,
+      'calculation': calculation ?? {'unit_price': price, 'quantity': qty},
+      'item_total_cost': itemTotalCost ?? price * qty,
+      'created_at': createdAt ?? '2024-01-01T00:00:00.000Z',
+      'updated_at': updatedAt ?? '2024-01-01T00:00:00.000Z',
+    };
+  }
+
+  static Map<String, dynamic> createLaborItemData({
+    String? id,
+    String? estimateId,
+    String? itemName,
+    String? description,
+    String? laborCalcMethod,
+    double? laborDays,
+    double? laborHours,
+    String? laborUnitType,
+    double? laborUnitValue,
+    int? crewSize,
+    String? productLink,
+    String? createdAt,
+    String? updatedAt,
+    Map<String, dynamic>? calculation,
+    double? itemTotalCost,
+  }) {
+    return {
+      'id': id ?? 'item-labor-1',
+      'estimate_id': estimateId ?? 'estimate-123',
+      'item_name': itemName ?? 'Test Labor',
+      'description': description ?? 'Test description',
+      'item_type': 'labor',
+      'unit_price': null,
+      'unit_measurement': null,
+      'quantity': null,
+      'product_link': productLink,
+      'labor_calc_method': laborCalcMethod ?? 'hourly',
+      'labor_days': laborDays,
+      'labor_hours': laborHours ?? 10.0,
+      'labor_unit_type': laborUnitType,
+      'labor_unit_value': laborUnitValue,
+      'crew_size': crewSize ?? 2,
+      'calculation': calculation ?? {'labor_hours': 10.0, 'crew_size': 2.0},
+      'item_total_cost': itemTotalCost ?? 20.0,
+      'created_at': createdAt ?? '2024-01-01T00:00:00.000Z',
+      'updated_at': updatedAt ?? '2024-01-01T00:00:00.000Z',
+    };
+  }
+
+  static Map<String, dynamic> createEquipmentItemData({
+    String? id,
+    String? estimateId,
+    String? itemName,
+    String? description,
+    double? unitPrice,
+    String? unit,
+    double? quantity,
+    String? productLink,
+    String? createdAt,
+    String? updatedAt,
+    Map<String, dynamic>? calculation,
+    double? itemTotalCost,
+  }) {
+    final price = unitPrice ?? 200.0;
+    final qty = quantity ?? 3.0;
+
+    return {
+      'id': id ?? 'item-equipment-1',
+      'estimate_id': estimateId ?? 'estimate-123',
+      'item_name': itemName ?? 'Test Equipment',
+      'description': description ?? 'Test description',
+      'item_type': 'equipment',
+      'unit_price': price,
+      'unit_measurement': unit ?? 'days',
+      'quantity': qty,
+      'product_link': productLink,
+      'labor_calc_method': null,
+      'labor_days': null,
+      'labor_hours': null,
+      'labor_unit_type': null,
+      'labor_unit_value': null,
+      'crew_size': null,
+      'calculation': calculation ?? {'unit_price': price, 'quantity': qty},
+      'item_total_cost': itemTotalCost ?? price * qty,
+      'created_at': createdAt ?? '2024-01-01T00:00:00.000Z',
+      'updated_at': updatedAt ?? '2024-01-01T00:00:00.000Z',
+    };
+  }
+
+  static List<Map<String, dynamic>> createMixedItemsList({
+    required String estimateId,
+    int materialCount = 1,
+    int laborCount = 1,
+    int equipmentCount = 1,
+  }) {
+    final items = <Map<String, dynamic>>[];
+
+    for (int i = 0; i < materialCount; i++) {
+      items.add(
+        createMaterialItemData(
+          id: 'material-$i',
+          estimateId: estimateId,
+          itemName: 'Material Item $i',
+        ),
+      );
+    }
+
+    for (int i = 0; i < laborCount; i++) {
+      items.add(
+        createLaborItemData(
+          id: 'labor-$i',
+          estimateId: estimateId,
+          itemName: 'Labor Item $i',
+        ),
+      );
+    }
+
+    for (int i = 0; i < equipmentCount; i++) {
+      items.add(
+        createEquipmentItemData(
+          id: 'equipment-$i',
+          estimateId: estimateId,
+          itemName: 'Equipment Item $i',
+        ),
+      );
+    }
+
+    return items;
+  }
+}

--- a/test/features/estimations/helpers/cost_item_test_data_map_factory.dart
+++ b/test/features/estimations/helpers/cost_item_test_data_map_factory.dart
@@ -13,19 +13,18 @@ class CostItemTestDataMapFactory {
     String? updatedAt,
     Map<String, dynamic>? calculation,
     double? itemTotalCost,
+    String? currency,
+    String? brand,
   }) {
-    final price = unitPrice ?? 100.0;
-    final qty = quantity ?? 5.0;
-
     return {
       'id': id ?? 'item-material-1',
       'estimate_id': estimateId ?? 'estimate-123',
       'item_name': itemName ?? 'Test Material',
       'description': description ?? 'Test description',
       'item_type': 'material',
-      'unit_price': price,
+      'unit_price': unitPrice ?? 100.0,
       'unit_measurement': unit ?? 'pieces',
-      'quantity': qty,
+      'quantity': quantity ?? 5.0,
       'product_link': productLink,
       'labor_calc_method': null,
       'labor_days': null,
@@ -33,10 +32,12 @@ class CostItemTestDataMapFactory {
       'labor_unit_type': null,
       'labor_unit_value': null,
       'crew_size': null,
-      'calculation': calculation ?? {'unit_price': price, 'quantity': qty},
-      'item_total_cost': itemTotalCost ?? price * qty,
+      'calculation': calculation ?? {'unit_price': 100.0, 'quantity': 5.0},
+      'item_total_cost': itemTotalCost ?? 500.0,
       'created_at': createdAt ?? '2024-01-01T00:00:00.000Z',
       'updated_at': updatedAt ?? '2024-01-01T00:00:00.000Z',
+      'currency': currency ?? 'USD',
+      'brand': brand,
     };
   }
 
@@ -56,6 +57,8 @@ class CostItemTestDataMapFactory {
     String? updatedAt,
     Map<String, dynamic>? calculation,
     double? itemTotalCost,
+    String? currency,
+    String? brand,
   }) {
     return {
       'id': id ?? 'item-labor-1',
@@ -67,7 +70,7 @@ class CostItemTestDataMapFactory {
       'unit_measurement': null,
       'quantity': null,
       'product_link': productLink,
-      'labor_calc_method': laborCalcMethod ?? 'hourly',
+      'labor_calc_method': laborCalcMethod ?? 'per_hour',
       'labor_days': laborDays,
       'labor_hours': laborHours ?? 10.0,
       'labor_unit_type': laborUnitType,
@@ -77,6 +80,8 @@ class CostItemTestDataMapFactory {
       'item_total_cost': itemTotalCost ?? 20.0,
       'created_at': createdAt ?? '2024-01-01T00:00:00.000Z',
       'updated_at': updatedAt ?? '2024-01-01T00:00:00.000Z',
+      'currency': currency ?? 'USD',
+      'brand': brand,
     };
   }
 
@@ -93,6 +98,8 @@ class CostItemTestDataMapFactory {
     String? updatedAt,
     Map<String, dynamic>? calculation,
     double? itemTotalCost,
+    String? currency,
+    String? brand,
   }) {
     final price = unitPrice ?? 200.0;
     final qty = quantity ?? 3.0;
@@ -117,6 +124,8 @@ class CostItemTestDataMapFactory {
       'item_total_cost': itemTotalCost ?? price * qty,
       'created_at': createdAt ?? '2024-01-01T00:00:00.000Z',
       'updated_at': updatedAt ?? '2024-01-01T00:00:00.000Z',
+      'currency': currency ?? 'USD',
+      'brand': brand,
     };
   }
 

--- a/test/features/estimations/units/data/models/cost_item_dto_test.dart
+++ b/test/features/estimations/units/data/models/cost_item_dto_test.dart
@@ -1,0 +1,456 @@
+import 'package:construculator/features/estimation/data/models/cost_item_dto.dart';
+import 'package:construculator/features/estimation/domain/entities/cost_item_entity.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../../../helpers/cost_item_test_data_map_factory.dart';
+
+void main() {
+  group('CostItemDto', () {
+    group('MaterialCostItem', () {
+      final testJson = CostItemTestDataMapFactory.createMaterialItemData(
+        id: 'item-123',
+        estimateId: 'estimate-456',
+        itemName: 'Concrete Mix',
+        description: 'High quality concrete mix',
+        unitPrice: 100.0,
+        quantity: 50.0,
+        unit: 'pieces',
+        productLink: 'https://example.com/concrete',
+        calculation: {'base': 100.0, 'tax': 10.0},
+        itemTotalCost: 5000.0,
+        createdAt: '2025-02-25T14:30:00.000Z',
+        updatedAt: '2025-02-25T14:30:00.000Z',
+      );
+
+      final testDto = CostItemDto(
+        id: 'item-123',
+        estimateId: 'estimate-456',
+        itemName: 'Concrete Mix',
+        itemType: 'material',
+        calculation: {'base': 100.0, 'tax': 10.0},
+        itemTotalCost: 5000.0,
+        createdAt: '2025-02-25T14:30:00.000Z',
+        updatedAt: '2025-02-25T14:30:00.000Z',
+        unitPrice: 100.0,
+        quantity: 50.0,
+        unitMeasurement: 'pieces',
+        productLink: 'https://example.com/concrete',
+        description: 'High quality concrete mix',
+      );
+
+      final testEntity = MaterialCostItem(
+        id: 'item-123',
+        estimateId: 'estimate-456',
+        itemName: 'Concrete Mix',
+        calculation: const {'base': 100.0, 'tax': 10.0},
+        itemTotalCost: 5000.0,
+        createdAt: DateTime.parse('2025-02-25T14:30:00.000Z'),
+        updatedAt: DateTime.parse('2025-02-25T14:30:00.000Z'),
+        unitPrice: const Money(amount: 100.0, currency: 'USD'),
+        quantity: const Quantity(value: 50.0, unit: Unit.pieces),
+        productLink: 'https://example.com/concrete',
+        description: 'High quality concrete mix',
+      );
+
+      group('fromJson', () {
+        test('creates MaterialCostItem DTO from complete JSON', () {
+          final dto = CostItemDto.fromJson(testJson);
+
+          expect(dto, testDto);
+        });
+
+        test('handles integer values for numeric fields', () {
+          final jsonWithInts = {
+            ...testJson,
+            'unit_price': 100,
+            'quantity': 50,
+            'item_total_cost': 5000,
+          };
+
+          final dto = CostItemDto.fromJson(jsonWithInts);
+
+          expect(dto.unitPrice, 100.0);
+          expect(dto.quantity, 50.0);
+          expect(dto, testDto);
+        });
+      });
+
+      group('toJson', () {
+        test('converts DTO to JSON with all fields', () {
+          final json = testDto.toJson();
+
+          expect(json, testJson);
+        });
+
+        test('uses snake_case for JSON keys', () {
+          final json = testDto.toJson();
+
+          expect(json.keys, contains('estimate_id'));
+          expect(json.keys, contains('item_name'));
+          expect(json.keys, contains('item_type'));
+          expect(json.keys, contains('item_total_cost'));
+          expect(json.keys, contains('created_at'));
+          expect(json.keys, contains('updated_at'));
+        });
+      });
+
+      group('toEntity', () {
+        test('converts DTO to MaterialCostItem domain entity', () {
+          final entity = testDto.toEntity();
+
+          expect(entity, testEntity);
+        });
+
+        test('correctly instantiates MaterialCostItem based on item_type', () {
+          final entity = testDto.toEntity();
+
+          expect(entity, isA<MaterialCostItem>());
+          expect(entity, testEntity);
+        });
+      });
+
+      group('fromEntity', () {
+        test('converts MaterialCostItem entity to DTO', () {
+          final dto = CostItemDto.fromEntity(testEntity);
+
+          expect(dto, testDto);
+        });
+      });
+    });
+
+    group('LaborCostItem', () {
+      final testJson = CostItemTestDataMapFactory.createLaborItemData(
+        id: 'item-789',
+        estimateId: 'estimate-456',
+        itemName: 'Electrician Work',
+        description: 'Electrical installation',
+        laborCalcMethod: 'per_hour',
+        laborDays: 5.0,
+        laborHours: 40.0,
+        laborUnitType: 'hourly',
+        laborUnitValue: 50.0,
+        crewSize: 2,
+        calculation: {'hours': 40.0, 'rate': 50.0},
+        itemTotalCost: 2000.0,
+        createdAt: '2025-02-25T15:00:00.000Z',
+        updatedAt: '2025-02-25T15:00:00.000Z',
+      );
+
+      final testDto = CostItemDto(
+        id: 'item-789',
+        estimateId: 'estimate-456',
+        itemName: 'Electrician Work',
+        itemType: 'labor',
+        calculation: {'hours': 40.0, 'rate': 50.0},
+        itemTotalCost: 2000.0,
+        createdAt: '2025-02-25T15:00:00.000Z',
+        updatedAt: '2025-02-25T15:00:00.000Z',
+        laborCalcMethod: 'per_hour',
+        laborDays: 5.0,
+        laborHours: 40.0,
+        laborUnitType: 'hourly',
+        laborUnitValue: 50.0,
+        crewSize: 2,
+        description: 'Electrical installation',
+      );
+
+      final testEntity = LaborCostItem(
+        id: 'item-789',
+        estimateId: 'estimate-456',
+        itemName: 'Electrician Work',
+        calculation: const {'hours': 40.0, 'rate': 50.0},
+        itemTotalCost: 2000.0,
+        createdAt: DateTime.parse('2025-02-25T15:00:00.000Z'),
+        updatedAt: DateTime.parse('2025-02-25T15:00:00.000Z'),
+        laborCalcMethod: LaborCalculationMethodType.perHour,
+        laborValue: const LaborValue(
+          laborDays: 5.0,
+          laborHours: 40.0,
+          laborUnitType: 'hourly',
+          laborUnitValue: 50.0,
+        ),
+        crewSize: 2,
+        description: 'Electrical installation',
+      );
+
+      group('fromJson', () {
+        test('creates LaborCostItem DTO from complete JSON', () {
+          final dto = CostItemDto.fromJson(testJson);
+
+          expect(dto, testDto);
+        });
+      });
+
+      group('toEntity', () {
+        test('converts DTO to LaborCostItem domain entity', () {
+          final entity = testDto.toEntity();
+
+          expect(entity, testEntity);
+        });
+
+        test('correctly instantiates LaborCostItem based on item_type', () {
+          final entity = testDto.toEntity();
+
+          expect(entity, isA<LaborCostItem>());
+          expect(entity, testEntity);
+        });
+      });
+
+      group('fromEntity', () {
+        test('converts LaborCostItem entity to DTO', () {
+          final dto = CostItemDto.fromEntity(testEntity);
+
+          expect(dto, testDto);
+        });
+      });
+    });
+
+    group('EquipmentCostItem', () {
+      final testJson = CostItemTestDataMapFactory.createEquipmentItemData(
+        id: 'item-999',
+        estimateId: 'estimate-456',
+        itemName: 'Excavator Rental',
+        description: 'Heavy equipment rental',
+        unitPrice: 500.0,
+        quantity: 5.0,
+        unit: 'days',
+        productLink: 'https://example.com/excavator',
+        calculation: {'days': 5.0, 'rate': 500.0},
+        itemTotalCost: 2500.0,
+        createdAt: '2025-02-25T16:00:00.000Z',
+        updatedAt: '2025-02-25T16:00:00.000Z',
+      );
+
+      final testDto = CostItemDto(
+        id: 'item-999',
+        estimateId: 'estimate-456',
+        itemName: 'Excavator Rental',
+        itemType: 'equipment',
+        calculation: {'days': 5.0, 'rate': 500.0},
+        itemTotalCost: 2500.0,
+        createdAt: '2025-02-25T16:00:00.000Z',
+        updatedAt: '2025-02-25T16:00:00.000Z',
+        unitPrice: 500.0,
+        quantity: 5.0,
+        unitMeasurement: 'days',
+        productLink: 'https://example.com/excavator',
+        description: 'Heavy equipment rental',
+      );
+
+      final testEntity = EquipmentCostItem(
+        id: 'item-999',
+        estimateId: 'estimate-456',
+        itemName: 'Excavator Rental',
+        calculation: const {'days': 5.0, 'rate': 500.0},
+        itemTotalCost: 2500.0,
+        createdAt: DateTime.parse('2025-02-25T16:00:00.000Z'),
+        updatedAt: DateTime.parse('2025-02-25T16:00:00.000Z'),
+        unitPrice: const Money(amount: 500.0, currency: 'USD'),
+        quantity: const Quantity(value: 5.0, unit: Unit.days),
+        productLink: 'https://example.com/excavator',
+        description: 'Heavy equipment rental',
+      );
+
+      group('fromJson', () {
+        test('creates EquipmentCostItem DTO from complete JSON', () {
+          final dto = CostItemDto.fromJson(testJson);
+
+          expect(dto, testDto);
+        });
+      });
+
+      group('toEntity', () {
+        test('converts DTO to EquipmentCostItem domain entity', () {
+          final entity = testDto.toEntity();
+
+          expect(entity, testEntity);
+        });
+
+        test('correctly instantiates EquipmentCostItem based on item_type', () {
+          final entity = testDto.toEntity();
+
+          expect(entity, isA<EquipmentCostItem>());
+          expect(entity, testEntity);
+        });
+      });
+
+      group('fromEntity', () {
+        test('converts EquipmentCostItem entity to DTO', () {
+          final dto = CostItemDto.fromEntity(testEntity);
+
+          expect(dto, testDto);
+        });
+      });
+    });
+
+    group('round-trip conversion', () {
+      test(
+        'JSON -> DTO -> Entity conversion is consistent for MaterialCostItem',
+        () {
+          final json = CostItemTestDataMapFactory.createMaterialItemData(
+            id: 'item-123',
+            estimateId: 'estimate-456',
+            itemName: 'Concrete Mix',
+            unitPrice: 100.0,
+            quantity: 50.0,
+            unit: 'pieces',
+            calculation: {'base': 100.0},
+            itemTotalCost: 5000.0,
+            createdAt: '2025-02-25T14:30:00.000Z',
+            updatedAt: '2025-02-25T14:30:00.000Z',
+          );
+
+          final dto = CostItemDto.fromJson(json);
+          final entity = dto.toEntity();
+          final dtoAgain = CostItemDto.fromEntity(entity);
+          final jsonAgain = dtoAgain.toJson();
+
+          expect(dtoAgain, dto);
+          expect(jsonAgain, json);
+        },
+      );
+
+      test(
+        'Entity -> DTO -> JSON conversion is consistent for LaborCostItem',
+        () {
+          final entity = LaborCostItem(
+            id: 'item-789',
+            estimateId: 'estimate-456',
+            itemName: 'Electrician Work',
+            calculation: const {'hours': 40.0},
+            itemTotalCost: 2000.0,
+            createdAt: DateTime.parse('2025-02-25T15:00:00.000Z'),
+            updatedAt: DateTime.parse('2025-02-25T15:00:00.000Z'),
+            laborCalcMethod: LaborCalculationMethodType.perHour,
+            laborValue: const LaborValue(laborHours: 40.0),
+          );
+
+          final dto = CostItemDto.fromEntity(entity);
+          final entityAgain = dto.toEntity();
+
+          expect(entityAgain, entity);
+          expect(dto, CostItemDto.fromJson(dto.toJson()));
+        },
+      );
+
+      test('JSON -> DTO -> JSON produces identical result', () {
+        final json = CostItemTestDataMapFactory.createEquipmentItemData(
+          id: 'item-999',
+          estimateId: 'estimate-456',
+          itemName: 'Excavator Rental',
+          unitPrice: 500.0,
+          quantity: 5.0,
+          unit: 'days',
+          calculation: {'days': 5.0},
+          itemTotalCost: 2500.0,
+          description: null,
+          createdAt: '2025-02-25T16:00:00.000Z',
+          updatedAt: '2025-02-25T16:00:00.000Z',
+        );
+
+        final dto = CostItemDto.fromJson(json);
+        final resultJson = dto.toJson();
+
+        expect(resultJson, json);
+      });
+
+      test('Entity -> DTO -> Entity produces equivalent result', () {
+        final entity = MaterialCostItem(
+          id: 'item-123',
+          estimateId: 'estimate-456',
+          itemName: 'Concrete Mix',
+          calculation: const {'base': 100.0},
+          itemTotalCost: 5000.0,
+          createdAt: DateTime.parse('2025-02-25T14:30:00.000Z'),
+          updatedAt: DateTime.parse('2025-02-25T14:30:00.000Z'),
+          unitPrice: const Money(amount: 100.0, currency: 'USD'),
+          quantity: const Quantity(value: 50.0, unit: Unit.pieces),
+        );
+
+        final dto = CostItemDto.fromEntity(entity);
+        final resultEntity = dto.toEntity();
+
+        expect(resultEntity, entity);
+      });
+    });
+
+    group('malformed JSON handling', () {
+      test('handles non-numeric values in calculation map', () {
+        final json = CostItemTestDataMapFactory.createMaterialItemData(
+          calculation: {
+            'valid_number': 100.0,
+            'invalid_string': 'not a number',
+            'invalid_map': {'nested': 'value'},
+          },
+        );
+
+        final dto = CostItemDto.fromJson(json);
+        final entity = dto.toEntity();
+
+        expect(entity.calculation, {'valid_number': 100.0});
+      });
+
+      test('handles unknown item_type by defaulting to material', () {
+        final json = CostItemTestDataMapFactory.createMaterialItemData();
+        json['item_type'] = 'unknown_type';
+
+        final dto = CostItemDto.fromJson(json);
+        final entity = dto.toEntity();
+
+        expect(entity, isA<MaterialCostItem>());
+        expect(entity.itemType, CostItemType.material);
+      });
+
+      test('handles unknown unit_measurement by defaulting to pieces', () {
+        final json = CostItemTestDataMapFactory.createMaterialItemData();
+        json['unit_measurement'] = 'unknown_unit';
+
+        final dto = CostItemDto.fromJson(json);
+        final entity = dto.toEntity() as MaterialCostItem;
+
+        expect(entity.quantity.unit, Unit.pieces);
+      });
+
+      test('handles null unit_measurement by defaulting to pieces', () {
+        final json = CostItemTestDataMapFactory.createMaterialItemData();
+        json['unit_measurement'] = null;
+
+        final dto = CostItemDto.fromJson(json);
+        final entity = dto.toEntity() as MaterialCostItem;
+
+        expect(entity.quantity.unit, Unit.pieces);
+      });
+
+      test('handles unknown labor_calc_method by defaulting to perHour', () {
+        final json = CostItemTestDataMapFactory.createLaborItemData();
+        json['labor_calc_method'] = 'unknown_method';
+
+        final dto = CostItemDto.fromJson(json);
+        final entity = dto.toEntity() as LaborCostItem;
+
+        expect(entity.laborCalcMethod, LaborCalculationMethodType.perHour);
+      });
+
+      test('handles null labor_calc_method by defaulting to perHour', () {
+        final json = CostItemTestDataMapFactory.createLaborItemData();
+        json['labor_calc_method'] = null;
+
+        final dto = CostItemDto.fromJson(json);
+        final entity = dto.toEntity() as LaborCostItem;
+
+        expect(entity.laborCalcMethod, LaborCalculationMethodType.perHour);
+      });
+
+      test('handles empty calculation map', () {
+        final json = CostItemTestDataMapFactory.createMaterialItemData(
+          calculation: {},
+        );
+
+        final dto = CostItemDto.fromJson(json);
+        final entity = dto.toEntity();
+
+        expect(entity.calculation, isEmpty);
+      });
+    });
+  });
+}

--- a/test/features/estimations/units/data/models/cost_item_dto_test.dart
+++ b/test/features/estimations/units/data/models/cost_item_dto_test.dart
@@ -31,6 +31,7 @@ void main() {
         itemTotalCost: 5000.0,
         createdAt: '2025-02-25T14:30:00.000Z',
         updatedAt: '2025-02-25T14:30:00.000Z',
+        currency: 'USD',
         unitPrice: 100.0,
         quantity: 50.0,
         unitMeasurement: 'pieces',
@@ -46,6 +47,7 @@ void main() {
         itemTotalCost: 5000.0,
         createdAt: DateTime.parse('2025-02-25T14:30:00.000Z'),
         updatedAt: DateTime.parse('2025-02-25T14:30:00.000Z'),
+        currency: 'USD',
         unitPrice: const Money(amount: 100.0, currency: 'USD'),
         quantity: const Quantity(value: 50.0, unit: Unit.pieces),
         productLink: 'https://example.com/concrete',
@@ -145,6 +147,7 @@ void main() {
         itemTotalCost: 2000.0,
         createdAt: '2025-02-25T15:00:00.000Z',
         updatedAt: '2025-02-25T15:00:00.000Z',
+        currency: 'USD',
         laborCalcMethod: 'per_hour',
         laborDays: 5.0,
         laborHours: 40.0,
@@ -162,6 +165,7 @@ void main() {
         itemTotalCost: 2000.0,
         createdAt: DateTime.parse('2025-02-25T15:00:00.000Z'),
         updatedAt: DateTime.parse('2025-02-25T15:00:00.000Z'),
+        currency: 'USD',
         laborCalcMethod: LaborCalculationMethodType.perHour,
         laborValue: const LaborValue(
           laborDays: 5.0,
@@ -230,6 +234,7 @@ void main() {
         itemTotalCost: 2500.0,
         createdAt: '2025-02-25T16:00:00.000Z',
         updatedAt: '2025-02-25T16:00:00.000Z',
+        currency: 'USD',
         unitPrice: 500.0,
         quantity: 5.0,
         unitMeasurement: 'days',
@@ -245,6 +250,7 @@ void main() {
         itemTotalCost: 2500.0,
         createdAt: DateTime.parse('2025-02-25T16:00:00.000Z'),
         updatedAt: DateTime.parse('2025-02-25T16:00:00.000Z'),
+        currency: 'USD',
         unitPrice: const Money(amount: 500.0, currency: 'USD'),
         quantity: const Quantity(value: 5.0, unit: Unit.days),
         productLink: 'https://example.com/excavator',
@@ -321,6 +327,7 @@ void main() {
             itemTotalCost: 2000.0,
             createdAt: DateTime.parse('2025-02-25T15:00:00.000Z'),
             updatedAt: DateTime.parse('2025-02-25T15:00:00.000Z'),
+            currency: 'USD',
             laborCalcMethod: LaborCalculationMethodType.perHour,
             laborValue: const LaborValue(laborHours: 40.0),
           );
@@ -363,6 +370,7 @@ void main() {
           itemTotalCost: 5000.0,
           createdAt: DateTime.parse('2025-02-25T14:30:00.000Z'),
           updatedAt: DateTime.parse('2025-02-25T14:30:00.000Z'),
+          currency: 'USD',
           unitPrice: const Money(amount: 100.0, currency: 'USD'),
           quantity: const Quantity(value: 50.0, unit: Unit.pieces),
         );
@@ -439,6 +447,13 @@ void main() {
         final entity = dto.toEntity() as LaborCostItem;
 
         expect(entity.laborCalcMethod, LaborCalculationMethodType.perHour);
+      });
+
+      test('throws TypeError when item_total_cost is non-numeric', () {
+        final json = CostItemTestDataMapFactory.createMaterialItemData();
+        json['item_total_cost'] = 'not_a_number';
+
+        expect(() => CostItemDto.fromJson(json), throwsA(isA<TypeError>()));
       });
 
       test('handles empty calculation map', () {


### PR DESCRIPTION
### 1. PR Summary

This PR adds the data layer for cost items: a flat `CostItemDto` that maps to/from the three domain entity subtypes, a `CostItemTestDataFactory` for test data generation, and a comprehensive DTO test suite covering `fromJson`, `toJson`, `toEntity`, `fromEntity`, and round-trip conversions. **PR size is L — justified for a new data model with full bidirectional serialization and test coverage.**

---
---

### Review Summary Table

| Issue Name | Description | Status | Notes |
|------------|-------------|--------|-------|
| `CostItemTestDataFactory` naming | `Factory` suffix is not in the approved helper naming convention. Should follow the existing `*TestDataMapFactory` pattern used elsewhere in the test suite. | ✅ | |
| Unsafe `calculation` map cast in `toEntity` | `(value as num).toDouble()` on `Map<String, dynamic>` will throw `TypeError` on non-numeric values at a parsing boundary. Should guard and log. | ✅ | |
| Wildcard `_` defeats sealed class exhaustiveness | `fromEntity` switch arms use `_` instead of explicitly handling `LaborCostItem`, losing compile-time safety when new subtypes are added. | ✅ | |
| Missing malformed JSON tests | No tests cover unrecognised `item_type`, non-numeric `calculation` values, or missing required fields in `fromJson`. | ✅ | |
| Business logic in test data factory | `createLaborItemData` conditionally derives `totalCost` and `calculationMap` — test factories should produce static data, not implement pricing logic. | ✅ | |