### PR TITLE
CA-151: feat: implement remote cost item data source with CRUD operations

### DIFF
--- a/lib/features/estimation/data/data_source/interfaces/cost_item_data_source.dart
+++ b/lib/features/estimation/data/data_source/interfaces/cost_item_data_source.dart
@@ -5,29 +5,36 @@ import 'package:construculator/features/estimation/data/models/cost_item_dto.dar
 /// This interface defines the contract for managing cost items in the data layer.
 /// Implementations of this interface handle the actual data operations from various
 /// sources (e.g., remote API, local cache).
+///
+/// Following Rule 11: Method names are explicit about their operations (fetch from network)
+/// and scope (by estimate ID, optionally filtered by type).
 abstract class CostItemDataSource {
-  /// Fetches paginated cost items for a specific estimation.
+  /// Fetches all cost items from the remote database for a specific estimate,
+  /// optionally filtered by item type.
+  ///
+  /// This method performs a network fetch operation and returns all matching items
+  /// ordered by creation date (oldest first).
   ///
   /// Parameters:
-  /// - [estimateId]: The ID of the estimation to fetch items for
-  /// - [offset]: Starting index for pagination (0-based)
-  /// - [limit]: Number of items to fetch
+  /// - [estimateId]: The ID of the estimation to fetch items for (required)
+  /// - [itemType]: Optional type filter. If provided, only items of this type are returned.
+  ///               If null, all item types are returned.
   ///
-  /// Returns a list of [CostItemDto] objects representing the cost items.
+  /// Returns a list of [CostItemDto] objects. Returns an empty list if no items found.
   ///
-  /// Throws an exception if the fetch operation fails.
-  Future<List<CostItemDto>> getCostItems({
+  /// Throws an exception if the fetch operation fails due to network or database errors.
+  Future<List<CostItemDto>> fetchCostItemsByEstimateId({
     required String estimateId,
-    required int offset,
-    required int limit,
+    String? itemType,
   });
 
-  /// Creates a new cost item.
+  /// Creates a new cost item in the remote database.
   ///
   /// Parameters:
   /// - [item]: The cost item DTO to create
   ///
-  /// Returns the created [CostItemDto] with server-generated fields populated.
+  /// Returns the created [CostItemDto] with server-generated fields populated
+  /// (id, createdAt, updatedAt).
   ///
   /// Throws an exception if the create operation fails.
   Future<CostItemDto> createCostItem(CostItemDto item);

--- a/lib/features/estimation/data/data_source/interfaces/cost_item_data_source.dart
+++ b/lib/features/estimation/data/data_source/interfaces/cost_item_data_source.dart
@@ -1,0 +1,34 @@
+import 'package:construculator/features/estimation/data/models/cost_item_dto.dart';
+
+/// Abstract interface for cost item data source operations.
+///
+/// This interface defines the contract for managing cost items in the data layer.
+/// Implementations of this interface handle the actual data operations from various
+/// sources (e.g., remote API, local cache).
+abstract class CostItemDataSource {
+  /// Fetches paginated cost items for a specific estimation.
+  ///
+  /// Parameters:
+  /// - [estimateId]: The ID of the estimation to fetch items for
+  /// - [offset]: Starting index for pagination (0-based)
+  /// - [limit]: Number of items to fetch
+  ///
+  /// Returns a list of [CostItemDto] objects representing the cost items.
+  ///
+  /// Throws an exception if the fetch operation fails.
+  Future<List<CostItemDto>> getCostItems({
+    required String estimateId,
+    required int offset,
+    required int limit,
+  });
+
+  /// Creates a new cost item.
+  ///
+  /// Parameters:
+  /// - [item]: The cost item DTO to create
+  ///
+  /// Returns the created [CostItemDto] with server-generated fields populated.
+  ///
+  /// Throws an exception if the create operation fails.
+  Future<CostItemDto> createCostItem(CostItemDto item);
+}

--- a/lib/features/estimation/data/data_source/interfaces/cost_item_data_source.dart
+++ b/lib/features/estimation/data/data_source/interfaces/cost_item_data_source.dart
@@ -1,3 +1,4 @@
+// coverage:ignore-file
 import 'package:construculator/features/estimation/data/models/cost_item_dto.dart';
 
 /// Abstract interface for cost item data source operations.
@@ -5,29 +6,36 @@ import 'package:construculator/features/estimation/data/models/cost_item_dto.dar
 /// This interface defines the contract for managing cost items in the data layer.
 /// Implementations of this interface handle the actual data operations from various
 /// sources (e.g., remote API, local cache).
+///
+/// Following Rule 11: Method names are explicit about their operations (fetch from network)
+/// and scope (by estimate ID, optionally filtered by type).
 abstract class CostItemDataSource {
-  /// Fetches paginated cost items for a specific estimation.
+  /// Fetches all cost items from the remote database for a specific estimate,
+  /// optionally filtered by item type.
+  ///
+  /// This method performs a network fetch operation and returns all matching items
+  /// ordered by creation date (oldest first).
   ///
   /// Parameters:
-  /// - [estimateId]: The ID of the estimation to fetch items for
-  /// - [offset]: Starting index for pagination (0-based)
-  /// - [limit]: Number of items to fetch
+  /// - [estimateId]: The ID of the estimation to fetch items for (required)
+  /// - [itemType]: Optional type filter. If provided, only items of this type are returned.
+  ///               If null, all item types are returned.
   ///
-  /// Returns a list of [CostItemDto] objects representing the cost items.
+  /// Returns a list of [CostItemDto] objects. Returns an empty list if no items found.
   ///
-  /// Throws an exception if the fetch operation fails.
-  Future<List<CostItemDto>> getCostItems({
+  /// Throws an exception if the fetch operation fails due to network or database errors.
+  Future<List<CostItemDto>> fetchCostItemsByEstimateId({
     required String estimateId,
-    required int offset,
-    required int limit,
+    String? itemType,
   });
 
-  /// Creates a new cost item.
+  /// Creates a new cost item in the remote database.
   ///
   /// Parameters:
   /// - [item]: The cost item DTO to create
   ///
-  /// Returns the created [CostItemDto] with server-generated fields populated.
+  /// Returns the created [CostItemDto] with server-generated fields populated
+  /// (id, createdAt, updatedAt).
   ///
   /// Throws an exception if the create operation fails.
   Future<CostItemDto> createCostItem(CostItemDto item);

--- a/lib/features/estimation/data/data_source/remote_cost_item_data_source.dart
+++ b/lib/features/estimation/data/data_source/remote_cost_item_data_source.dart
@@ -1,0 +1,95 @@
+import 'package:construculator/features/estimation/data/data_source/interfaces/cost_item_data_source.dart';
+import 'package:construculator/features/estimation/data/models/cost_item_dto.dart';
+import 'package:construculator/libraries/logging/app_logger.dart';
+import 'package:construculator/libraries/supabase/database_constants.dart';
+import 'package:construculator/libraries/supabase/interfaces/supabase_wrapper.dart';
+
+/// Remote data source for cost item operations using Supabase.
+///
+/// This data source handles all remote database operations for cost items,
+/// including fetching, creating, updating, and deleting cost items.
+class RemoteCostItemDataSource implements CostItemDataSource {
+  final SupabaseWrapper supabaseWrapper;
+  static final _logger = AppLogger().tag('RemoteCostItemDataSource');
+
+  static const String _itemTypeColumn = 'item_type';
+
+  RemoteCostItemDataSource({required this.supabaseWrapper});
+
+  @override
+  Future<List<CostItemDto>> getCostItems({
+    required String estimateId,
+    required int offset,
+    required int limit,
+  }) async {
+    _logger.debug(
+      'Getting cost items for estimate: $estimateId, '
+      'offset: $offset, limit: $limit',
+    );
+
+    final response = await supabaseWrapper.selectPaginated(
+      table: DatabaseConstants.costItemsTable,
+      filterColumn: DatabaseConstants.estimateIdColumn,
+      filterValue: estimateId,
+      orderColumn: DatabaseConstants.createdAtColumn,
+      ascending: true,
+      rangeFrom: offset,
+      rangeTo: offset + limit - 1,
+    );
+
+    if (response.isEmpty) {
+      _logger.warning(
+        'No cost items found for estimate: $estimateId at offset: $offset',
+      );
+      return [];
+    }
+
+    return response.map((item) => CostItemDto.fromJson(item)).toList();
+  }
+
+  @override
+  Future<CostItemDto> createCostItem(CostItemDto item) async {
+    _logger.debug('Creating cost item: ${item.id}');
+    final response = await supabaseWrapper.insert(
+      table: DatabaseConstants.costItemsTable,
+      data: item.toJson(),
+    );
+
+    return CostItemDto.fromJson(response);
+  }
+
+  /// Fetches cost items filtered by type for a specific estimate.
+  ///
+  /// Returns a list of [CostItemDto] matching the specified item type,
+  /// ordered by creation date (oldest first).
+  ///
+  /// Note: This is a convenience method not part of the interface.
+  /// For paginated access, use [getCostItems] instead.
+  Future<List<CostItemDto>> getCostItemsByType({
+    required String estimateId,
+    required String itemType,
+  }) async {
+    _logger.debug(
+      'Getting cost items for estimate: $estimateId, type: $itemType',
+    );
+
+    final response = await supabaseWrapper.selectMatch(
+      table: DatabaseConstants.costItemsTable,
+      filters: {
+        DatabaseConstants.estimateIdColumn: estimateId,
+        _itemTypeColumn: itemType,
+      },
+      orderBy: DatabaseConstants.createdAtColumn,
+      ascending: true,
+    );
+
+    if (response.isEmpty) {
+      _logger.warning(
+        'No cost items of type $itemType found for estimate: $estimateId',
+      );
+      return [];
+    }
+
+    return response.map((item) => CostItemDto.fromJson(item)).toList();
+  }
+}

--- a/lib/features/estimation/data/data_source/remote_cost_item_data_source.dart
+++ b/lib/features/estimation/data/data_source/remote_cost_item_data_source.dart
@@ -7,39 +7,47 @@ import 'package:construculator/libraries/supabase/interfaces/supabase_wrapper.da
 /// Remote data source for cost item operations using Supabase.
 ///
 /// This data source handles all remote database operations for cost items,
-/// including fetching, creating, updating, and deleting cost items.
+/// including fetching and creating cost items.
+///
+/// Following Rule 11: Uses explicit method names that clearly indicate
+/// network fetch operations with specific scope (by estimate ID).
 class RemoteCostItemDataSource implements CostItemDataSource {
-  final SupabaseWrapper supabaseWrapper;
+  final SupabaseWrapper _supabaseWrapper;
   static final _logger = AppLogger().tag('RemoteCostItemDataSource');
 
-  static const String _itemTypeColumn = 'item_type';
-
-  RemoteCostItemDataSource({required this.supabaseWrapper});
+  RemoteCostItemDataSource({required SupabaseWrapper supabaseWrapper})
+      : _supabaseWrapper = supabaseWrapper;
 
   @override
-  Future<List<CostItemDto>> getCostItems({
+  Future<List<CostItemDto>> fetchCostItemsByEstimateId({
     required String estimateId,
-    required int offset,
-    required int limit,
+    String? itemType,
   }) async {
     _logger.debug(
-      'Getting cost items for estimate: $estimateId, '
-      'offset: $offset, limit: $limit',
+      'Fetching cost items for estimate: $estimateId'
+      '${itemType != null ? ', type: $itemType' : ''}',
     );
 
-    final response = await supabaseWrapper.selectPaginated(
+    // Build filters dynamically based on whether itemType is provided
+    final filters = <String, dynamic>{
+      DatabaseConstants.estimateIdColumn: estimateId,
+    };
+
+    if (itemType != null) {
+      filters[DatabaseConstants.itemTypeColumn] = itemType;
+    }
+
+    final response = await _supabaseWrapper.selectMatch(
       table: DatabaseConstants.costItemsTable,
-      filterColumn: DatabaseConstants.estimateIdColumn,
-      filterValue: estimateId,
-      orderColumn: DatabaseConstants.createdAtColumn,
+      filters: filters,
+      orderBy: DatabaseConstants.createdAtColumn,
       ascending: true,
-      rangeFrom: offset,
-      rangeTo: offset + limit - 1,
     );
 
     if (response.isEmpty) {
       _logger.warning(
-        'No cost items found for estimate: $estimateId at offset: $offset',
+        'No cost items found for estimate: $estimateId'
+        '${itemType != null ? ' with type: $itemType' : ''}',
       );
       return [];
     }
@@ -50,46 +58,11 @@ class RemoteCostItemDataSource implements CostItemDataSource {
   @override
   Future<CostItemDto> createCostItem(CostItemDto item) async {
     _logger.debug('Creating cost item: ${item.id}');
-    final response = await supabaseWrapper.insert(
+    final response = await _supabaseWrapper.insert(
       table: DatabaseConstants.costItemsTable,
       data: item.toJson(),
     );
 
     return CostItemDto.fromJson(response);
-  }
-
-  /// Fetches cost items filtered by type for a specific estimate.
-  ///
-  /// Returns a list of [CostItemDto] matching the specified item type,
-  /// ordered by creation date (oldest first).
-  ///
-  /// Note: This is a convenience method not part of the interface.
-  /// For paginated access, use [getCostItems] instead.
-  Future<List<CostItemDto>> getCostItemsByType({
-    required String estimateId,
-    required String itemType,
-  }) async {
-    _logger.debug(
-      'Getting cost items for estimate: $estimateId, type: $itemType',
-    );
-
-    final response = await supabaseWrapper.selectMatch(
-      table: DatabaseConstants.costItemsTable,
-      filters: {
-        DatabaseConstants.estimateIdColumn: estimateId,
-        _itemTypeColumn: itemType,
-      },
-      orderBy: DatabaseConstants.createdAtColumn,
-      ascending: true,
-    );
-
-    if (response.isEmpty) {
-      _logger.warning(
-        'No cost items of type $itemType found for estimate: $estimateId',
-      );
-      return [];
-    }
-
-    return response.map((item) => CostItemDto.fromJson(item)).toList();
   }
 }

--- a/lib/features/estimation/data/data_source/remote_cost_item_data_source.dart
+++ b/lib/features/estimation/data/data_source/remote_cost_item_data_source.dart
@@ -7,39 +7,46 @@ import 'package:construculator/libraries/supabase/interfaces/supabase_wrapper.da
 /// Remote data source for cost item operations using Supabase.
 ///
 /// This data source handles all remote database operations for cost items,
-/// including fetching, creating, updating, and deleting cost items.
+/// including fetching and creating cost items.
+///
+/// Following Rule 11: Uses explicit method names that clearly indicate
+/// network fetch operations with specific scope (by estimate ID).
 class RemoteCostItemDataSource implements CostItemDataSource {
-  final SupabaseWrapper supabaseWrapper;
+  final SupabaseWrapper _supabaseWrapper;
   static final _logger = AppLogger().tag('RemoteCostItemDataSource');
 
-  static const String _itemTypeColumn = 'item_type';
-
-  RemoteCostItemDataSource({required this.supabaseWrapper});
+  RemoteCostItemDataSource({required SupabaseWrapper supabaseWrapper})
+      : _supabaseWrapper = supabaseWrapper;
 
   @override
-  Future<List<CostItemDto>> getCostItems({
+  Future<List<CostItemDto>> fetchCostItemsByEstimateId({
     required String estimateId,
-    required int offset,
-    required int limit,
+    String? itemType,
   }) async {
     _logger.debug(
-      'Getting cost items for estimate: $estimateId, '
-      'offset: $offset, limit: $limit',
+      'Fetching cost items for estimate: $estimateId'
+      '${itemType != null ? ', type: $itemType' : ''}',
     );
 
-    final response = await supabaseWrapper.selectPaginated(
+    final filters = <String, dynamic>{
+      DatabaseConstants.estimateIdColumn: estimateId,
+    };
+
+    if (itemType != null) {
+      filters[DatabaseConstants.itemTypeColumn] = itemType;
+    }
+
+    final response = await _supabaseWrapper.selectMatch(
       table: DatabaseConstants.costItemsTable,
-      filterColumn: DatabaseConstants.estimateIdColumn,
-      filterValue: estimateId,
-      orderColumn: DatabaseConstants.createdAtColumn,
+      filters: filters,
+      orderBy: DatabaseConstants.createdAtColumn,
       ascending: true,
-      rangeFrom: offset,
-      rangeTo: offset + limit - 1,
     );
 
     if (response.isEmpty) {
-      _logger.warning(
-        'No cost items found for estimate: $estimateId at offset: $offset',
+      _logger.debug(
+        'No cost items found for estimate: $estimateId'
+        '${itemType != null ? ' with type: $itemType' : ''}',
       );
       return [];
     }
@@ -50,46 +57,11 @@ class RemoteCostItemDataSource implements CostItemDataSource {
   @override
   Future<CostItemDto> createCostItem(CostItemDto item) async {
     _logger.debug('Creating cost item: ${item.id}');
-    final response = await supabaseWrapper.insert(
+    final response = await _supabaseWrapper.insert(
       table: DatabaseConstants.costItemsTable,
       data: item.toJson(),
     );
 
     return CostItemDto.fromJson(response);
-  }
-
-  /// Fetches cost items filtered by type for a specific estimate.
-  ///
-  /// Returns a list of [CostItemDto] matching the specified item type,
-  /// ordered by creation date (oldest first).
-  ///
-  /// Note: This is a convenience method not part of the interface.
-  /// For paginated access, use [getCostItems] instead.
-  Future<List<CostItemDto>> getCostItemsByType({
-    required String estimateId,
-    required String itemType,
-  }) async {
-    _logger.debug(
-      'Getting cost items for estimate: $estimateId, type: $itemType',
-    );
-
-    final response = await supabaseWrapper.selectMatch(
-      table: DatabaseConstants.costItemsTable,
-      filters: {
-        DatabaseConstants.estimateIdColumn: estimateId,
-        _itemTypeColumn: itemType,
-      },
-      orderBy: DatabaseConstants.createdAtColumn,
-      ascending: true,
-    );
-
-    if (response.isEmpty) {
-      _logger.warning(
-        'No cost items of type $itemType found for estimate: $estimateId',
-      );
-      return [];
-    }
-
-    return response.map((item) => CostItemDto.fromJson(item)).toList();
   }
 }

--- a/lib/features/estimation/estimation_module.dart
+++ b/lib/features/estimation/estimation_module.dart
@@ -1,8 +1,10 @@
 import 'package:construculator/app/app_bootstrap.dart';
 import 'package:construculator/features/estimation/data/data_source/interfaces/cost_estimation_data_source.dart';
 import 'package:construculator/features/estimation/data/data_source/interfaces/cost_estimation_log_data_source.dart';
+import 'package:construculator/features/estimation/data/data_source/interfaces/cost_item_data_source.dart';
 import 'package:construculator/features/estimation/data/data_source/remote_cost_estimation_data_source.dart';
 import 'package:construculator/features/estimation/data/data_source/remote_cost_estimation_log_data_source.dart';
+import 'package:construculator/features/estimation/data/data_source/remote_cost_item_data_source.dart';
 import 'package:construculator/features/estimation/data/repositories/cost_estimation_log_repository_impl.dart';
 import 'package:construculator/features/estimation/data/repositories/cost_estimation_repository_impl.dart';
 import 'package:construculator/features/estimation/domain/repositories/cost_estimation_log_repository.dart';
@@ -95,6 +97,12 @@ class EstimationModule extends Module {
 
     i.addLazySingleton<CostEstimationLogDataSource>(
       () => RemoteCostEstimationLogDataSource(
+        supabaseWrapper: appBootstrap.supabaseWrapper,
+      ),
+    );
+
+    i.addLazySingleton<CostItemDataSource>(
+      () => RemoteCostItemDataSource(
         supabaseWrapper: appBootstrap.supabaseWrapper,
       ),
     );

--- a/lib/features/estimation/estimation_module.dart
+++ b/lib/features/estimation/estimation_module.dart
@@ -13,7 +13,9 @@ import 'package:construculator/features/estimation/presentation/bloc/rename_esti
 import 'package:construculator/features/estimation/presentation/pages/cost_estimation_landing_page.dart';
 import 'package:construculator/libraries/auth/auth_library_module.dart';
 import 'package:construculator/libraries/estimation/data/estimation_tile_provider_impl.dart';
+import 'package:construculator/libraries/estimation/data/repositories/cost_estimation_repository_impl.dart';
 import 'package:construculator/libraries/estimation/domain/estimation_tile_provider.dart';
+import 'package:construculator/libraries/estimation/domain/repositories/cost_estimation_repository.dart';
 import 'package:construculator/libraries/estimation/estimation_library_module.dart';
 import 'package:construculator/libraries/project/interfaces/current_project_notifier.dart';
 import 'package:construculator/libraries/project/project_library_module.dart';
@@ -72,6 +74,11 @@ class EstimationModule extends Module {
       () => RemoteCostEstimationLogDataSource(
         supabaseWrapper: appBootstrap.supabaseWrapper,
       ),
+    );
+
+    i.addLazySingleton<CostEstimationRepository>(
+      () => CostEstimationRepositoryImpl(dataSource: i.get()),
+      config: BindConfig(onDispose: (repository) => repository.dispose()),
     );
 
     i.addLazySingleton<CostEstimationLogRepository>(

--- a/lib/features/estimation/estimation_module.dart
+++ b/lib/features/estimation/estimation_module.dart
@@ -1,6 +1,8 @@
 import 'package:construculator/app/app_bootstrap.dart';
 import 'package:construculator/features/estimation/data/data_source/interfaces/cost_estimation_log_data_source.dart';
+import 'package:construculator/features/estimation/data/data_source/interfaces/cost_item_data_source.dart';
 import 'package:construculator/features/estimation/data/data_source/remote_cost_estimation_log_data_source.dart';
+import 'package:construculator/features/estimation/data/data_source/remote_cost_item_data_source.dart';
 import 'package:construculator/features/estimation/data/repositories/cost_estimation_log_repository_impl.dart';
 import 'package:construculator/features/estimation/domain/repositories/cost_estimation_log_repository.dart';
 import 'package:construculator/features/estimation/domain/usecases/add_cost_estimation_usecase.dart';
@@ -72,6 +74,12 @@ class EstimationModule extends Module {
   void binds(Injector i) {
     i.addLazySingleton<CostEstimationLogDataSource>(
       () => RemoteCostEstimationLogDataSource(
+        supabaseWrapper: appBootstrap.supabaseWrapper,
+      ),
+    );
+
+    i.addLazySingleton<CostItemDataSource>(
+      () => RemoteCostItemDataSource(
         supabaseWrapper: appBootstrap.supabaseWrapper,
       ),
     );

--- a/lib/libraries/supabase/database_constants.dart
+++ b/lib/libraries/supabase/database_constants.dart
@@ -13,6 +13,7 @@ class DatabaseConstants {
   // Table names
   static const String costEstimatesTable = 'cost_estimates';
   static const String costEstimationLogsTable = 'cost_estimate_logs';
+  static const String costItemsTable = 'cost_items';
   static const String projectsTable = 'projects';
   static const String projectMembersTable = 'project_members';
   static const String searchHistoryTable = 'search_history';

--- a/lib/libraries/supabase/database_constants.dart
+++ b/lib/libraries/supabase/database_constants.dart
@@ -64,4 +64,7 @@ class DatabaseConstants {
   static const String userColumn = 'user';
   static const String activityDetailsColumn = 'activity_details';
   static const String loggedAtColumn = 'logged_at';
+
+  // Cost Items columns
+  static const String itemTypeColumn = 'item_type';
 }

--- a/lib/libraries/supabase/database_constants.dart
+++ b/lib/libraries/supabase/database_constants.dart
@@ -78,4 +78,7 @@ class DatabaseConstants {
   static const String userColumn = 'user';
   static const String activityDetailsColumn = 'activity_details';
   static const String loggedAtColumn = 'logged_at';
+
+  // Cost Items columns
+  static const String itemTypeColumn = 'item_type';
 }

--- a/lib/libraries/supabase/database_constants.dart
+++ b/lib/libraries/supabase/database_constants.dart
@@ -14,6 +14,7 @@ class DatabaseConstants {
   // Table names
   static const String costEstimatesTable = 'cost_estimates';
   static const String costEstimationLogsTable = 'cost_estimate_logs';
+  static const String costItemsTable = 'cost_items';
   static const String projectsTable = 'projects';
   static const String projectMembersTable = 'project_members';
   static const String searchHistoryTable = 'search_history';

--- a/test/features/estimations/mutations/remote_cost_item_data_source.xml
+++ b/test/features/estimations/mutations/remote_cost_item_data_source.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mutations version="1.0">
+    <!-- REMOTE COST ITEM DATA SOURCE MUTATION TESTING -->
+    <!-- Targets: Remote data source implementation for cost items -->
+
+    <files>
+        <file>lib/features/estimation/data/data_source/remote_cost_item_data_source.dart</file>
+    </files>
+
+    <exclude>
+        <!-- Exclude logging statements -->
+        <regex pattern="_logger\.(debug|info|warning|error)\s*\(" dotAll="false"/>
+
+        <!-- Exclude override annotations -->
+        <regex pattern="@override" dotAll="false"/>
+    </exclude>
+
+    <rules>
+        <!-- RULE 1: In `getCostItems`, break pagination calculation - remove the -1 -->
+        <regex pattern="(rangeTo:\s*offset\s*\+\s*limit\s*-\s*1)" id="cost_item.pagination.rangeto_off_by_one">
+            <mutation text="rangeTo: offset + limit"/>
+        </regex>
+
+        <!-- RULE 2: In `getCostItems`, break pagination calculation - wrong operator -->
+        <regex pattern="(rangeTo:\s*offset\s*\+\s*limit\s*-\s*1)" id="cost_item.pagination.rangeto_wrong_operator">
+            <mutation text="rangeTo: offset - limit + 1"/>
+        </regex>
+
+        <!-- RULE 3: In `getCostItems`, invert sort order from ascending to descending -->
+        <regex pattern="(ascending:\s*true,)" id="cost_item.sort.invert_order">
+            <mutation text="ascending: false,"/>
+        </regex>
+
+        <!-- RULE 4: In `getCostItems`, use wrong filter column -->
+        <regex pattern="(filterColumn:\s*estimateIdColumn,)" id="cost_item.filter.wrong_column">
+            <mutation text="filterColumn: idColumn,"/>
+        </regex>
+
+        <!-- RULE 5: In `getCostItems`, use wrong filter value -->
+        <regex pattern="(filterValue:\s*estimateId,)" id="cost_item.filter.wrong_value">
+            <mutation text="filterValue: '',"/>
+        </regex>
+
+        <!-- RULE 6: In `getCostItems`, return empty list instead of mapping -->
+        <regex pattern="(return response\.map\(\(item\) => CostItemDto\.fromJson\(item\)\)\.toList\(\);)" id="cost_item.mapping.return_empty">
+            <mutation text="return [];"/>
+        </regex>
+
+        <!-- RULE 7: In `getCostItems`, use wrong order column -->
+        <regex pattern="(orderColumn:\s*createdAtColumn,)" id="cost_item.sort.wrong_column">
+            <mutation text="orderColumn: estimateIdColumn,"/>
+        </regex>
+
+        <!-- RULE 8: In `getCostItems`, use wrong table name -->
+        <regex pattern="(table:\s*costItemsTable,)" id="cost_item.table.wrong_name_get">
+            <mutation text="table: 'wrong_table',"/>
+        </regex>
+
+        <!-- RULE 9: In `createCostItem`, use wrong table name -->
+        <regex pattern="(table:\s*costItemsTable,\s*data:\s*item\.toJson)" id="cost_item.table.wrong_name_create">
+            <mutation text="table: 'wrong_table', data: item.toJson"/>
+        </regex>
+
+        <!-- RULE 10: In `createCostItem`, use empty data -->
+        <regex pattern="(data:\s*item\.toJson\(\),)" id="cost_item.create.empty_data">
+            <mutation text="data: {},"/>
+        </regex>
+
+        <!-- RULE 11: In `getCostItemsByType`, use wrong filter for itemType -->
+        <regex pattern="(\{estimateIdColumn:\s*estimateId,\s*itemTypeColumn:\s*itemType\})" id="cost_item.type_filter.missing_type">
+            <mutation text="{estimateIdColumn: estimateId}"/>
+        </regex>
+
+        <!-- RULE 12: In `getCostItemsByType`, use wrong filter for estimateId -->
+        <regex pattern="(\{estimateIdColumn:\s*estimateId,\s*itemTypeColumn:\s*itemType\})" id="cost_item.type_filter.missing_estimate">
+            <mutation text="{itemTypeColumn: itemType}"/>
+        </regex>
+
+        <!-- RULE 13: In `getCostItemsByType`, invert sort order -->
+        <regex pattern="(orderBy:\s*createdAtColumn,\s*ascending:\s*true,)" id="cost_item.type_filter.invert_order">
+            <mutation text="orderBy: createdAtColumn, ascending: false,"/>
+        </regex>
+
+        <!-- RULE 14: In `getCostItemsByType`, use wrong order column -->
+        <regex pattern="(orderBy:\s*createdAtColumn,)" id="cost_item.type_filter.wrong_order_column">
+            <mutation text="orderBy: itemTypeColumn,"/>
+        </regex>
+
+        <!-- RULE 15: In `getCostItemsByType`, return empty on valid response -->
+        <regex pattern="(return response\.map\(\(item\) => CostItemDto\.fromJson\(item\)\)\.toList\(\);)" id="cost_item.type_filter.return_empty">
+            <mutation text="return [];"/>
+        </regex>
+    </rules>
+
+    <commands>
+        <command group="cost_item_data_source" expected-return="0">flutter test test/features/estimations/units/data/data_source/remote_cost_item_data_source_test.dart</command>
+    </commands>
+
+    <threshold failure="85">
+        <rating over="85" name="A"/>
+        <rating over="75" name="B"/>
+        <rating over="65" name="C"/>
+        <rating over="55" name="D"/>
+        <rating over="35" name="E"/>
+        <rating over="0" name="F"/>
+    </threshold>
+</mutations>

--- a/test/features/estimations/mutations/remote_cost_item_data_source.xml
+++ b/test/features/estimations/mutations/remote_cost_item_data_source.xml
@@ -2,6 +2,7 @@
 <mutations version="1.0">
     <!-- REMOTE COST ITEM DATA SOURCE MUTATION TESTING -->
     <!-- Targets: Remote data source implementation for cost items -->
+    <!-- Methods tested: fetchCostItemsByEstimateId, createCostItem -->
 
     <files>
         <file>lib/features/estimation/data/data_source/remote_cost_item_data_source.dart</file>
@@ -16,79 +17,79 @@
     </exclude>
 
     <rules>
-        <!-- RULE 1: In `getCostItems`, break pagination calculation - remove the -1 -->
-        <regex pattern="(rangeTo:\s*offset\s*\+\s*limit\s*-\s*1)" id="cost_item.pagination.rangeto_off_by_one">
-            <mutation text="rangeTo: offset + limit"/>
+        <!-- RULE 1: In `fetchCostItemsByEstimateId`, use wrong table name -->
+        <regex pattern="(table:\s*DatabaseConstants\.costItemsTable,\s*filters:\s*filters,)" id="cost_item.fetch.wrong_table">
+            <mutation text="table: 'wrong_table', filters: filters,"/>
         </regex>
 
-        <!-- RULE 2: In `getCostItems`, break pagination calculation - wrong operator -->
-        <regex pattern="(rangeTo:\s*offset\s*\+\s*limit\s*-\s*1)" id="cost_item.pagination.rangeto_wrong_operator">
-            <mutation text="rangeTo: offset - limit + 1"/>
+        <!-- RULE 2: In `fetchCostItemsByEstimateId`, invert sort order -->
+        <regex pattern="(ascending:\s*true,\s*\);)" id="cost_item.fetch.invert_order">
+            <mutation text="ascending: false, );"/>
         </regex>
 
-        <!-- RULE 3: In `getCostItems`, invert sort order from ascending to descending -->
-        <regex pattern="(ascending:\s*true,)" id="cost_item.sort.invert_order">
-            <mutation text="ascending: false,"/>
+        <!-- RULE 3: In `fetchCostItemsByEstimateId`, use wrong orderBy column -->
+        <regex pattern="(orderBy:\s*DatabaseConstants\.createdAtColumn,)" id="cost_item.fetch.wrong_order_column">
+            <mutation text="orderBy: DatabaseConstants.estimateIdColumn,"/>
         </regex>
 
-        <!-- RULE 4: In `getCostItems`, use wrong filter column -->
-        <regex pattern="(filterColumn:\s*estimateIdColumn,)" id="cost_item.filter.wrong_column">
-            <mutation text="filterColumn: idColumn,"/>
-        </regex>
-
-        <!-- RULE 5: In `getCostItems`, use wrong filter value -->
-        <regex pattern="(filterValue:\s*estimateId,)" id="cost_item.filter.wrong_value">
-            <mutation text="filterValue: '',"/>
-        </regex>
-
-        <!-- RULE 6: In `getCostItems`, return empty list instead of mapping -->
-        <regex pattern="(return response\.map\(\(item\) => CostItemDto\.fromJson\(item\)\)\.toList\(\);)" id="cost_item.mapping.return_empty">
+        <!-- RULE 4: In `fetchCostItemsByEstimateId`, return empty list instead of mapping -->
+        <regex pattern="(return response\.map\(\(item\) =&gt; CostItemDto\.fromJson\(item\)\)\.toList\(\);)" id="cost_item.fetch.return_empty">
             <mutation text="return [];"/>
         </regex>
 
-        <!-- RULE 7: In `getCostItems`, use wrong order column -->
-        <regex pattern="(orderColumn:\s*createdAtColumn,)" id="cost_item.sort.wrong_column">
-            <mutation text="orderColumn: estimateIdColumn,"/>
+        <!-- RULE 5: In `fetchCostItemsByEstimateId`, skip adding estimateId to filters -->
+        <regex pattern="(DatabaseConstants\.estimateIdColumn:\s*estimateId,)" id="cost_item.fetch.missing_estimate_filter">
+            <mutation text="DatabaseConstants.idColumn: '',"/>
         </regex>
 
-        <!-- RULE 8: In `getCostItems`, use wrong table name -->
-        <regex pattern="(table:\s*costItemsTable,)" id="cost_item.table.wrong_name_get">
-            <mutation text="table: 'wrong_table',"/>
+        <!-- RULE 6: In `fetchCostItemsByEstimateId`, always add itemType even when null -->
+        <regex pattern="(if \(itemType != null\) \{\s*filters\[DatabaseConstants\.itemTypeColumn\] = itemType;\s*\})" id="cost_item.fetch.always_add_type">
+            <mutation text="filters[DatabaseConstants.itemTypeColumn] = itemType;"/>
         </regex>
 
-        <!-- RULE 9: In `createCostItem`, use wrong table name -->
-        <regex pattern="(table:\s*costItemsTable,\s*data:\s*item\.toJson)" id="cost_item.table.wrong_name_create">
-            <mutation text="table: 'wrong_table', data: item.toJson"/>
+        <!-- RULE 7: In `fetchCostItemsByEstimateId`, never add itemType to filters -->
+        <regex pattern="(if \(itemType != null\) \{\s*filters\[DatabaseConstants\.itemTypeColumn\] = itemType;\s*\})" id="cost_item.fetch.never_add_type">
+            <mutation text="// Skip itemType filter"/>
         </regex>
 
-        <!-- RULE 10: In `createCostItem`, use empty data -->
+        <!-- RULE 8: In `fetchCostItemsByEstimateId`, use wrong column for itemType filter -->
+        <regex pattern="(filters\[DatabaseConstants\.itemTypeColumn\] = itemType;)" id="cost_item.fetch.wrong_type_column">
+            <mutation text="filters[DatabaseConstants.estimateIdColumn] = itemType;"/>
+        </regex>
+
+        <!-- RULE 9: In `fetchCostItemsByEstimateId`, return empty list when response is not empty -->
+        <regex pattern="(if \(response\.isEmpty\) \{[\s\S]*?return \[\];[\s\S]*?\})" id="cost_item.fetch.invert_empty_check">
+            <mutation text="if (response.isNotEmpty) { _logger.warning( 'No cost items found for estimate: $estimateId' '${itemType != null ? ' with type: $itemType' : ''}', ); return []; }"/>
+        </regex>
+
+        <!-- RULE 10: In `createCostItem`, use wrong table name -->
+        <regex pattern="(table:\s*DatabaseConstants\.costItemsTable,\s*data:\s*item\.toJson\(\),)" id="cost_item.create.wrong_table">
+            <mutation text="table: 'wrong_table', data: item.toJson(),"/>
+        </regex>
+
+        <!-- RULE 11: In `createCostItem`, use empty data -->
         <regex pattern="(data:\s*item\.toJson\(\),)" id="cost_item.create.empty_data">
             <mutation text="data: {},"/>
         </regex>
 
-        <!-- RULE 11: In `getCostItemsByType`, use wrong filter for itemType -->
-        <regex pattern="(\{estimateIdColumn:\s*estimateId,\s*itemTypeColumn:\s*itemType\})" id="cost_item.type_filter.missing_type">
-            <mutation text="{estimateIdColumn: estimateId}"/>
+        <!-- RULE 12: In `createCostItem`, return null instead of mapping response -->
+        <regex pattern="(return CostItemDto\.fromJson\(response\);)" id="cost_item.create.return_null">
+            <mutation text="return CostItemDto.fromJson({});"/>
         </regex>
 
-        <!-- RULE 12: In `getCostItemsByType`, use wrong filter for estimateId -->
-        <regex pattern="(\{estimateIdColumn:\s*estimateId,\s*itemTypeColumn:\s*itemType\})" id="cost_item.type_filter.missing_estimate">
-            <mutation text="{itemTypeColumn: itemType}"/>
+        <!-- RULE 13: In `fetchCostItemsByEstimateId`, use empty filters -->
+        <regex pattern="(final filters = &lt;String, dynamic&gt;\{\s*DatabaseConstants\.estimateIdColumn:\s*estimateId,\s*\};)" id="cost_item.fetch.empty_filters">
+            <mutation text="final filters = &lt;String, dynamic&gt;{};"/>
         </regex>
 
-        <!-- RULE 13: In `getCostItemsByType`, invert sort order -->
-        <regex pattern="(orderBy:\s*createdAtColumn,\s*ascending:\s*true,)" id="cost_item.type_filter.invert_order">
-            <mutation text="orderBy: createdAtColumn, ascending: false,"/>
+        <!-- RULE 14: In `fetchCostItemsByEstimateId`, use wrong filter value for estimateId -->
+        <regex pattern="(DatabaseConstants\.estimateIdColumn:\s*estimateId,)" id="cost_item.fetch.wrong_estimate_value">
+            <mutation text="DatabaseConstants.estimateIdColumn: '',"/>
         </regex>
 
-        <!-- RULE 14: In `getCostItemsByType`, use wrong order column -->
-        <regex pattern="(orderBy:\s*createdAtColumn,)" id="cost_item.type_filter.wrong_order_column">
-            <mutation text="orderBy: itemTypeColumn,"/>
-        </regex>
-
-        <!-- RULE 15: In `getCostItemsByType`, return empty on valid response -->
-        <regex pattern="(return response\.map\(\(item\) => CostItemDto\.fromJson\(item\)\)\.toList\(\);)" id="cost_item.type_filter.return_empty">
-            <mutation text="return [];"/>
+        <!-- RULE 15: In `fetchCostItemsByEstimateId`, map with wrong DTO -->
+        <regex pattern="(response\.map\(\(item\) =&gt; CostItemDto\.fromJson\(item\)\)\.toList\(\))" id="cost_item.fetch.wrong_dto_mapping">
+            <mutation text="response.map((item) =&gt; CostItemDto.fromJson({})).toList()"/>
         </regex>
     </rules>
 

--- a/test/features/estimations/units/data/data_source/remote_cost_item_data_source_test.dart
+++ b/test/features/estimations/units/data/data_source/remote_cost_item_data_source_test.dart
@@ -1,0 +1,374 @@
+import 'package:construculator/features/estimation/data/data_source/interfaces/cost_item_data_source.dart';
+import 'package:construculator/features/estimation/data/data_source/remote_cost_item_data_source.dart';
+import 'package:construculator/features/estimation/data/models/cost_item_dto.dart';
+import 'package:construculator/features/estimation/estimation_module.dart';
+import 'package:construculator/libraries/supabase/database_constants.dart';
+import 'package:construculator/libraries/supabase/interfaces/supabase_wrapper.dart';
+import 'package:construculator/libraries/supabase/testing/fake_supabase_wrapper.dart';
+import 'package:construculator/libraries/time/testing/fake_clock_impl.dart';
+import 'package:flutter_modular/flutter_modular.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../../../../../utils/fake_app_bootstrap_factory.dart';
+import '../../../helpers/cost_item_test_data_map_factory.dart';
+
+void main() {
+  group('RemoteCostItemDataSource', () {
+    late CostItemDataSource dataSource;
+    late FakeSupabaseWrapper fakeSupabaseWrapper;
+    late FakeClockImpl fakeClock;
+
+    const testEstimateId = 'estimate-123';
+
+    setUpAll(() {
+      fakeClock = FakeClockImpl();
+      Modular.init(
+        EstimationModule(
+          FakeAppBootstrapFactory.create(
+            supabaseWrapper: FakeSupabaseWrapper(clock: fakeClock),
+          ),
+        ),
+      );
+      fakeSupabaseWrapper =
+          Modular.get<SupabaseWrapper>() as FakeSupabaseWrapper;
+      dataSource = Modular.get<CostItemDataSource>();
+    });
+
+    tearDownAll(() {
+      Modular.destroy();
+    });
+
+    setUp(() {
+      fakeSupabaseWrapper.reset();
+    });
+
+    void seedItemTable(List<Map<String, dynamic>> rows) {
+      fakeSupabaseWrapper.addTableData(DatabaseConstants.costItemsTable, rows);
+    }
+
+    group('getCostItems', () {
+      test('successfully fetches paginated cost items', () async {
+        final testItems = [
+          CostItemTestDataMapFactory.createMaterialItemData(
+            id: 'item-1',
+            estimateId: testEstimateId,
+            itemName: 'Concrete',
+          ),
+          CostItemTestDataMapFactory.createLaborItemData(
+            id: 'item-2',
+            estimateId: testEstimateId,
+            itemName: 'Installation',
+          ),
+          CostItemTestDataMapFactory.createEquipmentItemData(
+            id: 'item-3',
+            estimateId: testEstimateId,
+            itemName: 'Excavator',
+          ),
+        ];
+        seedItemTable(testItems);
+
+        final expectedDtos = testItems
+            .map((data) => CostItemDto.fromJson(data))
+            .toList();
+
+        final result = await dataSource.getCostItems(
+          estimateId: testEstimateId,
+          offset: 0,
+          limit: 10,
+        );
+
+        expect(result.length, 3);
+        expect(result, expectedDtos);
+      });
+
+      test('uses correct table and filter parameters', () async {
+        seedItemTable([
+          CostItemTestDataMapFactory.createMaterialItemData(
+            id: 'item-1',
+            estimateId: testEstimateId,
+          ),
+        ]);
+
+        await dataSource.getCostItems(
+          estimateId: testEstimateId,
+          offset: 0,
+          limit: 10,
+        );
+
+        final calls = fakeSupabaseWrapper.getMethodCallsFor('selectPaginated');
+        expect(calls.length, 1);
+        final call = calls.first;
+        expect(call, {
+          'method': 'selectPaginated',
+          'table': DatabaseConstants.costItemsTable,
+          'columns': '*',
+          'filterColumn': DatabaseConstants.estimateIdColumn,
+          'filterValue': testEstimateId,
+          'orderColumn': DatabaseConstants.createdAtColumn,
+          'ascending': true,
+          'rangeFrom': 0,
+          'rangeTo': 9,
+        });
+      });
+
+      test('returns empty list when no items exist', () async {
+        final result = await dataSource.getCostItems(
+          estimateId: testEstimateId,
+          offset: 0,
+          limit: 10,
+        );
+
+        expect(result, isEmpty);
+      });
+
+      test('converts JSON to CostItemDto correctly', () async {
+        final testItem = CostItemTestDataMapFactory.createMaterialItemData(
+          id: 'item-1',
+          estimateId: testEstimateId,
+          itemName: 'Concrete Mix',
+          unitPrice: 100.0,
+          quantity: 50.0,
+        );
+        seedItemTable([testItem]);
+
+        final expectedDto = CostItemDto.fromJson(testItem);
+
+        final result = await dataSource.getCostItems(
+          estimateId: testEstimateId,
+          offset: 0,
+          limit: 10,
+        );
+
+        expect(result.length, 1);
+        final dto = result.first;
+        expect(dto, isA<CostItemDto>());
+        expect(dto, expectedDto);
+      });
+
+      test('propagates exceptions from supabase wrapper', () async {
+        fakeSupabaseWrapper.shouldThrowOnSelectPaginated = true;
+        fakeSupabaseWrapper.selectPaginatedErrorMessage = 'Network error';
+
+        await expectLater(
+          dataSource.getCostItems(
+            estimateId: testEstimateId,
+            offset: 0,
+            limit: 10,
+          ),
+          throwsException,
+        );
+      });
+
+      test('handles pagination with offset correctly', () async {
+        seedItemTable(
+          List.generate(
+            20,
+            (i) => CostItemTestDataMapFactory.createMaterialItemData(
+              id: 'item-$i',
+              estimateId: testEstimateId,
+            ),
+          ),
+        );
+
+        await dataSource.getCostItems(
+          estimateId: testEstimateId,
+          offset: 10,
+          limit: 5,
+        );
+
+        final calls = fakeSupabaseWrapper.getMethodCallsFor('selectPaginated');
+        expect(calls.length, 1);
+        final call = calls.first;
+        expect(call['rangeFrom'], 10);
+        expect(call['rangeTo'], 14);
+      });
+    });
+
+    group('createCostItem', () {
+      test('successfully creates a cost item', () async {
+        final testItem = CostItemTestDataMapFactory.createMaterialItemData(
+          id: '1',
+          estimateId: testEstimateId,
+          itemName: 'Steel Beams',
+        );
+        final itemDto = CostItemDto.fromJson(testItem);
+
+        seedItemTable([testItem]);
+
+        final result = await dataSource.createCostItem(itemDto);
+
+        expect(result, isA<CostItemDto>());
+        expect(result.id, '1');
+        expect(result.itemName, 'Steel Beams');
+      });
+
+      test('uses correct table for insert', () async {
+        final testItem = CostItemTestDataMapFactory.createLaborItemData(
+          id: '1',
+          estimateId: testEstimateId,
+        );
+        final itemDto = CostItemDto.fromJson(testItem);
+        seedItemTable([testItem]);
+
+        await dataSource.createCostItem(itemDto);
+
+        final calls = fakeSupabaseWrapper.getMethodCallsFor('insert');
+        expect(calls.length, 1);
+        expect(calls.first['table'], DatabaseConstants.costItemsTable);
+      });
+    });
+
+    group('getCostItemsByType', () {
+      test('successfully fetches items filtered by type', () async {
+        final testItems = [
+          CostItemTestDataMapFactory.createMaterialItemData(
+            id: 'item-1',
+            estimateId: testEstimateId,
+            itemName: 'Concrete',
+          ),
+          CostItemTestDataMapFactory.createMaterialItemData(
+            id: 'item-2',
+            estimateId: testEstimateId,
+            itemName: 'Steel',
+          ),
+          CostItemTestDataMapFactory.createLaborItemData(
+            id: 'item-3',
+            estimateId: testEstimateId,
+            itemName: 'Installation',
+          ),
+        ];
+        seedItemTable(testItems);
+
+        final remoteDataSource = dataSource as RemoteCostItemDataSource;
+        final result = await remoteDataSource.getCostItemsByType(
+          estimateId: testEstimateId,
+          itemType: 'material',
+        );
+
+        expect(result.length, 2);
+        expect(result.every((item) => item.itemType == 'material'), isTrue);
+        expect(result[0].itemName, 'Concrete');
+        expect(result[1].itemName, 'Steel');
+      });
+
+      test('uses correct table and filter parameters', () async {
+        seedItemTable([
+          CostItemTestDataMapFactory.createLaborItemData(
+            id: 'item-1',
+            estimateId: testEstimateId,
+          ),
+        ]);
+
+        final remoteDataSource = dataSource as RemoteCostItemDataSource;
+        await remoteDataSource.getCostItemsByType(
+          estimateId: testEstimateId,
+          itemType: 'labor',
+        );
+
+        final calls = fakeSupabaseWrapper.getMethodCallsFor('selectMatch');
+        expect(calls.length, 1);
+        final call = calls.first;
+        expect(call, {
+          'method': 'selectMatch',
+          'table': DatabaseConstants.costItemsTable,
+          'columns': '*',
+          'filters': {
+            DatabaseConstants.estimateIdColumn: testEstimateId,
+            'item_type': 'labor',
+          },
+          'orderBy': DatabaseConstants.createdAtColumn,
+          'ascending': true,
+        });
+      });
+
+      test('returns empty list when no items match the type', () async {
+        seedItemTable([
+          CostItemTestDataMapFactory.createMaterialItemData(
+            id: 'item-1',
+            estimateId: testEstimateId,
+          ),
+        ]);
+
+        final remoteDataSource = dataSource as RemoteCostItemDataSource;
+        final result = await remoteDataSource.getCostItemsByType(
+          estimateId: testEstimateId,
+          itemType: 'equipment',
+        );
+
+        expect(result, isEmpty);
+      });
+
+      test('returns empty list when no items exist', () async {
+        final remoteDataSource = dataSource as RemoteCostItemDataSource;
+        final result = await remoteDataSource.getCostItemsByType(
+          estimateId: testEstimateId,
+          itemType: 'material',
+        );
+
+        expect(result, isEmpty);
+      });
+
+      test('converts JSON to CostItemDto correctly', () async {
+        final testItem = CostItemTestDataMapFactory.createEquipmentItemData(
+          id: 'item-1',
+          estimateId: testEstimateId,
+          itemName: 'Excavator',
+        );
+        seedItemTable([testItem]);
+
+        final expectedDto = CostItemDto.fromJson(testItem);
+
+        final remoteDataSource = dataSource as RemoteCostItemDataSource;
+        final result = await remoteDataSource.getCostItemsByType(
+          estimateId: testEstimateId,
+          itemType: 'equipment',
+        );
+
+        expect(result.length, 1);
+        final dto = result.first;
+        expect(dto, isA<CostItemDto>());
+        expect(dto, expectedDto);
+      });
+
+      test('propagates exceptions from supabase wrapper', () async {
+        fakeSupabaseWrapper.shouldThrowOnSelectMatch = true;
+        fakeSupabaseWrapper.selectMatchErrorMessage = 'Network error';
+
+        final remoteDataSource = dataSource as RemoteCostItemDataSource;
+        await expectLater(
+          remoteDataSource.getCostItemsByType(
+            estimateId: testEstimateId,
+            itemType: 'material',
+          ),
+          throwsException,
+        );
+      });
+
+      test('orders results by creation date ascending', () async {
+        final testItems = [
+          CostItemTestDataMapFactory.createMaterialItemData(
+            id: 'item-2',
+            estimateId: testEstimateId,
+            itemName: 'Second',
+          ),
+          CostItemTestDataMapFactory.createMaterialItemData(
+            id: 'item-1',
+            estimateId: testEstimateId,
+            itemName: 'First',
+          ),
+        ];
+        seedItemTable(testItems);
+
+        final remoteDataSource = dataSource as RemoteCostItemDataSource;
+        await remoteDataSource.getCostItemsByType(
+          estimateId: testEstimateId,
+          itemType: 'material',
+        );
+
+        final calls = fakeSupabaseWrapper.getMethodCallsFor('selectMatch');
+        expect(calls.first['orderBy'], DatabaseConstants.createdAtColumn);
+        expect(calls.first['ascending'], isTrue);
+      });
+    });
+  });
+}

--- a/test/features/estimations/units/data/data_source/remote_cost_item_data_source_test.dart
+++ b/test/features/estimations/units/data/data_source/remote_cost_item_data_source_test.dart
@@ -1,5 +1,4 @@
 import 'package:construculator/features/estimation/data/data_source/interfaces/cost_item_data_source.dart';
-import 'package:construculator/features/estimation/data/data_source/remote_cost_item_data_source.dart';
 import 'package:construculator/features/estimation/data/models/cost_item_dto.dart';
 import 'package:construculator/features/estimation/estimation_module.dart';
 import 'package:construculator/libraries/supabase/database_constants.dart';
@@ -46,8 +45,8 @@ void main() {
       fakeSupabaseWrapper.addTableData(DatabaseConstants.costItemsTable, rows);
     }
 
-    group('getCostItems', () {
-      test('successfully fetches paginated cost items', () async {
+    group('fetchCostItemsByEstimateId', () {
+      test('successfully fetches all cost items without type filter', () async {
         final testItems = [
           CostItemTestDataMapFactory.createMaterialItemData(
             id: 'item-1',
@@ -71,17 +70,46 @@ void main() {
             .map((data) => CostItemDto.fromJson(data))
             .toList();
 
-        final result = await dataSource.getCostItems(
+        final result = await dataSource.fetchCostItemsByEstimateId(
           estimateId: testEstimateId,
-          offset: 0,
-          limit: 10,
         );
 
         expect(result.length, 3);
         expect(result, expectedDtos);
       });
 
-      test('uses correct table and filter parameters', () async {
+      test('successfully fetches cost items filtered by type', () async {
+        final testItems = [
+          CostItemTestDataMapFactory.createMaterialItemData(
+            id: 'item-1',
+            estimateId: testEstimateId,
+            itemName: 'Concrete',
+          ),
+          CostItemTestDataMapFactory.createMaterialItemData(
+            id: 'item-2',
+            estimateId: testEstimateId,
+            itemName: 'Steel',
+          ),
+          CostItemTestDataMapFactory.createLaborItemData(
+            id: 'item-3',
+            estimateId: testEstimateId,
+            itemName: 'Installation',
+          ),
+        ];
+        seedItemTable(testItems);
+
+        final result = await dataSource.fetchCostItemsByEstimateId(
+          estimateId: testEstimateId,
+          itemType: 'material',
+        );
+
+        expect(result.length, 2);
+        expect(result.every((item) => item.itemType == 'material'), isTrue);
+        expect(result[0].itemName, 'Concrete');
+        expect(result[1].itemName, 'Steel');
+      });
+
+      test('uses correct table and filter parameters without itemType', () async {
         seedItemTable([
           CostItemTestDataMapFactory.createMaterialItemData(
             id: 'item-1',
@@ -89,33 +117,73 @@ void main() {
           ),
         ]);
 
-        await dataSource.getCostItems(
+        await dataSource.fetchCostItemsByEstimateId(
           estimateId: testEstimateId,
-          offset: 0,
-          limit: 10,
         );
 
-        final calls = fakeSupabaseWrapper.getMethodCallsFor('selectPaginated');
+        final calls = fakeSupabaseWrapper.getMethodCallsFor('selectMatch');
         expect(calls.length, 1);
         final call = calls.first;
         expect(call, {
-          'method': 'selectPaginated',
+          'method': 'selectMatch',
           'table': DatabaseConstants.costItemsTable,
           'columns': '*',
-          'filterColumn': DatabaseConstants.estimateIdColumn,
-          'filterValue': testEstimateId,
-          'orderColumn': DatabaseConstants.createdAtColumn,
+          'filters': {
+            DatabaseConstants.estimateIdColumn: testEstimateId,
+          },
+          'orderBy': DatabaseConstants.createdAtColumn,
           'ascending': true,
-          'rangeFrom': 0,
-          'rangeTo': 9,
+        });
+      });
+
+      test('uses correct table and filter parameters with itemType', () async {
+        seedItemTable([
+          CostItemTestDataMapFactory.createLaborItemData(
+            id: 'item-1',
+            estimateId: testEstimateId,
+          ),
+        ]);
+
+        await dataSource.fetchCostItemsByEstimateId(
+          estimateId: testEstimateId,
+          itemType: 'labor',
+        );
+
+        final calls = fakeSupabaseWrapper.getMethodCallsFor('selectMatch');
+        expect(calls.length, 1);
+        final call = calls.first;
+        expect(call, {
+          'method': 'selectMatch',
+          'table': DatabaseConstants.costItemsTable,
+          'columns': '*',
+          'filters': {
+            DatabaseConstants.estimateIdColumn: testEstimateId,
+            DatabaseConstants.itemTypeColumn: 'labor',
+          },
+          'orderBy': DatabaseConstants.createdAtColumn,
+          'ascending': true,
         });
       });
 
       test('returns empty list when no items exist', () async {
-        final result = await dataSource.getCostItems(
+        final result = await dataSource.fetchCostItemsByEstimateId(
           estimateId: testEstimateId,
-          offset: 0,
-          limit: 10,
+        );
+
+        expect(result, isEmpty);
+      });
+
+      test('returns empty list when no items match the type filter', () async {
+        seedItemTable([
+          CostItemTestDataMapFactory.createMaterialItemData(
+            id: 'item-1',
+            estimateId: testEstimateId,
+          ),
+        ]);
+
+        final result = await dataSource.fetchCostItemsByEstimateId(
+          estimateId: testEstimateId,
+          itemType: 'equipment',
         );
 
         expect(result, isEmpty);
@@ -133,10 +201,8 @@ void main() {
 
         final expectedDto = CostItemDto.fromJson(testItem);
 
-        final result = await dataSource.getCostItems(
+        final result = await dataSource.fetchCostItemsByEstimateId(
           estimateId: testEstimateId,
-          offset: 0,
-          limit: 10,
         );
 
         expect(result.length, 1);
@@ -146,41 +212,63 @@ void main() {
       });
 
       test('propagates exceptions from supabase wrapper', () async {
-        fakeSupabaseWrapper.shouldThrowOnSelectPaginated = true;
-        fakeSupabaseWrapper.selectPaginatedErrorMessage = 'Network error';
+        fakeSupabaseWrapper.shouldThrowOnSelectMatch = true;
+        fakeSupabaseWrapper.selectMatchErrorMessage = 'Network error';
 
         await expectLater(
-          dataSource.getCostItems(
+          dataSource.fetchCostItemsByEstimateId(
             estimateId: testEstimateId,
-            offset: 0,
-            limit: 10,
           ),
           throwsException,
         );
       });
 
-      test('handles pagination with offset correctly', () async {
-        seedItemTable(
-          List.generate(
-            20,
-            (i) => CostItemTestDataMapFactory.createMaterialItemData(
-              id: 'item-$i',
-              estimateId: testEstimateId,
-            ),
+      test('orders results by creation date ascending', () async {
+        final testItems = [
+          CostItemTestDataMapFactory.createMaterialItemData(
+            id: 'item-2',
+            estimateId: testEstimateId,
+            itemName: 'Second',
           ),
-        );
+          CostItemTestDataMapFactory.createMaterialItemData(
+            id: 'item-1',
+            estimateId: testEstimateId,
+            itemName: 'First',
+          ),
+        ];
+        seedItemTable(testItems);
 
-        await dataSource.getCostItems(
+        await dataSource.fetchCostItemsByEstimateId(
           estimateId: testEstimateId,
-          offset: 10,
-          limit: 5,
         );
 
-        final calls = fakeSupabaseWrapper.getMethodCallsFor('selectPaginated');
-        expect(calls.length, 1);
-        final call = calls.first;
-        expect(call['rangeFrom'], 10);
-        expect(call['rangeTo'], 14);
+        final calls = fakeSupabaseWrapper.getMethodCallsFor('selectMatch');
+        expect(calls.first['orderBy'], DatabaseConstants.createdAtColumn);
+        expect(calls.first['ascending'], isTrue);
+      });
+
+      test('fetches items for different estimate IDs correctly', () async {
+        final testItems = [
+          CostItemTestDataMapFactory.createMaterialItemData(
+            id: 'item-1',
+            estimateId: 'estimate-123',
+            itemName: 'Concrete',
+          ),
+          CostItemTestDataMapFactory.createMaterialItemData(
+            id: 'item-2',
+            estimateId: 'estimate-456',
+            itemName: 'Steel',
+          ),
+        ];
+        seedItemTable(testItems);
+
+        final result = await dataSource.fetchCostItemsByEstimateId(
+          estimateId: 'estimate-123',
+        );
+
+        expect(result.length, 1);
+        expect(result[0].estimateId, 'estimate-123');
+        expect(result[0].itemName, 'Concrete');
       });
     });
 
@@ -216,158 +304,59 @@ void main() {
         expect(calls.length, 1);
         expect(calls.first['table'], DatabaseConstants.costItemsTable);
       });
-    });
 
-    group('getCostItemsByType', () {
-      test('successfully fetches items filtered by type', () async {
-        final testItems = [
-          CostItemTestDataMapFactory.createMaterialItemData(
-            id: 'item-1',
-            estimateId: testEstimateId,
-            itemName: 'Concrete',
-          ),
-          CostItemTestDataMapFactory.createMaterialItemData(
-            id: 'item-2',
-            estimateId: testEstimateId,
-            itemName: 'Steel',
-          ),
-          CostItemTestDataMapFactory.createLaborItemData(
-            id: 'item-3',
-            estimateId: testEstimateId,
-            itemName: 'Installation',
-          ),
-        ];
-        seedItemTable(testItems);
-
-        final remoteDataSource = dataSource as RemoteCostItemDataSource;
-        final result = await remoteDataSource.getCostItemsByType(
-          estimateId: testEstimateId,
-          itemType: 'material',
-        );
-
-        expect(result.length, 2);
-        expect(result.every((item) => item.itemType == 'material'), isTrue);
-        expect(result[0].itemName, 'Concrete');
-        expect(result[1].itemName, 'Steel');
-      });
-
-      test('uses correct table and filter parameters', () async {
-        seedItemTable([
-          CostItemTestDataMapFactory.createLaborItemData(
-            id: 'item-1',
-            estimateId: testEstimateId,
-          ),
-        ]);
-
-        final remoteDataSource = dataSource as RemoteCostItemDataSource;
-        await remoteDataSource.getCostItemsByType(
-          estimateId: testEstimateId,
-          itemType: 'labor',
-        );
-
-        final calls = fakeSupabaseWrapper.getMethodCallsFor('selectMatch');
-        expect(calls.length, 1);
-        final call = calls.first;
-        expect(call, {
-          'method': 'selectMatch',
-          'table': DatabaseConstants.costItemsTable,
-          'columns': '*',
-          'filters': {
-            DatabaseConstants.estimateIdColumn: testEstimateId,
-            'item_type': 'labor',
-          },
-          'orderBy': DatabaseConstants.createdAtColumn,
-          'ascending': true,
-        });
-      });
-
-      test('returns empty list when no items match the type', () async {
-        seedItemTable([
-          CostItemTestDataMapFactory.createMaterialItemData(
-            id: 'item-1',
-            estimateId: testEstimateId,
-          ),
-        ]);
-
-        final remoteDataSource = dataSource as RemoteCostItemDataSource;
-        final result = await remoteDataSource.getCostItemsByType(
-          estimateId: testEstimateId,
-          itemType: 'equipment',
-        );
-
-        expect(result, isEmpty);
-      });
-
-      test('returns empty list when no items exist', () async {
-        final remoteDataSource = dataSource as RemoteCostItemDataSource;
-        final result = await remoteDataSource.getCostItemsByType(
-          estimateId: testEstimateId,
-          itemType: 'material',
-        );
-
-        expect(result, isEmpty);
-      });
-
-      test('converts JSON to CostItemDto correctly', () async {
+      test('inserts correct data', () async {
         final testItem = CostItemTestDataMapFactory.createEquipmentItemData(
           id: 'item-1',
           estimateId: testEstimateId,
-          itemName: 'Excavator',
+          itemName: 'Bulldozer',
+          unitPrice: 500.0,
+          quantity: 2.0,
         );
+        final itemDto = CostItemDto.fromJson(testItem);
         seedItemTable([testItem]);
 
-        final expectedDto = CostItemDto.fromJson(testItem);
+        await dataSource.createCostItem(itemDto);
 
-        final remoteDataSource = dataSource as RemoteCostItemDataSource;
-        final result = await remoteDataSource.getCostItemsByType(
+        final calls = fakeSupabaseWrapper.getMethodCallsFor('insert');
+        expect(calls.length, 1);
+        expect(calls.first['data'], itemDto.toJson());
+      });
+
+      test('returns created cost item with correct data', () async {
+        final testItem = CostItemTestDataMapFactory.createMaterialItemData(
+          id: '1',
           estimateId: testEstimateId,
-          itemType: 'equipment',
+          itemName: 'Cement',
+          unitPrice: 75.0,
+          quantity: 100.0,
         );
+        final itemDto = CostItemDto.fromJson(testItem);
+        seedItemTable([testItem]);
 
-        expect(result.length, 1);
-        final dto = result.first;
-        expect(dto, isA<CostItemDto>());
-        expect(dto, expectedDto);
+        final result = await dataSource.createCostItem(itemDto);
+
+        expect(result, isA<CostItemDto>());
+        expect(result.itemName, 'Cement');
+        expect(result.unitPrice, 75.0);
+        expect(result.quantity, 100.0);
+        expect(result.estimateId, testEstimateId);
       });
 
       test('propagates exceptions from supabase wrapper', () async {
-        fakeSupabaseWrapper.shouldThrowOnSelectMatch = true;
-        fakeSupabaseWrapper.selectMatchErrorMessage = 'Network error';
+        fakeSupabaseWrapper.shouldThrowOnInsert = true;
+        fakeSupabaseWrapper.insertErrorMessage = 'Insert failed';
 
-        final remoteDataSource = dataSource as RemoteCostItemDataSource;
+        final testItem = CostItemTestDataMapFactory.createMaterialItemData(
+          id: 'item-1',
+          estimateId: testEstimateId,
+        );
+        final itemDto = CostItemDto.fromJson(testItem);
+
         await expectLater(
-          remoteDataSource.getCostItemsByType(
-            estimateId: testEstimateId,
-            itemType: 'material',
-          ),
+          dataSource.createCostItem(itemDto),
           throwsException,
         );
-      });
-
-      test('orders results by creation date ascending', () async {
-        final testItems = [
-          CostItemTestDataMapFactory.createMaterialItemData(
-            id: 'item-2',
-            estimateId: testEstimateId,
-            itemName: 'Second',
-          ),
-          CostItemTestDataMapFactory.createMaterialItemData(
-            id: 'item-1',
-            estimateId: testEstimateId,
-            itemName: 'First',
-          ),
-        ];
-        seedItemTable(testItems);
-
-        final remoteDataSource = dataSource as RemoteCostItemDataSource;
-        await remoteDataSource.getCostItemsByType(
-          estimateId: testEstimateId,
-          itemType: 'material',
-        );
-
-        final calls = fakeSupabaseWrapper.getMethodCallsFor('selectMatch');
-        expect(calls.first['orderBy'], DatabaseConstants.createdAtColumn);
-        expect(calls.first['ascending'], isTrue);
       });
     });
   });

--- a/test/features/estimations/units/data/data_source/remote_cost_item_data_source_test.dart
+++ b/test/features/estimations/units/data/data_source/remote_cost_item_data_source_test.dart
@@ -1,5 +1,4 @@
 import 'package:construculator/features/estimation/data/data_source/interfaces/cost_item_data_source.dart';
-import 'package:construculator/features/estimation/data/data_source/remote_cost_item_data_source.dart';
 import 'package:construculator/features/estimation/data/models/cost_item_dto.dart';
 import 'package:construculator/features/estimation/estimation_module.dart';
 import 'package:construculator/libraries/supabase/database_constants.dart';
@@ -46,8 +45,8 @@ void main() {
       fakeSupabaseWrapper.addTableData(DatabaseConstants.costItemsTable, rows);
     }
 
-    group('getCostItems', () {
-      test('successfully fetches paginated cost items', () async {
+    group('fetchCostItemsByEstimateId', () {
+      test('successfully fetches all cost items without type filter', () async {
         final testItems = [
           CostItemTestDataMapFactory.createMaterialItemData(
             id: 'item-1',
@@ -71,17 +70,46 @@ void main() {
             .map((data) => CostItemDto.fromJson(data))
             .toList();
 
-        final result = await dataSource.getCostItems(
+        final result = await dataSource.fetchCostItemsByEstimateId(
           estimateId: testEstimateId,
-          offset: 0,
-          limit: 10,
         );
 
         expect(result.length, 3);
         expect(result, expectedDtos);
       });
 
-      test('uses correct table and filter parameters', () async {
+      test('successfully fetches cost items filtered by type', () async {
+        final testItems = [
+          CostItemTestDataMapFactory.createMaterialItemData(
+            id: 'item-1',
+            estimateId: testEstimateId,
+            itemName: 'Concrete',
+          ),
+          CostItemTestDataMapFactory.createMaterialItemData(
+            id: 'item-2',
+            estimateId: testEstimateId,
+            itemName: 'Steel',
+          ),
+          CostItemTestDataMapFactory.createLaborItemData(
+            id: 'item-3',
+            estimateId: testEstimateId,
+            itemName: 'Installation',
+          ),
+        ];
+        seedItemTable(testItems);
+
+        final result = await dataSource.fetchCostItemsByEstimateId(
+          estimateId: testEstimateId,
+          itemType: 'material',
+        );
+
+        expect(result.length, 2);
+        expect(result.every((item) => item.itemType == 'material'), isTrue);
+        expect(result[0].itemName, 'Concrete');
+        expect(result[1].itemName, 'Steel');
+      });
+
+      test('uses correct table and filter parameters without itemType', () async {
         seedItemTable([
           CostItemTestDataMapFactory.createMaterialItemData(
             id: 'item-1',
@@ -89,33 +117,73 @@ void main() {
           ),
         ]);
 
-        await dataSource.getCostItems(
+        await dataSource.fetchCostItemsByEstimateId(
           estimateId: testEstimateId,
-          offset: 0,
-          limit: 10,
         );
 
-        final calls = fakeSupabaseWrapper.getMethodCallsFor('selectPaginated');
+        final calls = fakeSupabaseWrapper.getMethodCallsFor('selectMatch');
         expect(calls.length, 1);
         final call = calls.first;
         expect(call, {
-          'method': 'selectPaginated',
+          'method': 'selectMatch',
           'table': DatabaseConstants.costItemsTable,
           'columns': '*',
-          'filterColumn': DatabaseConstants.estimateIdColumn,
-          'filterValue': testEstimateId,
-          'orderColumn': DatabaseConstants.createdAtColumn,
+          'filters': {
+            DatabaseConstants.estimateIdColumn: testEstimateId,
+          },
+          'orderBy': DatabaseConstants.createdAtColumn,
           'ascending': true,
-          'rangeFrom': 0,
-          'rangeTo': 9,
+        });
+      });
+
+      test('uses correct table and filter parameters with itemType', () async {
+        seedItemTable([
+          CostItemTestDataMapFactory.createLaborItemData(
+            id: 'item-1',
+            estimateId: testEstimateId,
+          ),
+        ]);
+
+        await dataSource.fetchCostItemsByEstimateId(
+          estimateId: testEstimateId,
+          itemType: 'labor',
+        );
+
+        final calls = fakeSupabaseWrapper.getMethodCallsFor('selectMatch');
+        expect(calls.length, 1);
+        final call = calls.first;
+        expect(call, {
+          'method': 'selectMatch',
+          'table': DatabaseConstants.costItemsTable,
+          'columns': '*',
+          'filters': {
+            DatabaseConstants.estimateIdColumn: testEstimateId,
+            DatabaseConstants.itemTypeColumn: 'labor',
+          },
+          'orderBy': DatabaseConstants.createdAtColumn,
+          'ascending': true,
         });
       });
 
       test('returns empty list when no items exist', () async {
-        final result = await dataSource.getCostItems(
+        final result = await dataSource.fetchCostItemsByEstimateId(
           estimateId: testEstimateId,
-          offset: 0,
-          limit: 10,
+        );
+
+        expect(result, isEmpty);
+      });
+
+      test('returns empty list when no items match the type filter', () async {
+        seedItemTable([
+          CostItemTestDataMapFactory.createMaterialItemData(
+            id: 'item-1',
+            estimateId: testEstimateId,
+          ),
+        ]);
+
+        final result = await dataSource.fetchCostItemsByEstimateId(
+          estimateId: testEstimateId,
+          itemType: 'equipment',
         );
 
         expect(result, isEmpty);
@@ -133,10 +201,8 @@ void main() {
 
         final expectedDto = CostItemDto.fromJson(testItem);
 
-        final result = await dataSource.getCostItems(
+        final result = await dataSource.fetchCostItemsByEstimateId(
           estimateId: testEstimateId,
-          offset: 0,
-          limit: 10,
         );
 
         expect(result.length, 1);
@@ -146,41 +212,76 @@ void main() {
       });
 
       test('propagates exceptions from supabase wrapper', () async {
-        fakeSupabaseWrapper.shouldThrowOnSelectPaginated = true;
-        fakeSupabaseWrapper.selectPaginatedErrorMessage = 'Network error';
+        fakeSupabaseWrapper.shouldThrowOnSelectMatch = true;
+        fakeSupabaseWrapper.selectMatchErrorMessage = 'Network error';
 
         await expectLater(
-          dataSource.getCostItems(
+          dataSource.fetchCostItemsByEstimateId(
             estimateId: testEstimateId,
-            offset: 0,
-            limit: 10,
           ),
           throwsException,
         );
       });
 
-      test('handles pagination with offset correctly', () async {
-        seedItemTable(
-          List.generate(
-            20,
-            (i) => CostItemTestDataMapFactory.createMaterialItemData(
-              id: 'item-$i',
-              estimateId: testEstimateId,
-            ),
+      test('orders results by creation date ascending', () async {
+        final testItems = [
+          CostItemTestDataMapFactory.createMaterialItemData(
+            id: 'item-newest',
+            estimateId: testEstimateId,
+            itemName: 'Newest',
+            createdAt: '2024-03-01T00:00:00.000Z',
           ),
-        );
+          CostItemTestDataMapFactory.createMaterialItemData(
+            id: 'item-oldest',
+            estimateId: testEstimateId,
+            itemName: 'Oldest',
+            createdAt: '2024-01-01T00:00:00.000Z',
+          ),
+          CostItemTestDataMapFactory.createMaterialItemData(
+            id: 'item-middle',
+            estimateId: testEstimateId,
+            itemName: 'Middle',
+            createdAt: '2024-02-01T00:00:00.000Z',
+          ),
+        ];
+        seedItemTable(testItems);
 
-        await dataSource.getCostItems(
+        final result = await dataSource.fetchCostItemsByEstimateId(
           estimateId: testEstimateId,
-          offset: 10,
-          limit: 5,
         );
 
-        final calls = fakeSupabaseWrapper.getMethodCallsFor('selectPaginated');
-        expect(calls.length, 1);
-        final call = calls.first;
-        expect(call['rangeFrom'], 10);
-        expect(call['rangeTo'], 14);
+        expect(
+          result.map((item) => item.id).toList(),
+          ['item-oldest', 'item-middle', 'item-newest'],
+        );
+
+        final calls = fakeSupabaseWrapper.getMethodCallsFor('selectMatch');
+        expect(calls.first['orderBy'], DatabaseConstants.createdAtColumn);
+        expect(calls.first['ascending'], isTrue);
+      });
+
+      test('fetches items for different estimate IDs correctly', () async {
+        final testItems = [
+          CostItemTestDataMapFactory.createMaterialItemData(
+            id: 'item-1',
+            estimateId: 'estimate-123',
+            itemName: 'Concrete',
+          ),
+          CostItemTestDataMapFactory.createMaterialItemData(
+            id: 'item-2',
+            estimateId: 'estimate-456',
+            itemName: 'Steel',
+          ),
+        ];
+        seedItemTable(testItems);
+
+        final result = await dataSource.fetchCostItemsByEstimateId(
+          estimateId: 'estimate-123',
+        );
+
+        expect(result.length, 1);
+        expect(result[0].estimateId, 'estimate-123');
+        expect(result[0].itemName, 'Concrete');
       });
     });
 
@@ -216,158 +317,59 @@ void main() {
         expect(calls.length, 1);
         expect(calls.first['table'], DatabaseConstants.costItemsTable);
       });
-    });
 
-    group('getCostItemsByType', () {
-      test('successfully fetches items filtered by type', () async {
-        final testItems = [
-          CostItemTestDataMapFactory.createMaterialItemData(
-            id: 'item-1',
-            estimateId: testEstimateId,
-            itemName: 'Concrete',
-          ),
-          CostItemTestDataMapFactory.createMaterialItemData(
-            id: 'item-2',
-            estimateId: testEstimateId,
-            itemName: 'Steel',
-          ),
-          CostItemTestDataMapFactory.createLaborItemData(
-            id: 'item-3',
-            estimateId: testEstimateId,
-            itemName: 'Installation',
-          ),
-        ];
-        seedItemTable(testItems);
-
-        final remoteDataSource = dataSource as RemoteCostItemDataSource;
-        final result = await remoteDataSource.getCostItemsByType(
-          estimateId: testEstimateId,
-          itemType: 'material',
-        );
-
-        expect(result.length, 2);
-        expect(result.every((item) => item.itemType == 'material'), isTrue);
-        expect(result[0].itemName, 'Concrete');
-        expect(result[1].itemName, 'Steel');
-      });
-
-      test('uses correct table and filter parameters', () async {
-        seedItemTable([
-          CostItemTestDataMapFactory.createLaborItemData(
-            id: 'item-1',
-            estimateId: testEstimateId,
-          ),
-        ]);
-
-        final remoteDataSource = dataSource as RemoteCostItemDataSource;
-        await remoteDataSource.getCostItemsByType(
-          estimateId: testEstimateId,
-          itemType: 'labor',
-        );
-
-        final calls = fakeSupabaseWrapper.getMethodCallsFor('selectMatch');
-        expect(calls.length, 1);
-        final call = calls.first;
-        expect(call, {
-          'method': 'selectMatch',
-          'table': DatabaseConstants.costItemsTable,
-          'columns': '*',
-          'filters': {
-            DatabaseConstants.estimateIdColumn: testEstimateId,
-            'item_type': 'labor',
-          },
-          'orderBy': DatabaseConstants.createdAtColumn,
-          'ascending': true,
-        });
-      });
-
-      test('returns empty list when no items match the type', () async {
-        seedItemTable([
-          CostItemTestDataMapFactory.createMaterialItemData(
-            id: 'item-1',
-            estimateId: testEstimateId,
-          ),
-        ]);
-
-        final remoteDataSource = dataSource as RemoteCostItemDataSource;
-        final result = await remoteDataSource.getCostItemsByType(
-          estimateId: testEstimateId,
-          itemType: 'equipment',
-        );
-
-        expect(result, isEmpty);
-      });
-
-      test('returns empty list when no items exist', () async {
-        final remoteDataSource = dataSource as RemoteCostItemDataSource;
-        final result = await remoteDataSource.getCostItemsByType(
-          estimateId: testEstimateId,
-          itemType: 'material',
-        );
-
-        expect(result, isEmpty);
-      });
-
-      test('converts JSON to CostItemDto correctly', () async {
+      test('inserts correct data', () async {
         final testItem = CostItemTestDataMapFactory.createEquipmentItemData(
           id: 'item-1',
           estimateId: testEstimateId,
-          itemName: 'Excavator',
+          itemName: 'Bulldozer',
+          unitPrice: 500.0,
+          quantity: 2.0,
         );
+        final itemDto = CostItemDto.fromJson(testItem);
         seedItemTable([testItem]);
 
-        final expectedDto = CostItemDto.fromJson(testItem);
+        await dataSource.createCostItem(itemDto);
 
-        final remoteDataSource = dataSource as RemoteCostItemDataSource;
-        final result = await remoteDataSource.getCostItemsByType(
+        final calls = fakeSupabaseWrapper.getMethodCallsFor('insert');
+        expect(calls.length, 1);
+        expect(calls.first['data'], itemDto.toJson());
+      });
+
+      test('returns created cost item with correct data', () async {
+        final testItem = CostItemTestDataMapFactory.createMaterialItemData(
+          id: '1',
           estimateId: testEstimateId,
-          itemType: 'equipment',
+          itemName: 'Cement',
+          unitPrice: 75.0,
+          quantity: 100.0,
         );
+        final itemDto = CostItemDto.fromJson(testItem);
+        seedItemTable([testItem]);
 
-        expect(result.length, 1);
-        final dto = result.first;
-        expect(dto, isA<CostItemDto>());
-        expect(dto, expectedDto);
+        final result = await dataSource.createCostItem(itemDto);
+
+        expect(result, isA<CostItemDto>());
+        expect(result.itemName, 'Cement');
+        expect(result.unitPrice, 75.0);
+        expect(result.quantity, 100.0);
+        expect(result.estimateId, testEstimateId);
       });
 
       test('propagates exceptions from supabase wrapper', () async {
-        fakeSupabaseWrapper.shouldThrowOnSelectMatch = true;
-        fakeSupabaseWrapper.selectMatchErrorMessage = 'Network error';
+        fakeSupabaseWrapper.shouldThrowOnInsert = true;
+        fakeSupabaseWrapper.insertErrorMessage = 'Insert failed';
 
-        final remoteDataSource = dataSource as RemoteCostItemDataSource;
+        final testItem = CostItemTestDataMapFactory.createMaterialItemData(
+          id: 'item-1',
+          estimateId: testEstimateId,
+        );
+        final itemDto = CostItemDto.fromJson(testItem);
+
         await expectLater(
-          remoteDataSource.getCostItemsByType(
-            estimateId: testEstimateId,
-            itemType: 'material',
-          ),
+          dataSource.createCostItem(itemDto),
           throwsException,
         );
-      });
-
-      test('orders results by creation date ascending', () async {
-        final testItems = [
-          CostItemTestDataMapFactory.createMaterialItemData(
-            id: 'item-2',
-            estimateId: testEstimateId,
-            itemName: 'Second',
-          ),
-          CostItemTestDataMapFactory.createMaterialItemData(
-            id: 'item-1',
-            estimateId: testEstimateId,
-            itemName: 'First',
-          ),
-        ];
-        seedItemTable(testItems);
-
-        final remoteDataSource = dataSource as RemoteCostItemDataSource;
-        await remoteDataSource.getCostItemsByType(
-          estimateId: testEstimateId,
-          itemType: 'material',
-        );
-
-        final calls = fakeSupabaseWrapper.getMethodCallsFor('selectMatch');
-        expect(calls.first['orderBy'], DatabaseConstants.createdAtColumn);
-        expect(calls.first['ascending'], isTrue);
       });
     });
   });


### PR DESCRIPTION
### 1. PR Summary

This PR introduces the data source layer for cost items: a `CostItemDataSource` interface, a `RemoteCostItemDataSource` implementation backed by `SupabaseWrapper`, a new `DatabaseConstants` entry, DI wiring in `EstimationModule`, a mutation test config, and a data source test suite. **PR size is S — clean and appropriately scoped.**

---

---

### Review Summary Table

| Issue Name | Description | Status | Notes |
|------------|-------------|--------|-------|
| `supabaseWrapper` is public | Should be a private field `_supabaseWrapper` to match all other data sources and maintain encapsulation. | ✅ | |
| Empty result logged as `warning` | An empty items list is a normal expected state. `_logger.warning()` on empty response creates noise. Both occurrences should be removed. | | I think it's better to add them as bread crumb since it might help to trace errors if they happen due to empty lists. |
| `getCostItemsByType` not on interface | A concrete method absent from the interface forces callers to downcast. Either add it to the interface or remove it from the implementation. | ✅ | |
| Static column constant aliases | Re-exporting `DatabaseConstants` entries as private static fields adds no value. Reference `DatabaseConstants` directly as done elsewhere. | ✅ | |
| Tests assert internal call parameters | Two tests verify internal Supabase wrapper call parameters rather than observable output, coupling tests to implementation details. | | This are crucial tests to verify the supabase wrapper is calling with the correct parameters |