### PR TITLE
CA-659: docs: add Agentic Skills Migration Plan for transforming guidelines into development assistants

### DIFF
--- a/docs/Agentic-Skills-Migration-Plan.md
+++ b/docs/Agentic-Skills-Migration-Plan.md
@@ -1,0 +1,392 @@
+# Agentic Skills Migration Plan
+
+## Executive Summary
+
+We're transforming our 15 Flutter development guidelines into **4 comprehensive agent skills** that actively assist developers during feature development. By grouping related rules that share analysis techniques, we achieve better maintainability with fewer skills while providing the same comprehensive coverage. This initiative will reduce development friction, catch issues earlier, and accelerate feature delivery while maintaining our high code quality standards.
+
+## Overview
+
+This document outlines our plan to transform the 15 Flutter development guidelines into **professional agent skills** that assist developers throughout the development process.
+
+These skills will:
+- Provide real-time guidance during coding
+- Catch issues early before they reach PR review
+- Teach best practices through actionable feedback
+- Automate repetitive quality checks
+- Work as independent, composable modules
+
+**Impact on Feature Development:**
+- **Faster iterations:** Catch violations before committing
+- **Learning while coding:** Skills teach patterns, not just flag errors
+- **Reduced PR cycles:** Fewer review rounds needed
+- **Consistent quality:** Every developer gets the same guidance
+
+## Vision: Skills as Development Assistants
+
+**From:** Manual guideline enforcement during PR review
+**To:** Proactive development assistance throughout the coding workflow
+
+### How Skills Help Developers
+
+**During Coding:**
+- Suggest CoreUI components while writing UI code
+- Detect business logic creeping into widgets
+- Recommend proper naming conventions for new classes
+- Flag missing localization keys
+
+**Before Committing:**
+- Verify test coverage patterns
+- Check architectural boundaries
+- Validate stream lifecycle management
+- Detect AI-generated placeholder comments
+
+**During PR Review:**
+- Provide structured, consistent feedback
+- Generate actionable remediation guidance
+- Track quality trends over time
+- Enable automated quality gates
+
+---
+
+## How to Use Skills While Developing
+
+### During Feature Development
+
+**1. Ask for guidance proactively:**
+```bash
+# Before writing a new widget
+"I'm about to create a login screen widget. What should I watch out for?"
+
+# Before creating a new class
+"I need to create a class that validates user input. What should I name it?"
+
+# While writing UI code
+"Check this widget for CoreUI compliance and business logic separation"
+```
+
+**2. Run targeted checks on your changes:**
+```bash
+# Check a specific file
+"Run static analysis on lib/features/auth/presentation/login_screen.dart"
+
+# Check your current branch
+"Check my branch for UI/business separation issues"
+
+# Before committing
+"Review my changes for common violations"
+```
+
+**3. Use skills to learn patterns:**
+```bash
+# Learn the pattern
+"Show me examples of correct BLoC state management"
+
+# Understand why something is wrong
+"Why is hardcoded spacing a problem?"
+
+# Get architecture guidance
+"Where should this calculation logic live?"
+```
+
+### During Code Review
+
+**Run comprehensive checks:**
+```bash
+# Full PR review
+"Review this PR against all applicable rules"
+
+# Specific rule check
+"Check this PR for test double violations"
+
+# Compare branches
+"Compare feat/user-profile to main"
+```
+
+### Tips for Maximum Benefit
+
+**✅ Do:**
+- Ask skills questions before writing code
+- Run checks frequently on small changes
+- Use skills to learn patterns, not just find errors
+- Request specific skill checks when you know the area
+
+**❌ Don't:**
+- Wait until PR review to run checks
+- Ignore skill suggestions (they're based on team standards)
+- Disable skills without understanding why they flagged something
+- Use skills as a replacement for understanding the guidelines
+
+---
+
+## How to Add a New Rule
+
+### Decision: Add to Existing Skill or Create New Group?
+
+**First, determine where your rule belongs:**
+
+1. **Does it fit an existing group?**
+   - Static pattern matching → Add to `static-analysis` skill
+   - Layer boundaries/state → Add to `architectural-check` skill
+   - Test patterns → Add to `test-quality` skill
+   - Code cleanliness → Add to `code-health` skill
+
+2. **Does it require unique analysis?**
+   - Different file types than existing groups
+   - New analysis technique (e.g., performance profiling)
+   - Different execution characteristics
+   → Consider creating a new skill group
+
+### Adding a Rule to an Existing Skill
+
+**Step 1: Identify the target skill**
+
+```bash
+# Example: Adding a rule about forbidden imports
+"This checks for import patterns" → Goes in `static-analysis` skill
+```
+
+**Step 2: Add rule definition**
+
+Create `skills/{skill-name}/rules/{new-rule-id}.md`:
+```markdown
+# RULE_16: Forbidden Import Detection
+
+## Detection Patterns
+- Pattern: `import.*package:flutter/material.dart` in CoreUI files
+- Severity: major
+- Message: "Material import in CoreUI component"
+- Fix: "Use CoreUI components instead"
+
+## Examples
+...
+```
+
+**Step 3: Update skill's detection logic**
+
+Edit `skills/{skill-name}/SKILL.md` to include the new rule in the workflow.
+
+**Step 4: Test with existing skill**
+
+```bash
+"Run static-analysis skill with new RULE_16 on sample code"
+```
+
+### Creating a New Skill Group (Rare)
+
+Only create a new skill when you have multiple related rules that:
+- Share unique analysis techniques
+- Target different file types than existing groups
+- Have distinct performance characteristics
+
+**Example:** If adding performance profiling rules:
+```
+skills/performance-analysis/
+├── SKILL.md
+├── rules/
+│   ├── RULE_X-memory-leaks.md
+│   ├── RULE_Y-render-performance.md
+│   └── RULE_Z-build-optimization.md
+└── schemas/
+```
+
+### Validation Checklist
+
+Before considering a skill complete:
+
+- [ ] Skill has clear trigger conditions
+- [ ] Detection patterns are well-defined
+- [ ] Output matches standard schema
+- [ ] Tested on real code samples
+- [ ] False positive rate is acceptable (<10%)
+- [ ] Remediation guidance is actionable
+- [ ] Added to file routing matrix
+- [ ] Examples include violations and corrections
+
+---
+
+## Skill Groups
+
+We organize the 15 guidelines into **4 skill groups** based on analysis complexity:
+
+### 🔍 Group 1: Static Analysis Skills
+*Fast, pattern-based checks*
+
+**Skills:**
+- **RULE_2**: Class Naming Convention
+- **RULE_4**: CoreUI Components Usage
+- **RULE_10**: Localization Usage
+- **RULE_11**: Precision vs. Abstraction (Level-Based Naming)
+
+**What they do:**
+- Verify naming conventions (UseCase, Service, Repository suffixes)
+- Detect hardcoded spacing, colors, and Material components
+- Find missing localization for user-facing strings
+- Check abstraction-appropriate naming (abstract at UI, explicit at data layer)
+
+**Trigger:** Any `.dart` file in `lib/`
+**Speed:** Very fast (<1s per file), parallelizable
+
+---
+
+### 🏗️ Group 2: Architectural Analysis Skills
+*Context-aware checks for layer boundaries*
+
+**Skills:**
+- **RULE_5**: UI & Business Logic Separation
+- **RULE_12**: Clean Presentation & State Derivation
+- **RULE_6**: Stream-Based Performance & Lifecycle
+
+**What they do:**
+- Detect business logic leaking into widgets (guard checks, state derivation)
+- Flag UI performing calculations or cross-state coordination
+- Verify StreamControllers have proper lifecycle management
+- Ensure streams use `distinct()` and proper cancellation
+
+**Trigger:** Presentation layer files (`lib/features/**/presentation/**`, `lib/app/presentation/**`)
+**Speed:** Moderate (2-5s per file), may need AST parsing
+
+---
+
+### 🧪 Group 3: Testing Pattern Skills
+*Test quality and coverage verification*
+
+**Skills:**
+- **RULE_3**: Test Double Pattern (Real vs. Fake)
+- **RULE_8**: Widget Test Behavior & Robust Finders
+- **RULE_9**: Unit Test Behavior over Implementation
+- **RULE_13**: Mutation Testing
+- **RULE_14**: Accessibility Testing
+
+**What they do:**
+- Detect "fake everything" anti-pattern and mock/stub usage
+- Find fragile widget finders (byType, findsNWidgets)
+- Check tests focus on behavior vs implementation details
+- Run mutation testing on logic-heavy changes
+- Verify critical user flows have a11y tests
+
+**Trigger:** Test files (`test/**/*_test.dart`)
+**Speed:** Fast for most (1-3s), slow for mutation testing (minutes)
+
+---
+
+### 🛡️ Group 4: Quality & Monitoring Skills
+*Code health and observability*
+
+**Skills:**
+- **RULE_7**: Self-Documenting & Clean Code
+- **RULE_15**: Judicious Sentry Error Reporting
+
+**What they do:**
+- Detect AI-generated placeholder comments
+- Flag comments explaining "how" instead of "why"
+- Find errors logged multiple times in call stack
+- Identify expected errors incorrectly logged as critical
+
+**Trigger:** All Dart files
+**Speed:** Very fast (<1s per file)
+
+---
+
+## Migration Approach: 4 Skills, Not 15
+
+**Key Insight:** Create one skill per group, not per rule. Rules within a group share analysis techniques and can be checked together.
+
+**Current State:** POC `skills/pr-review/` already handles multiple rules (RULE_4, RULE_5, RULE_10)
+
+**Target Architecture:**
+
+```
+skills/
+├── static-analysis/        # Group 1: RULE_2, 4, 10, 11
+├── architectural-check/    # Group 2: RULE_5, 6, 12
+├── test-quality/           # Group 3: RULE_3, 8, 9, 13, 14
+└── code-health/            # Group 4: RULE_7, 15
+```
+
+**Benefits of Group-Level Skills:**
+- **Fewer skills to maintain** (4 instead of 15)
+- **Shared analysis infrastructure** within each group
+- **Single invocation** checks multiple related rules
+- **Natural modularity** based on analysis type
+
+**Next Steps:**
+
+1. **Refactor POC** into `static-analysis` skill
+   - Already handles RULE_4, RULE_10
+   - Add RULE_2 (Class Naming) and RULE_11 (Precision)
+
+2. **Extract `architectural-check`** from POC
+   - Move RULE_5 to new architectural skill
+   - Add RULE_6 and RULE_12 with AST parsing
+
+3. **Create `test-quality`** skill
+   - Combine all testing rules (RULE_3, 8, 9, 13, 14)
+   - Share test file detection and analysis logic
+
+4. **Create `code-health`** skill
+   - Combine RULE_7 and RULE_15
+   - Focus on comments and logging patterns
+
+---
+
+## Standard Skill Structure
+
+Every skill follows this structure:
+
+```
+skills/{skill-name}/
+├── SKILL.md                    # Agent execution instructions
+├── schemas/
+│   ├── input.schema.json       # Input contract
+│   └── output.schema.json      # Output contract (structured findings)
+├── rules/
+│   └── {rule-id}-{name}.md     # Detection patterns & remediation
+├── scripts/                    # Helper scripts for analysis
+└── references/                 # Examples & documentation
+```
+
+**Key Components:**
+- **SKILL.md**: Instructs the agent on when/how to run the skill
+- **Schemas**: Define structured input/output (enables composition)
+- **Rules**: Detection patterns and fix guidance
+- **Scripts**: Reusable analysis utilities
+
+---
+
+## File Routing Matrix
+
+This matrix determines which skills run on which files:
+
+| File Pattern | Group 1 | Group 2 | Group 3 | Group 4 |
+|-------------|---------|---------|---------|---------|
+| `lib/features/**/presentation/*.dart` | ✅ All | ✅ All | ❌ | ✅ All |
+| `lib/features/**/domain/*.dart` | RULE_2, RULE_11 | ❌ | ❌ | ✅ All |
+| `lib/features/**/data/*.dart` | RULE_2, RULE_11 | ❌ | ❌ | ✅ All |
+| `test/**/*_test.dart` | ❌ | ❌ | ✅ All | ✅ RULE_7 |
+| `test/**/*_a11y_test.dart` | ❌ | ❌ | ✅ RULE_14 | ❌ |
+| `**/*.g.dart`, `**/*.freezed.dart` | ❌ | ❌ | ❌ | ❌ |
+
+**Rules:**
+- Generated files (`*.g.dart`, `*.freezed.dart`) are always skipped
+- Presentation files trigger the most rules (UI-focused)
+- Test files only trigger testing rules (Group 3) + clean code (RULE_7)
+- Domain/data files trigger naming + quality rules
+
+---
+
+## Summary
+
+This plan transforms our 15 development guidelines into **4 comprehensive agent skills** that assist developers throughout the coding workflow.
+
+**Key Principles:**
+- **Group-based skills**: 4 skills covering 15 rules (not 15 individual skills)
+- **Development-focused**: Help developers during coding, not just in PR review
+- **Shared infrastructure**: Rules in same group share analysis techniques
+- **Progressive expansion**: Build on existing POC, add rules to groups
+- **Modular design**: Skills are independent, reusable, and composable
+
+**Final Architecture:**
+- `static-analysis` → RULE_2, 4, 10, 11
+- `architectural-check` → RULE_5, 6, 12
+- `test-quality` → RULE_3, 8, 9, 13, 14
+- `code-health` → RULE_7, 15

--- a/docs/Agentic-Skills-Migration-Plan.md
+++ b/docs/Agentic-Skills-Migration-Plan.md
@@ -1,392 +1,212 @@
-# Agentic Skills Migration Plan
+# Agentic Skills Plan — Story Lifecycle Edition
 
-## Executive Summary
+## Core Principle
 
-We're transforming our 15 Flutter development guidelines into **4 comprehensive agent skills** that actively assist developers during feature development. By grouping related rules that share analysis techniques, we achieve better maintainability with fewer skills while providing the same comprehensive coverage. This initiative will reduce development friction, catch issues earlier, and accelerate feature delivery while maintaining our high code quality standards.
+When a coding agent (Cursor, Claude Code) invokes a skill, it loads the entire `SKILL.md` into its context window. Every line costs tokens whether the agent needs it or not. A skill that bundles unrelated behaviors forces the agent to read past irrelevant content — and risks it anchoring on the wrong pattern for the moment.
 
-## Overview
+The question to ask for every skill: **what is the agent's single verb right now?**
 
-This document outlines our plan to transform the 15 Flutter development guidelines into **professional agent skills** that assist developers throughout the development process.
+Two tests determine skill boundaries:
+1. Does every rule in this skill apply at the same moment in the workflow?
+2. Is this skill always invoked, or only sometimes?
 
-These skills will:
-- Provide real-time guidance during coding
-- Catch issues early before they reach PR review
-- Teach best practices through actionable feedback
-- Automate repetitive quality checks
-- Work as independent, composable modules
+If the answer to either is no, that's a signal to split. The number of skills is an output of those answers, not a target set upfront.
 
-**Impact on Feature Development:**
-- **Faster iterations:** Catch violations before committing
-- **Learning while coding:** Skills teach patterns, not just flag errors
-- **Reduced PR cycles:** Fewer review rounds needed
-- **Consistent quality:** Every developer gets the same guidance
-
-## Vision: Skills as Development Assistants
-
-**From:** Manual guideline enforcement during PR review
-**To:** Proactive development assistance throughout the coding workflow
-
-### How Skills Help Developers
-
-**During Coding:**
-- Suggest CoreUI components while writing UI code
-- Detect business logic creeping into widgets
-- Recommend proper naming conventions for new classes
-- Flag missing localization keys
-
-**Before Committing:**
-- Verify test coverage patterns
-- Check architectural boundaries
-- Validate stream lifecycle management
-- Detect AI-generated placeholder comments
-
-**During PR Review:**
-- Provide structured, consistent feedback
-- Generate actionable remediation guidance
-- Track quality trends over time
-- Enable automated quality gates
+Skills are not advisory tools for humans. They are **construction briefs** prescriptive enough that the agent can follow them without asking clarifying questions, generating correct code from the start.
 
 ---
 
-## How to Use Skills While Developing
-
-### During Feature Development
-
-**1. Ask for guidance proactively:**
-```bash
-# Before writing a new widget
-"I'm about to create a login screen widget. What should I watch out for?"
-
-# Before creating a new class
-"I need to create a class that validates user input. What should I name it?"
-
-# While writing UI code
-"Check this widget for CoreUI compliance and business logic separation"
-```
-
-**2. Run targeted checks on your changes:**
-```bash
-# Check a specific file
-"Run static analysis on lib/features/auth/presentation/login_screen.dart"
-
-# Check your current branch
-"Check my branch for UI/business separation issues"
-
-# Before committing
-"Review my changes for common violations"
-```
-
-**3. Use skills to learn patterns:**
-```bash
-# Learn the pattern
-"Show me examples of correct BLoC state management"
-
-# Understand why something is wrong
-"Why is hardcoded spacing a problem?"
-
-# Get architecture guidance
-"Where should this calculation logic live?"
-```
-
-### During Code Review
-
-**Run comprehensive checks:**
-```bash
-# Full PR review
-"Review this PR against all applicable rules"
-
-# Specific rule check
-"Check this PR for test double violations"
-
-# Compare branches
-"Compare feat/user-profile to main"
-```
-
-### Tips for Maximum Benefit
-
-**✅ Do:**
-- Ask skills questions before writing code
-- Run checks frequently on small changes
-- Use skills to learn patterns, not just find errors
-- Request specific skill checks when you know the area
-
-**❌ Don't:**
-- Wait until PR review to run checks
-- Ignore skill suggestions (they're based on team standards)
-- Disable skills without understanding why they flagged something
-- Use skills as a replacement for understanding the guidelines
-
----
-
-## How to Add a New Rule
-
-### Decision: Add to Existing Skill or Create New Group?
-
-**First, determine where your rule belongs:**
-
-1. **Does it fit an existing group?**
-   - Static pattern matching → Add to `static-analysis` skill
-   - Layer boundaries/state → Add to `architectural-check` skill
-   - Test patterns → Add to `test-quality` skill
-   - Code cleanliness → Add to `code-health` skill
-
-2. **Does it require unique analysis?**
-   - Different file types than existing groups
-   - New analysis technique (e.g., performance profiling)
-   - Different execution characteristics
-   → Consider creating a new skill group
-
-### Adding a Rule to an Existing Skill
-
-**Step 1: Identify the target skill**
-
-```bash
-# Example: Adding a rule about forbidden imports
-"This checks for import patterns" → Goes in `static-analysis` skill
-```
-
-**Step 2: Add rule definition**
-
-Create `skills/{skill-name}/rules/{new-rule-id}.md`:
-```markdown
-# RULE_16: Forbidden Import Detection
-
-## Detection Patterns
-- Pattern: `import.*package:flutter/material.dart` in CoreUI files
-- Severity: major
-- Message: "Material import in CoreUI component"
-- Fix: "Use CoreUI components instead"
-
-## Examples
-...
-```
-
-**Step 3: Update skill's detection logic**
-
-Edit `skills/{skill-name}/SKILL.md` to include the new rule in the workflow.
-
-**Step 4: Test with existing skill**
-
-```bash
-"Run static-analysis skill with new RULE_16 on sample code"
-```
-
-### Creating a New Skill Group (Rare)
-
-Only create a new skill when you have multiple related rules that:
-- Share unique analysis techniques
-- Target different file types than existing groups
-- Have distinct performance characteristics
-
-**Example:** If adding performance profiling rules:
-```
-skills/performance-analysis/
-├── SKILL.md
-├── rules/
-│   ├── RULE_X-memory-leaks.md
-│   ├── RULE_Y-render-performance.md
-│   └── RULE_Z-build-optimization.md
-└── schemas/
-```
-
-### Validation Checklist
-
-Before considering a skill complete:
-
-- [ ] Skill has clear trigger conditions
-- [ ] Detection patterns are well-defined
-- [ ] Output matches standard schema
-- [ ] Tested on real code samples
-- [ ] False positive rate is acceptable (<10%)
-- [ ] Remediation guidance is actionable
-- [ ] Added to file routing matrix
-- [ ] Examples include violations and corrections
-
----
-
-## Skill Groups
-
-We organize the 15 guidelines into **4 skill groups** based on analysis complexity:
-
-### 🔍 Group 1: Static Analysis Skills
-*Fast, pattern-based checks*
-
-**Skills:**
-- **RULE_2**: Class Naming Convention
-- **RULE_4**: CoreUI Components Usage
-- **RULE_10**: Localization Usage
-- **RULE_11**: Precision vs. Abstraction (Level-Based Naming)
-
-**What they do:**
-- Verify naming conventions (UseCase, Service, Repository suffixes)
-- Detect hardcoded spacing, colors, and Material components
-- Find missing localization for user-facing strings
-- Check abstraction-appropriate naming (abstract at UI, explicit at data layer)
-
-**Trigger:** Any `.dart` file in `lib/`
-**Speed:** Very fast (<1s per file), parallelizable
-
----
-
-### 🏗️ Group 2: Architectural Analysis Skills
-*Context-aware checks for layer boundaries*
-
-**Skills:**
-- **RULE_5**: UI & Business Logic Separation
-- **RULE_12**: Clean Presentation & State Derivation
-- **RULE_6**: Stream-Based Performance & Lifecycle
-
-**What they do:**
-- Detect business logic leaking into widgets (guard checks, state derivation)
-- Flag UI performing calculations or cross-state coordination
-- Verify StreamControllers have proper lifecycle management
-- Ensure streams use `distinct()` and proper cancellation
-
-**Trigger:** Presentation layer files (`lib/features/**/presentation/**`, `lib/app/presentation/**`)
-**Speed:** Moderate (2-5s per file), may need AST parsing
-
----
-
-### 🧪 Group 3: Testing Pattern Skills
-*Test quality and coverage verification*
-
-**Skills:**
-- **RULE_3**: Test Double Pattern (Real vs. Fake)
-- **RULE_8**: Widget Test Behavior & Robust Finders
-- **RULE_9**: Unit Test Behavior over Implementation
-- **RULE_13**: Mutation Testing
-- **RULE_14**: Accessibility Testing
-
-**What they do:**
-- Detect "fake everything" anti-pattern and mock/stub usage
-- Find fragile widget finders (byType, findsNWidgets)
-- Check tests focus on behavior vs implementation details
-- Run mutation testing on logic-heavy changes
-- Verify critical user flows have a11y tests
-
-**Trigger:** Test files (`test/**/*_test.dart`)
-**Speed:** Fast for most (1-3s), slow for mutation testing (minutes)
-
----
-
-### 🛡️ Group 4: Quality & Monitoring Skills
-*Code health and observability*
-
-**Skills:**
-- **RULE_7**: Self-Documenting & Clean Code
-- **RULE_15**: Judicious Sentry Error Reporting
-
-**What they do:**
-- Detect AI-generated placeholder comments
-- Flag comments explaining "how" instead of "why"
-- Find errors logged multiple times in call stack
-- Identify expected errors incorrectly logged as critical
-
-**Trigger:** All Dart files
-**Speed:** Very fast (<1s per file)
-
----
-
-## Migration Approach: 4 Skills, Not 15
-
-**Key Insight:** Create one skill per group, not per rule. Rules within a group share analysis techniques and can be checked together.
-
-**Current State:** POC `skills/pr-review/` already handles multiple rules (RULE_4, RULE_5, RULE_10)
-
-**Target Architecture:**
+## Skill Architecture
 
 ```
 skills/
-├── static-analysis/        # Group 1: RULE_2, 4, 10, 11
-├── architectural-check/    # Group 2: RULE_5, 6, 12
-├── test-quality/           # Group 3: RULE_3, 8, 9, 13, 14
-└── code-health/            # Group 4: RULE_7, 15
+├── read-ticket/              # Stage 1: Intake
+├── plan-implementation/      # Stage 2: Planning
+├── code-presentation/        # Stage 3: Coding — UI layer
+├── code-domain/              # Stage 3: Coding — Domain layer
+├── code-data/                # Stage 3: Coding — Data layer
+├── code-integration/         # Stage 3: Coding — 3rd party (gated)
+├── write-tests/              # Stage 4: Testing — unit + widget (always)
+├── write-tests-golden/       # Stage 4: Testing — screenshot (gated)
+├── write-tests-mutation/     # Stage 4: Testing — mutation (gated)
+└── pr-review/                # Stage 5: Review (existing)
 ```
-
-**Benefits of Group-Level Skills:**
-- **Fewer skills to maintain** (4 instead of 15)
-- **Shared analysis infrastructure** within each group
-- **Single invocation** checks multiple related rules
-- **Natural modularity** based on analysis type
-
-**Next Steps:**
-
-1. **Refactor POC** into `static-analysis` skill
-   - Already handles RULE_4, RULE_10
-   - Add RULE_2 (Class Naming) and RULE_11 (Precision)
-
-2. **Extract `architectural-check`** from POC
-   - Move RULE_5 to new architectural skill
-   - Add RULE_6 and RULE_12 with AST parsing
-
-3. **Create `test-quality`** skill
-   - Combine all testing rules (RULE_3, 8, 9, 13, 14)
-   - Share test file detection and analysis logic
-
-4. **Create `code-health`** skill
-   - Combine RULE_7 and RULE_15
-   - Focus on comments and logging patterns
 
 ---
 
-## Standard Skill Structure
+## Stage 1 — Ticket Intake
 
-Every skill follows this structure:
+### `read-ticket` *(always)*
 
-```
-skills/{skill-name}/
-├── SKILL.md                    # Agent execution instructions
-├── schemas/
-│   ├── input.schema.json       # Input contract
-│   └── output.schema.json      # Output contract (structured findings)
-├── rules/
-│   └── {rule-id}-{name}.md     # Detection patterns & remediation
-├── scripts/                    # Helper scripts for analysis
-└── references/                 # Examples & documentation
-```
+**Verb:** Understand what to build.
 
-**Key Components:**
-- **SKILL.md**: Instructs the agent on when/how to run the skill
-- **Schemas**: Define structured input/output (enables composition)
-- **Rules**: Detection patterns and fix guidance
-- **Scripts**: Reusable analysis utilities
+The agent's first action when assigned a story. No coding rules live here — this skill is purely about orientation so that every subsequent skill loads with the right context.
+
+**What the agent does:**
+- Parses the ticket to identify which architecture layers are touched (presentation / domain / data / integration)
+- Identifies what new classes will be needed and their rough responsibilities
+- Anticipates which test types will be required (unit, widget, golden, mutation)
+- Flags ambiguities in the ticket to surface to the developer before coding begins
+
+**Output:** A shared mental model that primes the planning skill.
 
 ---
 
-## File Routing Matrix
+## Stage 2 — Implementation Planning
 
-This matrix determines which skills run on which files:
+### `plan-implementation` *(always)*
 
-| File Pattern | Group 1 | Group 2 | Group 3 | Group 4 |
-|-------------|---------|---------|---------|---------|
-| `lib/features/**/presentation/*.dart` | ✅ All | ✅ All | ❌ | ✅ All |
-| `lib/features/**/domain/*.dart` | RULE_2, RULE_11 | ❌ | ❌ | ✅ All |
-| `lib/features/**/data/*.dart` | RULE_2, RULE_11 | ❌ | ❌ | ✅ All |
-| `test/**/*_test.dart` | ❌ | ❌ | ✅ All | ✅ RULE_7 |
-| `test/**/*_a11y_test.dart` | ❌ | ❌ | ✅ RULE_14 | ❌ |
-| `**/*.g.dart`, `**/*.freezed.dart` | ❌ | ❌ | ❌ | ❌ |
+**Verb:** Decide what to create.
 
-**Rules:**
-- Generated files (`*.g.dart`, `*.freezed.dart`) are always skipped
-- Presentation files trigger the most rules (UI-focused)
-- Test files only trigger testing rules (Group 3) + clean code (RULE_7)
-- Domain/data files trigger naming + quality rules
+Covers everything the agent decides before writing the first line of production code. Correctness here eliminates naming and structure rework later.
+
+**What the agent does:**
+- Names all new classes using correct suffixes: `UseCase`, `Service`, `Repository`, `Datasource` (RULE_2)
+- Applies abstraction-level naming: abstract at UI layer, explicit and concrete at data layer (RULE_11)
+- Decides which files to create and where they live in the layer structure
+- Identifies any required CoreUI components — if a component doesn't exist, the agent surfaces this to the developer before coding, not after
+
+**What the agent does not do:** Write any implementation code. Planning and coding are separate verbs.
+
+---
+
+## Stage 3 — Coding
+
+The coding phase splits by architecture layer because each layer has genuinely different concerns. The agent should load only the guidance relevant to the layer it is currently writing.
+
+### `code-presentation` *(always, when story touches UI)*
+
+**Verb:** Write a widget, screen, or BLoC.
+
+BLoC lives here — it is the state coordinator for the screen, not a business rule author.
+
+**Rules applied:**
+- **RULE_4** — Use CoreUI components; never reach for Material widgets directly. If no CoreUI equivalent exists, ask the developer rather than substituting silently.
+- **RULE_5** — No business logic in widgets: no guard checks, no cross-state coordination, no inline calculations.
+- **RULE_10** — All user-facing strings must use localization keys; no hardcoded text.
+- **RULE_12** — State derivation belongs in the BLoC, not in the widget's build method.
+- **RULE_7** — Self-documenting code: comments explain *why*, not *how*. No AI-generated placeholder comments.
+
+---
+
+### `code-domain` *(always, when story touches domain)*
+
+**Verb:** Write a use case and its repository contract.
+
+These two travel together because in the same session the agent expresses the business intent (use case) and defines the interface the use case depends on (repository contract). No implementation details enter here.
+
+**Rules applied:**
+- **RULE_2 / RULE_11** — Naming: use case class names describe business intent; repository interfaces are named at the right abstraction level.
+- **RULE_5** — Pure business logic only. No data source concerns, no Flutter framework imports, no Sentry calls.
+- **RULE_7** — Self-documenting code; domain logic should read like a business rule, not an algorithm.
+
+**What does not live here:** Stream lifecycle, error logging, SDK wiring — those belong in the layers below.
+
+---
+
+### `code-data` *(always, when story touches data layer)*
+
+**Verb:** Write a repository implementation or datasource.
+
+This is the bridge between the domain contract and the outside world (remote API, local DB, device sensors).
+
+**Rules applied:**
+- **RULE_2 / RULE_11** — Concrete, explicit naming: `RemoteUserDatasource`, not `UserDatasourceImpl`.
+- **RULE_5** — Repository implementations translate data errors into domain failures; they do not contain business rules.
+- **RULE_6** — If the datasource exposes streams: use `distinct()`, manage `StreamController` lifecycle, ensure proper cancellation on dispose.
+- **RULE_15** — Sentry error logging lives here for unexpected data errors. Log once — do not re-log errors as they propagate up the call stack. Expected errors (e.g., 404, empty result) are not Sentry events.
+- **RULE_7** — Self-documenting code.
+
+---
+
+### `code-integration` *(gated — new 3rd party service)*
+
+**Verb:** Wire an external SDK into the app.
+
+**Decision gate:** Invoke only if this story introduces a new external package or service. If the story only uses an already-integrated SDK, this skill is not needed.
+
+This is a distinct verb because the agent is not writing business logic or UI — it is building an integration seam, which has its own ceremony and failure modes.
+
+**What the agent does:**
+- Initializes the SDK in the correct location (DI module, not in a widget or use case)
+- Wraps the SDK in an adapter so the domain layer never imports it directly — the domain depends on the repository contract, the adapter implements it
+- Translates SDK exceptions into typed domain failures at the adapter boundary
+- **RULE_15** — Logs unexpected SDK errors via Sentry once, at the adapter layer only
+- **RULE_2 / RULE_11** — Names the adapter and its contract at the correct abstraction level
+
+---
+
+## Stage 4 — Testing
+
+Testing splits not by content similarity but by **invocation pattern**: some tests are always written, others are opt-in based on a decision gate. The gate logic is the primary job of the gated skills — it cannot be buried inside a combined test file.
+
+### `write-tests` *(always)*
+
+**Verb:** Write unit and widget tests.
+
+Unit and widget tests stay together because they share the same Modular DI init/destroy setup, the same fake-at-lowest-boundary rule, and are typically written in the same session for the same feature.
+
+**Unit test side:**
+- **RULE_3** — Fake the real implementation at the lowest boundary; no mocks or stubs.
+- **RULE_9** — Tests assert on behavior (output, state changes, emitted events), never on internal implementation details or method call counts.
+- Stream testing: use `expectLater` with matchers, not `await` on individual emissions.
+
+**Widget test side:**
+- **RULE_8** — Use semantic finders (`find.byKey`, `find.text`); never `byType` or positional `findsNWidgets`.
+- `pumpAndSettle` caution: avoid for Lottie animations and indefinite streams; prefer `pump(duration)`.
+- **RULE_3** — Inject fakes through DI, not by overriding widget constructors.
+
+---
+
+### `write-tests-golden` *(gated — layout-sensitive UI)*
+
+**Verb:** Decide whether screenshot coverage is needed, then write it.
+
+**Decision gate (opens the skill):** Does this story introduce or change layout-sensitive UI? If no — skip. If yes — proceed.
+
+**What the agent does:**
+- Sets up golden test scaffolding with correct device frame configuration
+- Covers the primary happy-path visual state
+- **RULE_14** — For critical user flows verified visually, accessibility checks are included in the same test pass (semantic labels, contrast, tap target sizes)
+
+---
+
+### `write-tests-mutation` *(gated — logic-heavy changes)*
+
+**Verb:** Decide whether mutation testing is warranted, then run it.
+
+**Decision gate (opens the skill):** Does the use case being tested have 3 or more conditional branches? If no — skip. If yes — proceed.
+
+**What the agent does:**
+- **RULE_13** — Runs mutation testing on the logic-heavy use case
+- Ensures the test suite kills the generated mutants (i.e., tests are actually sensitive to logic changes, not just executing code paths)
+- Surfaces surviving mutants as missing test cases to the developer
+
+---
+
+## Stage 5 — PR Review *(existing)*
+
+### `pr-review` 
+
+**Verb:** Check a completed diff for violations.
+
+This skill is defensive. It checks after the fact. It is not a substitute for the construction-phase skills above — its job is to catch anything that slipped through, not to be the primary quality gate.
 
 ---
 
 ## Summary
 
-This plan transforms our 15 development guidelines into **4 comprehensive agent skills** that assist developers throughout the coding workflow.
+| Skill | Stage | Invocation | Rules Covered |
+|---|---|---|---|
+| `read-ticket` | Intake | Always | — |
+| `plan-implementation` | Planning | Always | RULE_2, RULE_11 |
+| `code-presentation` | Coding | Always (if layer touched) | RULE_4, RULE_5, RULE_7, RULE_10, RULE_12 |
+| `code-domain` | Coding | Always (if layer touched) | RULE_2, RULE_5, RULE_7, RULE_11 |
+| `code-data` | Coding | Always (if layer touched) | RULE_2, RULE_5, RULE_6, RULE_7, RULE_11, RULE_15 |
+| `code-integration` | Coding | Gated (new SDK) | RULE_2, RULE_11, RULE_15 + adapter patterns |
+| `write-tests` | Testing | Always | RULE_3, RULE_8, RULE_9 |
+| `write-tests-golden` | Testing | Gated (layout UI) | RULE_14 |
+| `write-tests-mutation` | Testing | Gated (3+ branches) | RULE_13 |
+| `pr-review` | Review | Existing | RULE_4, RULE_5, RULE_10 + others |
 
-**Key Principles:**
-- **Group-based skills**: 4 skills covering 15 rules (not 15 individual skills)
-- **Development-focused**: Help developers during coding, not just in PR review
-- **Shared infrastructure**: Rules in same group share analysis techniques
-- **Progressive expansion**: Build on existing POC, add rules to groups
-- **Modular design**: Skills are independent, reusable, and composable
-
-**Final Architecture:**
-- `static-analysis` → RULE_2, 4, 10, 11
-- `architectural-check` → RULE_5, 6, 12
-- `test-quality` → RULE_3, 8, 9, 13, 14
-- `code-health` → RULE_7, 15
+**10 skills total** (9 new + 1 existing), each with a single verb, each loading only what the agent needs at that moment in the story lifecycle.

--- a/docs/_Sidebar.md
+++ b/docs/_Sidebar.md
@@ -4,6 +4,9 @@
 ## Getting Started
 - [Localization](Localization)
 
+## Development Guidelines
+- [Agentic Skills Migration Plan](Agentic-Skills-Migration-Plan)
+
 ## Configuration
 - [Launcher Icons](Launcher-Icons-Configuration)
 


### PR DESCRIPTION
## Summary

  This PR introduces the **Agentic Skills Migration Plan** - our strategy to transform 15 Flutter
  development guidelines into **4 comprehensive agent skills** that actively assist developers
  during feature development.

  ## 🔑 Key Insight: 4 Skills, Not 15

  Rather than creating 15 individual skills, we're creating **4 group-based skills** that cover all
   rules:

  skills/
  ├── static-analysis/        # RULE_2, 4, 10, 11 (pattern matching)
  ├── architectural-check/    # RULE_5, 6, 12 (layer boundaries)├── test-quality/           #
  RULE_3, 8, 9, 13, 14 (test patterns)
  └── code-health/            # RULE_7, 15 (cleanliness)

  **Why this approach is better:**
  - ✅ **Fewer skills to maintain** (4 instead of 15)
  - ✅ **Shared infrastructure** within each group
  - ✅ **Single invocation** checks multiple related rules
  - ✅ **Natural modularity** based on analysis type
