### PR TITLE
CA-670: feat: add read-ticket skill for ticket analysis and implement

### DIFF
--- a/skills/plan-implementation/SKILL.md
+++ b/skills/plan-implementation/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: plan-implementation
+description: |
+  Stage 2: Implementation Planning - Decide what to create before writing code.
+  Applies RULE_1 (digestible PRs), RULE_2 (naming), checks CoreUI availability.
+
+  Trigger: "plan implementation" (implementation planning intent), "plan this feature" (ticket-to-file planning intent), "what files do we need for implementation"
+
+disable-model-invocation: false
+---
+
+# Plan Implementation Skill
+
+**Verb: Decide what to create.**
+
+Agent's blueprint phase before coding. Outputs: file paths, class names, dependencies, CoreUI checks, PR split strategy.
+
+## Input
+
+- **Context from `read-ticket`** (conversation history): layers touched, anticipated classes
+- `output_format` (optional): `structured` or `checklist`
+
+## Workflow
+
+1. **Review `read-ticket` context** (from conversation history)
+   - If missing: ask user to run `/read-ticket` or describe what they're building
+
+2. **Apply RULE_2** (naming conventions) → Load `skills/rules/02-naming-conventions.md`
+   - Use suffix table + decision tree to name all classes
+   - Apply abstraction naming: abstract at UI/domain, explicit at data layer
+   - Output: precise class names with responsibilities
+
+3. **Determine file structure** (Flutter conventions)
+   ```
+   lib/features/{feature}/
+     presentation/pages/    → {feature}_page.dart
+     presentation/bloc/     → {feature}_bloc|event|state.dart
+     domain/usecases/       → {verb}_{noun}_usecase.dart
+     domain/repositories/   → {noun}_repository.dart
+     data/repositories/     → {noun}_repository_impl.dart
+     data/data_source/      → remote|local_{noun}_data_source.dart
+   ```
+
+4. **Check CoreUI availability** (if presentation layer touched) → See RULE_4
+   - Identify required components from ticket (buttons, inputs, icons, cards, etc.)
+   - Check `skills/references/coreui-api.md` (⚠️ may be outdated - use as quick reference only)
+   - **Source of truth:** https://github.com/ripplearc/coreui#readme (always check live README)
+   - If component missing: flag as blocker with RULE_4-compliant options only:
+     1. Use existing CoreUI component with custom layout
+     2. Request CoreUI team to add it
+     3. Build custom component following CoreUI design patterns
+   - ❌ Never suggest "use Material temporarily" (violates RULE_4 Critical severity)
+
+5. **Verify dependencies** (no layer violations)
+   - BLoC depends on UseCase (not Repository/DataSource)
+   - UseCase depends on Repository interface (not RepositoryImpl/DataSource)
+   - RepositoryImpl depends on DataSource
+   - Flag violations if found
+
+6. **Apply RULE_1** (digestible PRs) → Load `skills/rules/01-digestible-pr.md`
+   - **Estimate production LOC** using this heuristic (before code is written):
+
+     | Class Type | Typical LOC |
+     |------------|-------------|
+     | Page (simple) | 80-120 |
+     | Page (complex) | 150-250 |
+     | BLoC (basic CRUD) | 60-100 |
+     | BLoC (complex state) | 120-180 |
+     | Event class | 10-20 |
+     | State class | 20-40 |
+     | UseCase (simple) | 20-40 |
+     | UseCase (complex) | 50-80 |
+     | Repository (interface) | 10-30 |
+     | RepositoryImpl | 40-70 |
+     | DataSource (remote) | 50-90 |
+     | DataSource (local) | 30-60 |
+     | DTO/Model | 15-30 |
+
+   - Sum LOC for all classes, exclude tests/generated files
+   - If >200 LOC: suggest PR split strategy
+     - By layer: Domain → Data → Presentation
+     - By dependency: Foundation → Feature → UI
+     - By scope: Core feature → Error handling → Polish
+   - Output: PR plan with each PR's focus + estimated LOC
+
+7. **Compile plan**
+   - Classes + file paths
+   - CoreUI check results + blockers
+   - Dependencies + violations
+   - PR split strategy
+   - Next skills to invoke
+
+## Output Format
+
+**Checklist (default):**
+```markdown
+# Plan: CA-123 - Add estimation screen
+
+## Classes (RULE_2 applied)
+- EstimationPage (lib/features/estimation/presentation/pages/estimation_page.dart)
+- EstimationBloc/Event/State (lib/features/estimation/presentation/bloc/...)
+- GetEstimationsUseCase (lib/features/estimation/domain/usecases/get_estimations_usecase.dart)
+- EstimationRepository (interface, lib/features/estimation/domain/repositories/...)
+- EstimationRepositoryImpl (lib/features/estimation/data/repositories/...)
+- RemoteEstimationDataSource (lib/features/estimation/data/data_source/...)
+
+## CoreUI Check (RULE_4)
+✅ CoreButton, CoreTextField, CoreLoadingIndicator
+❌ CoreCard (BLOCKER) → Options per RULE_4:
+  1. Use existing CoreUI component with custom layout
+  2. Request CoreUI team to add CoreCard
+  3. Build custom CoreCard following CoreUI patterns
+
+## Dependencies
+- EstimationBloc → GetEstimationsUseCase ✅
+- GetEstimationsUseCase → EstimationRepository ✅
+- EstimationRepositoryImpl → RemoteEstimationDataSource ✅
+
+## PR Strategy (RULE_1)
+Estimated: ~420 LOC production code → Split into 2 PRs
+
+PR1 (Domain + Data): ~150 LOC
+- GetEstimationsUseCase + EstimationRepository
+- EstimationRepositoryImpl + RemoteEstimationDataSource + EstimationDto
+- Unit tests for UseCase + Repository
+
+PR2 (Presentation): ~270 LOC
+- EstimationPage + EstimationBloc/Event/State
+- Widget tests + Golden tests
+- Depends on: PR1 merged
+
+→ Next: Resolve CoreCard blocker, then code PR1 with code-domain and code-data skills
+```
+
+## References
+
+- **RULE_1:** `skills/rules/01-digestible-pr.md` (PR size + split strategies)
+- **RULE_2:** `skills/rules/02-naming-conventions.md` (suffix + abstraction naming)
+- **RULE_4:** `skills/rules/04-coreui-components.md` (CoreUI usage + missing component handling)
+- **CoreUI API:** `skills/references/coreui-api.md` (quick reference - may be outdated)
+- **CoreUI Source of Truth:** https://github.com/ripplearc/coreui#readme (always check live)
+- **Next skills:** `code-presentation/`, `code-domain/`, `code-data/` (planned — coming in next PR)

--- a/skills/read-ticket/SKILL.md
+++ b/skills/read-ticket/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: read-ticket
+description: |
+  Stage 1: Ticket Intake - Understand what to build before coding begins.
+  Identifies architecture layers, anticipates classes, determines test types, flags ambiguities.
+
+  Trigger: "read ticket CA-123", "analyze ticket", "what does CA-456 require"
+
+disable-model-invocation: false
+---
+
+# Read Ticket Skill
+
+**Verb: Understand what to build.**
+
+Agent's first action when assigned a story. Output primes `plan-implementation` and subsequent coding skills.
+
+## Input
+
+- `ticket_id`: YouTrack ID (e.g., "CA-123")
+- `output_format` (optional): `structured` or `conversational`
+
+## Workflow
+
+1. **Fetch ticket** via `mcp__youtrack__get_issue(issueId: ticket_id)`
+   - Extract: summary, description, custom fields, comments
+   - Handle errors: ticket not found, missing description
+   - **Fallback:** If YouTrack MCP unavailable, ask user to paste ticket content directly
+
+2. **Identify layers touched** (presentation, domain, data, integration)
+   - UI changes/screens → presentation
+   - Business logic/rules → domain
+   - API/DB/cache → data
+   - New SDK → integration (ask user to confirm)
+
+3. **Anticipate classes** (rough scope, not final naming)
+   - Presentation: {Feature}Page, {Feature}Bloc/Event/State
+   - Domain: {Verb}{Noun}UseCase, {Noun}Repository (interface)
+   - Data: Remote/Local{Noun}DataSource, {Noun}RepositoryImpl
+
+4. **Determine test types**
+   - Unit tests: always
+   - Widget tests: if presentation touched
+   - Golden tests: if layout-sensitive UI
+   - Mutation tests: if 4+ conditional branches (per RULE_13: `skills/rules/13-mutation-testing.md`)
+   - Accessibility tests: if critical flow
+
+5. **Flag ambiguities**
+   - Missing: user flow, edge cases, data source, design refs
+   - Unclear: acceptance criteria, conflicting requirements
+   - Surface to developer before `plan-implementation`
+
+6. **Output analysis**
+   - Layers touched + next skills needed
+   - Anticipated classes
+   - Required test types
+   - Ambiguities + clarifying questions
+   - Estimated complexity
+
+## Output Format
+
+**Conversational (default):**
+```
+📋 Ticket CA-123: Add project estimation page
+
+Layers: Presentation + Domain
+Classes: EstimationPage, EstimationBloc, GetEstimationsUseCase
+Tests: Unit + Widget + Golden
+
+⚠️ Ambiguities:
+- No API endpoint specified
+- No error handling mentioned
+
+**Next:** Clarify ambiguities, then plan the implementation using the plan-implementation skill
+```
+
+## References
+
+- Next skill: `skills/plan-implementation/SKILL.md`


### PR DESCRIPTION
# PR Review: `feat/create-planning-skills` → `feat/migrate-rules-to-skills`

**Date:** Wed May 13, 2026
**Reviewer:** Automated Code Review
**PR Size Classification:** N/A — documentation only; production code size thresholds do not apply ✅

---

## 1. PR Summary

This PR introduces two new agentic skills that form the first two stages of a ticket-to-code pipeline: `read-ticket` (Stage 1 — understand what to build) and `plan-implementation` (Stage 2 — decide what to create before writing code). Together they create a structured handoff chain: YouTrack ticket → layer/class analysis → file structure → PR split strategy → downstream coding skills. Both skills correctly reference the shared `skills/rules/` directory established in the base branch, and the two-stage design cleanly separates concerns between intake and planning.

---

---

## 2. Review Summary Table

| Issue Name | Description | Status | Notes |
|---|---|---|---|
| **"Use Material temporarily" contradicts RULE_4** | The output example lists "use Material temporarily" as a fallback option when a CoreUI component is missing. RULE_4 classifies any Material component usage as Critical severity. Remove this option and replace with the three RULE_4-compliant alternatives. | ✅  | |
| **No LOC estimation heuristic for planning phase** | Step 6 instructs the agent to "estimate production LOC" but provides no method for doing so before code is written. RULE_1's git diff approach only works on existing diffs. Add a per-class LOC heuristic table so the estimate is actionable. | ✅  | |
| **RULE_4 and `coreui-api.md` missing from References** | Step 4 performs a CoreUI availability check but neither `RULE_4` nor `skills/references/coreui-api.md` appear in the References section. Add both. | ✅  | |
| **Downstream skills referenced but don't exist** | `skills/code-presentation/`, `skills/code-domain/`, `skills/code-data/` are listed as "Next skills" in both the output template and References section. These directories don't exist yet. Mark them as planned/upcoming to avoid agent confusion. |  | They will be available in the next PR |
| **Mutation test citation missing in `read-ticket`** | Step 4 of `read-ticket` correctly uses RULE_13's 3-branch gating threshold but doesn't cite the rule. Add `(per RULE_13: skills/rules/13-mutation-testing.md)` so future editors know the threshold is rule-derived, not arbitrary. | ✅  | |
| **Slash command invocation inconsistency** | `read-ticket` output shows `→ Next: /plan-implementation` but `plan-implementation` defines its triggers as natural-language phrases, not slash commands. Standardise the invocation convention across both skill files. | ✅  | |
| **No fallback when YouTrack MCP is unavailable** | `read-ticket` Step 1 calls `mcp__youtrack__get_issue` with no fallback if the tool is not connected. Add an instruction to ask the user to paste ticket content directly if the MCP tool is unavailable. | ✅  | |