### PR TITLE
CA-670: feat: add code-data, code-domain, and code-integration skills…

### DIFF
--- a/skills/code-data/SKILL.md
+++ b/skills/code-data/SKILL.md
@@ -115,7 +115,7 @@ void _registerDependencies(Injector i) {
 ## Key Principles
 
 1. **Explicit names** — `fetchInitialEstimationsByProjectId`, not `getEstimations` (RULE_2)
-2. **Error boundary** — RemoteDataSource logs error then rethrows; RepositoryImpl is the boundary where exceptions become Failures
+2. **Error boundary** — RemoteDataSource rethrows without logging; RepositoryImpl is the error boundary where exceptions become Failures
 3. **DTO ↔ Entity** — DTOs for JSON; Entities for domain; validate/handle invalid JSON
 4. **RULE_15: Log once** — At RepositoryImpl boundary only (don't re-log as errors propagate)
 5. **Never throw from repository** — Always `Either<Failure, T>`

--- a/skills/code-data/SKILL.md
+++ b/skills/code-data/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: code-data
+description: |
+  Stage 3: Coding (Data Layer) - Write RepositoryImpl, DataSources, and DTOs.
+  Data layer implements repository interfaces and handles external data sources (API, DB, cache).
+
+  ⚠️ INVOCATION: Only use when the ticket touches the data layer (repository implementations, data sources, API/DB access).
+
+  Trigger: "write data code", "implement data layer", "create datasource" (DataSource interface + related data layer classes)
+
+disable-model-invocation: false
+---
+
+# Code Data Skill
+
+**Verb:** Write data layer code (RepositoryImpl, DataSources, DTOs).
+
+**Input:** Context from `plan-implementation` + `code-domain` — repository interfaces, data classes, file paths.
+
+## 1. Class Overview
+
+| Class Type | Naming (RULE_2) | Purpose |
+|------------|-----------------|---------|
+| **DataSource** (interface) | `{Noun}DataSource` | Contract with **explicit method names** (e.g., `fetchInitialEstimationsByProjectId`) |
+| **RemoteDataSource** | `Remote{Noun}DataSource` | Fetches from API/DB via `SupabaseWrapper` |
+| **RepositoryImpl** | `{Noun}RepositoryImpl` | Implements domain repository; maps errors to Failures |
+| **DTO** | `{Noun}Dto` | JSON ↔ Entity mapping |
+
+## 2. RemoteDataSource Pattern
+
+**Purpose:** Fetch data from external source (Supabase); log debug on success; rethrow errors.
+
+**Required imports:**
+```dart
+import 'package:construculator/libraries/logging/app_logger.dart';
+import 'package:construculator/libraries/supabase/interfaces/supabase_wrapper.dart';
+import 'package:construculator/libraries/supabase/database_constants.dart';
+```
+
+**Logging:**
+- Log debug on success: `_logger.debug('Fetched N items')`
+- **Do NOT log errors** — RepositoryImpl is the error boundary (RULE_15)
+
+**Error handling:**
+- **Always rethrow** — Let RepositoryImpl handle error mapping and logging
+
+## 3. RepositoryImpl Pattern
+
+**Purpose:** Implement domain repository interface; delegate to DataSource; map exceptions to Failures.
+
+**Required imports:**
+```dart
+import 'dart:async';
+import 'dart:io';
+import 'package:construculator/libraries/either/either.dart';
+import 'package:construculator/libraries/errors/failures.dart';
+import 'package:supabase_flutter/supabase_flutter.dart' as supabase;
+```
+
+**Error mapping (at RepositoryImpl boundary):**
+
+| Exception Type | Log Level | Failure Type | Notes |
+|----------------|-----------|--------------|-------|
+| `TimeoutException` | warning | `{Feature}Failure(timeoutError)` | Expected — network timeout; log warning only |
+| `SocketException` | warning | `{Feature}Failure(connectionError)` | Expected — connection failure; log warning only |
+| `PostgrestException` (expected) | warning | `{Feature}Failure(notFound/duplicate)` | Expected — `PGRST116` (not found), `23505` (duplicate), `23503` (FK violation); log warning only |
+| `PostgrestException` (critical) | error | `{Feature}Failure(databaseError)` | Critical — unknown PG codes, server errors; log error (Sentry) |
+| Other | error | `UnexpectedFailure()` | Critical — unexpected exceptions; log error (Sentry) |
+
+**RULE_15 — Log once at RepositoryImpl only:**
+- **Warning level:** Expected errors; no Sentry event
+- **Error level:** Critical/unexpected errors; sends Sentry event
+
+**Pattern:** Wrap datasource call in try-catch; return `Either<Failure, T>` (never throw).
+
+**AppLogger signature:** `_logger.error('message', error, stackTrace)` or `_logger.warning('message', error, stackTrace)`
+
+## 4. DTO Pattern
+
+**Purpose:** Map JSON ↔ Domain entities.
+
+**Validation:** Handle invalid/missing JSON gracefully:
+- Use `as` casts with null-aware operators for required fields
+- Provide sensible defaults or throw during `fromJson` if critical data missing
+- Document expected JSON structure in dartdoc
+
+## 5. Dependency Registration
+
+Add to `lib/features/{feature}/{feature}_module.dart`:
+
+```dart
+void _registerDependencies(Injector i) {
+  i.addLazySingleton<{Noun}DataSource>(() => Remote{Noun}DataSource(supabaseWrapper: i()));
+  i.addLazySingleton<{Noun}Repository>(() => {Noun}RepositoryImpl(dataSource: i()));
+}
+```
+
+## 6. Layer Boundaries (RULE_5)
+
+| ❌ Data MUST NOT Import | ✅ Data CAN Import |
+|-------------------------|-------------------|
+| Presentation layer (BLoC, UI) | Domain interfaces (`{Noun}Repository`) |
+| | DTOs (own layer) |
+| | External SDKs (`SupabaseWrapper`, `Dio`) |
+| | Logging (`AppLogger`) |
+
+## Output Files
+
+- `lib/features/{feature}/data/data_source/interfaces/{noun}_data_source.dart`
+- `lib/features/{feature}/data/data_source/remote_{noun}_data_source.dart`
+- `lib/features/{feature}/data/repositories/{noun}_repository_impl.dart`
+- `lib/features/{feature}/data/models/{noun}_dto.dart`
+- Updated: `lib/features/{feature}/{feature}_module.dart`
+
+## Key Principles
+
+1. **Explicit names** — `fetchInitialEstimationsByProjectId`, not `getEstimations` (RULE_2)
+2. **Error boundary** — RemoteDataSource logs error then rethrows; RepositoryImpl is the boundary where exceptions become Failures
+3. **DTO ↔ Entity** — DTOs for JSON; Entities for domain; validate/handle invalid JSON
+4. **RULE_15: Log once** — At RepositoryImpl boundary only (don't re-log as errors propagate)
+5. **Never throw from repository** — Always `Either<Failure, T>`
+
+## References
+
+- **RULE_2:** `skills/rules/02-naming-conventions.md`
+- **RULE_5:** `skills/rules/05-ui-business-separation.md`
+- **RULE_15:** Sentry logging at boundaries
+- **Examples:** `lib/features/global_search/data/data_source/remote_global_search_data_source.dart`, `lib/features/global_search/data/repositories/global_search_repository_impl.dart`
+- **Future:** `write-tests` skill (planned — unit tests for data layer with fakes)
+

--- a/skills/code-data/SKILL.md
+++ b/skills/code-data/SKILL.md
@@ -30,13 +30,6 @@ disable-model-invocation: false
 
 **Purpose:** Fetch data from external source (Supabase); log debug on success; rethrow errors.
 
-**Required imports:**
-```dart
-import 'package:construculator/libraries/logging/app_logger.dart';
-import 'package:construculator/libraries/supabase/interfaces/supabase_wrapper.dart';
-import 'package:construculator/libraries/supabase/database_constants.dart';
-```
-
 **Logging:**
 - Log debug on success: `_logger.debug('Fetched N items')`
 - **Do NOT log errors** — RepositoryImpl is the error boundary (RULE_15)
@@ -50,11 +43,8 @@ import 'package:construculator/libraries/supabase/database_constants.dart';
 
 **Required imports:**
 ```dart
-import 'dart:async';
-import 'dart:io';
 import 'package:construculator/libraries/either/either.dart';
 import 'package:construculator/libraries/errors/failures.dart';
-import 'package:supabase_flutter/supabase_flutter.dart' as supabase;
 ```
 
 **Error mapping (at RepositoryImpl boundary):**

--- a/skills/code-domain/SKILL.md
+++ b/skills/code-domain/SKILL.md
@@ -29,6 +29,13 @@ disable-model-invocation: false
 - ✅ `fetchInitialEstimationsByProjectId`, `loadMoreLogs`, `hasMoreLogs`
 - ❌ `getEstimations`, `fetchData`, `load`
 
+## Entities
+
+Prefer `Equatable` for all entities to enable value equality without boilerplate:
+
+- ✅ Extend `Equatable` and override `props`
+- ❌ Don't manually override `==` and `hashCode`
+
 ## Enums
 
 Document each enum case with dartdoc comments explaining business meaning.

--- a/skills/code-domain/SKILL.md
+++ b/skills/code-domain/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: code-domain
+description: |
+  Stage 3: Coding (Domain Layer) - Write UseCases, Repositories (interfaces), and Services.
+  Domain layer contains pure business logic with no knowledge of UI or data sources.
+
+  ⚠️ INVOCATION: Only use when the ticket touches the domain layer (business logic, use cases, repository interfaces).
+
+  Trigger: "write domain layer code", "implement domain layer use cases", "create domain usecase"
+
+disable-model-invocation: false
+---
+
+# Code Domain Skill
+
+**Verb:** Write domain layer code (UseCases, Repository interfaces, Services).
+
+**Input:** Context from `plan-implementation` — class names, file paths, dependencies.
+
+## Domain Class Patterns
+
+| Class Type | Naming | Signature | Responsibilities | Forbidden |
+|------------|--------|-----------|------------------|-----------|
+| **UseCase** | `{Verb}{Noun}UseCase` | `Future<Either<Failure, T>> call(Param p)` | Single business operation; delegates to repository | Business logic implementation (delegate to repository) |
+| **Repository** | `{Noun}Repository` (abstract) | `Future<Either<Failure, T>> methodNameByScope(Param p)` | Data access contract with **explicit names** (RULE_2) | Implementation details (data sources, SDKs) |
+| **Service** | `{Noun}Service` | `Future<Either<Failure, T>> methodName(Param p)` | Coordinates multiple repositories | Direct data access (use repositories) |
+
+**Examples of explicit repository names (RULE_2):**
+- ✅ `fetchInitialEstimationsByProjectId`, `loadMoreLogs`, `hasMoreLogs`
+- ❌ `getEstimations`, `fetchData`, `load`
+
+## Enums
+
+Document each enum case with dartdoc comments explaining business meaning.
+
+
+## Required Imports
+
+```dart
+import 'package:construculator/libraries/either/either.dart';
+import 'package:construculator/libraries/errors/failures.dart';
+```
+
+## Dependency Registration
+
+Add to `lib/features/{feature}/{feature}_module.dart`:
+
+```dart
+void _registerDependencies(Injector i) {
+  i.add<{Verb}{Noun}UseCase>(() => {Verb}{Noun}UseCase(i()));
+  i.add<{Noun}Service>(() => {Noun}Service(repo1: i(), repo2: i())); // If needed
+}
+```
+
+## Layer Boundaries (RULE_5)
+
+| ❌ Domain MUST NOT Import | ✅ Domain CAN Import |
+|---------------------------|---------------------|
+| Flutter widgets (`package:flutter`) | Entities |
+| Data layer (`RepositoryImpl`, `DataSource`) | Failures |
+| Presentation layer (`BLoC`, UI) | Either |
+| | Repository interfaces (abstract) |
+
+## Output Files
+
+- `lib/features/{feature}/domain/usecases/{verb}_{noun}_usecase.dart`
+- `lib/features/{feature}/domain/repositories/{noun}_repository.dart`
+- `lib/features/{feature}/domain/services/{noun}_service.dart` (if coordinating multiple repos)
+- Updated: `lib/features/{feature}/{feature}_module.dart`
+
+## Priority Rules (Critical to Success)
+
+### 🔴 Non-Negotiable (Must Follow)
+1. **Pure business logic** — No UI, no data source knowledge
+2. **No layer violations** — Domain MUST NOT import Flutter, data layer, or presentation layer (see RULE_5)
+3. **Either, never throw** — Always return `Either<Failure, T>`, never throw exceptions
+
+### 🟡 Core Patterns (Always Apply)
+4. **UseCases orchestrate** — Delegate to repositories; don't implement business rules
+5. **Explicit repository names** — Use `fetchInitialByProjectId`, not `get` (RULE_2)
+6. **Dartdoc required** — Document parameters, return types, edge cases
+
+## References
+
+- **RULE_2:** `skills/rules/02-naming-conventions.md`
+- **RULE_5:** `skills/rules/05-ui-business-separation.md`
+- **Examples:** `lib/features/auth/domain/usecases/login_usecase.dart`, `lib/features/estimation/domain/repositories/cost_estimation_log_repository.dart`
+- **Next:** `code-data` (implements repository interfaces)
+- **Future:** `write-tests` skill (planned — unit tests for domain layer)

--- a/skills/code-domain/SKILL.md
+++ b/skills/code-domain/SKILL.md
@@ -87,3 +87,4 @@ void _registerDependencies(Injector i) {
 - **Examples:** `lib/features/auth/domain/usecases/login_usecase.dart`, `lib/features/estimation/domain/repositories/cost_estimation_log_repository.dart`
 - **Next:** `code-data` (implements repository interfaces)
 - **Future:** `write-tests` skill (planned — unit tests for domain layer)
+

--- a/skills/code-integration/SKILL.md
+++ b/skills/code-integration/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: code-integration
+description: |
+  Stage 3: Coding (Integration Layer) - GATED - Only for new third-party SDK integrations.
+  Creates wrapper layer so domain never imports SDKs directly.
+
+  ⚠️ GATED: Only use when ticket explicitly requires adding an external service/SDK that is not previously implemented or integrated in the codebase.
+  Examples: new payment provider, analytics SDK, push notification service.
+
+  Trigger: "integrate new SDK", "add third party service", "create wrapper"
+
+disable-model-invocation: false
+---
+
+# Code Integration Skill
+
+**Verb:** Write integration wrapper for a new third-party SDK.
+
+⚠️ **GATED** — Only when the ticket requires adding an external service or SDK that is not previously implemented or integrated in the codebase.
+
+## Gate Check
+
+| ✅ Use This Skill | ❌ Use `code-data` Instead |
+|------------------|---------------------------|
+| NEW payment provider (Stripe, PayPal) | Existing Supabase (use `SupabaseWrapper`) |
+| NEW analytics SDK (Mixpanel, Amplitude) | Existing auth (use `AuthManager`) |
+| NEW cloud service (AWS S3, Firebase Storage) | Regular data sources |
+| NEW push notification provider | |
+| NEW OAuth provider | |
+
+**Input:** Context from `plan-implementation` — SDK name, wrapper interface (if needed), operations needed.
+
+## Wrapper Pattern Classes
+
+| Class Type | Naming (RULE_2) | Signature | Responsibilities | Type Boundary |
+|------------|-----------------|-----------|------------------|---------------|
+| **Wrapper** | `{SDK}Wrapper` | Concrete class with SDK-specific methods | Wraps SDK client; maps SDK types ↔ domain types; handles SDK errors | **Only place SDK types appear** |
+| **Interface** (optional) | `{SDK}WrapperInterface` | Abstract class with domain types only | Domain-facing contract when abstraction needed | Domain sees this |
+| **Failure** | `{SDK}Failure extends Failure` | `{SDK}ErrorType errorType` | SDK-specific error types (timeout, auth, rate limit, etc.) | Domain error type |
+| **Fake** (test) | `Fake{SDK}Client` | `implements sdk.{SDK}Client` | Test double with pre-configured responses/errors (RULE_3) | Test boundary |
+
+**Pattern:** Create wrapper in `lib/libraries/{sdk}/{sdk}_wrapper.dart` that domain code depends on directly (or via optional interface).
+
+## Wrapper Error Mapping
+
+| SDK Exception | Log Level | Failure Type | Notes |
+|---------------|-----------|--------------|-------|
+| SDK-specific (e.g., `sdk.{SDK}Exception`) | error | `{SDK}Failure(errorType: ...)` | Map SDK error codes to domain types |
+| `TimeoutException` | warning | `{SDK}Failure(timeout)` | Expected error |
+| Other | error | `UnexpectedFailure()` | RULE_15: Log once at wrapper boundary |
+
+## Required Imports
+
+```dart
+// Wrapper
+import 'package:{sdk_package}/{sdk_package}.dart' as sdk;
+import 'package:construculator/libraries/logging/app_logger.dart';
+import 'package:construculator/libraries/either/either.dart';
+import 'package:construculator/libraries/errors/failures.dart';
+```
+
+## Dependency Registration
+
+Create `lib/libraries/{sdk}/_{sdk}_module.dart`:
+
+```dart
+import 'package:flutter_modular/flutter_modular.dart';
+import 'package:{sdk_package}/{sdk_package}.dart' as sdk;
+
+class {SDK}Module extends Module {
+  @override
+  void binds(Injector i) {
+    i.addLazySingleton<sdk.{SDK}Client>(() => sdk.{SDK}Client(apiKey: /* config */));
+    i.addLazySingleton<{SDK}Wrapper>(() => {SDK}Wrapper(client: i()));
+    // Or with interface: i.addLazySingleton<{SDK}WrapperInterface>(() => {SDK}Wrapper(client: i()));
+  }
+}
+```
+
+Then import in `lib/app/app_module.dart`.
+
+## Output Files
+
+- `lib/libraries/{sdk}/interfaces/{sdk}_wrapper_interface.dart` (optional — only if abstraction needed)
+- `lib/libraries/{sdk}/{sdk}_wrapper.dart`
+- `lib/libraries/{sdk}/_{sdk}_module.dart`
+- `lib/libraries/{sdk}/domain/{sdk}_failure.dart`
+- `test/libraries/{sdk}/fake_{sdk}_client.dart` (RULE_3: fake, not mock)
+- `test/libraries/{sdk}/{sdk}_wrapper_test.dart`
+- Updated: `lib/app/app_module.dart` (import `{SDK}Module`)
+
+## Key Principles
+
+1. **Domain isolation** — Wrapper is boundary; domain never imports SDK directly
+2. **Wrapper is type translation layer** — SDK types → Domain types
+3. **Error translation** — SDK exceptions → Domain Failures at wrapper boundary
+4. **Testability** — Fake SDK client (RULE_3), test wrapper mapping logic
+
+## References
+
+- **RULE_2:** `skills/rules/02-naming-conventions.md`
+- **RULE_3:** `skills/rules/03-test-double-pattern.md`
+- **RULE_15:** Sentry logging at boundaries
+- **Clean Architecture:** Domain depends on wrappers, not SDKs
+- **Example:** `lib/libraries/supabase/supabase_wrapper.dart`
+- **Future:** `write-tests` skill (planned — wrapper tests with fake SDK clients)
+
+⚠️ **Use sparingly** — Most data access uses existing wrappers (`SupabaseWrapper`, `AuthManager`). Only for external services or SDKs that are not previously implemented or integrated in the codebase.
+

--- a/skills/code-integration/SKILL.md
+++ b/skills/code-integration/SKILL.md
@@ -30,6 +30,8 @@ disable-model-invocation: false
 
 **Input:** Context from `plan-implementation` — SDK name, wrapper interface (if needed), operations needed.
 
+⚠️ **Gate failure:** If the SDK already exists in the codebase, **stop immediately** — do not write any code. Tell the user to use `code-data` instead and point to the existing wrapper (e.g. `SupabaseWrapper`, `AuthManager`).
+
 ## Wrapper Pattern Classes
 
 | Class Type | Naming (RULE_2) | Signature | Responsibilities | Type Boundary |
@@ -37,7 +39,7 @@ disable-model-invocation: false
 | **Wrapper** | `{SDK}Wrapper` | Concrete class with SDK-specific methods | Wraps SDK client; maps SDK types ↔ domain types; handles SDK errors | **Only place SDK types appear** |
 | **Interface** (optional) | `{SDK}WrapperInterface` | Abstract class with domain types only | Domain-facing contract when abstraction needed | Domain sees this |
 | **Failure** | `{SDK}Failure extends Failure` | `{SDK}ErrorType errorType` | SDK-specific error types (timeout, auth, rate limit, etc.) | Domain error type |
-| **Fake** (test) | `Fake{SDK}Client` | `implements sdk.{SDK}Client` | Test double with pre-configured responses/errors (RULE_3) | Test boundary |
+| **Fake** (test) | `Fake{SDK}Client` | `implements sdk.{SDK}Client` | Faithful re-implementation of the SDK client interface; injected in place of the real SDK in tests; exposes configurable fields to control responses and errors per-test (RULE_3) | Test boundary |
 
 **Pattern:** Create wrapper in `lib/libraries/{sdk}/{sdk}_wrapper.dart` that domain code depends on directly (or via optional interface).
 
@@ -49,15 +51,6 @@ disable-model-invocation: false
 | `TimeoutException` | warning | `{SDK}Failure(timeout)` | Expected error |
 | Other | error | `UnexpectedFailure()` | RULE_15: Log once at wrapper boundary |
 
-## Required Imports
-
-```dart
-// Wrapper
-import 'package:{sdk_package}/{sdk_package}.dart' as sdk;
-import 'package:construculator/libraries/logging/app_logger.dart';
-import 'package:construculator/libraries/either/either.dart';
-import 'package:construculator/libraries/errors/failures.dart';
-```
 
 ## Dependency Registration
 
@@ -70,12 +63,14 @@ import 'package:{sdk_package}/{sdk_package}.dart' as sdk;
 class {SDK}Module extends Module {
   @override
   void binds(Injector i) {
-    i.addLazySingleton<sdk.{SDK}Client>(() => sdk.{SDK}Client(apiKey: /* config */));
+    i.addLazySingleton<sdk.{SDK}Client>(() => sdk.{SDK}Client(apiKey: i.get<EnvLoader>().get('{SDK}_API_KEY') ?? ''));
     i.addLazySingleton<{SDK}Wrapper>(() => {SDK}Wrapper(client: i()));
     // Or with interface: i.addLazySingleton<{SDK}WrapperInterface>(() => {SDK}Wrapper(client: i()));
   }
 }
 ```
+
+**Config pattern:** Keys are read from `assets/env/.env.{dev|qa|prod}` via `EnvLoader` (already in DI — inject with `i.get<EnvLoader>()`). Never hardcode credentials. Add the key to all three `.env` files.
 
 Then import in `lib/app/app_module.dart`.
 

--- a/skills/code-presentation/SKILL.md
+++ b/skills/code-presentation/SKILL.md
@@ -33,14 +33,6 @@ If the input context from `plan-implementation` is incomplete or missing, respon
 
 **Purpose:** Top-level screen that provides BLoC and builds UI tree.
 
-**Required imports:**
-```dart
-import 'package:flutter/material.dart';
-import 'package:flutter_modular/flutter_modular.dart';
-import 'package:ripplearc_coreui/ripplearc_coreui.dart'; // RULE_4: CoreUI package
-import 'package:construculator/libraries/extensions/build_context_extensions.dart';
-```
-
 **Access via BuildContext extension:**
 - **Localization (RULE_10):** `context.l10n.keyName` (not `S.of(context)`)
 - **Colors:** `context.colorTheme.primary`, `context.colorTheme.pageBackground`

--- a/skills/code-presentation/SKILL.md
+++ b/skills/code-presentation/SKILL.md
@@ -1,0 +1,150 @@
+---
+name: code-presentation
+description: |
+  Stage 3: Coding (Presentation Layer) - Write Pages, BLoCs, and Widgets.
+  Presentation layer handles UI, state coordination, and user interaction with zero business logic.
+
+  ⚠️ INVOCATION: Only use when the ticket touches the presentation layer (UI, screens, BLoC state management).
+
+  Trigger: Any of the following phrases exactly: "write UI code", "implement presentation layer", "create page", "create bloc"
+
+disable-model-invocation: false
+---
+
+# Code Presentation Skill
+
+**Verb:** Write presentation layer code (Pages, BLoCs, Widgets).
+
+**Input:** Context from `plan-implementation` — page names, BLoC states, widget hierarchy.
+
+## 1. Class Overview
+
+| Class Type | Naming (RULE_2) | Purpose | Location |
+|------------|-----------------|---------|----------|
+| **Page** | `{Feature}Page` | Top-level screen with route; contains BLoC provider | `presentation/pages/{feature}_page.dart` |
+| **BLoC** | `{Feature}Bloc` | State coordinator; emits states based on events | `presentation/bloc/{feature}_bloc/{feature}_bloc.dart` |
+| **Event** | `{Feature}Event` (sealed) | User actions or lifecycle events | `presentation/bloc/{feature}_bloc/{feature}_event.dart` |
+| **State** | `{Feature}State` (sealed) | UI state representations | `presentation/bloc/{feature}_bloc/{feature}_state.dart` |
+| **Widget** | `{Purpose}Widget` | Reusable UI component | `presentation/widgets/{purpose}_widget.dart` |
+
+## 2. Page Pattern
+
+**Purpose:** Top-level screen that provides BLoC and builds UI tree.
+
+**Required imports:**
+```dart
+import 'package:flutter/material.dart';
+import 'package:flutter_modular/flutter_modular.dart';
+import 'package:ripplearc_coreui/ripplearc_coreui.dart'; // RULE_4: CoreUI package
+import 'package:construculator/libraries/extensions/build_context_extensions.dart';
+```
+
+**Access via BuildContext extension:**
+- **Localization (RULE_10):** `context.l10n.keyName` (not `S.of(context)`)
+- **Colors:** `context.colorTheme.primary`, `context.colorTheme.pageBackground`
+- **Typography:** `context.textTheme.bodyMediumRegular`, `context.textTheme.titleLargeBold`
+
+**Key rules:**
+- **RULE_4:** Use CoreUI components ONLY — never `Material` widgets directly
+- **RULE_10:** All text via `context.l10n.keyName` — no hardcoded strings
+- **RULE_5:** Zero business logic — no validation, calculations, or conditional state coordination
+- Pages are **passive** — they display state from BLoC; they don't decide what state means
+
+**BLoC access:** Use `Modular.get<{Feature}Bloc>()` in page widget, not constructor injection.
+
+**Routing:** Use `Modular.get<AppRouter>().push(...)` to navigate forward and `Modular.get<AppRouter>().pop()` to go back. Avoid direct `Navigator` usage.
+
+## 3. BLoC Pattern
+
+**Purpose:** Coordinate UI state; handle events; emit states. BLoC is NOT a business rule engine.
+
+**Structure:**
+```
+bloc/{feature}_bloc/
+├── {feature}_bloc.dart       # BLoC class with event handlers
+├── {feature}_event.dart       # Sealed event classes
+└── {feature}_state.dart       # Sealed state classes
+```
+
+**Key rules:**
+- **RULE_12:** State derivation happens HERE, not in widgets (e.g., `total`, `isValid`, `filteredItems`)
+- **RULE_5:** BLoC orchestrates UseCases; doesn't implement business logic
+- Events: User actions (`SubmitPressed`, `FieldChanged`) or lifecycle (`PageLoaded`)
+- States: UI representations (`Loading`, `Success`, `Error`)
+- Use `emit()` to transition states
+
+**Error handling:** Catch UseCase failures; emit error states with user-friendly messages (via RULE_10 localization).
+
+## 4. Widget Pattern
+
+**Purpose:** Reusable UI components; receive data via constructor; no state management.
+
+**Key rules:**
+- **RULE_4:** CoreUI components only (from `ripplearc_coreui` package)
+- **RULE_10:** Localized text via `context.l10n.keyName`
+- **RULE_5:** Zero logic — widgets are **dumb presenters**
+- Use `context.colorTheme` for colors, `context.textTheme` for typography
+- Prefer `const` constructors for performance
+- Extract complex UI trees into named widgets for readability
+
+**Forbidden in widgets:**
+- Business validation (`if (id != null) { bloc.add(...) }`)
+- State derivation (`total = items.fold(...)`)
+- Cross-field coordination
+- Direct UseCase calls
+- Hardcoded colors/text (use `context.colorTheme`, `context.l10n`)
+
+## 5. Dependency Registration
+
+Add to `lib/features/{feature}/{feature}_module.dart`:
+
+```dart
+void _registerDependencies(Injector i) {
+  // BLoCs (transient — new instance per request)
+  i.add<{Feature}Bloc>(() => {Feature}Bloc(useCase: i()));
+}
+```
+
+## 6. Layer Boundaries (RULE_5)
+
+| ❌ Presentation MUST NOT | ✅ Presentation CAN |
+|-------------------------|-------------------|
+| Implement business logic (validation, calculations) | Call UseCases (orchestrate) |
+| Import data layer (`RepositoryImpl`, `DataSource`) | Import domain (`UseCase`, `Entity`, `Failure`) |
+| Derive state in widgets (`build` method calculations) | Derive state in BLoC (`emit` computed states) |
+| Hardcode strings/colors | Use `context.l10n`, `context.colorTheme`, `context.textTheme` |
+| Use Material widgets directly | Import CoreUI (`ripplearc_coreui`) |
+
+## Output Files
+
+- `lib/features/{feature}/presentation/pages/{feature}_page.dart`
+- `lib/features/{feature}/presentation/bloc/{feature}_bloc/{feature}_bloc.dart`
+- `lib/features/{feature}/presentation/bloc/{feature}_bloc/{feature}_event.dart`
+- `lib/features/{feature}/presentation/bloc/{feature}_bloc/{feature}_state.dart`
+- `lib/features/{feature}/presentation/widgets/{purpose}_widget.dart` (if needed)
+- Updated: `lib/features/{feature}/{feature}_module.dart`
+
+## Priority Rules (Critical to Follow)
+
+### 🔴 Non-Negotiable
+1. **Zero business logic** — Presentation must not implement business rules; always call UseCases (RULE_5)
+2. **Localization & Theming** — All user-facing text via `context.l10n`; use `context.colorTheme` and `context.textTheme` for colors/typography (RULE_10)
+3. **CoreUI Only** — Use `ripplearc_coreui` components; avoid direct `Material` widgets (RULE_4)
+
+### 🟡 Core Patterns (Always Apply)
+4. **Pages are passive** — Pages display BLoC-provided state and do not contain logic
+5. **BLoC coordinates state** — Derive computed values and state transitions in BLoC (RULE_12)
+6. **Routing via AppRouter** — Use `Modular.get<AppRouter>().push(...)` and `.pop()` for navigation
+7. **Testable widgets** — Widgets are dumb presenters; prefer `const` constructors and constructor-based inputs
+
+## References
+
+- **RULE_4:** `skills/rules/04-coreui-components.md` — CoreUI components
+- **RULE_5:** `skills/rules/05-ui-business-separation.md` — No business logic in UI
+- **RULE_7:** `skills/rules/07-self-documenting-code.md` — Comments explain why
+- **RULE_10:** `skills/rules/10-localization.md` — All user-facing text
+- **RULE_12:** `skills/rules/12-state-derivation.md` — Derive in BLoC, not widgets
+- **CoreUI API:** `skills/references/coreui-api.md`
+- **Examples:** `lib/features/auth/presentation/`, `lib/features/project/presentation/`
+- **Future:** `write-tests` skill (planned — widget tests for pages)
+

--- a/skills/code-presentation/SKILL.md
+++ b/skills/code-presentation/SKILL.md
@@ -17,6 +17,8 @@ disable-model-invocation: false
 
 **Input:** Context from `plan-implementation` — page names, BLoC states, widget hierarchy.
 
+If the input context from `plan-implementation` is incomplete or missing, respond with an error message specifying the missing details before writing code.
+
 ## 1. Class Overview
 
 | Class Type | Naming (RULE_2) | Purpose | Location |
@@ -50,9 +52,27 @@ import 'package:construculator/libraries/extensions/build_context_extensions.dar
 - **RULE_5:** Zero business logic — no validation, calculations, or conditional state coordination
 - Pages are **passive** — they display state from BLoC; they don't decide what state means
 
-**BLoC access:** Use `Modular.get<{Feature}Bloc>()` in page widget, not constructor injection.
+**BLoC access (preferred):** Prefer resolving BLoCs via `BuildContext` instead of `Modular.get`. This keeps wiring explicit and works well with `BlocProvider`.
 
-**Routing:** Use `Modular.get<AppRouter>().push(...)` to navigate forward and `Modular.get<AppRouter>().pop()` to go back. Avoid direct `Navigator` usage.
+Two recommended approaches:
+
+1. Inline usage for simple callbacks:
+
+```dart
+onTabSelected: (index) => context.read<AppShellBloc>().add(AppShellTabSelected(index)),
+```
+
+2. Field resolution in `didChangeDependencies` (preferred when a `BlocProvider` is above the Page):
+
+Resolve the BLoC in `didChangeDependencies` (not in `build`) to avoid repeated lookups and to satisfy lints that forbid resolving dependencies during build.
+
+If your app does not provide the BLoC via `BlocProvider`, fall back to module registration and `Modular.get`.
+
+**Routing (three-tier model):**
+- **Tab switching** (within shell): Dispatch BLoC events (e.g. `context.read<AppShellBloc>().add(AppShellTabSelected(index))`) — handled by the shell's BLoC; widgets do not have to call `Navigator.push/pop` to switch tabs
+- **Full-screen navigation** (above shell): `Modular.get<AppRouter>().push(...)` / `.pop()` — replaces entire shell
+- **In-tab drill-downs** (within tab): `Navigator.of(context).push(...)` / `.pop()` — preserves tab state and other tabs
+  ⚠️ Never use AppRouter for tab-switching or in-tab navigation — it resets tab state and navigators.
 
 ## 3. BLoC Pattern
 

--- a/skills/code-presentation/SKILL.md
+++ b/skills/code-presentation/SKILL.md
@@ -66,7 +66,10 @@ onTabSelected: (index) => context.read<AppShellBloc>().add(AppShellTabSelected(i
 
 Resolve the BLoC in `didChangeDependencies` (not in `build`) to avoid repeated lookups and to satisfy lints that forbid resolving dependencies during build.
 
-If your app does not provide the BLoC via `BlocProvider`, fall back to module registration and `Modular.get`.
+If your app does not provide the BLoC via `BlocProvider`, fall back to module
+registration and resolve as a class field:
+  `final _bloc = Modular.get<FeatureBloc>();`
+Never call `Modular.get` inside `build()` — violates `forbid_modular_get_outside_module`.
 
 **Routing (three-tier model):**
 - **Tab switching** (within shell): Dispatch BLoC events (e.g. `context.read<AppShellBloc>().add(AppShellTabSelected(index))`) — handled by the shell's BLoC; widgets do not have to call `Navigator.push/pop` to switch tabs
@@ -154,7 +157,10 @@ void _registerDependencies(Injector i) {
 ### 🟡 Core Patterns (Always Apply)
 4. **Pages are passive** — Pages display BLoC-provided state and do not contain logic
 5. **BLoC coordinates state** — Derive computed values and state transitions in BLoC (RULE_12)
-6. **Routing via AppRouter** — Use `Modular.get<AppRouter>().push(...)` and `.pop()` for navigation
+6. **Routing (three-tier model):**
+   - Tab switching (within shell): `context.read<AppShellBloc>().add(AppShellTabSelected(index))`
+   - Full-screen (above shell): `_router.push(...)` — resolve as `final _router = Modular.get<AppRouter>();` class field
+   - In-tab drill-downs: `Navigator.of(context).push(...)` / `.pop()` — never AppRouter here
 7. **Testable widgets** — Widgets are dumb presenters; prefer `const` constructors and constructor-based inputs
 
 ## References
@@ -167,4 +173,3 @@ void _registerDependencies(Injector i) {
 - **CoreUI API:** `skills/references/coreui-api.md`
 - **Examples:** `lib/features/auth/presentation/`, `lib/features/project/presentation/`
 - **Future:** `write-tests` skill (planned — widget tests for pages)
-

--- a/skills/plan-implementation/SKILL.md
+++ b/skills/plan-implementation/SKILL.md
@@ -25,12 +25,33 @@ Agent's blueprint phase before coding. Outputs: file paths, class names, depende
 1. **Review `read-ticket` context** (from conversation history)
    - If missing: ask user to run `/read-ticket` or describe what they're building
 
-2. **Apply RULE_2** (naming conventions) → Load `skills/rules/02-naming-conventions.md`
+2. **Gather layer-specific inputs** — ask the user only for what the touched layers actually need; skip anything already clear from the ticket
+
+   **Domain layer (entities, use cases, repository interfaces):**
+   - Entity fields: ask for each field's name, type, and nullability (e.g. `id: String`, `title: String`, `completedAt: DateTime?`)
+   - Any enums or value objects that belong on the entity?
+
+   **Data layer (DataSource, RepositoryImpl, DTO):**
+   - Supabase table name(s) for each entity being fetched/mutated
+   - Column names + types if they differ from entity fields; otherwise confirm they match
+   - Any joins or related table names required for the query?
+
+   **Presentation layer (BLoC, Page):**
+   - Entry point: which screen navigates here, and what arguments does it pass?
+   - Any form inputs or user-submitted data on this screen?
+   - Any non-obvious loading / error / empty state behavior not described in the ticket?
+
+   **Rules:**
+   - Ask all relevant questions in one message grouped by layer — never drip-feed one question at a time
+   - Do not ask for info that is unambiguous from the ticket context
+   - If multiple layers are touched, ask for all their inputs together before proceeding
+
+3. **Apply RULE_2** (naming conventions) → Load `skills/rules/02-naming-conventions.md`
    - Use suffix table + decision tree to name all classes
    - Apply abstraction naming: abstract at UI/domain, explicit at data layer
    - Output: precise class names with responsibilities
 
-3. **Determine file structure** (Flutter conventions)
+4. **Determine file structure** (Flutter conventions)
    ```
    lib/features/{feature}/
      presentation/pages/    → {feature}_page.dart
@@ -41,7 +62,7 @@ Agent's blueprint phase before coding. Outputs: file paths, class names, depende
      data/data_source/      → remote|local_{noun}_data_source.dart
    ```
 
-4. **Check CoreUI availability** (if presentation layer touched) → See RULE_4
+5. **Check CoreUI availability** (if presentation layer touched) → See RULE_4
    - Identify required components from ticket (buttons, inputs, icons, cards, etc.)
    - Check `skills/references/coreui-api.md` (⚠️ may be outdated - use as quick reference only)
    - **Source of truth:** https://github.com/ripplearc/coreui#readme (always check live README)
@@ -51,13 +72,13 @@ Agent's blueprint phase before coding. Outputs: file paths, class names, depende
      3. Build custom component following CoreUI design patterns
    - ❌ Never suggest "use Material temporarily" (violates RULE_4 Critical severity)
 
-5. **Verify dependencies** (no layer violations)
+6. **Verify dependencies** (no layer violations)
    - BLoC depends on UseCase (not Repository/DataSource)
    - UseCase depends on Repository interface (not RepositoryImpl/DataSource)
    - RepositoryImpl depends on DataSource
    - Flag violations if found
 
-6. **Apply RULE_1** (digestible PRs) → Load `skills/rules/01-digestible-pr.md`
+7. **Apply RULE_1** (digestible PRs) → Load `skills/rules/01-digestible-pr.md`
    - **Estimate production LOC** using this heuristic (before code is written):
 
      | Class Type | Typical LOC |
@@ -83,7 +104,7 @@ Agent's blueprint phase before coding. Outputs: file paths, class names, depende
      - By scope: Core feature → Error handling → Polish
    - Output: PR plan with each PR's focus + estimated LOC
 
-7. **Compile plan**
+8. **Compile plan**
    - Classes + file paths
    - CoreUI check results + blockers
    - Dependencies + violations


### PR DESCRIPTION
# PR Review: `feat/add-coding-skills` → `feat/create-planning-skills` (Revised)

**Date:** Wed May 13, 2026
**Reviewer:** Automated Code Review
**PR Size Classification:** N/A — documentation only ✅

---

## 1. PR Summary

This is a significant revision of the previous coding skills PR. The three skill files (`code-domain`, `code-data`, `code-integration`) have been restructured from verbose step-by-step Dart templates into concise reference documents using tables and pattern summaries. The key fix from the previous review — `mocktail` in `code-integration`'s test template — has been resolved: the hand-written `Fake{SDK}Client` pattern is now correctly documented and RULE_3 is referenced. The skills are meaningfully more readable and maintainable in this form.

**Issues resolved from previous review:**
- ✅ `mocktail` removed from `code-integration`; `Fake{SDK}Client` (RULE_3) documented
- ✅ RULE_3 added to `code-integration` References section
- ✅ All three skills are substantially more concise and scannable

Three issues from the previous review remain open and are detailed below.

---

---

## 2. Review Summary Table

| Issue Name | Description | Status | Notes |
|---|---|---|---|
| **`AppLogger.error()` wrong signature in `code-data`** | Section 2 RemoteDataSource still shows `_logger.error('...fetching: $error', stackTrace.toString())` — error object dropped into message string, stackTrace passed as string. Correct signature: `_logger.error('message', error, stackTrace)`. | ✅ | |
| **Duplicate logging contradicts RULE_15 in `code-data`** | Section 2 instructs RemoteDataSource to log `error()` on failure, while Key Principle #4 says "Log once at RepositoryImpl boundary only." These contradict each other. RemoteDataSource should rethrow without logging; RepositoryImpl is the error boundary. | ✅ | |
| **`write-tests` next skill doesn't exist** | All three skills reference `write-tests` as the next skill. The directory doesn't exist. Mark as planned across all three files. Carried over unresolved from previous review. | ✅ | |
| **Missing trailing newline in `code-domain`** | `No newline at end of file` still present in the diff. Add trailing newline. Carried over unresolved from previous review. | ✅ | |