### PR TITLE
CA-249: Feat: project search remote datasource implementation

### DIFF
--- a/lib/libraries/project/data/data_source/interfaces/project_search_data_source.dart
+++ b/lib/libraries/project/data/data_source/interfaces/project_search_data_source.dart
@@ -1,0 +1,21 @@
+import 'package:construculator/libraries/project/data/models/project_dto.dart';
+
+/// Interface that abstracts project search data source operations.
+///
+/// Implementations must rethrow all exceptions — error mapping is the
+/// repository's responsibility.
+abstract class ProjectSearchDataSource {
+  /// Searches projects matching [query] for the given [userId].
+  ///
+  /// Returns an empty list when [query] or [userId] is empty without calling
+  /// the remote API. [userId] may be used as an early-exit guard; backend user
+  /// scoping is implementation-specific and not required to be forwarded as an
+  /// explicit parameter.
+  Future<List<ProjectDto>> fetchProjectsBySearchQuery({
+    required String userId,
+    required String query,
+    DateTime? filterByDate,
+    String? filterByTag,
+    String? filterByOwner,
+  });
+}

--- a/lib/libraries/project/data/data_source/remote_project_search_data_source.dart
+++ b/lib/libraries/project/data/data_source/remote_project_search_data_source.dart
@@ -1,0 +1,76 @@
+import 'package:construculator/libraries/logging/app_logger.dart';
+import 'package:construculator/libraries/project/data/data_source/interfaces/project_search_data_source.dart';
+import 'package:construculator/libraries/project/data/models/project_dto.dart';
+import 'package:construculator/libraries/supabase/database_constants.dart';
+import 'package:construculator/libraries/supabase/interfaces/supabase_wrapper.dart';
+import 'package:supabase_flutter/supabase_flutter.dart' as supabase;
+
+/// Remote implementation of [ProjectSearchDataSource] using Supabase.
+///
+/// Delegates to the [global_search] RPC with [scope] locked to [dashboard] and
+/// extracts only the projects array from the response. All other result types
+/// (estimations, members) are discarded.
+///
+/// [userId] is used only as an early-exit guard and is not forwarded in the
+/// RPC params. The backend derives the caller identity from the Supabase
+/// auth session JWT, so no explicit `user_id` param is needed.
+class RemoteProjectSearchDataSource implements ProjectSearchDataSource {
+  final SupabaseWrapper _supabaseWrapper;
+  static final _logger = AppLogger().tag('RemoteProjectSearchDataSource');
+
+  /// Creates a [RemoteProjectSearchDataSource] with the given [supabaseWrapper].
+  const RemoteProjectSearchDataSource({required SupabaseWrapper supabaseWrapper})
+    : _supabaseWrapper = supabaseWrapper;
+
+  @override
+  Future<List<ProjectDto>> fetchProjectsBySearchQuery({
+    required String userId,
+    required String query,
+    DateTime? filterByDate,
+    String? filterByTag,
+    String? filterByOwner,
+  }) async {
+    if (query.trim().isEmpty || userId.trim().isEmpty) {
+      _logger.debug('Empty query or userId — skipping RPC call');
+      return [];
+    }
+
+    try {
+      _logger.debug('Searching projects for query: $query, userId: $userId');
+
+      final response = await _supabaseWrapper.rpc<Map<String, dynamic>>(
+        DatabaseConstants.globalSearchRpcFunction,
+        params: {
+          'query': query,
+          'filter_by_tag': filterByTag,
+          'filter_by_date': filterByDate?.toIso8601String(),
+          'filter_by_owner': filterByOwner,
+          'scope': DatabaseConstants.globalSearchDashboardScope,
+          'offset': DatabaseConstants.globalSearchDefaultOffset,
+          'limit': DatabaseConstants.globalSearchDefaultLimit,
+        },
+      );
+
+      final projectsRaw = response['projects'] as List<dynamic>? ?? [];
+      final projects = projectsRaw
+          .whereType<Map<String, dynamic>>()
+          .map(ProjectDto.fromJson)
+          .toList();
+
+      _logger.debug('Found ${projects.length} projects for query: $query');
+      return projects;
+    } on supabase.PostgrestException catch (error, stackTrace) {
+      _logger.warning(
+        'Supabase error while searching projects for query: $query, error: $error',
+        stackTrace.toString(),
+      );
+      rethrow;
+    } catch (error, stackTrace) {
+      _logger.error(
+        'Unexpected error while searching projects for query: $query, error: $error',
+        stackTrace.toString(),
+      );
+      rethrow;
+    }
+  }
+}

--- a/lib/libraries/project/project_library_module.dart
+++ b/lib/libraries/project/project_library_module.dart
@@ -2,8 +2,10 @@ import 'package:construculator/app/app_bootstrap.dart';
 import 'package:construculator/libraries/project/data/current_project_notifier_impl.dart';
 import 'package:construculator/libraries/project/data/data_source/interfaces/permission_data_source.dart';
 import 'package:construculator/libraries/project/data/data_source/interfaces/project_data_source.dart';
+import 'package:construculator/libraries/project/data/data_source/interfaces/project_search_data_source.dart';
 import 'package:construculator/libraries/project/data/data_source/local_jwt_project_permission_data_source.dart';
 import 'package:construculator/libraries/project/data/data_source/remote_project_data_source.dart';
+import 'package:construculator/libraries/project/data/data_source/remote_project_search_data_source.dart';
 import 'package:construculator/libraries/project/data/repositories/project_repository_impl.dart';
 import 'package:construculator/libraries/project/domain/repositories/project_repository.dart';
 import 'package:construculator/libraries/project/interfaces/current_project_notifier.dart';
@@ -51,5 +53,11 @@ void _registerDependencies(Injector i) {
       permissionDataSource: Modular.get<ProjectPermissionDataSource>(),
     ),
     config: BindConfig(onDispose: (repository) => repository.dispose()),
+  );
+
+  i.addLazySingleton<ProjectSearchDataSource>(
+    () => RemoteProjectSearchDataSource(
+      supabaseWrapper: Modular.get<SupabaseWrapper>(),
+    ),
   );
 }

--- a/lib/libraries/supabase/database_constants.dart
+++ b/lib/libraries/supabase/database_constants.dart
@@ -23,10 +23,16 @@ class DatabaseConstants {
   static const String searchSuggestionsRpcFunction = 'get_search_suggestions';
 
   // RPC param values
+  /// The scope value passed to the [globalSearchRpcFunction] RPC to restrict
+  /// results to the dashboard context (projects, estimations, members).
   static const String globalSearchDashboardScope = 'dashboard';
 
   // global_search RPC defaults
+  /// Default maximum number of results returned by the
+  /// [globalSearchRpcFunction] RPC.
   static const int globalSearchDefaultLimit = 20;
+
+  /// Default result offset for the [globalSearchRpcFunction] RPC (zero-based).
   static const int globalSearchDefaultOffset = 0;
 
   // Column names

--- a/lib/libraries/supabase/database_constants.dart
+++ b/lib/libraries/supabase/database_constants.dart
@@ -21,6 +21,13 @@ class DatabaseConstants {
   static const String globalSearchRpcFunction = 'global_search';
   static const String searchSuggestionsRpcFunction = 'get_search_suggestions';
 
+  // RPC param values
+  static const String globalSearchDashboardScope = 'dashboard';
+
+  // global_search RPC defaults
+  static const int globalSearchDefaultLimit = 20;
+  static const int globalSearchDefaultOffset = 0;
+
   // Column names
   static const String idColumn = 'id';
   static const String projectIdColumn = 'project_id';

--- a/lib/libraries/supabase/database_constants.dart
+++ b/lib/libraries/supabase/database_constants.dart
@@ -22,6 +22,13 @@ class DatabaseConstants {
   static const String globalSearchRpcFunction = 'global_search';
   static const String searchSuggestionsRpcFunction = 'get_search_suggestions';
 
+  // RPC param values
+  static const String globalSearchDashboardScope = 'dashboard';
+
+  // global_search RPC defaults
+  static const int globalSearchDefaultLimit = 20;
+  static const int globalSearchDefaultOffset = 0;
+
   // Column names
   static const String idColumn = 'id';
   static const String projectIdColumn = 'project_id';

--- a/lib/libraries/supabase/database_constants.dart
+++ b/lib/libraries/supabase/database_constants.dart
@@ -22,10 +22,16 @@ class DatabaseConstants {
   static const String searchSuggestionsRpcFunction = 'get_search_suggestions';
 
   // RPC param values
+  /// The scope value passed to the [globalSearchRpcFunction] RPC to restrict
+  /// results to the dashboard context (projects, estimations, members).
   static const String globalSearchDashboardScope = 'dashboard';
 
   // global_search RPC defaults
+  /// Default maximum number of results returned by the
+  /// [globalSearchRpcFunction] RPC.
   static const int globalSearchDefaultLimit = 20;
+
+  /// Default result offset for the [globalSearchRpcFunction] RPC (zero-based).
   static const int globalSearchDefaultOffset = 0;
 
   // Column names

--- a/test/libraries/project/units/data/data_source/remote_project_search_data_source_test.dart
+++ b/test/libraries/project/units/data/data_source/remote_project_search_data_source_test.dart
@@ -1,0 +1,276 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:construculator/libraries/project/data/data_source/remote_project_search_data_source.dart';
+import 'package:construculator/libraries/supabase/data/supabase_types.dart';
+import 'package:construculator/libraries/supabase/database_constants.dart';
+import 'package:construculator/libraries/supabase/testing/fake_supabase_wrapper.dart';
+import 'package:construculator/libraries/time/testing/fake_clock_impl.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:supabase_flutter/supabase_flutter.dart' as supabase;
+
+Map<String, dynamic> _fakeProjectData({
+  String? id,
+  String? projectName,
+  String? creatorUserId,
+  String? createdAt,
+  String? updatedAt,
+  String? status,
+}) {
+  return {
+    DatabaseConstants.idColumn: id ?? 'project-1',
+    DatabaseConstants.projectNameColumn: projectName ?? 'Test Project',
+    DatabaseConstants.descriptionColumn: 'Test description',
+    DatabaseConstants.creatorUserIdColumn: creatorUserId ?? 'user-1',
+    DatabaseConstants.owningCompanyIdColumn: null,
+    DatabaseConstants.exportFolderLinkColumn: null,
+    DatabaseConstants.exportStorageProviderColumn: null,
+    DatabaseConstants.createdAtColumn: createdAt ?? '2024-01-01T00:00:00.000Z',
+    DatabaseConstants.updatedAtColumn: updatedAt ?? '2024-01-01T00:00:00.000Z',
+    DatabaseConstants.statusColumn: status ?? 'active',
+  };
+}
+
+void main() {
+  group('RemoteProjectSearchDataSource', () {
+    late FakeClockImpl clock;
+    late FakeSupabaseWrapper supabaseWrapper;
+    late RemoteProjectSearchDataSource dataSource;
+
+    setUp(() {
+      clock = FakeClockImpl(DateTime(2025, 1, 1, 8, 0));
+      supabaseWrapper = FakeSupabaseWrapper(clock: clock);
+      dataSource = RemoteProjectSearchDataSource(
+        supabaseWrapper: supabaseWrapper,
+      );
+    });
+
+    tearDown(() {
+      supabaseWrapper.reset();
+    });
+
+    group('fetchProjectsBySearchQuery', () {
+      test('returns mapped ProjectDto list when RPC succeeds with data', () async {
+        supabaseWrapper.setRpcResponse(
+          DatabaseConstants.globalSearchRpcFunction,
+          {
+            'projects': [
+              _fakeProjectData(id: 'p-1', projectName: 'Foundation Work'),
+              _fakeProjectData(id: 'p-2', projectName: 'Steel Frame'),
+            ],
+            'estimations': [],
+            'members': [],
+          },
+        );
+
+        final result = await dataSource.fetchProjectsBySearchQuery(
+          userId: 'user-1',
+          query: 'foundation',
+        );
+
+        expect(result, hasLength(2));
+        expect(result.first.id, equals('p-1'));
+        expect(result.first.projectName, equals('Foundation Work'));
+        expect(result.last.id, equals('p-2'));
+        expect(result.last.projectName, equals('Steel Frame'));
+      });
+
+      test('returns empty list when RPC returns empty projects array', () async {
+        supabaseWrapper.setRpcResponse(
+          DatabaseConstants.globalSearchRpcFunction,
+          {'projects': [], 'estimations': [], 'members': []},
+        );
+
+        final result = await dataSource.fetchProjectsBySearchQuery(
+          userId: 'user-1',
+          query: 'nothing',
+        );
+
+        expect(result, isEmpty);
+      });
+
+      test('returns empty list without calling RPC when query is empty', () async {
+        final result = await dataSource.fetchProjectsBySearchQuery(
+          userId: 'user-1',
+          query: '',
+        );
+
+        expect(result, isEmpty);
+        expect(supabaseWrapper.getMethodCallsFor('rpc'), isEmpty);
+      });
+
+      test(
+        'returns empty list without calling RPC when query is whitespace only',
+        () async {
+          final result = await dataSource.fetchProjectsBySearchQuery(
+            userId: 'user-1',
+            query: '   ',
+          );
+
+          expect(result, isEmpty);
+          expect(supabaseWrapper.getMethodCallsFor('rpc'), isEmpty);
+        },
+      );
+
+      test('returns empty list without calling RPC when userId is empty', () async {
+        final result = await dataSource.fetchProjectsBySearchQuery(
+          userId: '',
+          query: 'wall',
+        );
+
+        expect(result, isEmpty);
+        expect(supabaseWrapper.getMethodCallsFor('rpc'), isEmpty);
+      });
+
+      test(
+        'returns empty list without calling RPC when userId is whitespace only',
+        () async {
+          final result = await dataSource.fetchProjectsBySearchQuery(
+            userId: '   ',
+            query: 'wall',
+          );
+
+          expect(result, isEmpty);
+          expect(supabaseWrapper.getMethodCallsFor('rpc'), isEmpty);
+        },
+      );
+
+      test('always passes scope: dashboard in RPC params', () async {
+        supabaseWrapper.setRpcResponse(
+          DatabaseConstants.globalSearchRpcFunction,
+          {'projects': [], 'estimations': [], 'members': []},
+        );
+
+        await dataSource.fetchProjectsBySearchQuery(userId: 'user-1', query: 'wall');
+
+        final rpcCalls = supabaseWrapper.getMethodCallsFor('rpc');
+        expect(rpcCalls, hasLength(1));
+        final params = rpcCalls.first['params'] as Map<String, dynamic>?;
+        expect(params, isNotNull);
+        expect(params!['scope'], equals(DatabaseConstants.globalSearchDashboardScope));
+      });
+
+      test('does not forward userId in RPC params — auth scoping is JWT-based', () async {
+        supabaseWrapper.setRpcResponse(
+          DatabaseConstants.globalSearchRpcFunction,
+          {'projects': [], 'estimations': [], 'members': []},
+        );
+
+        await dataSource.fetchProjectsBySearchQuery(userId: 'user-1', query: 'wall');
+
+        final params = supabaseWrapper.getMethodCallsFor('rpc').first['params']
+            as Map<String, dynamic>?;
+        expect(params, isNotNull);
+        expect(params!.containsKey('user_id'), isFalse);
+      });
+
+      test('passes limit and offset constants in RPC params', () async {
+        supabaseWrapper.setRpcResponse(
+          DatabaseConstants.globalSearchRpcFunction,
+          {'projects': [], 'estimations': [], 'members': []},
+        );
+
+        await dataSource.fetchProjectsBySearchQuery(userId: 'user-1', query: 'wall');
+
+        final params = supabaseWrapper.getMethodCallsFor('rpc').first['params']
+            as Map<String, dynamic>?;
+        expect(params, isNotNull);
+        expect(params!['limit'], equals(DatabaseConstants.globalSearchDefaultLimit));
+        expect(params['offset'], equals(DatabaseConstants.globalSearchDefaultOffset));
+      });
+
+      test('passes filterByDate as ISO8601 string in RPC params', () async {
+        supabaseWrapper.setRpcResponse(
+          DatabaseConstants.globalSearchRpcFunction,
+          {'projects': [], 'estimations': [], 'members': []},
+        );
+
+        final filterDate = DateTime(2024, 6, 1);
+        await dataSource.fetchProjectsBySearchQuery(
+          userId: 'user-1',
+          query: 'wall',
+          filterByDate: filterDate,
+        );
+
+        final params = supabaseWrapper.getMethodCallsFor('rpc').first['params']
+            as Map<String, dynamic>?;
+        expect(params!['filter_by_date'], equals(filterDate.toIso8601String()));
+      });
+
+      test('passes filterByTag and filterByOwner in RPC params', () async {
+        supabaseWrapper.setRpcResponse(
+          DatabaseConstants.globalSearchRpcFunction,
+          {'projects': [], 'estimations': [], 'members': []},
+        );
+
+        await dataSource.fetchProjectsBySearchQuery(
+          userId: 'user-1',
+          query: 'wall',
+          filterByTag: 'structural',
+          filterByOwner: 'owner-42',
+        );
+
+        final params = supabaseWrapper.getMethodCallsFor('rpc').first['params']
+            as Map<String, dynamic>?;
+        expect(params!['filter_by_tag'], equals('structural'));
+        expect(params['filter_by_owner'], equals('owner-42'));
+      });
+
+      test('ignores estimations and members in RPC response', () async {
+        supabaseWrapper.setRpcResponse(
+          DatabaseConstants.globalSearchRpcFunction,
+          {
+            'projects': [_fakeProjectData(id: 'p-1')],
+            'estimations': [
+              {'id': 'e-1', 'estimate_name': 'Some Estimate'},
+            ],
+            'members': [
+              {'id': 'm-1', 'first_name': 'John'},
+            ],
+          },
+        );
+
+        final result = await dataSource.fetchProjectsBySearchQuery(
+          userId: 'user-1',
+          query: 'wall',
+        );
+
+        expect(result, hasLength(1));
+        expect(result.first.id, equals('p-1'));
+      });
+
+      test('rethrows PostgrestException when RPC throws', () async {
+        supabaseWrapper.shouldThrowOnRpc = true;
+        supabaseWrapper.rpcExceptionType = SupabaseExceptionType.postgrest;
+        supabaseWrapper.rpcErrorMessage = 'DB error';
+
+        await expectLater(
+          () => dataSource.fetchProjectsBySearchQuery(userId: 'user-1', query: 'wall'),
+          throwsA(isA<supabase.PostgrestException>()),
+        );
+      });
+
+      test('rethrows SocketException when RPC throws', () async {
+        supabaseWrapper.shouldThrowOnRpc = true;
+        supabaseWrapper.rpcExceptionType = SupabaseExceptionType.socket;
+        supabaseWrapper.rpcErrorMessage = 'Network error';
+
+        await expectLater(
+          () => dataSource.fetchProjectsBySearchQuery(userId: 'user-1', query: 'wall'),
+          throwsA(isA<SocketException>()),
+        );
+      });
+
+      test('rethrows TimeoutException when RPC throws', () async {
+        supabaseWrapper.shouldThrowOnRpc = true;
+        supabaseWrapper.rpcExceptionType = SupabaseExceptionType.timeout;
+        supabaseWrapper.rpcErrorMessage = 'Timeout';
+
+        await expectLater(
+          () => dataSource.fetchProjectsBySearchQuery(userId: 'user-1', query: 'wall'),
+          throwsA(isA<TimeoutException>()),
+        );
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Implements the data-source layer for project search by introducing the `ProjectSearchDataSource` abstract interface and its `RemoteProjectSearchDataSource` concrete implementation. The implementation delegates to the existing Supabase `global_search` RPC with the scope locked to `dashboard`, extracts only the `projects` array from the response, and discards all other result types (`estimations`, `members`). An early-exit guard returns an empty list without making an RPC call when either `query` or `userId` is empty or whitespace-only. All exceptions are rethrown, keeping error mapping the responsibility of the repository layer above. The new data source is registered as a lazy singleton in `ProjectLibraryModule`, and two new named constants (`globalSearchDefaultLimit`, `globalSearchDefaultOffset`) are added to `DatabaseConstants` alongside the existing `globalSearchDashboardScope` to eliminate all magic values from the RPC params map.

---

## Changes Overview

| Category | Value |
|----------|-------|
| **Files Changed** | 5 |
| **New Files** | 3 |
| **Modified Files** | 2 (`project_library_module.dart`, `database_constants.dart`) |
| **Total Lines Added** | 381 |
| **Production Lines Added** | 105 |
| **Test Lines Added** | 276 |
| **Test-to-Code Ratio** | ~2.6 : 1 |
| **PR Size** | **M (Medium)** — 105 production lines |

## Rule-Based Review


| Rule | Status | Notes |
|------|:------:|-------|
| **Rule 1 — Digestible PR** | ✅ Pass | Production code is 105 lines — classified as **M (Medium)** per the 100–200 line threshold. The PR has a single, clear purpose (project search data source layer) and is independently testable. No recommendation to split. |
| **Rule 2 — Class Naming Convention** | ✅ Pass | `RemoteProjectSearchDataSource` follows the `(Local\|Remote)NounDataSource` pattern exactly. The abstract interface `ProjectSearchDataSource` is correctly placed in the `interfaces/` subfolder. No `Helper` or `Util` suffixes present. All names are expressive and layer-appropriate. |
| **Rule 3 — Test Double Pattern** | ✅ Pass | Tests use `FakeSupabaseWrapper` to fake the external Supabase dependency — the only external boundary. `RemoteProjectSearchDataSource` itself is tested as a **real implementation**, not a fake. No mocks or stubs are used anywhere in the test file. The pattern of real class + faked external dependency is correctly applied. |
| **Rule 5 — UI & Business Logic Separation** |  N/A | This PR introduces no UI code, widgets, or BLoC event handling. No business logic has leaked into any presentation layer. Rule is not applicable but raises no concerns. |
| **Rule 6 — Stream-Based Performance & Lifecycle** |  N/A | No `StreamController`, stream subscription, or reactive pipeline is introduced in this PR. The data source is a stateless request/response class. No lifecycle or memory management concerns apply. |