### PR TITLE
CA-633: Enforce restrict_core_icon_data lint rule and abstract CoreIcons usage

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -36,10 +36,10 @@ custom_lint:
     - sealed_over_dynamic
     - avoid_static_colors
     - avoid_static_typography
+    - restrict_core_icon_data
     - forbid_modular_get_outside_module: false # TODO: [CA-627] [Infra] Publish forbid_modular_get_outside_module linter rule and audit construculator-app violations https://ripplearc.youtrack.cloud/issue/CA-627/Infra-Publish-forbidmodulargetinbloc-linter-rule-and-audit-construculator-app-violations
     - document_enum: false # TODO: [CA-641] [Infra] Enable & Resolve document_enum Linter Violations https://ripplearc.youtrack.cloud/issue/CA-641/Infra-Enable-Resolve-documentenum-Linter-Violations
     - feature_module_isolation: false # TODO: [CA-642] [Infra] Enforce Feature Module Isolation & Refactor Cross-Module Dependencies https://ripplearc.youtrack.cloud/issue/CA-642/Infra-Enforce-Feature-Module-Isolation-Refactor-Cross-Module-Dependencies
-    - restrict_core_icon_data: false # TODO: [CA-633] [Lint] Scope restrict_core_icon_data rule in ripplearc-flutter-lint to fire only outside coreui https://ripplearc.youtrack.cloud/issue/CA-633/Lint-Scope-restrictcoreicondata-rule-in-ripplearc-flutter-lint-to-fire-only-outside-coreui
 
   no_direct_instantiation:
     ignored_base_classes:

--- a/lib/features/estimation/presentation/widgets/estimation_actions_sheet.dart
+++ b/lib/features/estimation/presentation/widgets/estimation_actions_sheet.dart
@@ -106,17 +106,17 @@ class EstimationActionsSheet extends StatelessWidget {
                   mainAxisAlignment: MainAxisAlignment.spaceBetween,
                   children: [
                     _QuickActionButton(
-                      icon: CoreIcons.editDocument,
+                      icon: const EstimationActionIconEdit(),
                       label: l10n.renameAction,
                       onTap: onRename,
                     ),
                     _QuickActionButton(
-                      icon: CoreIcons.favorite,
+                      icon: const EstimationActionIconFavorite(),
                       label: l10n.favouriteAction,
                       onTap: onFavourite,
                     ),
                     _QuickActionButton(
-                      icon: CoreIcons.delete,
+                      icon: const EstimationActionIconDelete(),
                       label: l10n.removeAction,
                       onTap: onRemove,
                     ),
@@ -126,17 +126,17 @@ class EstimationActionsSheet extends StatelessWidget {
                 Column(
                   children: [
                     _ActionListItem(
-                      icon: CoreIcons.copy,
+                      icon: const EstimationActionIconCopy(),
                       label: l10n.copyEstimationAction,
                       onTap: onCopy,
                     ),
                     _ActionListItem(
-                      icon: CoreIcons.share,
+                      icon: const EstimationActionIconShare(),
                       label: l10n.shareExportAction,
                       onTap: onShare,
                     ),
                     _ActionListItem(
-                      icon: CoreIcons.calendar,
+                      icon: const EstimationActionIconCalendar(),
                       label: l10n.logsAction,
                       onTap: onLogs,
                     ),
@@ -144,7 +144,7 @@ class EstimationActionsSheet extends StatelessWidget {
                       valueListenable: lockStatusNotifier,
                       builder: (context, isLocked, _) {
                         return _ActionListItem(
-                          icon: isLocked ? CoreIcons.lock : CoreIcons.unlock,
+                          icon: isLocked ? const EstimationActionIconLock() : const EstimationActionIconUnlock(),
                           label: l10n.lockEstimationAction,
                           actionWidget: CoreSwitch(
                             value: isLocked,
@@ -167,8 +167,36 @@ class EstimationActionsSheet extends StatelessWidget {
   }
 }
 
+sealed class EstimationActionIcon {
+  const EstimationActionIcon();
+}
+
+class EstimationActionIconEdit extends EstimationActionIcon { const EstimationActionIconEdit(); }
+class EstimationActionIconFavorite extends EstimationActionIcon { const EstimationActionIconFavorite(); }
+class EstimationActionIconDelete extends EstimationActionIcon { const EstimationActionIconDelete(); }
+class EstimationActionIconCopy extends EstimationActionIcon { const EstimationActionIconCopy(); }
+class EstimationActionIconShare extends EstimationActionIcon { const EstimationActionIconShare(); }
+class EstimationActionIconCalendar extends EstimationActionIcon { const EstimationActionIconCalendar(); }
+class EstimationActionIconLock extends EstimationActionIcon { const EstimationActionIconLock(); }
+class EstimationActionIconUnlock extends EstimationActionIcon { const EstimationActionIconUnlock(); }
+
+extension _EstimationActionIconExt on EstimationActionIcon {
+  get coreIcon {
+    switch (this) {
+      case EstimationActionIconEdit(): return CoreIcons.editDocument;
+      case EstimationActionIconFavorite(): return CoreIcons.favorite;
+      case EstimationActionIconDelete(): return CoreIcons.delete;
+      case EstimationActionIconCopy(): return CoreIcons.copy;
+      case EstimationActionIconShare(): return CoreIcons.share;
+      case EstimationActionIconCalendar(): return CoreIcons.calendar;
+      case EstimationActionIconLock(): return CoreIcons.lock;
+      case EstimationActionIconUnlock(): return CoreIcons.unlock;
+    }
+  }
+}
+
 class _QuickActionButton extends StatelessWidget {
-  final CoreIconData icon;
+  final EstimationActionIcon icon;
   final String label;
   final VoidCallback? onTap;
 
@@ -198,7 +226,7 @@ class _QuickActionButton extends StatelessWidget {
             ),
             child: Center(
               child: CoreIconWidget(
-                icon: icon,
+                icon: icon.coreIcon,
                 size: 24,
                 color: colorTheme.iconDark,
               ),
@@ -212,7 +240,7 @@ class _QuickActionButton extends StatelessWidget {
 }
 
 class _ActionListItem extends StatelessWidget {
-  final CoreIconData icon;
+  final EstimationActionIcon icon;
   final String label;
   final VoidCallback? onTap;
   final Widget? actionWidget;
@@ -235,7 +263,7 @@ class _ActionListItem extends StatelessWidget {
         padding: const EdgeInsets.all(CoreSpacing.space3),
         child: Row(
           children: [
-            CoreIconWidget(icon: icon, size: 24, color: colorTheme.iconDark),
+            CoreIconWidget(icon: icon.coreIcon, size: 24, color: colorTheme.iconDark),
             const SizedBox(width: CoreSpacing.space2),
             Expanded(
               child: Text(

--- a/lib/features/estimation/presentation/widgets/estimation_actions_sheet.dart
+++ b/lib/features/estimation/presentation/widgets/estimation_actions_sheet.dart
@@ -106,17 +106,17 @@ class EstimationActionsSheet extends StatelessWidget {
                   mainAxisAlignment: MainAxisAlignment.spaceBetween,
                   children: [
                     _QuickActionButton(
-                      icon: const EstimationActionIconEdit(),
+                      icon: const _EstimationActionIconEdit(),
                       label: l10n.renameAction,
                       onTap: onRename,
                     ),
                     _QuickActionButton(
-                      icon: const EstimationActionIconFavorite(),
+                      icon: const _EstimationActionIconFavorite(),
                       label: l10n.favouriteAction,
                       onTap: onFavourite,
                     ),
                     _QuickActionButton(
-                      icon: const EstimationActionIconDelete(),
+                      icon: const _EstimationActionIconDelete(),
                       label: l10n.removeAction,
                       onTap: onRemove,
                     ),
@@ -126,17 +126,17 @@ class EstimationActionsSheet extends StatelessWidget {
                 Column(
                   children: [
                     _ActionListItem(
-                      icon: const EstimationActionIconCopy(),
+                      icon: const _EstimationActionIconCopy(),
                       label: l10n.copyEstimationAction,
                       onTap: onCopy,
                     ),
                     _ActionListItem(
-                      icon: const EstimationActionIconShare(),
+                      icon: const _EstimationActionIconShare(),
                       label: l10n.shareExportAction,
                       onTap: onShare,
                     ),
                     _ActionListItem(
-                      icon: const EstimationActionIconCalendar(),
+                      icon: const _EstimationActionIconCalendar(),
                       label: l10n.logsAction,
                       onTap: onLogs,
                     ),
@@ -144,7 +144,9 @@ class EstimationActionsSheet extends StatelessWidget {
                       valueListenable: lockStatusNotifier,
                       builder: (context, isLocked, _) {
                         return _ActionListItem(
-                          icon: isLocked ? const EstimationActionIconLock() : const EstimationActionIconUnlock(),
+                          icon: isLocked
+                              ? const _EstimationActionIconLock()
+                              : const _EstimationActionIconUnlock(),
                           label: l10n.lockEstimationAction,
                           actionWidget: CoreSwitch(
                             value: isLocked,
@@ -167,59 +169,67 @@ class EstimationActionsSheet extends StatelessWidget {
   }
 }
 
-sealed class EstimationActionIcon {
-  const EstimationActionIcon();
+sealed class _EstimationActionIcon {
+  const _EstimationActionIcon();
 }
 
-class EstimationActionIconEdit extends EstimationActionIcon {
-  const EstimationActionIconEdit();
+class _EstimationActionIconEdit extends _EstimationActionIcon {
+  const _EstimationActionIconEdit();
 }
 
-class EstimationActionIconFavorite extends EstimationActionIcon {
-  const EstimationActionIconFavorite();
+class _EstimationActionIconFavorite extends _EstimationActionIcon {
+  const _EstimationActionIconFavorite();
 }
 
-class EstimationActionIconDelete extends EstimationActionIcon {
-  const EstimationActionIconDelete();
+class _EstimationActionIconDelete extends _EstimationActionIcon {
+  const _EstimationActionIconDelete();
 }
 
-class EstimationActionIconCopy extends EstimationActionIcon {
-  const EstimationActionIconCopy();
+class _EstimationActionIconCopy extends _EstimationActionIcon {
+  const _EstimationActionIconCopy();
 }
 
-class EstimationActionIconShare extends EstimationActionIcon {
-  const EstimationActionIconShare();
+class _EstimationActionIconShare extends _EstimationActionIcon {
+  const _EstimationActionIconShare();
 }
 
-class EstimationActionIconCalendar extends EstimationActionIcon {
-  const EstimationActionIconCalendar();
+class _EstimationActionIconCalendar extends _EstimationActionIcon {
+  const _EstimationActionIconCalendar();
 }
 
-class EstimationActionIconLock extends EstimationActionIcon {
-  const EstimationActionIconLock();
+class _EstimationActionIconLock extends _EstimationActionIcon {
+  const _EstimationActionIconLock();
 }
 
-class EstimationActionIconUnlock extends EstimationActionIcon {
-  const EstimationActionIconUnlock();
+class _EstimationActionIconUnlock extends _EstimationActionIcon {
+  const _EstimationActionIconUnlock();
 }
 
-extension EstimationActionIconExt on EstimationActionIcon {
+extension _EstimationActionIconExt on _EstimationActionIcon {
   CoreIconData get coreIcon {
     switch (this) {
-      case EstimationActionIconEdit(): return CoreIcons.editDocument;
-      case EstimationActionIconFavorite(): return CoreIcons.favorite;
-      case EstimationActionIconDelete(): return CoreIcons.delete;
-      case EstimationActionIconCopy(): return CoreIcons.copy;
-      case EstimationActionIconShare(): return CoreIcons.share;
-      case EstimationActionIconCalendar(): return CoreIcons.calendar;
-      case EstimationActionIconLock(): return CoreIcons.lock;
-      case EstimationActionIconUnlock(): return CoreIcons.unlock;
+      case _EstimationActionIconEdit():
+        return CoreIcons.editDocument;
+      case _EstimationActionIconFavorite():
+        return CoreIcons.favorite;
+      case _EstimationActionIconDelete():
+        return CoreIcons.delete;
+      case _EstimationActionIconCopy():
+        return CoreIcons.copy;
+      case _EstimationActionIconShare():
+        return CoreIcons.share;
+      case _EstimationActionIconCalendar():
+        return CoreIcons.calendar;
+      case _EstimationActionIconLock():
+        return CoreIcons.lock;
+      case _EstimationActionIconUnlock():
+        return CoreIcons.unlock;
     }
   }
 }
 
 class _QuickActionButton extends StatelessWidget {
-  final EstimationActionIcon icon;
+  final _EstimationActionIcon icon;
   final String label;
   final VoidCallback? onTap;
 
@@ -263,7 +273,7 @@ class _QuickActionButton extends StatelessWidget {
 }
 
 class _ActionListItem extends StatelessWidget {
-  final EstimationActionIcon icon;
+  final _EstimationActionIcon icon;
   final String label;
   final VoidCallback? onTap;
   final Widget? actionWidget;
@@ -286,7 +296,11 @@ class _ActionListItem extends StatelessWidget {
         padding: const EdgeInsets.all(CoreSpacing.space3),
         child: Row(
           children: [
-            CoreIconWidget(icon: icon.coreIcon, size: 24, color: colorTheme.iconDark),
+            CoreIconWidget(
+              icon: icon.coreIcon,
+              size: 24,
+              color: colorTheme.iconDark,
+            ),
             const SizedBox(width: CoreSpacing.space2),
             Expanded(
               child: Text(

--- a/lib/features/estimation/presentation/widgets/estimation_actions_sheet.dart
+++ b/lib/features/estimation/presentation/widgets/estimation_actions_sheet.dart
@@ -171,17 +171,40 @@ sealed class EstimationActionIcon {
   const EstimationActionIcon();
 }
 
-class EstimationActionIconEdit extends EstimationActionIcon { const EstimationActionIconEdit(); }
-class EstimationActionIconFavorite extends EstimationActionIcon { const EstimationActionIconFavorite(); }
-class EstimationActionIconDelete extends EstimationActionIcon { const EstimationActionIconDelete(); }
-class EstimationActionIconCopy extends EstimationActionIcon { const EstimationActionIconCopy(); }
-class EstimationActionIconShare extends EstimationActionIcon { const EstimationActionIconShare(); }
-class EstimationActionIconCalendar extends EstimationActionIcon { const EstimationActionIconCalendar(); }
-class EstimationActionIconLock extends EstimationActionIcon { const EstimationActionIconLock(); }
-class EstimationActionIconUnlock extends EstimationActionIcon { const EstimationActionIconUnlock(); }
+class EstimationActionIconEdit extends EstimationActionIcon {
+  const EstimationActionIconEdit();
+}
 
-extension _EstimationActionIconExt on EstimationActionIcon {
-  get coreIcon {
+class EstimationActionIconFavorite extends EstimationActionIcon {
+  const EstimationActionIconFavorite();
+}
+
+class EstimationActionIconDelete extends EstimationActionIcon {
+  const EstimationActionIconDelete();
+}
+
+class EstimationActionIconCopy extends EstimationActionIcon {
+  const EstimationActionIconCopy();
+}
+
+class EstimationActionIconShare extends EstimationActionIcon {
+  const EstimationActionIconShare();
+}
+
+class EstimationActionIconCalendar extends EstimationActionIcon {
+  const EstimationActionIconCalendar();
+}
+
+class EstimationActionIconLock extends EstimationActionIcon {
+  const EstimationActionIconLock();
+}
+
+class EstimationActionIconUnlock extends EstimationActionIcon {
+  const EstimationActionIconUnlock();
+}
+
+extension EstimationActionIconExt on EstimationActionIcon {
+  CoreIconData get coreIcon {
     switch (this) {
       case EstimationActionIconEdit(): return CoreIcons.editDocument;
       case EstimationActionIconFavorite(): return CoreIcons.favorite;

--- a/test/features/estimations/widgets/widgets/estimation_actions_sheet_test.dart
+++ b/test/features/estimations/widgets/widgets/estimation_actions_sheet_test.dart
@@ -264,4 +264,17 @@ void main() {
       expect(revertedSwitch.value, isFalse);
     });
   });
+
+  group('EstimationActionIcon.coreIcon', () {
+    test('each variant maps to the expected CoreIconData', () {
+      expect(const EstimationActionIconEdit().coreIcon, same(CoreIcons.editDocument));
+      expect(const EstimationActionIconFavorite().coreIcon, same(CoreIcons.favorite));
+      expect(const EstimationActionIconDelete().coreIcon, same(CoreIcons.delete));
+      expect(const EstimationActionIconCopy().coreIcon, same(CoreIcons.copy));
+      expect(const EstimationActionIconShare().coreIcon, same(CoreIcons.share));
+      expect(const EstimationActionIconCalendar().coreIcon, same(CoreIcons.calendar));
+      expect(const EstimationActionIconLock().coreIcon, same(CoreIcons.lock));
+      expect(const EstimationActionIconUnlock().coreIcon, same(CoreIcons.unlock));
+    });
+  });
 }

--- a/test/features/estimations/widgets/widgets/estimation_actions_sheet_test.dart
+++ b/test/features/estimations/widgets/widgets/estimation_actions_sheet_test.dart
@@ -263,18 +263,31 @@ void main() {
       final revertedSwitch = tester.widget<CoreSwitch>(find.byType(CoreSwitch));
       expect(revertedSwitch.value, isFalse);
     });
-  });
 
-  group('EstimationActionIcon.coreIcon', () {
-    test('each variant maps to the expected CoreIconData', () {
-      expect(const EstimationActionIconEdit().coreIcon, same(CoreIcons.editDocument));
-      expect(const EstimationActionIconFavorite().coreIcon, same(CoreIcons.favorite));
-      expect(const EstimationActionIconDelete().coreIcon, same(CoreIcons.delete));
-      expect(const EstimationActionIconCopy().coreIcon, same(CoreIcons.copy));
-      expect(const EstimationActionIconShare().coreIcon, same(CoreIcons.share));
-      expect(const EstimationActionIconCalendar().coreIcon, same(CoreIcons.calendar));
-      expect(const EstimationActionIconLock().coreIcon, same(CoreIcons.lock));
-      expect(const EstimationActionIconUnlock().coreIcon, same(CoreIcons.unlock));
+    group('icon mapping', () {
+      testWidgets('renders the correct CoreIconWidget for every action variant', (
+        WidgetTester tester,
+      ) async {
+        await tester.pumpWidget(createWidget(isLocked: false));
+
+        for (final expectedIcon in <CoreIconData>[
+          CoreIcons.editDocument,
+          CoreIcons.favorite,
+          CoreIcons.delete,
+          CoreIcons.copy,
+          CoreIcons.share,
+          CoreIcons.calendar,
+          CoreIcons.unlock,
+        ]) {
+          expect(
+            find.byWidgetPredicate(
+              (w) => w is CoreIconWidget && w.icon == expectedIcon,
+            ),
+            findsOneWidget,
+          );
+        }
+      });
     });
   });
 }
+


### PR DESCRIPTION
### Summary

**Description:**
This PR enables the `restrict_core_icon_data` custom lint rule and resolves its existing violations in the codebase, specifically within the estimation module. It replaces direct `CoreIconData` usages with a custom, type-safe sealed class abstraction to adhere to architectural guidelines.

**Key Changes:**
* **Linting Configuration:** Enabled the `restrict_core_icon_data` rule in `analysis_options.yaml` to prevent future direct usages of core icons outside of designated UI modules.
* **Estimation Actions Refactor:** 
  * Introduced the `EstimationActionIcon` sealed class hierarchy in `estimation_actions_sheet.dart`.
  * Replaced all direct `CoreIcons` references (e.g., `CoreIcons.editDocument`, `CoreIcons.favorite`) in `_QuickActionButton` and `_ActionListItem` with their respective sealed class wrappers.
  * Added an extension mapping to safely resolve the sealed classes back to their underlying `CoreIconData` for rendering.

**Motivation:**
To comply with the newly enforced `restrict_core_icon_data` and existing `sealed_over_dynamic` linting rules, ensuring stronger type safety and proper abstraction of UI elements from business/feature logic.