### PR TITLE
[CA-658]: Fail CI when new source files have zero test coverage

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -64,7 +64,11 @@ workflows:
           fi
 
           # Identify changed source files (excluding generated code)
-          CHANGED_SOURCE_FILES=$(git diff --name-only --diff-filter=d $BASE_COMMIT HEAD -- 'lib/**/*.dart' | grep -v -E '(\.g\.dart$|\.freezed\.dart$|/generated/|/l10n/)' || true)
+          CHANGED_SOURCE_FILES=$(git diff --name-only --diff-filter=A $BASE_COMMIT HEAD -- 'lib/**/*.dart' \
+            | grep -v -E '(\.g\.dart$|\.freezed\.dart$|/generated/|/l10n/)' \
+            | while IFS= read -r f; do
+                head -1 "$f" 2>/dev/null | grep -q '// coverage:ignore-file' || echo "$f"
+              done || true)
 
           if [ -z "$CHANGED_TESTS" ]; then
             echo "✅ No test files modified. Skipping test execution..."

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -64,7 +64,7 @@ workflows:
           fi
 
           # Identify changed source files (excluding generated code)
-          CHANGED_SOURCE_FILES=$(git diff --name-only --diff-filter=A $BASE_COMMIT HEAD -- 'lib/**/*.dart' \
+          CHANGED_SOURCE_FILES=$(git diff --name-only --diff-filter=A $BASE_COMMIT HEAD -- 'lib/*.dart' 'lib/**/*.dart' \
             | grep -v -E '(\.g\.dart$|\.freezed\.dart$|/generated/|/l10n/)' \
             | while IFS= read -r f; do
                 head -1 "$f" 2>/dev/null | grep -q '// coverage:ignore-file' || echo "$f"

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -63,11 +63,26 @@ workflows:
             CHANGED_TESTS=$(git diff --name-only --diff-filter=d $BASE_COMMIT HEAD -- "${PATTERNS[@]}")
           fi
 
+          # Identify changed source files (excluding generated code)
+          CHANGED_SOURCE_FILES=$(git diff --name-only --diff-filter=d $BASE_COMMIT HEAD -- 'lib/**/*.dart' | grep -v -E '(\.g\.dart$|\.freezed\.dart$|/generated/|/l10n/)' || true)
 
           if [ -z "$CHANGED_TESTS" ]; then
-            echo "✅ No test files modified. Skipping tests..."
+            echo "✅ No test files modified. Skipping test execution..."
+
+            # Even with no changed tests, fail if new source files were added
+            # without any coverage (they won't be in any tracefile).
+            if [ -n "$CHANGED_SOURCE_FILES" ]; then
+              echo "❌ The following changed source files have zero coverage (no tests exist for them):"
+              while IFS= read -r file; do
+                [ -z "$file" ] && continue
+                echo "  - $file"
+              done <<< "$CHANGED_SOURCE_FILES"
+              echo "Every new or modified lib/**/*.dart file must be exercised by at least one test."
+              exit 1
+            fi
             exit 0
           fi
+
           echo "🔍 Running tests for changed files:"
           echo "$CHANGED_TESTS"
           TARGET=$ARC_CODE_COVERAGE_TARGET
@@ -80,8 +95,6 @@ workflows:
           fvm flutter test $CHANGED_TESTS --coverage --machine > test-results/flutter.json
           lcov --quiet --remove coverage/lcov.info '**/*.g.dart' '**/*.freezed.dart' '**/l10n/**' -o coverage/lcov.info --ignore-errors unused
 
-          CHANGED_SOURCE_FILES=$(git diff --name-only --diff-filter=d $BASE_COMMIT HEAD -- 'lib/**/*.dart' | grep -v -E '(\.g\.dart$|\.freezed\.dart$|/generated/|/l10n/)' || true)
-
           if [ -z "$CHANGED_SOURCE_FILES" ]; then
             echo "✅ No changed source files in lib/. Skipping coverage threshold check."
             exit 0
@@ -89,12 +102,24 @@ workflows:
 
           COVERED_SOURCES=$(grep '^SF:' coverage/lcov.info | cut -d: -f2-)
           EXTRACT_PATTERNS=()
+          MISSING_FILES=()
           while IFS= read -r file; do
             [ -z "$file" ] && continue
             if printf '%s\n' "$COVERED_SOURCES" | grep -Fxq "$file" || printf '%s\n' "$COVERED_SOURCES" | grep -Fxq "$FCI_BUILD_DIR/$file"; then
               EXTRACT_PATTERNS+=("*/$file")
+            else
+              MISSING_FILES+=("$file")
             fi
           done <<< "$CHANGED_SOURCE_FILES"
+
+          if [ ${#MISSING_FILES[@]} -gt 0 ]; then
+            echo "❌ The following changed source files have zero coverage and are absent from lcov.info:"
+            for missing in "${MISSING_FILES[@]}"; do
+              echo "  - $missing"
+            done
+            echo "Every new or modified lib/**/*.dart file must be exercised by at least one test."
+            exit 1
+          fi
 
           if [ ${#EXTRACT_PATTERNS[@]} -eq 0 ]; then
             echo "✅ No changed source files with coverage records. Skipping coverage threshold check."

--- a/scripts/run_check.sh
+++ b/scripts/run_check.sh
@@ -141,7 +141,7 @@ pre_check() {
       filter_coverage_tracefile "coverage/lcov.info"
 
       local changed_source_files
-      changed_source_files=$(git diff --name-only --diff-filter=A "$base_commit" HEAD -- 'lib/**/*.dart' \
+      changed_source_files=$(git diff --name-only --diff-filter=A "$base_commit" HEAD -- 'lib/*.dart' 'lib/**/*.dart' \
         | grep -v -E '(\.g\.dart$|\.freezed\.dart$|/generated/|/l10n/)' \
         | while IFS= read -r f; do
             head -1 "$f" 2>/dev/null | grep -q '// coverage:ignore-file' || echo "$f"
@@ -207,7 +207,7 @@ pre_check() {
 
   if [[ -z "$changed_tests" ]]; then
     local changed_source_files_all
-    changed_source_files_all=$(git diff --name-only --diff-filter=A "$base_commit" HEAD -- 'lib/**/*.dart' \
+    changed_source_files_all=$(git diff --name-only --diff-filter=A "$base_commit" HEAD -- 'lib/*.dart' 'lib/**/*.dart' \
       | grep -v -E '(\.g\.dart$|\.freezed\.dart$|/generated/|/l10n/)' \
       | while IFS= read -r f; do
           head -1 "$f" 2>/dev/null | grep -q '// coverage:ignore-file' || echo "$f"

--- a/scripts/run_check.sh
+++ b/scripts/run_check.sh
@@ -141,7 +141,11 @@ pre_check() {
       filter_coverage_tracefile "coverage/lcov.info"
 
       local changed_source_files
-      changed_source_files=$(git diff --name-only --diff-filter=d "$base_commit" HEAD -- 'lib/**/*.dart' | grep -v -E '(\.g\.dart$|\.freezed\.dart$|/generated/|/l10n/)' || true)
+      changed_source_files=$(git diff --name-only --diff-filter=A "$base_commit" HEAD -- 'lib/**/*.dart' \
+        | grep -v -E '(\.g\.dart$|\.freezed\.dart$|/generated/|/l10n/)' \
+        | while IFS= read -r f; do
+            head -1 "$f" 2>/dev/null | grep -q '// coverage:ignore-file' || echo "$f"
+          done || true)
 
       if [[ -z "$changed_source_files" ]]; then
         echo "✅ No changed source files in lib/. Skipping coverage threshold check for --pre."
@@ -166,6 +170,7 @@ pre_check() {
           for missing in "${missing_files[@]}"; do
             echo "  - $missing"
           done
+          echo "Every new or modified lib/**/*.dart file must be exercised by at least one test."
           exit 1
         fi
 
@@ -200,32 +205,38 @@ pre_check() {
     fi
   fi
 
-  local changed_source_files_all
-  changed_source_files_all=$(git diff --name-only --diff-filter=d "$base_commit" HEAD -- 'lib/**/*.dart' | grep -v -E '(\.g\.dart$|\.freezed\.dart$|/generated/|/l10n/)' || true)
+  if [[ -z "$changed_tests" ]]; then
+    local changed_source_files_all
+    changed_source_files_all=$(git diff --name-only --diff-filter=A "$base_commit" HEAD -- 'lib/**/*.dart' \
+      | grep -v -E '(\.g\.dart$|\.freezed\.dart$|/generated/|/l10n/)' \
+      | while IFS= read -r f; do
+          head -1 "$f" 2>/dev/null | grep -q '// coverage:ignore-file' || echo "$f"
+        done || true)
 
-  if [[ -n "$changed_source_files_all" ]]; then
-    local covered_all=""
-    if [[ -s "coverage/lcov.info" ]]; then
-      covered_all=$(grep '^SF:' "coverage/lcov.info" | cut -d: -f2- || true)
-    fi
-
-    local uncovered_files=()
-    while IFS= read -r file; do
-      [[ -z "$file" ]] && continue
-      if [[ -z "$covered_all" ]] || \
-         { ! printf '%s\n' "$covered_all" | grep -Fxq "$file" && \
-           ! printf '%s\n' "$covered_all" | grep -Fxq "$PWD/$file"; }; then
-        uncovered_files+=("$file")
+    if [[ -n "$changed_source_files_all" ]]; then
+      local covered_all=""
+      if [[ -s "coverage/lcov.info" ]]; then
+        covered_all=$(grep '^SF:' "coverage/lcov.info" | cut -d: -f2- || true)
       fi
-    done <<< "$changed_source_files_all"
 
-    if [[ ${#uncovered_files[@]} -gt 0 ]]; then
-      echo "❌ The following changed source files have zero coverage (not found in any tracefile):"
-      for f in "${uncovered_files[@]}"; do
-        echo "  - $f"
-      done
-      echo "Every new or modified lib/**/*.dart file must be exercised by at least one test."
-      exit 1
+      local uncovered_files=()
+      while IFS= read -r file; do
+        [[ -z "$file" ]] && continue
+        if [[ -z "$covered_all" ]] || \
+           { ! printf '%s\n' "$covered_all" | grep -Fxq "$file" && \
+             ! printf '%s\n' "$covered_all" | grep -Fxq "$PWD/$file"; }; then
+          uncovered_files+=("$file")
+        fi
+      done <<< "$changed_source_files_all"
+
+      if [[ ${#uncovered_files[@]} -gt 0 ]]; then
+        echo "❌ The following changed source files have zero coverage (not found in any tracefile):"
+        for f in "${uncovered_files[@]}"; do
+          echo "  - $f"
+        done
+        echo "Every new or modified lib/**/*.dart file must be exercised by at least one test."
+        exit 1
+      fi
     fi
   fi
 }

--- a/scripts/run_check.sh
+++ b/scripts/run_check.sh
@@ -77,22 +77,6 @@ filter_coverage_tracefile() {
     --ignore-errors unused
 }
 
-build_extract_patterns_from_tracefile() {
-  local tracefile="$1"
-  local changed_files="$2"
-
-  local covered_sources
-  covered_sources=$(grep '^SF:' "$tracefile" | cut -d: -f2- || true)
-
-  local file
-  while IFS= read -r file; do
-    [[ -z "$file" ]] && continue
-    if printf '%s\n' "$covered_sources" | grep -Fxq "$file" || printf '%s\n' "$covered_sources" | grep -Fxq "$PWD/$file"; then
-      printf '*/%s\n' "$file"
-    fi
-  done <<< "$changed_files"
-}
-
 pre_check() {
   echo "🚀 Running Pre-check..."
 
@@ -162,10 +146,28 @@ pre_check() {
       if [[ -z "$changed_source_files" ]]; then
         echo "✅ No changed source files in lib/. Skipping coverage threshold check for --pre."
       else
+        local covered_sources
+        covered_sources=$(grep '^SF:' "coverage/lcov.info" | cut -d: -f2- || true)
+
         local extract_patterns=()
+        local missing_files=()
+
         while IFS= read -r file; do
-          [[ -n "$file" ]] && extract_patterns+=("$file")
-        done < <(build_extract_patterns_from_tracefile "coverage/lcov.info" "$changed_source_files")
+          [[ -z "$file" ]] && continue
+          if printf '%s\n' "$covered_sources" | grep -Fxq "$file" || printf '%s\n' "$covered_sources" | grep -Fxq "$PWD/$file"; then
+            extract_patterns+=("*/$file")
+          else
+            missing_files+=("$file")
+          fi
+        done <<< "$changed_source_files"
+
+        if [[ ${#missing_files[@]} -gt 0 ]]; then
+          echo "❌ The following changed source files have zero coverage and are absent from lcov.info:"
+          for missing in "${missing_files[@]}"; do
+            echo "  - $missing"
+          done
+          exit 1
+        fi
 
         if [[ ${#extract_patterns[@]} -eq 0 ]]; then
           echo "✅ No changed source files with coverage records. Skipping coverage threshold check."
@@ -194,6 +196,35 @@ pre_check() {
       fi
     else
       echo "❌ Coverage file missing"
+      exit 1
+    fi
+  fi
+
+  local changed_source_files_all
+  changed_source_files_all=$(git diff --name-only --diff-filter=d "$base_commit" HEAD -- 'lib/**/*.dart' | grep -v -E '(\.g\.dart$|\.freezed\.dart$|/generated/|/l10n/)' || true)
+
+  if [[ -n "$changed_source_files_all" ]]; then
+    local covered_all=""
+    if [[ -s "coverage/lcov.info" ]]; then
+      covered_all=$(grep '^SF:' "coverage/lcov.info" | cut -d: -f2- || true)
+    fi
+
+    local uncovered_files=()
+    while IFS= read -r file; do
+      [[ -z "$file" ]] && continue
+      if [[ -z "$covered_all" ]] || \
+         { ! printf '%s\n' "$covered_all" | grep -Fxq "$file" && \
+           ! printf '%s\n' "$covered_all" | grep -Fxq "$PWD/$file"; }; then
+        uncovered_files+=("$file")
+      fi
+    done <<< "$changed_source_files_all"
+
+    if [[ ${#uncovered_files[@]} -gt 0 ]]; then
+      echo "❌ The following changed source files have zero coverage (not found in any tracefile):"
+      for f in "${uncovered_files[@]}"; do
+        echo "  - $f"
+      done
+      echo "Every new or modified lib/**/*.dart file must be exercised by at least one test."
       exit 1
     fi
   fi


### PR DESCRIPTION
### Summary

#### Problem
When a PR introduces a brand-new `lib/**/*.dart` file with no tests importing it, the file is completely absent from `coverage/lcov.info`. The coverage scripts only check files that *exist* in the tracefile, so the new file is silently skipped and CI passes — even if it contains significant untested logic.

#### Solution
Added an explicit missing-file check in both `scripts/run_check.sh` and `codemagic.yaml` (pre-check workflow). After identifying changed source files via `git diff`, each file is verified against the `SF:` entries in `lcov.info`. If any changed source file is absent from the tracefile, CI now **fails with exit 1** and prints the missing file path(s).

#### Changes
- **`scripts/run_check.sh`**: Inlined the `COVERED_SOURCES` lookup (removed `build_extract_patterns_from_tracefile` helper), added `missing_files` detection with explicit failure.
- **`codemagic.yaml`**: Added `MISSING_FILES` array with the same detection and failure logic in the pre-check coverage step.

#### Behavior Before → After
| Scenario | Before | After |
|---|---|---|
| New file, zero tests | CI passes ✅ (silently skipped) | CI fails ❌ with clear error listing the file |
| New file, has tests | CI checks coverage threshold ✅ | No change ✅ |
| No new source files | Skips coverage check ✅ | No change ✅ |