### PR TITLE
CA-688: Feat: project search history datasource impl

### DIFF
--- a/lib/features/dashboard/presentation/bloc/project_search_bloc/project_search_bloc.dart
+++ b/lib/features/dashboard/presentation/bloc/project_search_bloc/project_search_bloc.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:construculator/libraries/auth/domain/types/auth_types.dart';
 import 'package:construculator/libraries/auth/interfaces/auth_manager.dart';
 import 'package:construculator/libraries/errors/failures.dart';
@@ -5,6 +7,7 @@ import 'package:construculator/libraries/logging/app_logger.dart';
 import 'package:construculator/libraries/project/domain/entities/project_entity.dart';
 import 'package:construculator/libraries/project/domain/repositories/project_search_repository.dart';
 import 'package:equatable/equatable.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:rxdart/rxdart.dart';
 
@@ -13,17 +16,29 @@ part 'project_search_state.dart';
 
 const Duration _kQueryDebounceDuration = Duration(milliseconds: 300);
 
+/// Upper bound on the cached recents list to prevent unbounded growth.
+const int _kMaxCachedRecents = 20;
+
 EventTransformer<E> _debounce<E>(Duration duration) =>
     (events, mapper) => events.debounceTime(duration).switchMap(mapper);
 
 /// BLoC for managing project search state on the dashboard.
 ///
-/// Handles debounced query updates and explicit search submissions, delegating
-/// to [ProjectSearchRepository] and mapping results to typed states.
+/// Handles debounced query updates and explicit search submissions, plus the
+/// recent-searches and suggestions surfaces shown on the idle state.
+/// Delegates to [ProjectSearchRepository] and maps results to typed states.
 class ProjectSearchBloc extends Bloc<ProjectSearchEvent, ProjectSearchState> {
   final ProjectSearchRepository _repository;
   final AuthManager _authManager;
   static final _logger = AppLogger().tag('ProjectSearchBloc');
+
+  List<String> _cachedRecents = const [];
+  List<String> _cachedSuggestions = const [];
+
+  /// Exposed for testing only — resolves when the last save-after-search
+  /// completes, allowing tests to await it instead of using wall-clock waits.
+  @visibleForTesting
+  Future<void>? lastSaveCompleted;
 
   /// Creates a [ProjectSearchBloc] with the given [repository] and [authManager].
   ProjectSearchBloc({
@@ -36,9 +51,9 @@ class ProjectSearchBloc extends Bloc<ProjectSearchEvent, ProjectSearchState> {
       (event, emit) => _handleQuery(event.query, emit),
       transformer: _debounce(_kQueryDebounceDuration),
     );
-    on<ProjectSearchPerformedEvent>(
-      (event, emit) => _handleQuery(event.query, emit),
-    );
+    on<ProjectSearchPerformedEvent>(_onPerformed);
+    on<ProjectSearchHistoryRequestedEvent>(_onHistoryRequested);
+    on<ProjectSearchHistoryItemDismissedEvent>(_onHistoryItemDismissed);
   }
 
   Future<void> _handleQuery(
@@ -46,10 +61,104 @@ class ProjectSearchBloc extends Bloc<ProjectSearchEvent, ProjectSearchState> {
     Emitter<ProjectSearchState> emit,
   ) async {
     if (query.trim().isEmpty) {
-      emit(const ProjectSearchInitial());
+      // Clearing the field restores the history surface rather than blanking it.
+      emit(_initialFromCache());
       return;
     }
     await _executeSearch(query, emit);
+  }
+
+  Future<void> _onPerformed(
+    ProjectSearchPerformedEvent event,
+    Emitter<ProjectSearchState> emit,
+  ) async {
+    if (event.query.trim().isEmpty) {
+      emit(const ProjectSearchInitial());
+      return;
+    }
+    await _executeSearch(event.query, emit);
+  }
+
+  Future<void> _onHistoryRequested(
+    ProjectSearchHistoryRequestedEvent event,
+    Emitter<ProjectSearchState> emit,
+  ) async {
+    final userId = _authManager.getCurrentCredentials().data?.id;
+    if (userId == null || userId.isEmpty) {
+      _logger.warning('History request aborted: no authenticated user');
+      emit(const ProjectSearchInitial());
+      return;
+    }
+
+    emit(
+      ProjectSearchInitial(
+        recentSearches: _cachedRecents,
+        suggestions: _cachedSuggestions,
+        isLoadingHistory: true,
+      ),
+    );
+
+    final results = await Future.wait([
+      _repository.getRecentProjectSearches(userId: userId),
+      _repository.getProjectSearchSuggestions(userId: userId),
+    ]);
+
+    // On failure, keep the previously cached value so a transient network
+    // hiccup does not blank the history surface.
+    _cachedRecents = results[0].fold<List<String>>(
+      (failure) {
+        _logger.warning('Failed to load recent project searches: $failure');
+        return _cachedRecents;
+      },
+      (terms) => terms,
+    );
+    _cachedSuggestions = results[1].fold<List<String>>(
+      (failure) {
+        _logger.warning('Failed to load project search suggestions: $failure');
+        return _cachedSuggestions;
+      },
+      (terms) => terms,
+    );
+
+    emit(_initialFromCache());
+  }
+
+  Future<void> _onHistoryItemDismissed(
+    ProjectSearchHistoryItemDismissedEvent event,
+    Emitter<ProjectSearchState> emit,
+  ) async {
+    final userId = _authManager.getCurrentCredentials().data?.id;
+    if (userId == null || userId.isEmpty) {
+      _logger.warning('History dismiss aborted: no authenticated user');
+      return;
+    }
+
+    final result = await _repository.deleteRecentProjectSearch(
+      userId: userId,
+      searchTerm: event.searchTerm,
+    );
+
+    result.fold(
+      (failure) {
+        _logger.warning(
+          'Failed to delete recent project search "${event.searchTerm}": $failure',
+        );
+      },
+      (_) => _removeDismissedTermAndEmit(event.searchTerm, emit),
+    );
+  }
+
+  void _removeDismissedTermAndEmit(
+    String searchTerm,
+    Emitter<ProjectSearchState> emit,
+  ) {
+    final normalized = searchTerm.toLowerCase().trim();
+    _cachedRecents = _cachedRecents
+        .where((term) => term.toLowerCase().trim() != normalized)
+        .toList(growable: false);
+    if (state is ProjectSearchInitial) {
+      emit(_initialFromCache());
+    }
   }
 
   Future<void> _executeSearch(
@@ -79,9 +188,58 @@ class ProjectSearchBloc extends Bloc<ProjectSearchEvent, ProjectSearchState> {
       (failure) {
         _logger.warning('Project search failed: $failure');
         emit(ProjectSearchFailureState(failure: failure, query: query));
+        // Skip history save on failure — backend has_results contract requires
+        // a confirmed result set.
       },
-      (projects) =>
-          emit(ProjectSearchResultsLoaded(results: projects, query: query)),
+      (projects) {
+        emit(ProjectSearchResultsLoaded(results: projects, query: query));
+        lastSaveCompleted = _saveSearchToHistory(
+          userId: userId,
+          query: query,
+          hasResults: projects.isNotEmpty,
+        );
+        unawaited(lastSaveCompleted!);
+      },
     );
   }
+
+  Future<void> _saveSearchToHistory({
+    required String userId,
+    required String query,
+    required bool hasResults,
+  }) async {
+    final saveResult = await _repository.saveRecentProjectSearch(
+      userId: userId,
+      searchTerm: query,
+      hasResults: hasResults,
+    );
+    saveResult.fold(
+      (failure) {
+        _logger.warning(
+          'Failed to save recent project search "$query": $failure',
+        );
+      },
+      (_) {
+        // Cache stores terms normalised to lowercase; repository receives the original-case query.
+        final normalized = query.toLowerCase().trim();
+        if (normalized.isEmpty) return;
+        final updated = <String>[
+          normalized,
+          ..._cachedRecents.where(
+            (term) => term.toLowerCase().trim() != normalized,
+          ),
+        ];
+        if (updated.length > _kMaxCachedRecents) {
+          _cachedRecents = updated.sublist(0, _kMaxCachedRecents);
+        } else {
+          _cachedRecents = updated;
+        }
+      },
+    );
+  }
+
+  ProjectSearchInitial _initialFromCache() => ProjectSearchInitial(
+    recentSearches: _cachedRecents,
+    suggestions: _cachedSuggestions,
+  );
 }

--- a/lib/features/dashboard/presentation/bloc/project_search_bloc/project_search_event.dart
+++ b/lib/features/dashboard/presentation/bloc/project_search_bloc/project_search_event.dart
@@ -37,3 +37,23 @@ class ProjectSearchPerformedEvent extends ProjectSearchEvent {
   @override
   List<Object?> get props => [query];
 }
+
+/// Dispatched when the project-search surface opens to request recent searches
+/// and personalized suggestions in parallel.
+class ProjectSearchHistoryRequestedEvent extends ProjectSearchEvent {
+  /// Creates a [ProjectSearchHistoryRequestedEvent].
+  const ProjectSearchHistoryRequestedEvent();
+}
+
+/// Dispatched when the user dismisses a single recent-search chip.
+class ProjectSearchHistoryItemDismissedEvent extends ProjectSearchEvent {
+  /// The recent-search term to remove from history.
+  final String searchTerm;
+
+  /// Creates a [ProjectSearchHistoryItemDismissedEvent] with the given
+  /// [searchTerm].
+  const ProjectSearchHistoryItemDismissedEvent({required this.searchTerm});
+
+  @override
+  List<Object?> get props => [searchTerm];
+}

--- a/lib/features/dashboard/presentation/bloc/project_search_bloc/project_search_state.dart
+++ b/lib/features/dashboard/presentation/bloc/project_search_bloc/project_search_state.dart
@@ -10,10 +10,31 @@ sealed class ProjectSearchState extends Equatable {
   List<Object?> get props => [];
 }
 
-/// Cold start before any search has been performed.
+/// Idle / cold-start state shown when no active search is in flight.
+///
+/// Carries the user's [recentSearches] and personalized [suggestions] so the
+/// UI can render both surfaces from a single state. [isLoadingHistory] is
+/// `true` while the parallel fetch of recents + suggestions is in flight.
 class ProjectSearchInitial extends ProjectSearchState {
-  /// Creates a [ProjectSearchInitial].
-  const ProjectSearchInitial();
+  /// The user's recent project-search terms, most recently used first.
+  final List<String> recentSearches;
+
+  /// Personalized project-search suggestion terms.
+  final List<String> suggestions;
+
+  /// `true` while recents and suggestions are being fetched.
+  final bool isLoadingHistory;
+
+  /// Creates a [ProjectSearchInitial] with the given [recentSearches],
+  /// [suggestions], and [isLoadingHistory] flag.
+  const ProjectSearchInitial({
+    this.recentSearches = const [],
+    this.suggestions = const [],
+    this.isLoadingHistory = false,
+  });
+
+  @override
+  List<Object?> get props => [recentSearches, suggestions, isLoadingHistory];
 }
 
 /// Emitted while a search request is in flight.

--- a/lib/libraries/project/data/data_source/interfaces/project_search_data_source.dart
+++ b/lib/libraries/project/data/data_source/interfaces/project_search_data_source.dart
@@ -18,4 +18,36 @@ abstract class ProjectSearchDataSource {
     String? filterByTag,
     String? filterByOwner,
   });
+
+  /// Persists [searchTerm] as a recent project-search entry for [userId].
+  ///
+  /// [hasResults] should be `true` only when the caller has confirmed the
+  /// search returned at least one result. Repeat saves of the same term
+  /// increment the per-term count rather than producing duplicates.
+  ///
+  /// Does nothing when [userId] is empty or [searchTerm] is empty/whitespace.
+  Future<void> saveRecentProjectSearch({
+    required String userId,
+    required String searchTerm,
+    bool hasResults = false,
+  });
+
+  /// Returns [userId]'s recent project-search terms, most recently used first.
+  ///
+  /// Implementations may cap the number of entries returned. Returns an empty
+  /// list when [userId] is empty.
+  Future<List<String>> getRecentProjectSearches({required String userId});
+
+  /// Removes [searchTerm] from [userId]'s recent project-search history.
+  ///
+  /// Does nothing when [userId] is empty or [searchTerm] is empty/whitespace.
+  Future<void> deleteRecentProjectSearch({
+    required String userId,
+    required String searchTerm,
+  });
+
+  /// Returns up to 10 personalized project-search suggestion terms for [userId].
+  ///
+  /// Returns an empty list when [userId] is empty or no suggestions exist.
+  Future<List<String>> getProjectSearchSuggestions({required String userId});
 }

--- a/lib/libraries/project/data/data_source/remote_project_search_data_source.dart
+++ b/lib/libraries/project/data/data_source/remote_project_search_data_source.dart
@@ -73,4 +73,164 @@ class RemoteProjectSearchDataSource implements ProjectSearchDataSource {
       rethrow;
     }
   }
+
+  @override
+  Future<void> saveRecentProjectSearch({
+    required String userId,
+    required String searchTerm,
+    bool hasResults = false,
+  }) async {
+    final normalized = searchTerm.toLowerCase().trim();
+    if (userId.trim().isEmpty || normalized.isEmpty) {
+      _logger.debug('Empty userId or searchTerm — skipping save');
+      return;
+    }
+
+    try {
+      _logger.debug(
+        'Saving recent project search: $normalized for userId: $userId, '
+        'hasResults: $hasResults',
+      );
+
+      await _supabaseWrapper.upsert(
+        table: DatabaseConstants.projectSearchHistoryTable,
+        data: {
+          DatabaseConstants.userIdColumn: userId,
+          DatabaseConstants.searchTermColumn: normalized,
+          DatabaseConstants.hasResultsColumn: hasResults,
+          // search_count intentionally omitted — incremented atomically by the
+          // BEFORE UPDATE trigger on conflict.
+          // created_at intentionally omitted — DB DEFAULT handles insert; the
+          // trigger preserves OLD.created_at on conflict update.
+        },
+        onConflict: DatabaseConstants.projectSearchHistoryUpsertConflictColumns,
+      );
+    } on supabase.PostgrestException catch (error, stackTrace) {
+      _logger.warning(
+        'Supabase error while saving recent project search: $normalized, error: $error',
+        stackTrace.toString(),
+      );
+      rethrow;
+    } catch (error, stackTrace) {
+      _logger.warning(
+        'Unexpected error while saving recent project search: $normalized, error: $error',
+        stackTrace.toString(),
+      );
+      rethrow;
+    }
+  }
+
+  @override
+  Future<List<String>> getRecentProjectSearches({
+    required String userId,
+  }) async {
+    if (userId.trim().isEmpty) {
+      _logger.debug('Empty userId — skipping recent project search fetch');
+      return [];
+    }
+
+    try {
+      _logger.debug('Fetching recent project searches for userId: $userId');
+
+      final rows = await _supabaseWrapper.selectMatch(
+        table: DatabaseConstants.projectSearchHistoryTable,
+        filters: {DatabaseConstants.userIdColumn: userId},
+        orderBy: DatabaseConstants.updatedAtColumn,
+        ascending: false,
+      );
+
+      return rows
+          .map(
+            (row) => row[DatabaseConstants.searchTermColumn]?.toString() ?? '',
+          )
+          .where((term) => term.isNotEmpty)
+          .take(DatabaseConstants.recentProjectSearchesMaxResults)
+          .toList();
+    } on supabase.PostgrestException catch (error, stackTrace) {
+      _logger.warning(
+        'Supabase error while fetching recent project searches for userId: $userId, error: $error',
+        stackTrace.toString(),
+      );
+      rethrow;
+    } catch (error, stackTrace) {
+      _logger.warning(
+        'Unexpected error while fetching recent project searches for userId: $userId, error: $error',
+        stackTrace.toString(),
+      );
+      rethrow;
+    }
+  }
+
+  @override
+  Future<void> deleteRecentProjectSearch({
+    required String userId,
+    required String searchTerm,
+  }) async {
+    final normalized = searchTerm.toLowerCase().trim();
+    if (userId.trim().isEmpty || normalized.isEmpty) {
+      _logger.debug('Empty userId or searchTerm — skipping delete');
+      return;
+    }
+
+    try {
+      _logger.debug(
+        'Deleting recent project search: $normalized for userId: $userId',
+      );
+
+      await _supabaseWrapper.deleteMatch(
+        table: DatabaseConstants.projectSearchHistoryTable,
+        filters: {
+          DatabaseConstants.userIdColumn: userId,
+          DatabaseConstants.searchTermColumn: normalized,
+        },
+      );
+    } on supabase.PostgrestException catch (error, stackTrace) {
+      _logger.warning(
+        'Supabase error while deleting recent project search: $normalized, error: $error',
+        stackTrace.toString(),
+      );
+      rethrow;
+    } catch (error, stackTrace) {
+      _logger.warning(
+        'Unexpected error while deleting recent project search: $normalized, error: $error',
+        stackTrace.toString(),
+      );
+      rethrow;
+    }
+  }
+
+  @override
+  Future<List<String>> getProjectSearchSuggestions({
+    required String userId,
+  }) async {
+    if (userId.trim().isEmpty) {
+      _logger.debug('Empty userId — skipping project search suggestions fetch');
+      return [];
+    }
+
+    try {
+      _logger.debug('Fetching project search suggestions for userId: $userId');
+
+      final response = await _supabaseWrapper.rpc<List<dynamic>>(
+        DatabaseConstants.projectSearchSuggestionsRpcFunction,
+        params: {
+          DatabaseConstants.projectSearchSuggestionsUserIdParam: userId,
+        },
+      );
+
+      return response.whereType<String>().toList();
+    } on supabase.PostgrestException catch (error, stackTrace) {
+      _logger.warning(
+        'Supabase error while fetching project search suggestions for userId: $userId, error: $error',
+        stackTrace.toString(),
+      );
+      rethrow;
+    } catch (error, stackTrace) {
+      _logger.warning(
+        'Unexpected error while fetching project search suggestions for userId: $userId, error: $error',
+        stackTrace.toString(),
+      );
+      rethrow;
+    }
+  }
 }

--- a/lib/libraries/project/data/repositories/project_search_repository_impl.dart
+++ b/lib/libraries/project/data/repositories/project_search_repository_impl.dart
@@ -110,4 +110,88 @@ class ProjectSearchRepositoryImpl implements ProjectSearchRepository {
       return Left(_handleError(e, 'searching projects'));
     }
   }
+
+  @override
+  Future<Either<Failure, void>> saveRecentProjectSearch({
+    required String userId,
+    required String searchTerm,
+    bool hasResults = false,
+  }) async {
+    if (userId.trim().isEmpty || searchTerm.trim().isEmpty) {
+      return Right(null);
+    }
+
+    try {
+      _logger.debug(
+        'Saving recent project search: $searchTerm, hasResults: $hasResults',
+      );
+      await _dataSource.saveRecentProjectSearch(
+        userId: userId,
+        searchTerm: searchTerm,
+        hasResults: hasResults,
+      );
+      return Right(null);
+    } catch (e) {
+      return Left(_handleError(e, 'saving recent project search'));
+    }
+  }
+
+  @override
+  Future<Either<Failure, List<String>>> getRecentProjectSearches({
+    required String userId,
+  }) async {
+    if (userId.trim().isEmpty) {
+      return Right([]);
+    }
+
+    try {
+      _logger.debug('Fetching recent project searches for userId: $userId');
+      final terms = await _dataSource.getRecentProjectSearches(userId: userId);
+      _logger.debug('Fetched ${terms.length} recent project searches');
+      return Right(terms);
+    } catch (e) {
+      return Left(_handleError(e, 'fetching recent project searches'));
+    }
+  }
+
+  @override
+  Future<Either<Failure, void>> deleteRecentProjectSearch({
+    required String userId,
+    required String searchTerm,
+  }) async {
+    if (userId.trim().isEmpty || searchTerm.trim().isEmpty) {
+      return Right(null);
+    }
+
+    try {
+      _logger.debug('Deleting recent project search: $searchTerm');
+      await _dataSource.deleteRecentProjectSearch(
+        userId: userId,
+        searchTerm: searchTerm,
+      );
+      return Right(null);
+    } catch (e) {
+      return Left(_handleError(e, 'deleting recent project search'));
+    }
+  }
+
+  @override
+  Future<Either<Failure, List<String>>> getProjectSearchSuggestions({
+    required String userId,
+  }) async {
+    if (userId.trim().isEmpty) {
+      return Right([]);
+    }
+
+    try {
+      _logger.debug('Fetching project search suggestions for userId: $userId');
+      final suggestions = await _dataSource.getProjectSearchSuggestions(
+        userId: userId,
+      );
+      _logger.debug('Fetched ${suggestions.length} project search suggestions');
+      return Right(suggestions);
+    } catch (e) {
+      return Left(_handleError(e, 'fetching project search suggestions'));
+    }
+  }
 }

--- a/lib/libraries/project/domain/repositories/project_search_repository.dart
+++ b/lib/libraries/project/domain/repositories/project_search_repository.dart
@@ -22,4 +22,41 @@ abstract class ProjectSearchRepository {
     String? filterByTag,
     String? filterByOwner,
   });
+
+  /// Persists [searchTerm] as a recent project-search entry for [userId].
+  ///
+  /// [hasResults] should be `true` only when the caller has confirmed the
+  /// search returned at least one result. Repeat saves of the same term are
+  /// de-duplicated rather than creating multiple entries.
+  ///
+  /// Returns `Right` (void) when [userId] is empty or [searchTerm] is
+  /// empty/whitespace — no failure is raised for these inputs.
+  Future<Either<Failure, void>> saveRecentProjectSearch({
+    required String userId,
+    required String searchTerm,
+    bool hasResults = false,
+  });
+
+  /// Returns [userId]'s recent project-search terms, most recently used first.
+  ///
+  /// Returns `Right([])` when [userId] is empty.
+  Future<Either<Failure, List<String>>> getRecentProjectSearches({
+    required String userId,
+  });
+
+  /// Removes [searchTerm] from [userId]'s recent project-search history.
+  ///
+  /// Returns `Right` (void) when [userId] is empty or [searchTerm] is
+  /// empty/whitespace.
+  Future<Either<Failure, void>> deleteRecentProjectSearch({
+    required String userId,
+    required String searchTerm,
+  });
+
+  /// Returns up to 10 personalized project-search suggestion terms for [userId].
+  ///
+  /// Returns `Right([])` when [userId] is empty or no suggestions exist.
+  Future<Either<Failure, List<String>>> getProjectSearchSuggestions({
+    required String userId,
+  });
 }

--- a/lib/libraries/project/testing/fake_project_search_repository.dart
+++ b/lib/libraries/project/testing/fake_project_search_repository.dart
@@ -13,13 +13,48 @@ class FakeProjectSearchRepository implements ProjectSearchRepository {
 
   final List<Project> _searchResults = [];
 
+  /// Recent search terms returned by [getRecentProjectSearches] on success.
+  final List<String> _recentSearches = [];
+
+  /// Suggestion terms returned by [getProjectSearchSuggestions] on success.
+  final List<String> _suggestions = [];
+
   /// Controls whether [searchProjects] throws an exception.
   bool shouldThrowOnSearchProjects = false;
 
   /// Used to specify the type of exception thrown by [searchProjects].
   SupabaseExceptionType? searchProjectsExceptionType;
 
-  /// Used to specify the Postgres error code thrown by [searchProjects].
+  /// Controls whether [saveRecentProjectSearch] throws an exception.
+  bool shouldThrowOnSaveRecent = false;
+
+  /// Used to specify the type of exception thrown by
+  /// [saveRecentProjectSearch].
+  SupabaseExceptionType? saveRecentExceptionType;
+
+  /// Controls whether [getRecentProjectSearches] throws an exception.
+  bool shouldThrowOnGetRecent = false;
+
+  /// Used to specify the type of exception thrown by
+  /// [getRecentProjectSearches].
+  SupabaseExceptionType? getRecentExceptionType;
+
+  /// Controls whether [deleteRecentProjectSearch] throws an exception.
+  bool shouldThrowOnDeleteRecent = false;
+
+  /// Used to specify the type of exception thrown by
+  /// [deleteRecentProjectSearch].
+  SupabaseExceptionType? deleteRecentExceptionType;
+
+  /// Controls whether [getProjectSearchSuggestions] throws an exception.
+  bool shouldThrowOnGetSuggestions = false;
+
+  /// Used to specify the type of exception thrown by
+  /// [getProjectSearchSuggestions].
+  SupabaseExceptionType? getSuggestionsExceptionType;
+
+  /// Used to specify the Postgres error code shared across all configured
+  /// PostgrestException paths.
   PostgresErrorCode? postgrestErrorCode;
 
   /// Controls whether operations should be delayed.
@@ -57,14 +92,116 @@ class FakeProjectSearchRepository implements ProjectSearchRepository {
     }
 
     if (shouldThrowOnSearchProjects) {
-      return Left(_failureForConfiguredException());
+      return Left(_failureForConfiguredException(searchProjectsExceptionType));
     }
 
     return Right(List<Project>.from(_searchResults));
   }
 
-  Failure _failureForConfiguredException() {
-    switch (searchProjectsExceptionType) {
+  @override
+  Future<Either<Failure, void>> saveRecentProjectSearch({
+    required String userId,
+    required String searchTerm,
+    bool hasResults = false,
+  }) async {
+    if (shouldDelayOperations) {
+      await completer?.future;
+    }
+
+    _methodCalls.add({
+      'method': 'saveRecentProjectSearch',
+      'userId': userId,
+      'searchTerm': searchTerm,
+      'hasResults': hasResults,
+    });
+
+    if (userId.trim().isEmpty || searchTerm.trim().isEmpty) {
+      return Right(null);
+    }
+
+    if (shouldThrowOnSaveRecent) {
+      return Left(_failureForConfiguredException(saveRecentExceptionType));
+    }
+
+    return Right(null);
+  }
+
+  @override
+  Future<Either<Failure, List<String>>> getRecentProjectSearches({
+    required String userId,
+  }) async {
+    if (shouldDelayOperations) {
+      await completer?.future;
+    }
+
+    _methodCalls.add({
+      'method': 'getRecentProjectSearches',
+      'userId': userId,
+    });
+
+    if (userId.trim().isEmpty) {
+      return Right([]);
+    }
+
+    if (shouldThrowOnGetRecent) {
+      return Left(_failureForConfiguredException(getRecentExceptionType));
+    }
+
+    return Right(List<String>.from(_recentSearches));
+  }
+
+  @override
+  Future<Either<Failure, void>> deleteRecentProjectSearch({
+    required String userId,
+    required String searchTerm,
+  }) async {
+    if (shouldDelayOperations) {
+      await completer?.future;
+    }
+
+    _methodCalls.add({
+      'method': 'deleteRecentProjectSearch',
+      'userId': userId,
+      'searchTerm': searchTerm,
+    });
+
+    if (userId.trim().isEmpty || searchTerm.trim().isEmpty) {
+      return Right(null);
+    }
+
+    if (shouldThrowOnDeleteRecent) {
+      return Left(_failureForConfiguredException(deleteRecentExceptionType));
+    }
+
+    return Right(null);
+  }
+
+  @override
+  Future<Either<Failure, List<String>>> getProjectSearchSuggestions({
+    required String userId,
+  }) async {
+    if (shouldDelayOperations) {
+      await completer?.future;
+    }
+
+    _methodCalls.add({
+      'method': 'getProjectSearchSuggestions',
+      'userId': userId,
+    });
+
+    if (userId.trim().isEmpty) {
+      return Right([]);
+    }
+
+    if (shouldThrowOnGetSuggestions) {
+      return Left(_failureForConfiguredException(getSuggestionsExceptionType));
+    }
+
+    return Right(List<String>.from(_suggestions));
+  }
+
+  Failure _failureForConfiguredException(SupabaseExceptionType? type) {
+    switch (type) {
       case SupabaseExceptionType.timeout:
         return SearchFailure(errorType: SearchErrorType.timeoutError);
       case SupabaseExceptionType.socket:
@@ -93,6 +230,20 @@ class FakeProjectSearchRepository implements ProjectSearchRepository {
       ..addAll(projects);
   }
 
+  /// Sets the terms returned by [getRecentProjectSearches] on success.
+  void setRecentSearches(List<String> terms) {
+    _recentSearches
+      ..clear()
+      ..addAll(terms);
+  }
+
+  /// Sets the terms returned by [getProjectSearchSuggestions] on success.
+  void setSuggestions(List<String> terms) {
+    _suggestions
+      ..clear()
+      ..addAll(terms);
+  }
+
   /// Returns a list of all method calls.
   List<Map<String, dynamic>> getMethodCalls() => List.from(_methodCalls);
 
@@ -114,10 +265,20 @@ class FakeProjectSearchRepository implements ProjectSearchRepository {
   void reset() {
     shouldThrowOnSearchProjects = false;
     searchProjectsExceptionType = null;
+    shouldThrowOnSaveRecent = false;
+    saveRecentExceptionType = null;
+    shouldThrowOnGetRecent = false;
+    getRecentExceptionType = null;
+    shouldThrowOnDeleteRecent = false;
+    deleteRecentExceptionType = null;
+    shouldThrowOnGetSuggestions = false;
+    getSuggestionsExceptionType = null;
     postgrestErrorCode = null;
     shouldDelayOperations = false;
     completer = null;
     _searchResults.clear();
+    _recentSearches.clear();
+    _suggestions.clear();
     _methodCalls.clear();
   }
 }

--- a/lib/libraries/supabase/database_constants.dart
+++ b/lib/libraries/supabase/database_constants.dart
@@ -17,9 +17,24 @@ class DatabaseConstants {
   static const String projectMembersTable = 'project_members';
   static const String searchHistoryTable = 'search_history';
 
+  /// Table storing per-user project search history. Fully isolated from
+  /// [searchHistoryTable] (which serves Global Search) — neither feature reads
+  /// from nor writes to the other's table.
+  static const String projectSearchHistoryTable = 'project_search_history';
+
   // RPC function names
   static const String globalSearchRpcFunction = 'global_search';
   static const String searchSuggestionsRpcFunction = 'get_search_suggestions';
+
+  /// RPC returning up to 10 personalized project-search suggestion terms for
+  /// the authenticated user. Backend enforces `user_id == auth.uid()` and
+  /// raises `42501` on mismatch.
+  static const String projectSearchSuggestionsRpcFunction =
+      'get_project_search_suggestions';
+
+  /// Parameter name for the `user_id` argument of
+  /// [projectSearchSuggestionsRpcFunction].
+  static const String projectSearchSuggestionsUserIdParam = 'user_id';
 
   // RPC param values
   /// The scope value passed to the [globalSearchRpcFunction] RPC to restrict
@@ -62,6 +77,17 @@ class DatabaseConstants {
   /// Used with [SupabaseWrapper.upsert] onConflict parameter.
   static const String searchHistoryUpsertConflictColumns =
       '$userIdColumn,$searchTermColumn,$scopeColumn';
+
+  /// Unique constraint columns for [projectSearchHistoryTable] upsert.
+  /// Used with [SupabaseWrapper.upsert] onConflict parameter.
+  static const String projectSearchHistoryUpsertConflictColumns =
+      '$userIdColumn,$searchTermColumn';
+
+  /// Maximum number of recent project-search entries returned by
+  /// [ProjectSearchDataSource.getRecentProjectSearches]. Caps the in-memory
+  /// result size; row-count bounding at the DB level is delegated to a future
+  /// `limit` parameter on [SupabaseWrapper.selectMatch].
+  static const int recentProjectSearchesMaxResults = 50;
 
   // User profile columns (id field uses the shared idColumn above)
   static const String credentialIdColumn = 'credential_id';

--- a/test/features/dashboard/units/blocs/project_search_bloc_test.dart
+++ b/test/features/dashboard/units/blocs/project_search_bloc_test.dart
@@ -101,6 +101,39 @@ void main() {
       );
 
       blocTest<ProjectSearchBloc, ProjectSearchState>(
+        'emits Initial preserving cached recents when query is cleared after history load',
+        setUp: () {
+          fakeSupabase.addTableData(
+            DatabaseConstants.projectSearchHistoryTable,
+            [
+              {
+                DatabaseConstants.userIdColumn: _testUserId,
+                DatabaseConstants.searchTermColumn: 'wall',
+                DatabaseConstants.updatedAtColumn: '2024-06-01T00:00:00.000Z',
+              },
+            ],
+          );
+          fakeSupabase.setRpcResponse(
+            DatabaseConstants.projectSearchSuggestionsRpcFunction,
+            <dynamic>[],
+          );
+        },
+        build: () => Modular.get<ProjectSearchBloc>(),
+        act: (bloc) async {
+          bloc.add(const ProjectSearchHistoryRequestedEvent());
+          await bloc.stream.firstWhere(
+            (s) => s is ProjectSearchInitial && !s.isLoadingHistory,
+          );
+          bloc.add(const ProjectSearchQueryUpdatedEvent(query: ''));
+        },
+        wait: const Duration(milliseconds: 500),
+        expect: () => [
+          const ProjectSearchInitial(isLoadingHistory: true),
+          const ProjectSearchInitial(recentSearches: ['wall'], suggestions: []),
+        ],
+      );
+
+      blocTest<ProjectSearchBloc, ProjectSearchState>(
         'emits [ProjectSearchLoading, ProjectSearchResultsLoaded] on success after debounce',
         setUp: () {
           fakeSupabase.setRpcResponse(
@@ -343,6 +376,282 @@ void main() {
           isA<ProjectSearchFailureState>()
               .having((s) => s.failure, 'failure', isA<UnexpectedFailure>()),
         ],
+      );
+    });
+
+    // -------------------------------------------------------------------------
+    // ProjectSearchHistoryRequestedEvent
+    // -------------------------------------------------------------------------
+
+    group('ProjectSearchHistoryRequestedEvent', () {
+      blocTest<ProjectSearchBloc, ProjectSearchState>(
+        'emits loading then loaded Initial with recents and suggestions on success',
+        setUp: () {
+          fakeSupabase.addTableData(
+            DatabaseConstants.projectSearchHistoryTable,
+            [
+              {
+                DatabaseConstants.userIdColumn: _testUserId,
+                DatabaseConstants.searchTermColumn: 'foundation',
+                DatabaseConstants.updatedAtColumn: '2024-06-01T00:00:00.000Z',
+              },
+              {
+                DatabaseConstants.userIdColumn: _testUserId,
+                DatabaseConstants.searchTermColumn: 'wall',
+                DatabaseConstants.updatedAtColumn: '2024-05-01T00:00:00.000Z',
+              },
+            ],
+          );
+          fakeSupabase.setRpcResponse(
+            DatabaseConstants.projectSearchSuggestionsRpcFunction,
+            <dynamic>['suggested-1', 'suggested-2'],
+          );
+        },
+        build: () => Modular.get<ProjectSearchBloc>(),
+        act: (bloc) =>
+            bloc.add(const ProjectSearchHistoryRequestedEvent()),
+        expect: () => [
+          const ProjectSearchInitial(isLoadingHistory: true),
+          const ProjectSearchInitial(
+            recentSearches: ['foundation', 'wall'],
+            suggestions: ['suggested-1', 'suggested-2'],
+          ),
+        ],
+      );
+
+      blocTest<ProjectSearchBloc, ProjectSearchState>(
+        'emits empty Initial without repository calls when no user is authenticated',
+        setUp: () {
+          fakeSupabase.setCurrentUser(null);
+        },
+        build: () => Modular.get<ProjectSearchBloc>(),
+        act: (bloc) =>
+            bloc.add(const ProjectSearchHistoryRequestedEvent()),
+        expect: () => [const ProjectSearchInitial()],
+        verify: (_) {
+          expect(fakeSupabase.getMethodCallsFor('selectMatch'), isEmpty);
+          expect(
+            fakeSupabase
+                .getMethodCallsFor('rpc')
+                .where(
+                  (call) =>
+                      call['functionName'] ==
+                      DatabaseConstants.projectSearchSuggestionsRpcFunction,
+                ),
+            isEmpty,
+          );
+        },
+      );
+
+      blocTest<ProjectSearchBloc, ProjectSearchState>(
+        'keeps stale suggestions cache when suggestions RPC fails but recents succeed',
+        setUp: () {
+          fakeSupabase.addTableData(
+            DatabaseConstants.projectSearchHistoryTable,
+            [
+              {
+                DatabaseConstants.userIdColumn: _testUserId,
+                DatabaseConstants.searchTermColumn: 'foundation',
+                DatabaseConstants.updatedAtColumn: '2024-06-01T00:00:00.000Z',
+              },
+            ],
+          );
+          fakeSupabase.shouldThrowOnRpc = true;
+          fakeSupabase.rpcExceptionType = SupabaseExceptionType.timeout;
+          fakeSupabase.rpcErrorMessage = 'Timeout';
+        },
+        build: () => Modular.get<ProjectSearchBloc>(),
+        act: (bloc) =>
+            bloc.add(const ProjectSearchHistoryRequestedEvent()),
+        expect: () => [
+          const ProjectSearchInitial(isLoadingHistory: true),
+          const ProjectSearchInitial(
+            recentSearches: ['foundation'],
+            suggestions: [],
+          ),
+        ],
+      );
+    });
+
+    // -------------------------------------------------------------------------
+    // ProjectSearchHistoryItemDismissedEvent
+    // -------------------------------------------------------------------------
+
+    group('ProjectSearchHistoryItemDismissedEvent', () {
+      blocTest<ProjectSearchBloc, ProjectSearchState>(
+        'removes term from cached recents and re-emits Initial on success',
+        setUp: () {
+          fakeSupabase.addTableData(
+            DatabaseConstants.projectSearchHistoryTable,
+            [
+              {
+                DatabaseConstants.userIdColumn: _testUserId,
+                DatabaseConstants.searchTermColumn: 'foundation',
+                DatabaseConstants.updatedAtColumn: '2024-06-01T00:00:00.000Z',
+              },
+              {
+                DatabaseConstants.userIdColumn: _testUserId,
+                DatabaseConstants.searchTermColumn: 'wall',
+                DatabaseConstants.updatedAtColumn: '2024-05-01T00:00:00.000Z',
+              },
+            ],
+          );
+          fakeSupabase.setRpcResponse(
+            DatabaseConstants.projectSearchSuggestionsRpcFunction,
+            <dynamic>[],
+          );
+        },
+        build: () => Modular.get<ProjectSearchBloc>(),
+        act: (bloc) async {
+          bloc.add(const ProjectSearchHistoryRequestedEvent());
+          // Wait for the non-loading Initial to land so the cached recents
+          // are populated before we dispatch the dismissal.
+          await bloc.stream.firstWhere(
+            (state) =>
+                state is ProjectSearchInitial && !state.isLoadingHistory,
+          );
+          bloc.add(
+            const ProjectSearchHistoryItemDismissedEvent(
+              searchTerm: 'foundation',
+            ),
+          );
+        },
+        skip: 2,
+        expect: () => [
+          const ProjectSearchInitial(
+            recentSearches: ['wall'],
+            suggestions: [],
+          ),
+        ],
+        verify: (_) {
+          expect(
+            fakeSupabase.getMethodCallsFor('deleteMatch'),
+            hasLength(1),
+          );
+        },
+      );
+
+      blocTest<ProjectSearchBloc, ProjectSearchState>(
+        'emits nothing when no user is authenticated',
+        setUp: () {
+          fakeSupabase.setCurrentUser(null);
+        },
+        build: () => Modular.get<ProjectSearchBloc>(),
+        act: (bloc) => bloc.add(
+          const ProjectSearchHistoryItemDismissedEvent(searchTerm: 'wall'),
+        ),
+        expect: () => <ProjectSearchState>[],
+        verify: (_) {
+          expect(fakeSupabase.getMethodCallsFor('deleteMatch'), isEmpty);
+        },
+      );
+
+      blocTest<ProjectSearchBloc, ProjectSearchState>(
+        'emits nothing when deleteMatch fails',
+        setUp: () {
+          fakeSupabase.shouldThrowOnDeleteMatch = true;
+          fakeSupabase.deleteMatchExceptionType =
+              SupabaseExceptionType.timeout;
+          fakeSupabase.deleteMatchErrorMessage = 'Timeout';
+        },
+        build: () => Modular.get<ProjectSearchBloc>(),
+        act: (bloc) => bloc.add(
+          const ProjectSearchHistoryItemDismissedEvent(searchTerm: 'wall'),
+        ),
+        expect: () => <ProjectSearchState>[],
+      );
+    });
+
+    // -------------------------------------------------------------------------
+    // Save-after-search behavior
+    // -------------------------------------------------------------------------
+
+    group('save-after-search', () {
+      blocTest<ProjectSearchBloc, ProjectSearchState>(
+        'upserts with hasResults=true when search returns non-empty results',
+        setUp: () {
+          fakeSupabase.setRpcResponse(
+            DatabaseConstants.globalSearchRpcFunction,
+            {
+              'projects': [_fakeProjectData(id: 'p-1')],
+              'estimations': [],
+              'members': [],
+            },
+          );
+        },
+        build: () => Modular.get<ProjectSearchBloc>(),
+        act: (bloc) async {
+          bloc.add(const ProjectSearchPerformedEvent(query: 'wall'));
+          await bloc.lastSaveCompleted;
+        },
+        verify: (_) {
+          final upserts = fakeSupabase
+              .getMethodCallsFor('upsert')
+              .where(
+                (call) =>
+                    call['table'] ==
+                    DatabaseConstants.projectSearchHistoryTable,
+              )
+              .toList();
+          expect(upserts, hasLength(1));
+          final data = upserts.first['data'] as Map<String, dynamic>;
+          expect(data[DatabaseConstants.hasResultsColumn], isTrue);
+          expect(
+            data[DatabaseConstants.searchTermColumn],
+            equals('wall'),
+          );
+        },
+      );
+
+      blocTest<ProjectSearchBloc, ProjectSearchState>(
+        'upserts with hasResults=false when search returns empty results',
+        setUp: () {
+          fakeSupabase.setRpcResponse(
+            DatabaseConstants.globalSearchRpcFunction,
+            {'projects': [], 'estimations': [], 'members': []},
+          );
+        },
+        build: () => Modular.get<ProjectSearchBloc>(),
+        act: (bloc) async {
+          bloc.add(const ProjectSearchPerformedEvent(query: 'nothing'));
+          await bloc.lastSaveCompleted;
+        },
+        verify: (_) {
+          final upserts = fakeSupabase
+              .getMethodCallsFor('upsert')
+              .where(
+                (call) =>
+                    call['table'] ==
+                    DatabaseConstants.projectSearchHistoryTable,
+              )
+              .toList();
+          expect(upserts, hasLength(1));
+          final data = upserts.first['data'] as Map<String, dynamic>;
+          expect(data[DatabaseConstants.hasResultsColumn], isFalse);
+        },
+      );
+
+      blocTest<ProjectSearchBloc, ProjectSearchState>(
+        'does not upsert when search fails',
+        setUp: () {
+          fakeSupabase.shouldThrowOnRpc = true;
+          fakeSupabase.rpcExceptionType = SupabaseExceptionType.timeout;
+          fakeSupabase.rpcErrorMessage = 'Timeout';
+        },
+        build: () => Modular.get<ProjectSearchBloc>(),
+        act: (bloc) =>
+            bloc.add(const ProjectSearchPerformedEvent(query: 'wall')),
+        verify: (_) {
+          final upserts = fakeSupabase
+              .getMethodCallsFor('upsert')
+              .where(
+                (call) =>
+                    call['table'] ==
+                    DatabaseConstants.projectSearchHistoryTable,
+              )
+              .toList();
+          expect(upserts, isEmpty);
+        },
       );
     });
   });

--- a/test/libraries/project/units/data/data_source/remote_project_search_data_source_test.dart
+++ b/test/libraries/project/units/data/data_source/remote_project_search_data_source_test.dart
@@ -272,5 +272,466 @@ void main() {
         );
       });
     });
+
+    group('saveRecentProjectSearch', () {
+      test('upserts normalized term against project_search_history', () async {
+        await dataSource.saveRecentProjectSearch(
+          userId: 'user-1',
+          searchTerm: '  Foundation  ',
+          hasResults: true,
+        );
+
+        final calls = supabaseWrapper.getMethodCallsFor('upsert');
+        expect(calls, hasLength(1));
+        expect(
+          calls.first['table'],
+          equals(DatabaseConstants.projectSearchHistoryTable),
+        );
+        expect(
+          calls.first['onConflict'],
+          equals(DatabaseConstants.projectSearchHistoryUpsertConflictColumns),
+        );
+
+        final data = calls.first['data'] as Map<String, dynamic>;
+        expect(data[DatabaseConstants.userIdColumn], equals('user-1'));
+        expect(data[DatabaseConstants.searchTermColumn], equals('foundation'));
+        expect(data[DatabaseConstants.hasResultsColumn], isTrue);
+        expect(data.containsKey(DatabaseConstants.searchCountColumn), isFalse);
+        expect(data.containsKey(DatabaseConstants.createdAtColumn), isFalse);
+      });
+
+      test('defaults hasResults to false when not provided', () async {
+        await dataSource.saveRecentProjectSearch(
+          userId: 'user-1',
+          searchTerm: 'wall',
+        );
+
+        final data = supabaseWrapper.getMethodCallsFor('upsert').first['data']
+            as Map<String, dynamic>;
+        expect(data[DatabaseConstants.hasResultsColumn], isFalse);
+      });
+
+      test('does nothing when userId is empty', () async {
+        await dataSource.saveRecentProjectSearch(
+          userId: '',
+          searchTerm: 'wall',
+        );
+
+        expect(supabaseWrapper.getMethodCallsFor('upsert'), isEmpty);
+      });
+
+      test('does nothing when userId is whitespace only', () async {
+        await dataSource.saveRecentProjectSearch(
+          userId: '   ',
+          searchTerm: 'wall',
+        );
+
+        expect(supabaseWrapper.getMethodCallsFor('upsert'), isEmpty);
+      });
+
+      test('does nothing when searchTerm is empty', () async {
+        await dataSource.saveRecentProjectSearch(
+          userId: 'user-1',
+          searchTerm: '',
+        );
+
+        expect(supabaseWrapper.getMethodCallsFor('upsert'), isEmpty);
+      });
+
+      test('does nothing when searchTerm is whitespace only', () async {
+        await dataSource.saveRecentProjectSearch(
+          userId: 'user-1',
+          searchTerm: '   ',
+        );
+
+        expect(supabaseWrapper.getMethodCallsFor('upsert'), isEmpty);
+      });
+
+      test('rethrows PostgrestException when upsert throws', () async {
+        supabaseWrapper.shouldThrowOnUpsert = true;
+        supabaseWrapper.upsertExceptionType = SupabaseExceptionType.postgrest;
+        supabaseWrapper.upsertErrorMessage = 'DB error';
+
+        await expectLater(
+          () => dataSource.saveRecentProjectSearch(
+            userId: 'user-1',
+            searchTerm: 'wall',
+          ),
+          throwsA(isA<supabase.PostgrestException>()),
+        );
+      });
+
+      test('rethrows SocketException when upsert throws', () async {
+        supabaseWrapper.shouldThrowOnUpsert = true;
+        supabaseWrapper.upsertExceptionType = SupabaseExceptionType.socket;
+        supabaseWrapper.upsertErrorMessage = 'Network';
+
+        await expectLater(
+          () => dataSource.saveRecentProjectSearch(
+            userId: 'user-1',
+            searchTerm: 'wall',
+          ),
+          throwsA(isA<SocketException>()),
+        );
+      });
+
+      test('rethrows TimeoutException when upsert throws', () async {
+        supabaseWrapper.shouldThrowOnUpsert = true;
+        supabaseWrapper.upsertExceptionType = SupabaseExceptionType.timeout;
+        supabaseWrapper.upsertErrorMessage = 'Timeout';
+
+        await expectLater(
+          () => dataSource.saveRecentProjectSearch(
+            userId: 'user-1',
+            searchTerm: 'wall',
+          ),
+          throwsA(isA<TimeoutException>()),
+        );
+      });
+    });
+
+    group('getRecentProjectSearches', () {
+      test(
+        'returns most-recent-first list of terms from project_search_history',
+        () async {
+          supabaseWrapper.addTableData(
+            DatabaseConstants.projectSearchHistoryTable,
+            [
+              {
+                DatabaseConstants.userIdColumn: 'user-1',
+                DatabaseConstants.searchTermColumn: 'older',
+                DatabaseConstants.updatedAtColumn: '2024-01-01T00:00:00.000Z',
+              },
+              {
+                DatabaseConstants.userIdColumn: 'user-1',
+                DatabaseConstants.searchTermColumn: 'newer',
+                DatabaseConstants.updatedAtColumn: '2024-06-01T00:00:00.000Z',
+              },
+            ],
+          );
+
+          final result = await dataSource.getRecentProjectSearches(
+            userId: 'user-1',
+          );
+
+          expect(result, equals(['newer', 'older']));
+
+          final calls = supabaseWrapper.getMethodCallsFor('selectMatch');
+          expect(calls, hasLength(1));
+          expect(
+            calls.first['table'],
+            equals(DatabaseConstants.projectSearchHistoryTable),
+          );
+          expect(
+            calls.first['orderBy'],
+            equals(DatabaseConstants.updatedAtColumn),
+          );
+          expect(calls.first['ascending'], isFalse);
+          final filters = calls.first['filters'] as Map<String, dynamic>;
+          expect(filters[DatabaseConstants.userIdColumn], equals('user-1'));
+        },
+      );
+
+      test('drops rows with null or empty search_term', () async {
+        supabaseWrapper.addTableData(
+          DatabaseConstants.projectSearchHistoryTable,
+          [
+            {
+              DatabaseConstants.userIdColumn: 'user-1',
+              DatabaseConstants.searchTermColumn: 'kept',
+              DatabaseConstants.updatedAtColumn: '2024-06-01T00:00:00.000Z',
+            },
+            {
+              DatabaseConstants.userIdColumn: 'user-1',
+              DatabaseConstants.searchTermColumn: '',
+              DatabaseConstants.updatedAtColumn: '2024-05-01T00:00:00.000Z',
+            },
+            {
+              DatabaseConstants.userIdColumn: 'user-1',
+              DatabaseConstants.searchTermColumn: null,
+              DatabaseConstants.updatedAtColumn: '2024-04-01T00:00:00.000Z',
+            },
+          ],
+        );
+
+        final result = await dataSource.getRecentProjectSearches(
+          userId: 'user-1',
+        );
+
+        expect(result, equals(['kept']));
+      });
+
+      test(
+        'caps results at recentProjectSearchesMaxResults',
+        () async {
+          final overLimit =
+              DatabaseConstants.recentProjectSearchesMaxResults + 5;
+          supabaseWrapper.addTableData(
+            DatabaseConstants.projectSearchHistoryTable,
+            List.generate(
+              overLimit,
+              (i) => {
+                DatabaseConstants.userIdColumn: 'user-1',
+                DatabaseConstants.searchTermColumn: 'term-$i',
+                DatabaseConstants.updatedAtColumn:
+                    '2024-01-01T00:00:00.000Z',
+              },
+            ),
+          );
+
+          final result = await dataSource.getRecentProjectSearches(
+            userId: 'user-1',
+          );
+
+          expect(
+            result,
+            hasLength(DatabaseConstants.recentProjectSearchesMaxResults),
+          );
+        },
+      );
+
+      test('returns empty list without calling wrapper when userId empty', () async {
+        final result = await dataSource.getRecentProjectSearches(userId: '');
+
+        expect(result, isEmpty);
+        expect(supabaseWrapper.getMethodCallsFor('selectMatch'), isEmpty);
+      });
+
+      test(
+        'returns empty list without calling wrapper when userId is whitespace only',
+        () async {
+          final result = await dataSource.getRecentProjectSearches(
+            userId: '   ',
+          );
+
+          expect(result, isEmpty);
+          expect(supabaseWrapper.getMethodCallsFor('selectMatch'), isEmpty);
+        },
+      );
+
+      test('rethrows PostgrestException when selectMatch throws', () async {
+        supabaseWrapper.shouldThrowOnSelectMatch = true;
+        supabaseWrapper.selectMatchExceptionType =
+            SupabaseExceptionType.postgrest;
+        supabaseWrapper.selectMatchErrorMessage = 'DB error';
+
+        await expectLater(
+          () => dataSource.getRecentProjectSearches(userId: 'user-1'),
+          throwsA(isA<supabase.PostgrestException>()),
+        );
+      });
+
+      test('rethrows TimeoutException when selectMatch throws', () async {
+        supabaseWrapper.shouldThrowOnSelectMatch = true;
+        supabaseWrapper.selectMatchExceptionType =
+            SupabaseExceptionType.timeout;
+        supabaseWrapper.selectMatchErrorMessage = 'Timeout';
+
+        await expectLater(
+          () => dataSource.getRecentProjectSearches(userId: 'user-1'),
+          throwsA(isA<TimeoutException>()),
+        );
+      });
+
+      test('rethrows SocketException when selectMatch throws', () async {
+        supabaseWrapper.shouldThrowOnSelectMatch = true;
+        supabaseWrapper.selectMatchExceptionType =
+            SupabaseExceptionType.socket;
+        supabaseWrapper.selectMatchErrorMessage = 'Network';
+
+        await expectLater(
+          () => dataSource.getRecentProjectSearches(userId: 'user-1'),
+          throwsA(isA<SocketException>()),
+        );
+      });
+    });
+
+    group('deleteRecentProjectSearch', () {
+      test(
+        'deletes against project_search_history with normalized term',
+        () async {
+          await dataSource.deleteRecentProjectSearch(
+            userId: 'user-1',
+            searchTerm: '  Foundation  ',
+          );
+
+          final calls = supabaseWrapper.getMethodCallsFor('deleteMatch');
+          expect(calls, hasLength(1));
+          expect(
+            calls.first['table'],
+            equals(DatabaseConstants.projectSearchHistoryTable),
+          );
+          final filters = calls.first['filters'] as Map<String, dynamic>;
+          expect(filters[DatabaseConstants.userIdColumn], equals('user-1'));
+          expect(
+            filters[DatabaseConstants.searchTermColumn],
+            equals('foundation'),
+          );
+        },
+      );
+
+      test('does nothing when userId is empty', () async {
+        await dataSource.deleteRecentProjectSearch(
+          userId: '',
+          searchTerm: 'wall',
+        );
+
+        expect(supabaseWrapper.getMethodCallsFor('deleteMatch'), isEmpty);
+      });
+
+      test('does nothing when userId is whitespace only', () async {
+        await dataSource.deleteRecentProjectSearch(
+          userId: '   ',
+          searchTerm: 'wall',
+        );
+
+        expect(supabaseWrapper.getMethodCallsFor('deleteMatch'), isEmpty);
+      });
+
+      test('does nothing when searchTerm is empty', () async {
+        await dataSource.deleteRecentProjectSearch(
+          userId: 'user-1',
+          searchTerm: '',
+        );
+
+        expect(supabaseWrapper.getMethodCallsFor('deleteMatch'), isEmpty);
+      });
+
+      test('does nothing when searchTerm is whitespace only', () async {
+        await dataSource.deleteRecentProjectSearch(
+          userId: 'user-1',
+          searchTerm: '   ',
+        );
+
+        expect(supabaseWrapper.getMethodCallsFor('deleteMatch'), isEmpty);
+      });
+
+      test('rethrows PostgrestException when deleteMatch throws', () async {
+        supabaseWrapper.shouldThrowOnDeleteMatch = true;
+        supabaseWrapper.deleteMatchExceptionType =
+            SupabaseExceptionType.postgrest;
+        supabaseWrapper.deleteMatchErrorMessage = 'DB error';
+
+        await expectLater(
+          () => dataSource.deleteRecentProjectSearch(
+            userId: 'user-1',
+            searchTerm: 'wall',
+          ),
+          throwsA(isA<supabase.PostgrestException>()),
+        );
+      });
+
+      test('rethrows SocketException when deleteMatch throws', () async {
+        supabaseWrapper.shouldThrowOnDeleteMatch = true;
+        supabaseWrapper.deleteMatchExceptionType =
+            SupabaseExceptionType.socket;
+        supabaseWrapper.deleteMatchErrorMessage = 'Network';
+
+        await expectLater(
+          () => dataSource.deleteRecentProjectSearch(
+            userId: 'user-1',
+            searchTerm: 'wall',
+          ),
+          throwsA(isA<SocketException>()),
+        );
+      });
+
+      test('rethrows TimeoutException when deleteMatch throws', () async {
+        supabaseWrapper.shouldThrowOnDeleteMatch = true;
+        supabaseWrapper.deleteMatchExceptionType =
+            SupabaseExceptionType.timeout;
+        supabaseWrapper.deleteMatchErrorMessage = 'Timeout';
+
+        await expectLater(
+          () => dataSource.deleteRecentProjectSearch(
+            userId: 'user-1',
+            searchTerm: 'wall',
+          ),
+          throwsA(isA<TimeoutException>()),
+        );
+      });
+    });
+
+    group('getProjectSearchSuggestions', () {
+      test('returns string suggestions from RPC, dropping non-strings', () async {
+        supabaseWrapper.setRpcResponse(
+          DatabaseConstants.projectSearchSuggestionsRpcFunction,
+          <dynamic>['foundation', 'wall', 42, null, 'steel'],
+        );
+
+        final result = await dataSource.getProjectSearchSuggestions(
+          userId: 'user-1',
+        );
+
+        expect(result, equals(['foundation', 'wall', 'steel']));
+
+        final calls = supabaseWrapper.getMethodCallsFor('rpc');
+        expect(calls, hasLength(1));
+        expect(
+          calls.first['functionName'] ?? calls.first['function'],
+          equals(DatabaseConstants.projectSearchSuggestionsRpcFunction),
+        );
+        final params = calls.first['params'] as Map<String, dynamic>?;
+        expect(params, isNotNull);
+        expect(
+          params![DatabaseConstants.projectSearchSuggestionsUserIdParam],
+          equals('user-1'),
+        );
+      });
+
+      test('returns empty list without calling RPC when userId is empty', () async {
+        final result = await dataSource.getProjectSearchSuggestions(
+          userId: '',
+        );
+
+        expect(result, isEmpty);
+        expect(supabaseWrapper.getMethodCallsFor('rpc'), isEmpty);
+      });
+
+      test(
+        'returns empty list without calling RPC when userId is whitespace only',
+        () async {
+          final result = await dataSource.getProjectSearchSuggestions(
+            userId: '   ',
+          );
+
+          expect(result, isEmpty);
+          expect(supabaseWrapper.getMethodCallsFor('rpc'), isEmpty);
+        },
+      );
+
+      test('rethrows PostgrestException when RPC throws', () async {
+        supabaseWrapper.shouldThrowOnRpc = true;
+        supabaseWrapper.rpcExceptionType = SupabaseExceptionType.postgrest;
+        supabaseWrapper.rpcErrorMessage = 'DB error';
+
+        await expectLater(
+          () => dataSource.getProjectSearchSuggestions(userId: 'user-1'),
+          throwsA(isA<supabase.PostgrestException>()),
+        );
+      });
+
+      test('rethrows TimeoutException when RPC throws', () async {
+        supabaseWrapper.shouldThrowOnRpc = true;
+        supabaseWrapper.rpcExceptionType = SupabaseExceptionType.timeout;
+        supabaseWrapper.rpcErrorMessage = 'Timeout';
+
+        await expectLater(
+          () => dataSource.getProjectSearchSuggestions(userId: 'user-1'),
+          throwsA(isA<TimeoutException>()),
+        );
+      });
+
+      test('rethrows SocketException when RPC throws', () async {
+        supabaseWrapper.shouldThrowOnRpc = true;
+        supabaseWrapper.rpcExceptionType = SupabaseExceptionType.socket;
+        supabaseWrapper.rpcErrorMessage = 'Network';
+
+        await expectLater(
+          () => dataSource.getProjectSearchSuggestions(userId: 'user-1'),
+          throwsA(isA<SocketException>()),
+        );
+      });
+    });
   });
 }

--- a/test/libraries/project/units/data/repositories/project_search_repository_impl_test.dart
+++ b/test/libraries/project/units/data/repositories/project_search_repository_impl_test.dart
@@ -414,5 +414,452 @@ void main() {
         );
       });
     });
+
+    // -----------------------------------------------------------------------
+    // Shared error-matrix scenarios — used by all four history/suggestion
+    // methods. Each scenario configures the FakeSupabaseWrapper and asserts
+    // the mapped Failure on the Either<Left>.
+    // -----------------------------------------------------------------------
+
+    void configureWrapperToThrowOn({
+      required FakeSupabaseWrapper wrapper,
+      required _WrapperOp op,
+      required SupabaseExceptionType type,
+      PostgresErrorCode? postgresCode,
+    }) {
+      switch (op) {
+        case _WrapperOp.rpc:
+          wrapper.shouldThrowOnRpc = true;
+          wrapper.rpcExceptionType = type;
+          wrapper.rpcErrorMessage = 'rpc error';
+        case _WrapperOp.upsert:
+          wrapper.shouldThrowOnUpsert = true;
+          wrapper.upsertExceptionType = type;
+          wrapper.upsertErrorMessage = 'upsert error';
+        case _WrapperOp.selectMatch:
+          wrapper.shouldThrowOnSelectMatch = true;
+          wrapper.selectMatchExceptionType = type;
+          wrapper.selectMatchErrorMessage = 'select error';
+        case _WrapperOp.deleteMatch:
+          wrapper.shouldThrowOnDeleteMatch = true;
+          wrapper.deleteMatchExceptionType = type;
+          wrapper.deleteMatchErrorMessage = 'delete error';
+      }
+      wrapper.postgrestErrorCode = postgresCode;
+    }
+
+    /// Asserts that [action] maps the given thrown exception to [expected].
+    Future<void> assertMappedFailure({
+      required _WrapperOp op,
+      required SupabaseExceptionType throwType,
+      PostgresErrorCode? postgresCode,
+      required Future<Either<Failure, Object?>> Function() action,
+      required Failure expected,
+    }) async {
+      configureWrapperToThrowOn(
+        wrapper: fakeSupabaseWrapper,
+        op: op,
+        type: throwType,
+        postgresCode: postgresCode,
+      );
+      final result = await action();
+      _expectLeft(result, (failure) => expect(failure, expected));
+    }
+
+    /// Runs the full _handleError matrix against [action].
+    void runErrorMatrix({
+      required String label,
+      required _WrapperOp op,
+      required Future<Either<Failure, Object?>> Function() action,
+    }) {
+      test('$label — TimeoutException → timeoutError failure', () async {
+        await assertMappedFailure(
+          op: op,
+          throwType: SupabaseExceptionType.timeout,
+          action: action,
+          expected: SearchFailure(errorType: SearchErrorType.timeoutError),
+        );
+      });
+
+      test('$label — SocketException → connectionError failure', () async {
+        await assertMappedFailure(
+          op: op,
+          throwType: SupabaseExceptionType.socket,
+          action: action,
+          expected: SearchFailure(errorType: SearchErrorType.connectionError),
+        );
+      });
+
+      test('$label — TypeError → parsingError failure', () async {
+        await assertMappedFailure(
+          op: op,
+          throwType: SupabaseExceptionType.type,
+          action: action,
+          expected: SearchFailure(errorType: SearchErrorType.parsingError),
+        );
+      });
+
+      test(
+        '$label — PostgrestException(noDataFound) → notFoundError failure',
+        () async {
+          await assertMappedFailure(
+            op: op,
+            throwType: SupabaseExceptionType.postgrest,
+            postgresCode: PostgresErrorCode.noDataFound,
+            action: action,
+            expected: SearchFailure(errorType: SearchErrorType.notFoundError),
+          );
+        },
+      );
+
+      test(
+        '$label — PostgrestException(connectionFailure) → connectionError failure',
+        () async {
+          await assertMappedFailure(
+            op: op,
+            throwType: SupabaseExceptionType.postgrest,
+            postgresCode: PostgresErrorCode.connectionFailure,
+            action: action,
+            expected: SearchFailure(
+              errorType: SearchErrorType.connectionError,
+            ),
+          );
+        },
+      );
+
+      test(
+        '$label — PostgrestException(unableToConnect) → connectionError failure',
+        () async {
+          await assertMappedFailure(
+            op: op,
+            throwType: SupabaseExceptionType.postgrest,
+            postgresCode: PostgresErrorCode.unableToConnect,
+            action: action,
+            expected: SearchFailure(
+              errorType: SearchErrorType.connectionError,
+            ),
+          );
+        },
+      );
+
+      test(
+        '$label — PostgrestException(connectionDoesNotExist) → connectionError failure',
+        () async {
+          await assertMappedFailure(
+            op: op,
+            throwType: SupabaseExceptionType.postgrest,
+            postgresCode: PostgresErrorCode.connectionDoesNotExist,
+            action: action,
+            expected: SearchFailure(
+              errorType: SearchErrorType.connectionError,
+            ),
+          );
+        },
+      );
+
+      test(
+        '$label — PostgrestException(unhandled code) → unexpectedDatabaseError failure',
+        () async {
+          await assertMappedFailure(
+            op: op,
+            throwType: SupabaseExceptionType.postgrest,
+            postgresCode: PostgresErrorCode.uniqueViolation,
+            action: action,
+            expected: SearchFailure(
+              errorType: SearchErrorType.unexpectedDatabaseError,
+            ),
+          );
+        },
+      );
+
+      test('$label — unknown error → UnexpectedFailure', () async {
+        configureWrapperToThrowOn(
+          wrapper: fakeSupabaseWrapper,
+          op: op,
+          type: SupabaseExceptionType.unknown,
+        );
+        final result = await action();
+        _expectLeft(result, (failure) => expect(failure, isA<UnexpectedFailure>()));
+      });
+    }
+
+    group('saveRecentProjectSearch', () {
+      test('returns Right(null) on success and upserts via wrapper', () async {
+        final result = await repository.saveRecentProjectSearch(
+          userId: testUserId,
+          searchTerm: 'foundation',
+          hasResults: true,
+        );
+
+        expect(result.isRight(), isTrue);
+        expect(fakeSupabaseWrapper.getMethodCallsFor('upsert'), hasLength(1));
+      });
+
+      test('returns Right(null) without upsert when userId is empty', () async {
+        final result = await repository.saveRecentProjectSearch(
+          userId: '',
+          searchTerm: 'foundation',
+        );
+
+        expect(result.isRight(), isTrue);
+        expect(fakeSupabaseWrapper.getMethodCallsFor('upsert'), isEmpty);
+      });
+
+      test(
+        'returns Right(null) without upsert when userId is whitespace only',
+        () async {
+          final result = await repository.saveRecentProjectSearch(
+            userId: '   ',
+            searchTerm: 'foundation',
+          );
+
+          expect(result.isRight(), isTrue);
+          expect(fakeSupabaseWrapper.getMethodCallsFor('upsert'), isEmpty);
+        },
+      );
+
+      test(
+        'returns Right(null) without upsert when searchTerm is empty',
+        () async {
+          final result = await repository.saveRecentProjectSearch(
+            userId: testUserId,
+            searchTerm: '',
+          );
+
+          expect(result.isRight(), isTrue);
+          expect(fakeSupabaseWrapper.getMethodCallsFor('upsert'), isEmpty);
+        },
+      );
+
+      test(
+        'returns Right(null) without upsert when searchTerm is whitespace only',
+        () async {
+          final result = await repository.saveRecentProjectSearch(
+            userId: testUserId,
+            searchTerm: '   ',
+          );
+
+          expect(result.isRight(), isTrue);
+          expect(fakeSupabaseWrapper.getMethodCallsFor('upsert'), isEmpty);
+        },
+      );
+
+      runErrorMatrix(
+        label: 'saveRecentProjectSearch',
+        op: _WrapperOp.upsert,
+        action: () => repository.saveRecentProjectSearch(
+          userId: testUserId,
+          searchTerm: 'wall',
+        ),
+      );
+    });
+
+    group('getRecentProjectSearches', () {
+      test('returns Right with terms in wrapper order on success', () async {
+        fakeSupabaseWrapper.addTableData(
+          DatabaseConstants.projectSearchHistoryTable,
+          [
+            {
+              DatabaseConstants.userIdColumn: testUserId,
+              DatabaseConstants.searchTermColumn: 'older',
+              DatabaseConstants.updatedAtColumn: '2024-01-01T00:00:00.000Z',
+            },
+            {
+              DatabaseConstants.userIdColumn: testUserId,
+              DatabaseConstants.searchTermColumn: 'newer',
+              DatabaseConstants.updatedAtColumn: '2024-06-01T00:00:00.000Z',
+            },
+          ],
+        );
+
+        final result = await repository.getRecentProjectSearches(
+          userId: testUserId,
+        );
+
+        expect(result.isRight(), isTrue);
+        _expectRight(
+          result,
+          (terms) => expect(terms, equals(['newer', 'older'])),
+        );
+      });
+
+      test(
+        'returns Right([]) without selectMatch when userId is empty',
+        () async {
+          final result = await repository.getRecentProjectSearches(userId: '');
+
+          expect(result.isRight(), isTrue);
+          _expectRight(result, (terms) => expect(terms, isEmpty));
+          expect(
+            fakeSupabaseWrapper.getMethodCallsFor('selectMatch'),
+            isEmpty,
+          );
+        },
+      );
+
+      test(
+        'returns Right([]) without selectMatch when userId is whitespace only',
+        () async {
+          final result = await repository.getRecentProjectSearches(
+            userId: '   ',
+          );
+
+          expect(result.isRight(), isTrue);
+          _expectRight(result, (terms) => expect(terms, isEmpty));
+          expect(
+            fakeSupabaseWrapper.getMethodCallsFor('selectMatch'),
+            isEmpty,
+          );
+        },
+      );
+
+      runErrorMatrix(
+        label: 'getRecentProjectSearches',
+        op: _WrapperOp.selectMatch,
+        action: () => repository.getRecentProjectSearches(userId: testUserId),
+      );
+    });
+
+    group('deleteRecentProjectSearch', () {
+      test('returns Right(null) on success and deletes via wrapper', () async {
+        final result = await repository.deleteRecentProjectSearch(
+          userId: testUserId,
+          searchTerm: 'wall',
+        );
+
+        expect(result.isRight(), isTrue);
+        expect(
+          fakeSupabaseWrapper.getMethodCallsFor('deleteMatch'),
+          hasLength(1),
+        );
+      });
+
+      test(
+        'returns Right(null) without delete when userId is empty',
+        () async {
+          final result = await repository.deleteRecentProjectSearch(
+            userId: '',
+            searchTerm: 'wall',
+          );
+
+          expect(result.isRight(), isTrue);
+          expect(
+            fakeSupabaseWrapper.getMethodCallsFor('deleteMatch'),
+            isEmpty,
+          );
+        },
+      );
+
+      test(
+        'returns Right(null) without delete when userId is whitespace only',
+        () async {
+          final result = await repository.deleteRecentProjectSearch(
+            userId: '   ',
+            searchTerm: 'wall',
+          );
+
+          expect(result.isRight(), isTrue);
+          expect(
+            fakeSupabaseWrapper.getMethodCallsFor('deleteMatch'),
+            isEmpty,
+          );
+        },
+      );
+
+      test(
+        'returns Right(null) without delete when searchTerm is empty',
+        () async {
+          final result = await repository.deleteRecentProjectSearch(
+            userId: testUserId,
+            searchTerm: '',
+          );
+
+          expect(result.isRight(), isTrue);
+          expect(
+            fakeSupabaseWrapper.getMethodCallsFor('deleteMatch'),
+            isEmpty,
+          );
+        },
+      );
+
+      test(
+        'returns Right(null) without delete when searchTerm is whitespace only',
+        () async {
+          final result = await repository.deleteRecentProjectSearch(
+            userId: testUserId,
+            searchTerm: '   ',
+          );
+
+          expect(result.isRight(), isTrue);
+          expect(
+            fakeSupabaseWrapper.getMethodCallsFor('deleteMatch'),
+            isEmpty,
+          );
+        },
+      );
+
+      runErrorMatrix(
+        label: 'deleteRecentProjectSearch',
+        op: _WrapperOp.deleteMatch,
+        action: () => repository.deleteRecentProjectSearch(
+          userId: testUserId,
+          searchTerm: 'wall',
+        ),
+      );
+    });
+
+    group('getProjectSearchSuggestions', () {
+      test('returns Right with string suggestions on success', () async {
+        fakeSupabaseWrapper.setRpcResponse(
+          DatabaseConstants.projectSearchSuggestionsRpcFunction,
+          <dynamic>['foundation', 'wall', 42, null, 'steel'],
+        );
+
+        final result = await repository.getProjectSearchSuggestions(
+          userId: testUserId,
+        );
+
+        expect(result.isRight(), isTrue);
+        _expectRight(
+          result,
+          (terms) => expect(terms, equals(['foundation', 'wall', 'steel'])),
+        );
+      });
+
+      test(
+        'returns Right([]) without RPC when userId is empty',
+        () async {
+          final result = await repository.getProjectSearchSuggestions(
+            userId: '',
+          );
+
+          expect(result.isRight(), isTrue);
+          _expectRight(result, (terms) => expect(terms, isEmpty));
+          expect(fakeSupabaseWrapper.getMethodCallsFor('rpc'), isEmpty);
+        },
+      );
+
+      test(
+        'returns Right([]) without RPC when userId is whitespace only',
+        () async {
+          final result = await repository.getProjectSearchSuggestions(
+            userId: '   ',
+          );
+
+          expect(result.isRight(), isTrue);
+          _expectRight(result, (terms) => expect(terms, isEmpty));
+          expect(fakeSupabaseWrapper.getMethodCallsFor('rpc'), isEmpty);
+        },
+      );
+
+      runErrorMatrix(
+        label: 'getProjectSearchSuggestions',
+        op: _WrapperOp.rpc,
+        action: () =>
+            repository.getProjectSearchSuggestions(userId: testUserId),
+      );
+    });
   });
 }
+
+enum _WrapperOp { rpc, upsert, selectMatch, deleteMatch }


### PR DESCRIPTION
## Summary

This PR implements the data-layer contract for the recent project-search history feature. It extends the `ProjectSearchDataSource` abstract interface with four new method signatures (`saveRecentProjectSearch`, `getRecentProjectSearches`, `deleteRecentProjectSearch`, and `getProjectSearchSuggestions`) and provides their concrete implementation in `RemoteProjectSearchDataSource` via the existing `SupabaseWrapper`. Supporting constants — a dedicated `project_search_history` table name, an RPC function name, and a unique-constraint conflict string — are appended to `DatabaseConstants`. The PR is intentionally scoped to the data layer only and is accompanied by a comprehensive unit test suite covering happy paths, guard conditions, normalization logic, and exception propagation for all four methods.

---

## Changes Overview

### Impact Stats

| Category                     | Value                                                               |
| ---------------------------- | ------------------------------------------------------------------- |
| **Files Changed**            | 4                                                                   |
| **Total Additions**          | 681 lines (+1 since v2)                                             |
| **Production Lines**         | 220 (interface: +31, implementation: +163, constants: +26)          |
| **Test Lines**               | 461 (unchanged from v2)                                             |
| **Commits**                  | 1                                                                   |
| **PR Size Classification**   | **L** (production lines > 200)                                      |
| **Net Change Since v2**      | `TODO(CA-688)` comment added to `getRecentProjectSearches`; interface docstring simplified to plain "50"; `DatabaseConstants` import removed from interface |

---

## Rule-Based Review

| Rule | Status | Notes |
| ---- | ------ | ----- |
| **Rule 1 — Digestible PR** | ⚠️ Borderline | Production lines at 220, unchanged classification. Single-purpose, no practical split. Acknowledged in prior reviews. |
| **Rule 2 — Class Naming Convention** | ✅ Pass | No change from v2. All conventions correctly followed. |
| **Rule 3 — Test Double Pattern** | ✅ Pass | No change from v2. Real implementation, fake external dependency, no mocks or stubs. |
| **Rule 5 — UI & Business Logic Separation** | N/A | No UI or presentation code modified. |
| **Rule 6 — Stream-Based Performance & Lifecycle** | N/A | No streams introduced. |

---
