### PR TITLE
CA-688: feat/project-search-history-bloc-dismiss-save

### DIFF
--- a/lib/features/dashboard/presentation/bloc/project_search_bloc/project_search_bloc.dart
+++ b/lib/features/dashboard/presentation/bloc/project_search_bloc/project_search_bloc.dart
@@ -7,6 +7,7 @@ import 'package:construculator/libraries/logging/app_logger.dart';
 import 'package:construculator/libraries/project/domain/entities/project_entity.dart';
 import 'package:construculator/libraries/project/domain/repositories/project_search_repository.dart';
 import 'package:equatable/equatable.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:rxdart/rxdart.dart';
 
@@ -34,6 +35,11 @@ class ProjectSearchBloc extends Bloc<ProjectSearchEvent, ProjectSearchState> {
   List<String> _cachedRecents = const [];
   List<String> _cachedSuggestions = const [];
 
+  /// Exposed for testing only — resolves when the last save-after-search
+  /// completes, allowing tests to await it instead of using wall-clock waits.
+  @visibleForTesting
+  Future<void>? lastSaveCompleted;
+
   /// Creates a [ProjectSearchBloc] with the given [repository] and [authManager].
   ProjectSearchBloc({
     required ProjectSearchRepository repository,
@@ -55,7 +61,8 @@ class ProjectSearchBloc extends Bloc<ProjectSearchEvent, ProjectSearchState> {
     Emitter<ProjectSearchState> emit,
   ) async {
     if (query.trim().isEmpty) {
-      emit(const ProjectSearchInitial());
+      // Clearing the field restores the history surface rather than blanking it.
+      emit(_initialFromCache());
       return;
     }
     await _executeSearch(query, emit);
@@ -96,23 +103,22 @@ class ProjectSearchBloc extends Bloc<ProjectSearchEvent, ProjectSearchState> {
       _repository.getProjectSearchSuggestions(userId: userId),
     ]);
 
-    final recents = results[0].fold<List<String>>(
+    // On failure, keep the previously cached value so a transient network
+    // hiccup does not blank the history surface.
+    _cachedRecents = results[0].fold<List<String>>(
       (failure) {
         _logger.warning('Failed to load recent project searches: $failure');
-        return const [];
+        return _cachedRecents;
       },
       (terms) => terms,
     );
-    final suggestions = results[1].fold<List<String>>(
+    _cachedSuggestions = results[1].fold<List<String>>(
       (failure) {
         _logger.warning('Failed to load project search suggestions: $failure');
-        return const [];
+        return _cachedSuggestions;
       },
       (terms) => terms,
     );
-
-    _cachedRecents = recents;
-    _cachedSuggestions = suggestions;
 
     emit(_initialFromCache());
   }
@@ -138,16 +144,21 @@ class ProjectSearchBloc extends Bloc<ProjectSearchEvent, ProjectSearchState> {
           'Failed to delete recent project search "${event.searchTerm}": $failure',
         );
       },
-      (_) {
-        final normalized = event.searchTerm.toLowerCase().trim();
-        _cachedRecents = _cachedRecents
-            .where((term) => term.toLowerCase().trim() != normalized)
-            .toList(growable: false);
-        if (state is ProjectSearchInitial) {
-          emit(_initialFromCache());
-        }
-      },
+      (_) => _removeDismissedTermAndEmit(event.searchTerm, emit),
     );
+  }
+
+  void _removeDismissedTermAndEmit(
+    String searchTerm,
+    Emitter<ProjectSearchState> emit,
+  ) {
+    final normalized = searchTerm.toLowerCase().trim();
+    _cachedRecents = _cachedRecents
+        .where((term) => term.toLowerCase().trim() != normalized)
+        .toList(growable: false);
+    if (state is ProjectSearchInitial) {
+      emit(_initialFromCache());
+    }
   }
 
   Future<void> _executeSearch(
@@ -182,13 +193,12 @@ class ProjectSearchBloc extends Bloc<ProjectSearchEvent, ProjectSearchState> {
       },
       (projects) {
         emit(ProjectSearchResultsLoaded(results: projects, query: query));
-        unawaited(
-          _saveSearchToHistory(
-            userId: userId,
-            query: query,
-            hasResults: projects.isNotEmpty,
-          ),
+        lastSaveCompleted = _saveSearchToHistory(
+          userId: userId,
+          query: query,
+          hasResults: projects.isNotEmpty,
         );
+        unawaited(lastSaveCompleted!);
       },
     );
   }
@@ -210,6 +220,7 @@ class ProjectSearchBloc extends Bloc<ProjectSearchEvent, ProjectSearchState> {
         );
       },
       (_) {
+        // Cache stores terms normalised to lowercase; repository receives the original-case query.
         final normalized = query.toLowerCase().trim();
         if (normalized.isEmpty) return;
         final updated = <String>[

--- a/lib/features/dashboard/presentation/bloc/project_search_bloc/project_search_bloc.dart
+++ b/lib/features/dashboard/presentation/bloc/project_search_bloc/project_search_bloc.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:construculator/libraries/auth/domain/types/auth_types.dart';
 import 'package:construculator/libraries/auth/interfaces/auth_manager.dart';
 import 'package:construculator/libraries/errors/failures.dart';
@@ -12,6 +14,9 @@ part 'project_search_event.dart';
 part 'project_search_state.dart';
 
 const Duration _kQueryDebounceDuration = Duration(milliseconds: 300);
+
+/// Upper bound on the cached recents list to prevent unbounded growth.
+const int _kMaxCachedRecents = 20;
 
 EventTransformer<E> _debounce<E>(Duration duration) =>
     (events, mapper) => events.debounceTime(duration).switchMap(mapper);
@@ -42,6 +47,7 @@ class ProjectSearchBloc extends Bloc<ProjectSearchEvent, ProjectSearchState> {
     );
     on<ProjectSearchPerformedEvent>(_onPerformed);
     on<ProjectSearchHistoryRequestedEvent>(_onHistoryRequested);
+    on<ProjectSearchHistoryItemDismissedEvent>(_onHistoryItemDismissed);
   }
 
   Future<void> _handleQuery(
@@ -111,6 +117,39 @@ class ProjectSearchBloc extends Bloc<ProjectSearchEvent, ProjectSearchState> {
     emit(_initialFromCache());
   }
 
+  Future<void> _onHistoryItemDismissed(
+    ProjectSearchHistoryItemDismissedEvent event,
+    Emitter<ProjectSearchState> emit,
+  ) async {
+    final userId = _authManager.getCurrentCredentials().data?.id;
+    if (userId == null || userId.isEmpty) {
+      _logger.warning('History dismiss aborted: no authenticated user');
+      return;
+    }
+
+    final result = await _repository.deleteRecentProjectSearch(
+      userId: userId,
+      searchTerm: event.searchTerm,
+    );
+
+    result.fold(
+      (failure) {
+        _logger.warning(
+          'Failed to delete recent project search "${event.searchTerm}": $failure',
+        );
+      },
+      (_) {
+        final normalized = event.searchTerm.toLowerCase().trim();
+        _cachedRecents = _cachedRecents
+            .where((term) => term.toLowerCase().trim() != normalized)
+            .toList(growable: false);
+        if (state is ProjectSearchInitial) {
+          emit(_initialFromCache());
+        }
+      },
+    );
+  }
+
   Future<void> _executeSearch(
     String query,
     Emitter<ProjectSearchState> emit,
@@ -138,9 +177,53 @@ class ProjectSearchBloc extends Bloc<ProjectSearchEvent, ProjectSearchState> {
       (failure) {
         _logger.warning('Project search failed: $failure');
         emit(ProjectSearchFailureState(failure: failure, query: query));
+        // Skip history save on failure — backend has_results contract requires
+        // a confirmed result set.
       },
-      (projects) =>
-          emit(ProjectSearchResultsLoaded(results: projects, query: query)),
+      (projects) {
+        emit(ProjectSearchResultsLoaded(results: projects, query: query));
+        unawaited(
+          _saveSearchToHistory(
+            userId: userId,
+            query: query,
+            hasResults: projects.isNotEmpty,
+          ),
+        );
+      },
+    );
+  }
+
+  Future<void> _saveSearchToHistory({
+    required String userId,
+    required String query,
+    required bool hasResults,
+  }) async {
+    final saveResult = await _repository.saveRecentProjectSearch(
+      userId: userId,
+      searchTerm: query,
+      hasResults: hasResults,
+    );
+    saveResult.fold(
+      (failure) {
+        _logger.warning(
+          'Failed to save recent project search "$query": $failure',
+        );
+      },
+      (_) {
+        final normalized = query.toLowerCase().trim();
+        if (normalized.isEmpty) return;
+        final updated = <String>[
+          normalized,
+          ..._cachedRecents.where(
+            (term) => term.toLowerCase().trim() != normalized,
+          ),
+        ];
+        if (updated.length > _kMaxCachedRecents) {
+          _cachedRecents = updated.sublist(0, _kMaxCachedRecents);
+        } else {
+          _cachedRecents = updated;
+        }
+      },
     );
   }
 

--- a/lib/features/dashboard/presentation/bloc/project_search_bloc/project_search_event.dart
+++ b/lib/features/dashboard/presentation/bloc/project_search_bloc/project_search_event.dart
@@ -44,3 +44,16 @@ class ProjectSearchHistoryRequestedEvent extends ProjectSearchEvent {
   /// Creates a [ProjectSearchHistoryRequestedEvent].
   const ProjectSearchHistoryRequestedEvent();
 }
+
+/// Dispatched when the user dismisses a single recent-search chip.
+class ProjectSearchHistoryItemDismissedEvent extends ProjectSearchEvent {
+  /// The recent-search term to remove from history.
+  final String searchTerm;
+
+  /// Creates a [ProjectSearchHistoryItemDismissedEvent] with the given
+  /// [searchTerm].
+  const ProjectSearchHistoryItemDismissedEvent({required this.searchTerm});
+
+  @override
+  List<Object?> get props => [searchTerm];
+}

--- a/test/features/dashboard/units/blocs/project_search_bloc_test.dart
+++ b/test/features/dashboard/units/blocs/project_search_bloc_test.dart
@@ -101,6 +101,39 @@ void main() {
       );
 
       blocTest<ProjectSearchBloc, ProjectSearchState>(
+        'emits Initial preserving cached recents when query is cleared after history load',
+        setUp: () {
+          fakeSupabase.addTableData(
+            DatabaseConstants.projectSearchHistoryTable,
+            [
+              {
+                DatabaseConstants.userIdColumn: _testUserId,
+                DatabaseConstants.searchTermColumn: 'wall',
+                DatabaseConstants.updatedAtColumn: '2024-06-01T00:00:00.000Z',
+              },
+            ],
+          );
+          fakeSupabase.setRpcResponse(
+            DatabaseConstants.projectSearchSuggestionsRpcFunction,
+            <dynamic>[],
+          );
+        },
+        build: () => Modular.get<ProjectSearchBloc>(),
+        act: (bloc) async {
+          bloc.add(const ProjectSearchHistoryRequestedEvent());
+          await bloc.stream.firstWhere(
+            (s) => s is ProjectSearchInitial && !s.isLoadingHistory,
+          );
+          bloc.add(const ProjectSearchQueryUpdatedEvent(query: ''));
+        },
+        wait: const Duration(milliseconds: 500),
+        expect: () => [
+          const ProjectSearchInitial(isLoadingHistory: true),
+          const ProjectSearchInitial(recentSearches: ['wall'], suggestions: []),
+        ],
+      );
+
+      blocTest<ProjectSearchBloc, ProjectSearchState>(
         'emits [ProjectSearchLoading, ProjectSearchResultsLoaded] on success after debounce',
         setUp: () {
           fakeSupabase.setRpcResponse(
@@ -411,7 +444,7 @@ void main() {
       );
 
       blocTest<ProjectSearchBloc, ProjectSearchState>(
-        'degrades suggestions to [] when suggestions RPC fails but recents succeed',
+        'keeps stale suggestions cache when suggestions RPC fails but recents succeed',
         setUp: () {
           fakeSupabase.addTableData(
             DatabaseConstants.projectSearchHistoryTable,
@@ -547,9 +580,10 @@ void main() {
           );
         },
         build: () => Modular.get<ProjectSearchBloc>(),
-        act: (bloc) =>
-            bloc.add(const ProjectSearchPerformedEvent(query: 'wall')),
-        wait: const Duration(milliseconds: 50),
+        act: (bloc) async {
+          bloc.add(const ProjectSearchPerformedEvent(query: 'wall'));
+          await bloc.lastSaveCompleted;
+        },
         verify: (_) {
           final upserts = fakeSupabase
               .getMethodCallsFor('upsert')
@@ -578,9 +612,10 @@ void main() {
           );
         },
         build: () => Modular.get<ProjectSearchBloc>(),
-        act: (bloc) =>
-            bloc.add(const ProjectSearchPerformedEvent(query: 'nothing')),
-        wait: const Duration(milliseconds: 50),
+        act: (bloc) async {
+          bloc.add(const ProjectSearchPerformedEvent(query: 'nothing'));
+          await bloc.lastSaveCompleted;
+        },
         verify: (_) {
           final upserts = fakeSupabase
               .getMethodCallsFor('upsert')
@@ -606,7 +641,6 @@ void main() {
         build: () => Modular.get<ProjectSearchBloc>(),
         act: (bloc) =>
             bloc.add(const ProjectSearchPerformedEvent(query: 'wall')),
-        wait: const Duration(milliseconds: 50),
         verify: (_) {
           final upserts = fakeSupabase
               .getMethodCallsFor('upsert')

--- a/test/features/dashboard/units/blocs/project_search_bloc_test.dart
+++ b/test/features/dashboard/units/blocs/project_search_bloc_test.dart
@@ -439,6 +439,187 @@ void main() {
         ],
       );
     });
+
+    // -------------------------------------------------------------------------
+    // ProjectSearchHistoryItemDismissedEvent
+    // -------------------------------------------------------------------------
+
+    group('ProjectSearchHistoryItemDismissedEvent', () {
+      blocTest<ProjectSearchBloc, ProjectSearchState>(
+        'removes term from cached recents and re-emits Initial on success',
+        setUp: () {
+          fakeSupabase.addTableData(
+            DatabaseConstants.projectSearchHistoryTable,
+            [
+              {
+                DatabaseConstants.userIdColumn: _testUserId,
+                DatabaseConstants.searchTermColumn: 'foundation',
+                DatabaseConstants.updatedAtColumn: '2024-06-01T00:00:00.000Z',
+              },
+              {
+                DatabaseConstants.userIdColumn: _testUserId,
+                DatabaseConstants.searchTermColumn: 'wall',
+                DatabaseConstants.updatedAtColumn: '2024-05-01T00:00:00.000Z',
+              },
+            ],
+          );
+          fakeSupabase.setRpcResponse(
+            DatabaseConstants.projectSearchSuggestionsRpcFunction,
+            <dynamic>[],
+          );
+        },
+        build: () => Modular.get<ProjectSearchBloc>(),
+        act: (bloc) async {
+          bloc.add(const ProjectSearchHistoryRequestedEvent());
+          // Wait for the non-loading Initial to land so the cached recents
+          // are populated before we dispatch the dismissal.
+          await bloc.stream.firstWhere(
+            (state) =>
+                state is ProjectSearchInitial && !state.isLoadingHistory,
+          );
+          bloc.add(
+            const ProjectSearchHistoryItemDismissedEvent(
+              searchTerm: 'foundation',
+            ),
+          );
+        },
+        skip: 2,
+        expect: () => [
+          const ProjectSearchInitial(
+            recentSearches: ['wall'],
+            suggestions: [],
+          ),
+        ],
+        verify: (_) {
+          expect(
+            fakeSupabase.getMethodCallsFor('deleteMatch'),
+            hasLength(1),
+          );
+        },
+      );
+
+      blocTest<ProjectSearchBloc, ProjectSearchState>(
+        'emits nothing when no user is authenticated',
+        setUp: () {
+          fakeSupabase.setCurrentUser(null);
+        },
+        build: () => Modular.get<ProjectSearchBloc>(),
+        act: (bloc) => bloc.add(
+          const ProjectSearchHistoryItemDismissedEvent(searchTerm: 'wall'),
+        ),
+        expect: () => <ProjectSearchState>[],
+        verify: (_) {
+          expect(fakeSupabase.getMethodCallsFor('deleteMatch'), isEmpty);
+        },
+      );
+
+      blocTest<ProjectSearchBloc, ProjectSearchState>(
+        'emits nothing when deleteMatch fails',
+        setUp: () {
+          fakeSupabase.shouldThrowOnDeleteMatch = true;
+          fakeSupabase.deleteMatchExceptionType =
+              SupabaseExceptionType.timeout;
+          fakeSupabase.deleteMatchErrorMessage = 'Timeout';
+        },
+        build: () => Modular.get<ProjectSearchBloc>(),
+        act: (bloc) => bloc.add(
+          const ProjectSearchHistoryItemDismissedEvent(searchTerm: 'wall'),
+        ),
+        expect: () => <ProjectSearchState>[],
+      );
+    });
+
+    // -------------------------------------------------------------------------
+    // Save-after-search behavior
+    // -------------------------------------------------------------------------
+
+    group('save-after-search', () {
+      blocTest<ProjectSearchBloc, ProjectSearchState>(
+        'upserts with hasResults=true when search returns non-empty results',
+        setUp: () {
+          fakeSupabase.setRpcResponse(
+            DatabaseConstants.globalSearchRpcFunction,
+            {
+              'projects': [_fakeProjectData(id: 'p-1')],
+              'estimations': [],
+              'members': [],
+            },
+          );
+        },
+        build: () => Modular.get<ProjectSearchBloc>(),
+        act: (bloc) =>
+            bloc.add(const ProjectSearchPerformedEvent(query: 'wall')),
+        wait: const Duration(milliseconds: 50),
+        verify: (_) {
+          final upserts = fakeSupabase
+              .getMethodCallsFor('upsert')
+              .where(
+                (call) =>
+                    call['table'] ==
+                    DatabaseConstants.projectSearchHistoryTable,
+              )
+              .toList();
+          expect(upserts, hasLength(1));
+          final data = upserts.first['data'] as Map<String, dynamic>;
+          expect(data[DatabaseConstants.hasResultsColumn], isTrue);
+          expect(
+            data[DatabaseConstants.searchTermColumn],
+            equals('wall'),
+          );
+        },
+      );
+
+      blocTest<ProjectSearchBloc, ProjectSearchState>(
+        'upserts with hasResults=false when search returns empty results',
+        setUp: () {
+          fakeSupabase.setRpcResponse(
+            DatabaseConstants.globalSearchRpcFunction,
+            {'projects': [], 'estimations': [], 'members': []},
+          );
+        },
+        build: () => Modular.get<ProjectSearchBloc>(),
+        act: (bloc) =>
+            bloc.add(const ProjectSearchPerformedEvent(query: 'nothing')),
+        wait: const Duration(milliseconds: 50),
+        verify: (_) {
+          final upserts = fakeSupabase
+              .getMethodCallsFor('upsert')
+              .where(
+                (call) =>
+                    call['table'] ==
+                    DatabaseConstants.projectSearchHistoryTable,
+              )
+              .toList();
+          expect(upserts, hasLength(1));
+          final data = upserts.first['data'] as Map<String, dynamic>;
+          expect(data[DatabaseConstants.hasResultsColumn], isFalse);
+        },
+      );
+
+      blocTest<ProjectSearchBloc, ProjectSearchState>(
+        'does not upsert when search fails',
+        setUp: () {
+          fakeSupabase.shouldThrowOnRpc = true;
+          fakeSupabase.rpcExceptionType = SupabaseExceptionType.timeout;
+          fakeSupabase.rpcErrorMessage = 'Timeout';
+        },
+        build: () => Modular.get<ProjectSearchBloc>(),
+        act: (bloc) =>
+            bloc.add(const ProjectSearchPerformedEvent(query: 'wall')),
+        wait: const Duration(milliseconds: 50),
+        verify: (_) {
+          final upserts = fakeSupabase
+              .getMethodCallsFor('upsert')
+              .where(
+                (call) =>
+                    call['table'] ==
+                    DatabaseConstants.projectSearchHistoryTable,
+              )
+              .toList();
+          expect(upserts, isEmpty);
+        },
+      );
+    });
   });
 }
 


### PR DESCRIPTION
# PR Review: feat: add dismiss flow and save-after-search to ProjectSearchBloc

**PR:** [#302](https://github.com/ripplearc/construculator-app/pull/302)
**Author:** Bazabizi
**Source Branch:** `CA-688-feat/project-search-history-bloc-dismiss-save`
**Target Branch:** `CA-688-feat/project-search-history-bloc-history-surface`
**Date:** 2026-05-22

---

## Summary

This PR is the second of two focused changes split from the original PR #300. Building on the cache and state infrastructure introduced in PR #301, it adds the dismiss flow via `ProjectSearchHistoryItemDismissedEvent` — which deletes a single term from the backend, applies normalised case-insensitive removal from `_cachedRecents`, and re-emits the idle state — and wires a non-blocking save-after-search side-effect into `_executeSearch` via `unawaited(_saveSearchToHistory(...))`, which persists successful searches to the repository and prepends them to the in-memory cache, capped at `_kMaxCachedRecents = 20` to prevent unbounded growth. Searches that fail are explicitly excluded from history saving.

---

## Changes Overview

| Category | Value |
|---|---|
| Files Changed | 3 |
| Total Additions | 279 |
| Total Deletions | 2 |
| Production Files Changed | 2 |
| Production Lines Added | 98 |
| Production Lines Deleted | 2 |
| Production Lines Changed | 100 |
| Test Lines Added | 181 |
| **PR Size Classification** | **M (100–200 production lines)** |

---

## Rule-Based Review

| Rule | Status | Notes |
|---|---|---|
| **Rule 1 – Digestible PR** | ✅ PASS | PR is classified **M** (100 production lines), within the threshold. The scope is tightly focused on two related behaviours — dismiss and save-after-search — that share the same `_cachedRecents` mutation concern and are correctly delivered together. This is the direct result of the planned split from PR #300. |
| **Rule 2 – Class Naming Convention** | ✅ PASS | `ProjectSearchHistoryItemDismissedEvent` correctly follows the `NounEvent` BLoC pattern with a descriptive name that communicates the user intent. `_saveSearchToHistory` and `_onHistoryItemDismissed` are expressive private method names. `_kMaxCachedRecents` follows the `_kCamelCase` constant convention. No forbidden suffixes present. |
| **Rule 3 – Test Double Pattern** | ✅ PASS | Tests use the real `ProjectSearchBloc` via `Modular.get()` and the real `ProjectSearchRepository`, with only `FakeSupabaseWrapper` as the external substitute. Coverage is thorough: dismiss success (with sequential `HistoryRequested` → `HistoryItemDismissed` dispatch to pre-populate the cache), dismiss when unauthenticated (no repository calls), dismiss when `deleteMatch` fails (no state emitted), save with non-empty results (`hasResults: true`), save with empty results (`hasResults: false`), and no save when search itself fails. No mocks or stubs. |
| **Rule 5 – UI & Business Logic Separation** | ✅ PASS | No UI files are modified. The auth-guard, cache mutation, normalisation logic, and `unawaited` side-effect are all correctly placed inside the BLoC. |
| **Rule 6 – Stream-Based Performance & Lifecycle** | ✅ PASS | `_onHistoryItemDismissed` is correctly registered in the constructor. `unawaited(_saveSearchToHistory(...))` is the correct pattern for a non-blocking, non-critical side-effect that must not delay the primary emit. Cache growth is bounded by `_kMaxCachedRecents = 20`. No `StreamController` instances or dangling subscriptions introduced. |

