### PR TITLE
CA-250: feat: add ProjectErrorType, ProjectFailure, and ProjectSetting

### DIFF
--- a/lib/features/project/domain/usecases/get_project_header_usecase.dart
+++ b/lib/features/project/domain/usecases/get_project_header_usecase.dart
@@ -38,6 +38,8 @@ class GetProjectHeaderUseCase {
       return Right(
         ProjectHeaderData(project: project, userProfile: userProfile),
       );
+    } on Failure catch (failure) {
+      return Left(failure);
     } on TimeoutException {
       return Left(NetworkFailure());
     } on SocketException {

--- a/lib/libraries/errors/failures.dart
+++ b/lib/libraries/errors/failures.dart
@@ -1,6 +1,7 @@
 import 'package:construculator/libraries/auth/domain/types/auth_types.dart';
 import 'package:construculator/libraries/estimation/domain/estimation_error_type.dart';
 import 'package:construculator/libraries/global_search/domain/search_error_type.dart';
+import 'package:construculator/libraries/project/domain/project_error_type.dart';
 import 'package:equatable/equatable.dart';
 
 /// Failure represents specific, anticipated error conditions or alternative outcomes of an operation (e.g., a use case or repository method).
@@ -71,6 +72,18 @@ class SearchFailure extends Failure {
 
   /// Creates a [SearchFailure] with the given [errorType].
   const SearchFailure({required this.errorType});
+
+  @override
+  List<Object?> get props => [errorType];
+}
+
+/// Failure thrown when a project setting operation fails.
+class ProjectFailure extends Failure {
+  /// The type of project error that occurred.
+  final ProjectErrorType errorType;
+
+  /// Creates a [ProjectFailure] with the given [errorType].
+  const ProjectFailure({required this.errorType});
 
   @override
   List<Object?> get props => [errorType];

--- a/lib/libraries/project/data/data_source/interfaces/project_setting_data_source.dart
+++ b/lib/libraries/project/data/data_source/interfaces/project_setting_data_source.dart
@@ -1,0 +1,30 @@
+import 'package:construculator/libraries/project/data/models/project_dto.dart';
+
+/// Provides raw data access for project setting mutations and single-project reads.
+///
+/// Implementations communicate directly with a remote data store (e.g., Supabase).
+/// Methods throw on failure — callers are responsible for converting exceptions
+/// to domain [Failure] objects.
+abstract class ProjectSettingDataSource {
+  /// Fetches the current state of a single project by its [projectId].
+  ///
+  /// Throws if the project does not exist or if a network error occurs.
+  Future<ProjectDto> getProjectSetting(String projectId);
+
+  /// Persists the editable fields of [projectDto] to remote storage.
+  ///
+  /// Returns the updated [ProjectDto] as stored after the write.
+  /// Throws on network or database errors.
+  Future<ProjectDto> updateProject(ProjectDto projectDto);
+
+  /// Permanently deletes the project identified by [projectId].
+  ///
+  /// Throws on network or database errors.
+  Future<void> deleteProject(String projectId);
+
+  /// Emits a void event whenever the project row identified by [projectId]
+  /// changes in remote storage.
+  ///
+  /// Errors from the underlying stream are forwarded to subscribers.
+  Stream<void> watchProjectChanges(String projectId);
+}

--- a/lib/libraries/project/data/data_source/interfaces/project_setting_data_source.dart
+++ b/lib/libraries/project/data/data_source/interfaces/project_setting_data_source.dart
@@ -9,7 +9,7 @@ abstract class ProjectSettingDataSource {
   /// Fetches the current state of a single project by its [projectId].
   ///
   /// Throws if the project does not exist or if a network error occurs.
-  Future<ProjectDto> getProjectSetting(String projectId);
+  Future<ProjectDto> fetchProjectSetting(String projectId);
 
   /// Persists the editable fields of [projectDto] to remote storage.
   ///
@@ -22,9 +22,9 @@ abstract class ProjectSettingDataSource {
   /// Throws on network or database errors.
   Future<void> deleteProject(String projectId);
 
-  /// Emits a void event whenever the project row identified by [projectId]
-  /// changes in remote storage.
+  /// Emits the latest project snapshot whenever the project row identified by
+  /// [projectId] changes in remote storage.
   ///
   /// Errors from the underlying stream are forwarded to subscribers.
-  Stream<void> watchProjectChanges(String projectId);
+  Stream<ProjectDto?> watchProjectChanges(String projectId);
 }

--- a/lib/libraries/project/data/project_error_mapper.dart
+++ b/lib/libraries/project/data/project_error_mapper.dart
@@ -1,0 +1,59 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:construculator/libraries/errors/failures.dart';
+import 'package:construculator/libraries/project/domain/project_error_type.dart';
+import 'package:construculator/libraries/supabase/data/supabase_types.dart';
+import 'package:supabase_flutter/supabase_flutter.dart' as supabase;
+
+/// Maps low-level project data exceptions into typed project failures.
+class ProjectErrorMapper {
+  const ProjectErrorMapper._();
+
+  /// Converts an exception into a typed [ProjectFailure].
+  static ProjectFailure toFailure(Object error) {
+    return ProjectFailure(errorType: toErrorType(error));
+  }
+
+  /// Converts an exception into a typed [ProjectErrorType].
+  static ProjectErrorType toErrorType(Object error) {
+    if (error is TimeoutException) {
+      return ProjectErrorType.timeoutError;
+    }
+
+    if (error is SocketException) {
+      return ProjectErrorType.connectionError;
+    }
+
+    if (error is FormatException || error is TypeError) {
+      return ProjectErrorType.parsingError;
+    }
+
+    if (error is supabase.PostgrestException) {
+      final postgresErrorCode = PostgresErrorCode.fromCode(error.code);
+
+      switch (postgresErrorCode) {
+        case PostgresErrorCode.noDataFound:
+          return ProjectErrorType.notFoundError;
+        case PostgresErrorCode.connectionFailure:
+        case PostgresErrorCode.unableToConnect:
+        case PostgresErrorCode.connectionDoesNotExist:
+          return ProjectErrorType.connectionError;
+        case PostgresErrorCode.uniqueViolation:
+          return ProjectErrorType.unexpectedDatabaseError;
+        case PostgresErrorCode.unknownError:
+          return _isPermissionDenied(error)
+              ? ProjectErrorType.permissionDenied
+              : ProjectErrorType.unexpectedDatabaseError;
+      }
+    }
+
+    return ProjectErrorType.unexpectedError;
+  }
+
+  static bool _isPermissionDenied(supabase.PostgrestException error) {
+    return error.code == '42501' ||
+        error.code == 'PGRST301' ||
+        error.message.toLowerCase().contains('permission denied');
+  }
+}

--- a/lib/libraries/project/data/repositories/project_repository_impl.dart
+++ b/lib/libraries/project/data/repositories/project_repository_impl.dart
@@ -1,8 +1,10 @@
 import 'dart:async';
 
+import 'package:construculator/libraries/errors/failures.dart';
 import 'package:construculator/libraries/logging/app_logger.dart';
 import 'package:construculator/libraries/project/data/data_source/interfaces/permission_data_source.dart';
 import 'package:construculator/libraries/project/data/data_source/interfaces/project_data_source.dart';
+import 'package:construculator/libraries/project/data/project_error_mapper.dart';
 import 'package:construculator/libraries/project/domain/entities/enums.dart';
 import 'package:construculator/libraries/project/domain/entities/project_entity.dart';
 import 'package:construculator/libraries/project/domain/repositories/project_repository.dart';
@@ -51,7 +53,7 @@ class ProjectRepositoryImpl implements ProjectRepository {
         'Error while getting project by id: $id, error: $error',
         stackTrace.toString(),
       );
-      rethrow;
+      throw ProjectErrorMapper.toFailure(error);
     }
   }
 
@@ -83,17 +85,18 @@ class ProjectRepositoryImpl implements ProjectRepository {
         'Error while getting accessible projects: $error',
         stackTrace.toString(),
       );
-      rethrow;
+      throw ProjectErrorMapper.toFailure(error);
     }
   }
 
   @override
   Stream<List<Project>> watchProjects(String userId) {
     _watchUserId = userId;
-    final controller = _projectsController ??= StreamController<List<Project>>.broadcast(
-      onListen: _startWatchingProjectChanges,
-      onCancel: _stopWatchingIfNoListeners,
-    );
+    final controller = _projectsController ??=
+        StreamController<List<Project>>.broadcast(
+          onListen: _startWatchingProjectChanges,
+          onCancel: _stopWatchingIfNoListeners,
+        );
 
     return controller.stream;
   }
@@ -118,7 +121,10 @@ class ProjectRepositoryImpl implements ProjectRepository {
               'Error while watching project changes: $error',
               stackTrace.toString(),
             );
-            _projectsController?.addError(error, stackTrace);
+            _projectsController?.addError(
+              ProjectErrorMapper.toFailure(error),
+              stackTrace,
+            );
           },
         );
 
@@ -156,7 +162,10 @@ class ProjectRepositoryImpl implements ProjectRepository {
             'Error while refreshing accessible projects: $error',
             stackTrace.toString(),
           );
-          _projectsController?.addError(error, stackTrace);
+          _projectsController?.addError(
+            error is Failure ? error : ProjectErrorMapper.toFailure(error),
+            stackTrace,
+          );
           break;
         }
       } while (_hasPendingRefresh);

--- a/lib/libraries/project/domain/project_error_type.dart
+++ b/lib/libraries/project/domain/project_error_type.dart
@@ -1,0 +1,20 @@
+// coverage:ignore-file
+
+/// Error type for project setting operations.
+///
+/// - [connectionError]: network connectivity issues
+/// - [parsingError]: data parsing or mapping failed
+/// - [timeoutError]: the operation timed out
+/// - [unexpectedDatabaseError]: database query or operation failed
+/// - [unexpectedError]: an unclassified error occurred
+/// - [notFoundError]: the requested project does not exist
+/// - [permissionDenied]: user lacks required permission for the operation
+enum ProjectErrorType {
+  connectionError,
+  parsingError,
+  timeoutError,
+  unexpectedDatabaseError,
+  unexpectedError,
+  notFoundError,
+  permissionDenied,
+}

--- a/test/app/shell/app_shell_page_test.dart
+++ b/test/app/shell/app_shell_page_test.dart
@@ -4,6 +4,8 @@ import 'package:construculator/app/shell/app_shell_page.dart';
 import 'package:construculator/app/shell/default_tab_providers.dart';
 import 'package:construculator/app/shell/module_model.dart';
 import 'package:construculator/app/shell/tab_module_manager.dart';
+import 'package:construculator/features/dashboard/domain/usecases/watch_recent_estimations_usecase.dart';
+import 'package:construculator/features/dashboard/presentation/bloc/recent_estimations_bloc/recent_estimations_bloc.dart';
 import 'package:construculator/features/calculations/presentation/pages/calculations_page.dart';
 import 'package:construculator/features/dashboard/presentation/pages/dashboard_page.dart';
 import 'package:construculator/features/estimation/estimation_module.dart';
@@ -17,6 +19,7 @@ import 'package:construculator/libraries/auth/testing/fake_auth_notifier.dart';
 import 'package:construculator/libraries/auth/testing/fake_auth_repository.dart';
 import 'package:construculator/libraries/config/testing/fake_app_config.dart';
 import 'package:construculator/libraries/config/testing/fake_env_loader.dart';
+import 'package:construculator/libraries/estimation/testing/never_estimation_repository.dart';
 import 'package:construculator/libraries/project/interfaces/current_project_notifier.dart';
 import 'package:construculator/libraries/project/presentation/project_ui_provider.dart';
 import 'package:construculator/libraries/project/testing/fake_current_project_notifier.dart';
@@ -72,6 +75,19 @@ class _AppShellTestModule extends Module {
     i.addLazySingleton<AppRouter>(FakeAppRouter.new);
     i.addLazySingleton<CurrentProjectNotifier>(() => currentProjectNotifier);
     i.addLazySingleton<ProjectUIProvider>(() => _FakeProjectUiProvider());
+    i.addLazySingleton<WatchRecentEstimationsUseCase>(
+      () => WatchRecentEstimationsUseCase(
+        NeverEstimationRepository(),
+        i.get<CurrentProjectNotifier>(),
+      ),
+    );
+    i.addLazySingleton<RecentEstimationsBloc>(
+      () => RecentEstimationsBloc(
+        watchRecentEstimationsUseCase: i(),
+        currentProjectNotifier: i(),
+      ),
+      config: BindConfig(onDispose: (bloc) => bloc.close()),
+    );
     i.addLazySingleton<TabModuleManager>(
       () => TabModuleManager(
         appBootstrap,
@@ -304,16 +320,17 @@ void main() {
   });
 
   group('Cost Estimation Tab', () {
-    testWidgets('shows CostEstimationLandingPage when estimation tab is tapped', (
-      tester,
-    ) async {
-      await tester.pumpWidget(makeApp());
-      await tester.pumpAndSettle();
+    testWidgets(
+      'shows CostEstimationLandingPage when estimation tab is tapped',
+      (tester) async {
+        await tester.pumpWidget(makeApp());
+        await tester.pumpAndSettle();
 
-      await tapTabByLabel(tester, l10n().costEstimation);
+        await tapTabByLabel(tester, l10n().costEstimation);
 
-      expect(find.byType(CostEstimationLandingPage), findsOneWidget);
-    });
+        expect(find.byType(CostEstimationLandingPage), findsOneWidget);
+      },
+    );
   });
 
   group('App Bar', () {

--- a/test/libraries/project/units/data/project_error_mapper_test.dart
+++ b/test/libraries/project/units/data/project_error_mapper_test.dart
@@ -1,0 +1,83 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:construculator/libraries/project/data/project_error_mapper.dart';
+import 'package:construculator/libraries/project/domain/project_error_type.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:supabase_flutter/supabase_flutter.dart' as supabase;
+
+void main() {
+  group('ProjectErrorMapper', () {
+    test('maps timeout exceptions to timeoutError', () {
+      expect(
+        ProjectErrorMapper.toErrorType(TimeoutException('request timed out')),
+        ProjectErrorType.timeoutError,
+      );
+    });
+
+    test('maps socket exceptions to connectionError', () {
+      expect(
+        ProjectErrorMapper.toErrorType(
+          const SocketException('connection lost'),
+        ),
+        ProjectErrorType.connectionError,
+      );
+    });
+
+    test('maps format and type errors to parsingError', () {
+      expect(
+        ProjectErrorMapper.toErrorType(
+          const FormatException('invalid payload'),
+        ),
+        ProjectErrorType.parsingError,
+      );
+
+      expect(
+        ProjectErrorMapper.toErrorType(TypeError()),
+        ProjectErrorType.parsingError,
+      );
+    });
+
+    test('maps PostgrestException no-data responses to notFoundError', () {
+      expect(
+        ProjectErrorMapper.toErrorType(
+          const supabase.PostgrestException(
+            message: 'record not found',
+            code: 'PGRST116',
+          ),
+        ),
+        ProjectErrorType.notFoundError,
+      );
+    });
+
+    test('maps permission denied responses to permissionDenied', () {
+      expect(
+        ProjectErrorMapper.toErrorType(
+          const supabase.PostgrestException(
+            message: 'permission denied for table projects',
+            code: '42501',
+          ),
+        ),
+        ProjectErrorType.permissionDenied,
+      );
+    });
+
+    test('maps unknown errors to unexpectedError', () {
+      expect(
+        ProjectErrorMapper.toErrorType(Exception('boom')),
+        ProjectErrorType.unexpectedError,
+      );
+    });
+
+    test('toFailure wraps the mapped error type', () {
+      final failure = ProjectErrorMapper.toFailure(
+        const supabase.PostgrestException(
+          message: 'permission denied for table projects',
+          code: '42501',
+        ),
+      );
+
+      expect(failure.errorType, ProjectErrorType.permissionDenied);
+    });
+  });
+}

--- a/test/libraries/project/units/data/repositories/project_reposiotory_test.dart
+++ b/test/libraries/project/units/data/repositories/project_reposiotory_test.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:construculator/app/app_bootstrap.dart';
+import 'package:construculator/libraries/errors/failures.dart';
 import 'package:construculator/libraries/project/data/data_source/interfaces/permission_data_source.dart';
 import 'package:construculator/libraries/project/data/data_source/interfaces/project_data_source.dart';
 import 'package:construculator/libraries/project/data/data_source/local_jwt_project_permission_data_source.dart';
@@ -161,6 +162,15 @@ void main() {
           );
         },
       );
+
+      test('throws ProjectFailure when owned projects fetch fails', () async {
+        projectDataSource.getOwnedProjectsError = TimeoutException('timeout');
+
+        expect(
+          () => repository.getProjects('user-123'),
+          throwsA(isA<ProjectFailure>()),
+        );
+      });
     });
 
     group('watchProjects', () {
@@ -257,7 +267,7 @@ void main() {
                 if (!firstEmission.isCompleted) firstEmission.complete();
               },
               onError: (error, _) {
-                expect(error, isA<Exception>());
+                expect(error, isA<ProjectFailure>());
                 if (!errorReceived.isCompleted) errorReceived.complete();
               },
             );
@@ -464,6 +474,8 @@ class _FakeProjectDataSource implements ProjectDataSource {
   List<ProjectDto> sharedProjects = [];
   String? lastOwnedUserId;
   String? lastSharedUserId;
+  Object? getOwnedProjectsError;
+  Object? getSharedProjectsError;
   int getOwnedProjectsCalls = 0;
   Completer<void>? firstGetOwnedProjectsStartedCompleter;
   Completer<void>? nextGetOwnedProjectsCompleter;
@@ -474,6 +486,11 @@ class _FakeProjectDataSource implements ProjectDataSource {
   Future<List<ProjectDto>> getOwnedProjects(String userId) async {
     lastOwnedUserId = userId;
     getOwnedProjectsCalls++;
+
+    final error = getOwnedProjectsError;
+    if (error != null) {
+      throw error;
+    }
 
     final snapshot = List<ProjectDto>.from(ownedProjects);
     if (firstGetOwnedProjectsStartedCompleter?.isCompleted == false) {
@@ -492,6 +509,12 @@ class _FakeProjectDataSource implements ProjectDataSource {
   @override
   Future<List<ProjectDto>> getSharedProjects(String userId) async {
     lastSharedUserId = userId;
+
+    final error = getSharedProjectsError;
+    if (error != null) {
+      throw error;
+    }
+
     return sharedProjects;
   }
 


### PR DESCRIPTION
## **PR Summary**

- Adds a `ProjectErrorType` enum, a `ProjectSettingDataSource` interface, and a `ProjectFailure` type to surface project-setting errors across the codebase. Changes touch domain error typing and the errors contract.

**Files changed**
- failures.dart
- project_setting_data_source.dart
- project_error_type.dart
- project_error_mapper.dart

**Positives**
- **Intent:** Clear separation of concerns — domain-level error enum, data-source contract, and a Failure type to carry project error metadata.
- **Docs:** Public methods and enum values include brief comments, improving discoverability.
- **Safety:** `ProjectErrorType` covers common cases (connectivity, parsing, permissions, not-found), which helps consistent error handling.

**Issues & Recommendations**

## REVIEW SUMMARY

| Issue Name | Description | Status | Notes |
|------------|-------------|--------|-------|
| Data-layer method naming | `getProjectSetting` in the data source is ambiguous for a data-layer contract. | :heavy_check_mark:  | Prefer explicit names that indicate side-effects/source (see suggestion). |
| `watchProjectChanges` stream shape | Returns `Stream<void>` — subscriber cannot obtain the updated DTO. | :heavy_check_mark:  | Consider emitting `ProjectDto` (or `ProjectDto?`) so consumers receive new state without extra fetch. |
| Repository/Failure mapping gap | New `ProjectFailure` added but review doesn't show repository mappings or conversion guidance. | :heavy_check_mark:  | Ensure DataSource/Repository convert exceptions to `ProjectErrorType` and produce `ProjectFailure`. |