### PR TITLE
CA-250: feat: add RemoteProjectSettingDataSource

### DIFF
--- a/lib/libraries/errors/exceptions.dart
+++ b/lib/libraries/errors/exceptions.dart
@@ -45,6 +45,14 @@ class ServerException extends AppException {
   ServerException(super.stackTrace, super.exception);
 }
 
+/// Exception thrown when a requested resource does not exist.
+///
+/// Use this exception for expected not-found outcomes so callers can map it to
+/// a not-found failure without treating it as a Sentry-level error.
+class NotFoundException extends AppException {
+  NotFoundException(super.stackTrace, super.exception);
+}
+
 /// Exception thrown when a client error occurs.
 ///
 /// Throw this exception when status of an upstream request

--- a/lib/libraries/project/data/data_source/remote_project_setting_data_source.dart
+++ b/lib/libraries/project/data/data_source/remote_project_setting_data_source.dart
@@ -1,0 +1,114 @@
+import 'package:construculator/libraries/errors/exceptions.dart';
+import 'package:construculator/libraries/logging/app_logger.dart';
+import 'package:construculator/libraries/project/data/data_source/interfaces/project_setting_data_source.dart';
+import 'package:construculator/libraries/project/data/models/project_dto.dart';
+import 'package:construculator/libraries/supabase/database_constants.dart';
+import 'package:construculator/libraries/supabase/interfaces/supabase_wrapper.dart';
+import 'package:rxdart/rxdart.dart';
+import 'package:stack_trace/stack_trace.dart';
+
+class RemoteProjectSettingDataSource implements ProjectSettingDataSource {
+  final SupabaseWrapper _supabaseWrapper;
+  static final _logger = AppLogger().tag('RemoteProjectSettingDataSource');
+
+  const RemoteProjectSettingDataSource({
+    required SupabaseWrapper supabaseWrapper,
+  }) : _supabaseWrapper = supabaseWrapper;
+
+  @override
+  Future<ProjectDto> getProjectSetting(String projectId) async {
+    try {
+      _logger.debug('Getting project setting for projectId: $projectId');
+
+      final row = await _supabaseWrapper.selectSingle(
+        table: DatabaseConstants.projectsTable,
+        filterColumn: DatabaseConstants.idColumn,
+        filterValue: projectId,
+      );
+
+      if (row == null) {
+        throw ServerException(
+          Trace.current(),
+          Exception('Project not found for id: $projectId'),
+        );
+      }
+
+      return ProjectDto.fromJson(row);
+    } catch (error, stackTrace) {
+      _logger.error(
+        'Error while getting project setting for projectId: $projectId, error: $error',
+        stackTrace.toString(),
+      );
+      rethrow;
+    }
+  }
+
+  @override
+  Future<ProjectDto> updateProject(ProjectDto projectDto) async {
+    try {
+      _logger.debug('Updating project with id: ${projectDto.id}');
+
+      final data = <String, dynamic>{
+        DatabaseConstants.projectNameColumn: projectDto.projectName,
+        if (projectDto.description != null)
+          DatabaseConstants.descriptionColumn: projectDto.description,
+        if (projectDto.exportFolderLink != null)
+          DatabaseConstants.exportFolderLinkColumn: projectDto.exportFolderLink,
+        if (projectDto.exportStorageProvider != null)
+          DatabaseConstants.exportStorageProviderColumn:
+              projectDto.exportStorageProvider,
+      };
+
+      final result = await _supabaseWrapper.update(
+        table: DatabaseConstants.projectsTable,
+        data: data,
+        filterColumn: DatabaseConstants.idColumn,
+        filterValue: projectDto.id,
+      );
+
+      return ProjectDto.fromJson(result);
+    } catch (error, stackTrace) {
+      _logger.error(
+        'Error while updating project with id: ${projectDto.id}, error: $error',
+        stackTrace.toString(),
+      );
+      rethrow;
+    }
+  }
+
+  @override
+  Future<void> deleteProject(String projectId) async {
+    try {
+      _logger.debug('Deleting project with id: $projectId');
+
+      await _supabaseWrapper.deleteMatch(
+        table: DatabaseConstants.projectsTable,
+        filters: {DatabaseConstants.idColumn: projectId},
+      );
+    } catch (error, stackTrace) {
+      _logger.error(
+        'Error while deleting project with id: $projectId, error: $error',
+        stackTrace.toString(),
+      );
+      rethrow;
+    }
+  }
+
+  @override
+  Stream<void> watchProjectChanges(String projectId) {
+    return _supabaseWrapper
+        .watchTableFiltered(
+          table: DatabaseConstants.projectsTable,
+          primaryKey: const [DatabaseConstants.idColumn],
+          filterColumn: DatabaseConstants.idColumn,
+          filterValue: projectId,
+        )
+        .map((_) {})
+        .doOnError((Object error, StackTrace stackTrace) {
+          _logger.error(
+            'Error while watching project changes for projectId: $projectId, error: $error',
+            stackTrace.toString(),
+          );
+        });
+  }
+}

--- a/lib/libraries/project/data/data_source/remote_project_setting_data_source.dart
+++ b/lib/libraries/project/data/data_source/remote_project_setting_data_source.dart
@@ -7,16 +7,25 @@ import 'package:construculator/libraries/supabase/interfaces/supabase_wrapper.da
 import 'package:rxdart/rxdart.dart';
 import 'package:stack_trace/stack_trace.dart';
 
+/// Remote data source for reading and mutating a single project's settings.
+///
+/// This layer talks directly to Supabase and throws low-level exceptions that
+/// higher layers map into project failures.
 class RemoteProjectSettingDataSource implements ProjectSettingDataSource {
   final SupabaseWrapper _supabaseWrapper;
   static final _logger = AppLogger().tag('RemoteProjectSettingDataSource');
 
+  /// Creates a remote project setting data source.
   const RemoteProjectSettingDataSource({
     required SupabaseWrapper supabaseWrapper,
   }) : _supabaseWrapper = supabaseWrapper;
 
   @override
-  Future<ProjectDto> getProjectSetting(String projectId) async {
+  /// Fetches a single project setting row by [projectId].
+  ///
+  /// Throws [NotFoundException] when the project does not exist and rethrows
+  /// unexpected Supabase or parsing errors.
+  Future<ProjectDto> fetchProjectSetting(String projectId) async {
     try {
       _logger.debug('Getting project setting for projectId: $projectId');
 
@@ -27,13 +36,16 @@ class RemoteProjectSettingDataSource implements ProjectSettingDataSource {
       );
 
       if (row == null) {
-        throw ServerException(
+        _logger.warning('Project not found for projectId: $projectId');
+        throw NotFoundException(
           Trace.current(),
           Exception('Project not found for id: $projectId'),
         );
       }
 
       return ProjectDto.fromJson(row);
+    } on NotFoundException {
+      rethrow;
     } catch (error, stackTrace) {
       _logger.error(
         'Error while getting project setting for projectId: $projectId, error: $error',
@@ -44,6 +56,10 @@ class RemoteProjectSettingDataSource implements ProjectSettingDataSource {
   }
 
   @override
+  /// Persists the editable project settings in remote storage.
+  ///
+  /// Returns the updated project row as stored remotely and rethrows
+  /// unexpected Supabase or parsing errors.
   Future<ProjectDto> updateProject(ProjectDto projectDto) async {
     try {
       _logger.debug('Updating project with id: ${projectDto.id}');
@@ -77,6 +93,9 @@ class RemoteProjectSettingDataSource implements ProjectSettingDataSource {
   }
 
   @override
+  /// Deletes the project row identified by [projectId].
+  ///
+  /// Throws on unexpected Supabase errors.
   Future<void> deleteProject(String projectId) async {
     try {
       _logger.debug('Deleting project with id: $projectId');
@@ -95,7 +114,11 @@ class RemoteProjectSettingDataSource implements ProjectSettingDataSource {
   }
 
   @override
-  Stream<void> watchProjectChanges(String projectId) {
+  /// Streams the latest project setting snapshot whenever the project row changes.
+  ///
+  /// Emits `null` when the project is deleted or temporarily missing and
+  /// forwards stream errors to subscribers.
+  Stream<ProjectDto?> watchProjectChanges(String projectId) {
     return _supabaseWrapper
         .watchTableFiltered(
           table: DatabaseConstants.projectsTable,
@@ -103,7 +126,7 @@ class RemoteProjectSettingDataSource implements ProjectSettingDataSource {
           filterColumn: DatabaseConstants.idColumn,
           filterValue: projectId,
         )
-        .map((_) {})
+        .map((rows) => rows.isEmpty ? null : ProjectDto.fromJson(rows.first))
         .doOnError((Object error, StackTrace stackTrace) {
           _logger.error(
             'Error while watching project changes for projectId: $projectId, error: $error',

--- a/lib/libraries/project/data/project_error_mapper.dart
+++ b/lib/libraries/project/data/project_error_mapper.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:construculator/libraries/errors/exceptions.dart';
 import 'package:construculator/libraries/errors/failures.dart';
 import 'package:construculator/libraries/project/domain/project_error_type.dart';
 import 'package:construculator/libraries/supabase/data/supabase_types.dart';
@@ -27,6 +28,10 @@ class ProjectErrorMapper {
 
     if (error is FormatException || error is TypeError) {
       return ProjectErrorType.parsingError;
+    }
+
+    if (error is NotFoundException) {
+      return ProjectErrorType.notFoundError;
     }
 
     if (error is supabase.PostgrestException) {

--- a/test/libraries/project/units/data/data_source/remote_project_setting_data_source_test.dart
+++ b/test/libraries/project/units/data/data_source/remote_project_setting_data_source_test.dart
@@ -1,0 +1,252 @@
+import 'dart:async';
+
+import 'package:construculator/libraries/errors/exceptions.dart';
+import 'package:construculator/libraries/project/data/data_source/remote_project_setting_data_source.dart';
+import 'package:construculator/libraries/project/data/models/project_dto.dart';
+import 'package:construculator/libraries/project/domain/entities/enums.dart';
+import 'package:construculator/libraries/supabase/data/supabase_types.dart';
+import 'package:construculator/libraries/supabase/database_constants.dart';
+import 'package:construculator/libraries/supabase/testing/fake_supabase_wrapper.dart';
+import 'package:construculator/libraries/time/testing/fake_clock_impl.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:supabase_flutter/supabase_flutter.dart' as supabase;
+
+void main() {
+  group('RemoteProjectSettingDataSource', () {
+    late FakeClockImpl clock;
+    late FakeSupabaseWrapper supabaseWrapper;
+    late RemoteProjectSettingDataSource dataSource;
+
+    setUp(() {
+      clock = FakeClockImpl(DateTime(2025, 1, 1, 8, 0));
+      supabaseWrapper = FakeSupabaseWrapper(clock: clock);
+      dataSource = RemoteProjectSettingDataSource(
+        supabaseWrapper: supabaseWrapper,
+      );
+    });
+
+    tearDown(() {
+      supabaseWrapper.reset();
+    });
+
+    group('getProjectSetting', () {
+      test('returns ProjectDto when project exists', () async {
+        supabaseWrapper.addTableData(DatabaseConstants.projectsTable, [
+          _projectRow(id: 'project-1', projectName: 'My Project'),
+        ]);
+
+        final result = await dataSource.getProjectSetting('project-1');
+
+        expect(result.id, equals('project-1'));
+        expect(result.projectName, equals('My Project'));
+      });
+
+      test('throws ServerException when project does not exist', () async {
+        await expectLater(
+          dataSource.getProjectSetting('non-existent'),
+          throwsA(isA<ServerException>()),
+        );
+      });
+
+      test('rethrows when selectSingle throws due to shouldReturnNullOnSelect', () async {
+        supabaseWrapper.shouldReturnNullOnSelect = true;
+
+        await expectLater(
+          dataSource.getProjectSetting('project-1'),
+          throwsA(isA<ServerException>()),
+        );
+      });
+
+      test('rethrows PostgrestException from supabaseWrapper', () async {
+        supabaseWrapper.shouldThrowOnSelect = true;
+        supabaseWrapper.selectExceptionType = SupabaseExceptionType.postgrest;
+
+        await expectLater(
+          dataSource.getProjectSetting('project-1'),
+          throwsA(isA<supabase.PostgrestException>()),
+        );
+      });
+    });
+
+    group('updateProject', () {
+      test('calls update with correct table, data map, and filter', () async {
+        supabaseWrapper.addTableData(DatabaseConstants.projectsTable, [
+          _projectRow(id: 'project-1', projectName: 'Old Name'),
+        ]);
+
+        final dto = _projectDto(id: 'project-1', projectName: 'New Name');
+        final result = await dataSource.updateProject(dto);
+
+        expect(result.id, equals('project-1'));
+        expect(result.projectName, equals('New Name'));
+
+        final updateCalls = supabaseWrapper.getMethodCallsFor('update');
+        expect(updateCalls, hasLength(1));
+        expect(
+          updateCalls.first['table'],
+          equals(DatabaseConstants.projectsTable),
+        );
+        expect(
+          updateCalls.first['filterColumn'],
+          equals(DatabaseConstants.idColumn),
+        );
+        expect(updateCalls.first['filterValue'], equals('project-1'));
+      });
+
+      test('includes description in data map when provided', () async {
+        supabaseWrapper.addTableData(DatabaseConstants.projectsTable, [
+          _projectRow(
+            id: 'project-1',
+            projectName: 'Project',
+            description: 'Old desc',
+          ),
+        ]);
+
+        final dto = _projectDto(
+          id: 'project-1',
+          projectName: 'Project',
+          description: 'New desc',
+        );
+        await dataSource.updateProject(dto);
+
+        final updateCalls = supabaseWrapper.getMethodCallsFor('update');
+        final data =
+            updateCalls.first['data'] as Map<String, dynamic>;
+        expect(data[DatabaseConstants.descriptionColumn], equals('New desc'));
+      });
+
+      test('rethrows PostgrestException on shouldThrowOnUpdate', () async {
+        supabaseWrapper.shouldThrowOnUpdate = true;
+        supabaseWrapper.updateExceptionType = SupabaseExceptionType.postgrest;
+
+        final dto = _projectDto(id: 'project-1', projectName: 'Name');
+        await expectLater(
+          dataSource.updateProject(dto),
+          throwsA(isA<supabase.PostgrestException>()),
+        );
+      });
+    });
+
+    group('deleteProject', () {
+      test('calls deleteMatch with correct table and filters', () async {
+        supabaseWrapper.addTableData(DatabaseConstants.projectsTable, [
+          _projectRow(id: 'project-1', projectName: 'To Delete'),
+        ]);
+
+        await dataSource.deleteProject('project-1');
+
+        final deleteMatchCalls =
+            supabaseWrapper.getMethodCallsFor('deleteMatch');
+        expect(deleteMatchCalls, hasLength(1));
+        expect(
+          deleteMatchCalls.first['table'],
+          equals(DatabaseConstants.projectsTable),
+        );
+        expect(
+          (deleteMatchCalls.first['filters']
+              as Map<String, dynamic>)[DatabaseConstants.idColumn],
+          equals('project-1'),
+        );
+      });
+
+      test('rethrows on shouldThrowOnDeleteMatch', () async {
+        supabaseWrapper.shouldThrowOnDeleteMatch = true;
+        supabaseWrapper.deleteMatchExceptionType =
+            SupabaseExceptionType.postgrest;
+
+        await expectLater(
+          dataSource.deleteProject('project-1'),
+          throwsA(isA<supabase.PostgrestException>()),
+        );
+      });
+    });
+
+    group('watchProjectChanges', () {
+      test('emits when project row changes', () async {
+        supabaseWrapper.addTableData(DatabaseConstants.projectsTable, [
+          _projectRow(id: 'project-1', projectName: 'Initial'),
+        ]);
+
+        final emissionCompleter = Completer<void>();
+        var emissionCount = 0;
+        final subscription = dataSource.watchProjectChanges('project-1').listen(
+          (_) {
+            emissionCount++;
+            if (emissionCount >= 2 && !emissionCompleter.isCompleted) {
+              emissionCompleter.complete();
+            }
+          },
+        );
+
+        await pumpEventQueue();
+
+        supabaseWrapper.addTableData(DatabaseConstants.projectsTable, [
+          _projectRow(id: 'project-1', projectName: 'Updated'),
+        ]);
+
+        await expectLater(emissionCompleter.future, completes);
+        await subscription.cancel();
+      });
+
+      test('forwards stream errors to subscribers', () async {
+        final errorCompleter = Completer<Object>();
+        final subscription = dataSource
+            .watchProjectChanges('project-1')
+            .listen(
+              (_) {},
+              onError: (Object error, StackTrace _) {
+                if (!errorCompleter.isCompleted) errorCompleter.complete(error);
+              },
+            );
+
+        await pumpEventQueue();
+
+        supabaseWrapper.shouldEmitStreamErrors = true;
+        supabaseWrapper.addTableData(DatabaseConstants.projectsTable, [
+          _projectRow(id: 'project-1', projectName: 'Trigger'),
+        ]);
+
+        final receivedError = await errorCompleter.future;
+        expect(receivedError, isA<ServerException>());
+        await subscription.cancel();
+      });
+    });
+  });
+}
+
+Map<String, dynamic> _projectRow({
+  required String id,
+  required String projectName,
+  String? description,
+}) {
+  return {
+    DatabaseConstants.idColumn: id,
+    DatabaseConstants.projectNameColumn: projectName,
+    DatabaseConstants.descriptionColumn:
+        description ?? '$projectName description',
+    DatabaseConstants.creatorUserIdColumn: 'user-1',
+    DatabaseConstants.owningCompanyIdColumn: 'company-1',
+    DatabaseConstants.exportFolderLinkColumn: null,
+    DatabaseConstants.exportStorageProviderColumn: null,
+    DatabaseConstants.createdAtColumn: DateTime(2025, 1, 1).toIso8601String(),
+    DatabaseConstants.updatedAtColumn: DateTime(2025, 1, 2).toIso8601String(),
+    DatabaseConstants.statusColumn: 'active',
+  };
+}
+
+ProjectDto _projectDto({
+  required String id,
+  required String projectName,
+  String? description,
+}) {
+  return ProjectDto(
+    id: id,
+    projectName: projectName,
+    description: description,
+    creatorUserId: 'user-1',
+    owningCompanyId: 'company-1',
+    createdAt: DateTime(2025, 1, 1),
+    updatedAt: DateTime(2025, 1, 2),
+    status: ProjectStatus.active,
+  );
+}

--- a/test/libraries/project/units/data/data_source/remote_project_setting_data_source_test.dart
+++ b/test/libraries/project/units/data/data_source/remote_project_setting_data_source_test.dart
@@ -35,34 +35,37 @@ void main() {
           _projectRow(id: 'project-1', projectName: 'My Project'),
         ]);
 
-        final result = await dataSource.getProjectSetting('project-1');
+        final result = await dataSource.fetchProjectSetting('project-1');
 
         expect(result.id, equals('project-1'));
         expect(result.projectName, equals('My Project'));
       });
 
-      test('throws ServerException when project does not exist', () async {
+      test('throws NotFoundException when project does not exist', () async {
         await expectLater(
-          dataSource.getProjectSetting('non-existent'),
-          throwsA(isA<ServerException>()),
+          dataSource.fetchProjectSetting('non-existent'),
+          throwsA(isA<NotFoundException>()),
         );
       });
 
-      test('rethrows when selectSingle throws due to shouldReturnNullOnSelect', () async {
-        supabaseWrapper.shouldReturnNullOnSelect = true;
+      test(
+        'rethrows when selectSingle throws due to shouldReturnNullOnSelect',
+        () async {
+          supabaseWrapper.shouldReturnNullOnSelect = true;
 
-        await expectLater(
-          dataSource.getProjectSetting('project-1'),
-          throwsA(isA<ServerException>()),
-        );
-      });
+          await expectLater(
+            dataSource.fetchProjectSetting('project-1'),
+            throwsA(isA<NotFoundException>()),
+          );
+        },
+      );
 
       test('rethrows PostgrestException from supabaseWrapper', () async {
         supabaseWrapper.shouldThrowOnSelect = true;
         supabaseWrapper.selectExceptionType = SupabaseExceptionType.postgrest;
 
         await expectLater(
-          dataSource.getProjectSetting('project-1'),
+          dataSource.fetchProjectSetting('project-1'),
           throwsA(isA<supabase.PostgrestException>()),
         );
       });
@@ -110,8 +113,7 @@ void main() {
         await dataSource.updateProject(dto);
 
         final updateCalls = supabaseWrapper.getMethodCallsFor('update');
-        final data =
-            updateCalls.first['data'] as Map<String, dynamic>;
+        final data = updateCalls.first['data'] as Map<String, dynamic>;
         expect(data[DatabaseConstants.descriptionColumn], equals('New desc'));
       });
 
@@ -135,8 +137,9 @@ void main() {
 
         await dataSource.deleteProject('project-1');
 
-        final deleteMatchCalls =
-            supabaseWrapper.getMethodCallsFor('deleteMatch');
+        final deleteMatchCalls = supabaseWrapper.getMethodCallsFor(
+          'deleteMatch',
+        );
         expect(deleteMatchCalls, hasLength(1));
         expect(
           deleteMatchCalls.first['table'],
@@ -167,10 +170,12 @@ void main() {
           _projectRow(id: 'project-1', projectName: 'Initial'),
         ]);
 
+        final emissions = <ProjectDto?>[];
         final emissionCompleter = Completer<void>();
         var emissionCount = 0;
         final subscription = dataSource.watchProjectChanges('project-1').listen(
-          (_) {
+          (projectDto) {
+            emissions.add(projectDto);
             emissionCount++;
             if (emissionCount >= 2 && !emissionCompleter.isCompleted) {
               emissionCompleter.complete();
@@ -185,6 +190,8 @@ void main() {
         ]);
 
         await expectLater(emissionCompleter.future, completes);
+        expect(emissions.first?.projectName, equals('Initial'));
+        expect(emissions.last?.projectName, equals('Updated'));
         await subscription.cancel();
       });
 

--- a/test/libraries/project/units/data/project_error_mapper_test.dart
+++ b/test/libraries/project/units/data/project_error_mapper_test.dart
@@ -1,10 +1,12 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:construculator/libraries/errors/exceptions.dart';
 import 'package:construculator/libraries/project/data/project_error_mapper.dart';
 import 'package:construculator/libraries/project/domain/project_error_type.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:supabase_flutter/supabase_flutter.dart' as supabase;
+import 'package:stack_trace/stack_trace.dart';
 
 void main() {
   group('ProjectErrorMapper', () {
@@ -35,6 +37,15 @@ void main() {
       expect(
         ProjectErrorMapper.toErrorType(TypeError()),
         ProjectErrorType.parsingError,
+      );
+    });
+
+    test('maps NotFoundException to notFoundError', () {
+      expect(
+        ProjectErrorMapper.toErrorType(
+          NotFoundException(Trace.current(), Exception('missing project')),
+        ),
+        ProjectErrorType.notFoundError,
       );
     });
 


### PR DESCRIPTION
**PR SUMMARY**

- Adds `RemoteProjectSettingDataSource` (data source for project settings) and unit tests for it. Implements CRUD operations (`getProjectSetting`, `updateProject`, `deleteProject`) and a filtered watch stream via the `SupabaseWrapper`.

**REVIEW — Findings & Recommendations**

- **Naming & layering**
  - ✅ Class name `RemoteProjectSettingDataSource` follows conventions for a data layer `Remote...DataSource`.
  - Suggestion: consider a more explicit data-layer method name for clarity (e.g., `fetchProjectSettingById`) to match Rule 11 (precision at lower levels). This is optional.

- **Error handling & logging (Rule 15)**
  - The expected not-found path is now handled as a non-Sentry outcome by using NotFoundException and warning-level logging.
  - Logging remains confined to the data source, so there is no duplicate Sentry reporting upstream.
  - This resolves the original concern about noisy error reporting for expected DB outcomes.

- **Exceptions rethrow behavior**
  - ✅ The code rethrows exceptions after logging which preserves stack traces upstream; good.
  - Suggestion: when rethrowing, prefer `rethrow` (already used) so stack traces are preserved — keep as-is.

- **Stream handling & performance (Rule 6)**
  - `watchProjectChanges` maps events to `void` and uses `doOnError` for side-effect logging — acceptable.
  - Suggestion: document whether high-frequency updates require throttling (e.g., `distinct()`, `debounceTime()`), depending on typical update rates. If the upstream wrapper already de-duplicates, no action needed.

- **Test Double pattern / unit tests (Rule 3)**
  - ✅ Tests use `FakeSupabaseWrapper` for the external DB wrapper while exercising the real `RemoteProjectSettingDataSource` and `ProjectDto` — this follows the Test Double pattern correctly.
  - Tests cover normal flows, supabase exceptions, and stream errors — good coverage for the data source behavior.
  - Minor suggestion: add a test asserting that an intentional "not found" case maps to the chosen exception type (NotFound vs ServerException) after addressing logging/exception guidance above.

- **Self-documenting code (Rule 7)**
  - Suggest adding brief docstrings for the public class and methods describing purpose and behavior (e.g., whether `getProjectSetting` throws when absent), to improve discoverability and avoid implementation comments.

- **Edge cases**
  - `updateProject` only includes non-null DTO fields in the update payload — this prevents accidental null-writes; ensure callers can clear fields when needed (if clearing is required, consider explicit semantics).
  - Consider validating `projectDto.id` in `updateProject` early and throwing a clear exception if empty.

**Suggested Code Changes (concise)**

- Replace logging level in expected error cases:
  - Example: in `getProjectSetting`, when row is null:
    - Either throw a `NotFoundException` and use `_logger.warning(...)`
    - Or keep current `ServerException` but log with `_logger.warning(...)` instead of `_logger.error(...)`

- Add class/method docstrings:
  - Brief `///` comments on `RemoteProjectSettingDataSource` and each public method describing behavior and exceptions.

**TESTS**
- Tests look well-written and aligned with rules. After the logging/exception decision above, add or update one test to assert the chosen "not found" exception type and that it does not produce an unexpected Sentry-level error.

---

**REVIEW SUMMARY (issues needing author action)**

| Issue Name | Description | Status | Notes |
|------------|-------------|--------|-------|
| Sentry-level logging for expected errors | Data source logged expected outcomes with Sentry-level error reporting. | Agree and Have Addressed | Switched the not-found path to NotFoundException with warning-level logging, and kept logging scoped to the data source to avoid duplicate upstream reporting. |
| Public API docstrings | Public class/methods lacked docstrings describing contract and thrown exceptions. | Agree and Have Addressed | Added brief public API docstrings for the class and methods, including behavior and exception expectations. |