### PR TITLE
CA-250: feat: add FakeProjectSettingDataSource for testing

### DIFF
--- a/lib/libraries/project/testing/fake_project_setting_data_source.dart
+++ b/lib/libraries/project/testing/fake_project_setting_data_source.dart
@@ -10,10 +10,10 @@ class FakeProjectSettingDataSource implements ProjectSettingDataSource {
   /// Tracks method calls for boundary assertions.
   final List<Map<String, dynamic>> _methodCalls = [];
 
-  /// The [ProjectDto] returned by [fetchProjectSetting] and [updateProject].
+  /// Project returned by [fetchProjectSetting] and [updateProject].
   ProjectDto? projectToReturn;
 
-  /// Controls whether [getProjectSetting] throws a [ServerException].
+  /// Controls whether [fetchProjectSetting] throws a [ServerException].
   bool shouldThrowOnGet = false;
 
   /// Controls whether [updateProject] throws a [ServerException].
@@ -25,7 +25,7 @@ class FakeProjectSettingDataSource implements ProjectSettingDataSource {
   /// Controls whether [watchProjectChanges] throws a [ServerException].
   bool shouldThrowOnWatch = false;
 
-  /// Error messages used when the corresponding [shouldThrowOn*] flag is set.
+  /// Error message for [fetchProjectSetting] when [shouldThrowOnGet] is true.
   String? getErrorMessage;
 
   /// Error message for [updateProject] when [shouldThrowOnUpdate] is true.
@@ -40,6 +40,7 @@ class FakeProjectSettingDataSource implements ProjectSettingDataSource {
   /// Creates a [FakeProjectSettingDataSource].
   FakeProjectSettingDataSource();
 
+  /// Returns the configured [projectToReturn] for the given [projectId].
   @override
   Future<ProjectDto> fetchProjectSetting(String projectId) async {
     _methodCalls.add({'method': 'fetchProjectSetting', 'projectId': projectId});
@@ -62,6 +63,7 @@ class FakeProjectSettingDataSource implements ProjectSettingDataSource {
     return project;
   }
 
+  /// Updates a project and returns either [projectToReturn] or [projectDto].
   @override
   Future<ProjectDto> updateProject(ProjectDto projectDto) async {
     _methodCalls.add({'method': 'updateProject', 'projectDto': projectDto});
@@ -76,6 +78,7 @@ class FakeProjectSettingDataSource implements ProjectSettingDataSource {
     return projectToReturn ?? projectDto;
   }
 
+  /// Records deletion of the project with the given [projectId].
   @override
   Future<void> deleteProject(String projectId) async {
     _methodCalls.add({'method': 'deleteProject', 'projectId': projectId});
@@ -88,6 +91,7 @@ class FakeProjectSettingDataSource implements ProjectSettingDataSource {
     }
   }
 
+  /// Watches project changes emitted through [emitChange] and [emitError].
   @override
   Stream<ProjectDto?> watchProjectChanges(String projectId) {
     _methodCalls.add({'method': 'watchProjectChanges', 'projectId': projectId});

--- a/lib/libraries/project/testing/fake_project_setting_data_source.dart
+++ b/lib/libraries/project/testing/fake_project_setting_data_source.dart
@@ -1,0 +1,145 @@
+import 'dart:async';
+
+import 'package:construculator/libraries/errors/exceptions.dart';
+import 'package:construculator/libraries/project/data/data_source/interfaces/project_setting_data_source.dart';
+import 'package:construculator/libraries/project/data/models/project_dto.dart';
+import 'package:stack_trace/stack_trace.dart';
+
+/// Fake implementation of [ProjectSettingDataSource] for testing.
+class FakeProjectSettingDataSource implements ProjectSettingDataSource {
+  /// Tracks method calls for boundary assertions.
+  final List<Map<String, dynamic>> _methodCalls = [];
+
+  /// The [ProjectDto] returned by [getProjectSetting] and [updateProject].
+  ProjectDto? projectToReturn;
+
+  /// Controls whether [getProjectSetting] throws a [ServerException].
+  bool shouldThrowOnGet = false;
+
+  /// Controls whether [updateProject] throws a [ServerException].
+  bool shouldThrowOnUpdate = false;
+
+  /// Controls whether [deleteProject] throws a [ServerException].
+  bool shouldThrowOnDelete = false;
+
+  /// Controls whether [watchProjectChanges] throws a [ServerException].
+  bool shouldThrowOnWatch = false;
+
+  /// Error messages used when the corresponding [shouldThrowOn*] flag is set.
+  String? getErrorMessage;
+
+  /// Error message for [updateProject] when [shouldThrowOnUpdate] is true.
+  String? updateErrorMessage;
+
+  /// Error message for [deleteProject] when [shouldThrowOnDelete] is true.
+  String? deleteErrorMessage;
+
+  final StreamController<void> _changesController =
+      StreamController<void>.broadcast();
+
+  /// Creates a [FakeProjectSettingDataSource].
+  FakeProjectSettingDataSource();
+
+  @override
+  Future<ProjectDto> getProjectSetting(String projectId) async {
+    _methodCalls.add({'method': 'getProjectSetting', 'projectId': projectId});
+
+    if (shouldThrowOnGet) {
+      throw ServerException(
+        Trace.current(),
+        Exception(getErrorMessage ?? 'Get project setting failed'),
+      );
+    }
+
+    final project = projectToReturn;
+    if (project == null) {
+      throw ServerException(
+        Trace.current(),
+        Exception('No project configured in FakeProjectSettingDataSource'),
+      );
+    }
+
+    return project;
+  }
+
+  @override
+  Future<ProjectDto> updateProject(ProjectDto projectDto) async {
+    _methodCalls.add({'method': 'updateProject', 'projectDto': projectDto});
+
+    if (shouldThrowOnUpdate) {
+      throw ServerException(
+        Trace.current(),
+        Exception(updateErrorMessage ?? 'Update project failed'),
+      );
+    }
+
+    return projectToReturn ?? projectDto;
+  }
+
+  @override
+  Future<void> deleteProject(String projectId) async {
+    _methodCalls.add({'method': 'deleteProject', 'projectId': projectId});
+
+    if (shouldThrowOnDelete) {
+      throw ServerException(
+        Trace.current(),
+        Exception(deleteErrorMessage ?? 'Delete project failed'),
+      );
+    }
+  }
+
+  @override
+  Stream<void> watchProjectChanges(String projectId) {
+    _methodCalls.add({
+      'method': 'watchProjectChanges',
+      'projectId': projectId,
+    });
+
+    if (shouldThrowOnWatch) {
+      throw ServerException(
+        Trace.current(),
+        Exception('Watch project changes failed'),
+      );
+    }
+
+    return _changesController.stream;
+  }
+
+  /// Emits a change event to active [watchProjectChanges] subscribers.
+  void emitChange() {
+    _changesController.add(null);
+  }
+
+  /// Emits an error to active [watchProjectChanges] subscribers.
+  void emitError(Object error, [StackTrace? stackTrace]) {
+    _changesController.addError(error, stackTrace);
+  }
+
+  /// Returns a copy of all recorded method calls.
+  List<Map<String, dynamic>> getMethodCalls() => List.from(_methodCalls);
+
+  /// Returns all calls for the given [methodName].
+  List<Map<String, dynamic>> getMethodCallsFor(String methodName) {
+    return _methodCalls
+        .where((call) => call['method'] == methodName)
+        .toList();
+  }
+
+  /// Resets all flags, error messages, data, and recorded calls.
+  void reset() {
+    shouldThrowOnGet = false;
+    shouldThrowOnUpdate = false;
+    shouldThrowOnDelete = false;
+    shouldThrowOnWatch = false;
+    getErrorMessage = null;
+    updateErrorMessage = null;
+    deleteErrorMessage = null;
+    projectToReturn = null;
+    _methodCalls.clear();
+  }
+
+  /// Releases resources held by this fake.
+  void dispose() {
+    _changesController.close();
+  }
+}

--- a/lib/libraries/project/testing/fake_project_setting_data_source.dart
+++ b/lib/libraries/project/testing/fake_project_setting_data_source.dart
@@ -10,7 +10,7 @@ class FakeProjectSettingDataSource implements ProjectSettingDataSource {
   /// Tracks method calls for boundary assertions.
   final List<Map<String, dynamic>> _methodCalls = [];
 
-  /// The [ProjectDto] returned by [getProjectSetting] and [updateProject].
+  /// The [ProjectDto] returned by [fetchProjectSetting] and [updateProject].
   ProjectDto? projectToReturn;
 
   /// Controls whether [getProjectSetting] throws a [ServerException].
@@ -34,15 +34,15 @@ class FakeProjectSettingDataSource implements ProjectSettingDataSource {
   /// Error message for [deleteProject] when [shouldThrowOnDelete] is true.
   String? deleteErrorMessage;
 
-  final StreamController<void> _changesController =
-      StreamController<void>.broadcast();
+  final StreamController<ProjectDto?> _changesController =
+      StreamController<ProjectDto?>.broadcast();
 
   /// Creates a [FakeProjectSettingDataSource].
   FakeProjectSettingDataSource();
 
   @override
-  Future<ProjectDto> getProjectSetting(String projectId) async {
-    _methodCalls.add({'method': 'getProjectSetting', 'projectId': projectId});
+  Future<ProjectDto> fetchProjectSetting(String projectId) async {
+    _methodCalls.add({'method': 'fetchProjectSetting', 'projectId': projectId});
 
     if (shouldThrowOnGet) {
       throw ServerException(
@@ -89,11 +89,8 @@ class FakeProjectSettingDataSource implements ProjectSettingDataSource {
   }
 
   @override
-  Stream<void> watchProjectChanges(String projectId) {
-    _methodCalls.add({
-      'method': 'watchProjectChanges',
-      'projectId': projectId,
-    });
+  Stream<ProjectDto?> watchProjectChanges(String projectId) {
+    _methodCalls.add({'method': 'watchProjectChanges', 'projectId': projectId});
 
     if (shouldThrowOnWatch) {
       throw ServerException(
@@ -107,7 +104,7 @@ class FakeProjectSettingDataSource implements ProjectSettingDataSource {
 
   /// Emits a change event to active [watchProjectChanges] subscribers.
   void emitChange() {
-    _changesController.add(null);
+    _changesController.add(projectToReturn);
   }
 
   /// Emits an error to active [watchProjectChanges] subscribers.
@@ -120,9 +117,7 @@ class FakeProjectSettingDataSource implements ProjectSettingDataSource {
 
   /// Returns all calls for the given [methodName].
   List<Map<String, dynamic>> getMethodCallsFor(String methodName) {
-    return _methodCalls
-        .where((call) => call['method'] == methodName)
-        .toList();
+    return _methodCalls.where((call) => call['method'] == methodName).toList();
   }
 
   /// Resets all flags, error messages, data, and recorded calls.

--- a/test/libraries/project/units/fakes/fake_project_setting_data_source_test.dart
+++ b/test/libraries/project/units/fakes/fake_project_setting_data_source_test.dart
@@ -1,0 +1,210 @@
+import 'dart:async';
+
+import 'package:construculator/libraries/errors/exceptions.dart';
+import 'package:construculator/libraries/project/data/models/project_dto.dart';
+import 'package:construculator/libraries/project/domain/entities/enums.dart';
+import 'package:construculator/libraries/project/testing/fake_project_setting_data_source.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('FakeProjectSettingDataSource', () {
+    late FakeProjectSettingDataSource fake;
+
+    setUp(() {
+      fake = FakeProjectSettingDataSource();
+    });
+
+    tearDown(() {
+      fake.reset();
+      fake.dispose();
+    });
+
+    group('getProjectSetting', () {
+      test('records method call with projectId', () async {
+        fake.projectToReturn = _fakeDto(id: 'p-1');
+
+        await fake.getProjectSetting('p-1');
+
+        final calls = fake.getMethodCallsFor('getProjectSetting');
+        expect(calls, hasLength(1));
+        expect(calls.first['projectId'], equals('p-1'));
+      });
+
+      test('returns projectToReturn when set', () async {
+        final dto = _fakeDto(id: 'p-1', projectName: 'My Project');
+        fake.projectToReturn = dto;
+
+        final result = await fake.getProjectSetting('p-1');
+
+        expect(result.id, equals('p-1'));
+        expect(result.projectName, equals('My Project'));
+      });
+
+      test('throws ServerException when shouldThrowOnGet is true', () async {
+        fake.shouldThrowOnGet = true;
+
+        await expectLater(
+          fake.getProjectSetting('p-1'),
+          throwsA(isA<ServerException>()),
+        );
+      });
+
+      test('throws ServerException with custom message when getErrorMessage is set', () async {
+        fake.shouldThrowOnGet = true;
+        fake.getErrorMessage = 'Custom get error';
+
+        await expectLater(
+          fake.getProjectSetting('p-1'),
+          throwsA(isA<ServerException>()),
+        );
+      });
+
+      test('throws ServerException when projectToReturn is null and no error flag', () async {
+        await expectLater(
+          fake.getProjectSetting('p-1'),
+          throwsA(isA<ServerException>()),
+        );
+      });
+    });
+
+    group('updateProject', () {
+      test('records method call with projectDto', () async {
+        final dto = _fakeDto(id: 'p-1', projectName: 'Updated');
+        fake.projectToReturn = dto;
+
+        await fake.updateProject(dto);
+
+        final calls = fake.getMethodCallsFor('updateProject');
+        expect(calls, hasLength(1));
+        expect(calls.first['projectDto'], equals(dto));
+      });
+
+      test('returns projectToReturn when set', () async {
+        final updated = _fakeDto(id: 'p-1', projectName: 'Returned Name');
+        fake.projectToReturn = updated;
+
+        final result = await fake.updateProject(_fakeDto(id: 'p-1'));
+
+        expect(result.projectName, equals('Returned Name'));
+      });
+
+      test('returns the passed dto when projectToReturn is null', () async {
+        final dto = _fakeDto(id: 'p-1', projectName: 'Fallback');
+
+        final result = await fake.updateProject(dto);
+
+        expect(result.projectName, equals('Fallback'));
+      });
+
+      test('throws ServerException when shouldThrowOnUpdate is true', () async {
+        fake.shouldThrowOnUpdate = true;
+
+        await expectLater(
+          fake.updateProject(_fakeDto(id: 'p-1')),
+          throwsA(isA<ServerException>()),
+        );
+      });
+    });
+
+    group('deleteProject', () {
+      test('records method call with projectId', () async {
+        await fake.deleteProject('p-1');
+
+        final calls = fake.getMethodCallsFor('deleteProject');
+        expect(calls, hasLength(1));
+        expect(calls.first['projectId'], equals('p-1'));
+      });
+
+      test('completes successfully by default', () async {
+        await expectLater(fake.deleteProject('p-1'), completes);
+      });
+
+      test('throws ServerException when shouldThrowOnDelete is true', () async {
+        fake.shouldThrowOnDelete = true;
+
+        await expectLater(
+          fake.deleteProject('p-1'),
+          throwsA(isA<ServerException>()),
+        );
+      });
+    });
+
+    group('watchProjectChanges', () {
+      test('records method call with projectId', () {
+        fake.watchProjectChanges('p-1').listen((_) {});
+
+        final calls = fake.getMethodCallsFor('watchProjectChanges');
+        expect(calls, hasLength(1));
+        expect(calls.first['projectId'], equals('p-1'));
+      });
+
+      test('emits when emitChange is called', () async {
+        final emittedCompleter = Completer<void>();
+        final subscription = fake.watchProjectChanges('p-1').listen((_) {
+          if (!emittedCompleter.isCompleted) emittedCompleter.complete();
+        });
+
+        fake.emitChange();
+
+        await expectLater(emittedCompleter.future, completes);
+        await subscription.cancel();
+      });
+
+      test('forwards errors when emitError is called', () async {
+        final errorCompleter = Completer<Object>();
+        final subscription = fake.watchProjectChanges('p-1').listen(
+          (_) {},
+          onError: (Object error, StackTrace _) {
+            if (!errorCompleter.isCompleted) errorCompleter.complete(error);
+          },
+        );
+
+        fake.emitError(Exception('test error'));
+
+        final receivedError = await errorCompleter.future;
+        expect(receivedError, isA<Exception>());
+        await subscription.cancel();
+      });
+
+      test('throws ServerException when shouldThrowOnWatch is true', () {
+        fake.shouldThrowOnWatch = true;
+
+        expect(
+          () => fake.watchProjectChanges('p-1'),
+          throwsA(isA<ServerException>()),
+        );
+      });
+    });
+
+    group('reset', () {
+      test('clears all flags and recorded calls', () async {
+        fake.shouldThrowOnGet = true;
+        fake.shouldThrowOnUpdate = true;
+        fake.shouldThrowOnDelete = true;
+        fake.getErrorMessage = 'error';
+        fake.projectToReturn = _fakeDto(id: 'p-1');
+        fake.getMethodCallsFor('deleteProject');
+
+        fake.reset();
+
+        expect(fake.shouldThrowOnGet, isFalse);
+        expect(fake.shouldThrowOnUpdate, isFalse);
+        expect(fake.shouldThrowOnDelete, isFalse);
+        expect(fake.getErrorMessage, isNull);
+        expect(fake.projectToReturn, isNull);
+        expect(fake.getMethodCalls(), isEmpty);
+      });
+    });
+  });
+}
+
+ProjectDto _fakeDto({required String id, String? projectName}) {
+  return ProjectDto(
+    id: id,
+    projectName: projectName ?? 'Test Project',
+    creatorUserId: 'user-1',
+    createdAt: DateTime(2025, 1, 1),
+    updatedAt: DateTime(2025, 1, 2),
+    status: ProjectStatus.active,
+  );
+}

--- a/test/libraries/project/units/fakes/fake_project_setting_data_source_test.dart
+++ b/test/libraries/project/units/fakes/fake_project_setting_data_source_test.dart
@@ -19,13 +19,13 @@ void main() {
       fake.dispose();
     });
 
-    group('getProjectSetting', () {
+    group('fetchProjectSetting', () {
       test('records method call with projectId', () async {
         fake.projectToReturn = _fakeDto(id: 'p-1');
 
-        await fake.getProjectSetting('p-1');
+        await fake.fetchProjectSetting('p-1');
 
-        final calls = fake.getMethodCallsFor('getProjectSetting');
+        final calls = fake.getMethodCallsFor('fetchProjectSetting');
         expect(calls, hasLength(1));
         expect(calls.first['projectId'], equals('p-1'));
       });
@@ -34,7 +34,7 @@ void main() {
         final dto = _fakeDto(id: 'p-1', projectName: 'My Project');
         fake.projectToReturn = dto;
 
-        final result = await fake.getProjectSetting('p-1');
+        final result = await fake.fetchProjectSetting('p-1');
 
         expect(result.id, equals('p-1'));
         expect(result.projectName, equals('My Project'));
@@ -44,27 +44,33 @@ void main() {
         fake.shouldThrowOnGet = true;
 
         await expectLater(
-          fake.getProjectSetting('p-1'),
+          fake.fetchProjectSetting('p-1'),
           throwsA(isA<ServerException>()),
         );
       });
 
-      test('throws ServerException with custom message when getErrorMessage is set', () async {
-        fake.shouldThrowOnGet = true;
-        fake.getErrorMessage = 'Custom get error';
+      test(
+        'throws ServerException with custom message when getErrorMessage is set',
+        () async {
+          fake.shouldThrowOnGet = true;
+          fake.getErrorMessage = 'Custom get error';
 
-        await expectLater(
-          fake.getProjectSetting('p-1'),
-          throwsA(isA<ServerException>()),
-        );
-      });
+          await expectLater(
+            fake.fetchProjectSetting('p-1'),
+            throwsA(isA<ServerException>()),
+          );
+        },
+      );
 
-      test('throws ServerException when projectToReturn is null and no error flag', () async {
-        await expectLater(
-          fake.getProjectSetting('p-1'),
-          throwsA(isA<ServerException>()),
-        );
-      });
+      test(
+        'throws ServerException when projectToReturn is null and no error flag',
+        () async {
+          await expectLater(
+            fake.fetchProjectSetting('p-1'),
+            throwsA(isA<ServerException>()),
+          );
+        },
+      );
     });
 
     group('updateProject', () {
@@ -139,25 +145,29 @@ void main() {
       });
 
       test('emits when emitChange is called', () async {
-        final emittedCompleter = Completer<void>();
-        final subscription = fake.watchProjectChanges('p-1').listen((_) {
-          if (!emittedCompleter.isCompleted) emittedCompleter.complete();
+        final emittedCompleter = Completer<ProjectDto?>();
+        final subscription = fake.watchProjectChanges('p-1').listen((dto) {
+          if (!emittedCompleter.isCompleted) emittedCompleter.complete(dto);
         });
 
+        fake.projectToReturn = _fakeDto(id: 'p-1');
         fake.emitChange();
 
-        await expectLater(emittedCompleter.future, completes);
+        final emitted = await emittedCompleter.future;
+        expect(emitted, isA<ProjectDto>());
         await subscription.cancel();
       });
 
       test('forwards errors when emitError is called', () async {
         final errorCompleter = Completer<Object>();
-        final subscription = fake.watchProjectChanges('p-1').listen(
-          (_) {},
-          onError: (Object error, StackTrace _) {
-            if (!errorCompleter.isCompleted) errorCompleter.complete(error);
-          },
-        );
+        final subscription = fake
+            .watchProjectChanges('p-1')
+            .listen(
+              (_) {},
+              onError: (Object error, StackTrace _) {
+                if (!errorCompleter.isCompleted) errorCompleter.complete(error);
+              },
+            );
 
         fake.emitError(Exception('test error'));
 


### PR DESCRIPTION
**1. PR Summary**

This PR adds a fake `ProjectSettingDataSource` plus unit tests for the fake itself. The intent is to support project-setting tests with a controllable test double.

**Review Summary**

| Issue Name | Description | Status | Notes |
|------------|-------------|--------|-------|
| Contract mismatch in `FakeProjectSettingDataSource` | The fake does not implement the current interface contract, so it will not compile. The interface expects `fetchProjectSetting(String)` and `watchProjectChanges(String)` returning `Stream<ProjectDto?>`, but the fake defines `getProjectSetting(String)` and returns `Stream<void>`. This also means the test file is exercising the wrong method name. See [fake_project_setting_data_source.dart](/home/ayana/Documents/work/construculator-app/lib/libraries/project/testing/fake_project_setting_data_source.dart#L43) and [project_setting_data_source.dart](/home/ayana/Documents/work/construculator-app/lib/libraries/project/data/data_source/interfaces/project_setting_data_source.dart#L12). | Agree and Have Addressed | Updated the fake to implement `fetchProjectSetting`, corrected `watchProjectChanges` to return `Stream<ProjectDto?>`, and aligned the unit test to the current contract. |