### PR TITLE
CA-250: feat: add updateProject and deleteProject to repository

### DIFF
--- a/lib/libraries/project/data/data_source/interfaces/permission_data_source.dart
+++ b/lib/libraries/project/data/data_source/interfaces/permission_data_source.dart
@@ -17,6 +17,8 @@ abstract class ProjectPermissionDataSource {
   ///
   /// Convenience method that checks if [permissionKey] exists in the
   /// permissions list for [projectId].
+  /// This must remain synchronous because callers use it as a local JWT claim
+  /// lookup and gate mutations before starting async data-source operations.
   ///
   /// [projectId] The UUID of the project
   /// [permissionKey] The permission key to check (e.g., 'edit_cost_estimation')

--- a/lib/libraries/project/data/repositories/project_setting_repository_impl.dart
+++ b/lib/libraries/project/data/repositories/project_setting_repository_impl.dart
@@ -5,8 +5,11 @@ import 'package:construculator/libraries/either/either.dart';
 import 'package:construculator/libraries/errors/exceptions.dart';
 import 'package:construculator/libraries/errors/failures.dart';
 import 'package:construculator/libraries/logging/app_logger.dart';
+import 'package:construculator/libraries/project/data/data_source/interfaces/permission_data_source.dart';
 import 'package:construculator/libraries/project/data/data_source/interfaces/project_setting_data_source.dart';
+import 'package:construculator/libraries/project/data/models/project_dto.dart';
 import 'package:construculator/libraries/project/domain/entities/project_entity.dart';
+import 'package:construculator/libraries/project/domain/permission_constants.dart';
 import 'package:construculator/libraries/project/domain/project_error_type.dart';
 import 'package:construculator/libraries/project/domain/repositories/project_setting_repository.dart';
 import 'package:construculator/libraries/supabase/data/supabase_types.dart';
@@ -15,11 +18,14 @@ import 'package:supabase_flutter/supabase_flutter.dart' as supabase;
 /// Supabase-backed implementation of [ProjectSettingRepository].
 class ProjectSettingRepositoryImpl implements ProjectSettingRepository {
   final ProjectSettingDataSource _dataSource;
-
+  final ProjectPermissionDataSource _permissionDataSource;
   static final _logger = AppLogger().tag('ProjectSettingRepositoryImpl');
 
-  ProjectSettingRepositoryImpl({required ProjectSettingDataSource dataSource})
-    : _dataSource = dataSource;
+  ProjectSettingRepositoryImpl({
+    required ProjectSettingDataSource dataSource,
+    required ProjectPermissionDataSource permissionDataSource,
+  }) : _dataSource = dataSource,
+       _permissionDataSource = permissionDataSource;
 
   @override
   Future<Either<Failure, Project>> getProjectSetting(String projectId) async {
@@ -35,6 +41,74 @@ class ProjectSettingRepositoryImpl implements ProjectSettingRepository {
         ),
       );
     }
+  }
+
+  @override
+  Future<Either<Failure, Project>> updateProject(Project project) async {
+    final hasPermission = _permissionDataSource.hasProjectPermission(
+      project.id,
+      PermissionConstants.editProject,
+    );
+    if (!hasPermission) {
+      return const Left(
+        ProjectFailure(errorType: ProjectErrorType.permissionDenied),
+      );
+    }
+
+    try {
+      final dto = _toDtoFromEntity(project);
+      final result = await _dataSource.updateProject(dto);
+      return Right(result.toDomain());
+    } catch (error, stackTrace) {
+      return Left(
+        _handleError(
+          error,
+          'updating project with id: ${project.id}',
+          stackTrace,
+        ),
+      );
+    }
+  }
+
+  @override
+  Future<Either<Failure, void>> deleteProject(String projectId) async {
+    final hasPermission = _permissionDataSource.hasProjectPermission(
+      projectId,
+      PermissionConstants.deleteProject,
+    );
+    if (!hasPermission) {
+      return const Left(
+        ProjectFailure(errorType: ProjectErrorType.permissionDenied),
+      );
+    }
+
+    try {
+      await _dataSource.deleteProject(projectId);
+      return const Right(null);
+    } catch (error, stackTrace) {
+      return Left(
+        _handleError(
+          error,
+          'deleting project with id: $projectId',
+          stackTrace,
+        ),
+      );
+    }
+  }
+
+  ProjectDto _toDtoFromEntity(Project project) {
+    return ProjectDto(
+      id: project.id,
+      projectName: project.projectName,
+      description: project.description,
+      creatorUserId: project.creatorUserId,
+      owningCompanyId: project.owningCompanyId,
+      exportFolderLink: project.exportFolderLink,
+      exportStorageProvider: project.exportStorageProvider?.name,
+      createdAt: project.createdAt,
+      updatedAt: project.updatedAt,
+      status: project.status,
+    );
   }
 
   Failure _handleError(Object error, String operation, StackTrace stackTrace) {

--- a/lib/libraries/project/data/repositories/project_setting_repository_impl.dart
+++ b/lib/libraries/project/data/repositories/project_setting_repository_impl.dart
@@ -87,11 +87,7 @@ class ProjectSettingRepositoryImpl implements ProjectSettingRepository {
       return const Right(null);
     } catch (error, stackTrace) {
       return Left(
-        _handleError(
-          error,
-          'deleting project with id: $projectId',
-          stackTrace,
-        ),
+        _handleError(error, 'deleting project with id: $projectId', stackTrace),
       );
     }
   }

--- a/lib/libraries/project/domain/repositories/project_setting_repository.dart
+++ b/lib/libraries/project/domain/repositories/project_setting_repository.dart
@@ -1,11 +1,12 @@
 import 'package:construculator/libraries/either/either.dart';
 import 'package:construculator/libraries/errors/failures.dart';
 import 'package:construculator/libraries/project/domain/entities/project_entity.dart';
+import 'package:construculator/libraries/project/domain/permission_constants.dart';
 
 /// Repository that manages a single project's settings.
 ///
-/// Mutating operations and live updates are introduced in follow-up PRs
-/// of the stack.
+/// Mutating methods perform a permission check before delegating to the
+/// data layer. Permission keys are declared in [PermissionConstants].
 ///
 /// Details: https://ripplearc.youtrack.cloud/issue/CA-250
 abstract class ProjectSettingRepository {
@@ -14,6 +15,20 @@ abstract class ProjectSettingRepository {
   /// Returns [Right] with the [Project] on success, or [Left] with a
   /// [Failure] if the project is not found or a data error occurs.
   Future<Either<Failure, Project>> getProjectSetting(String projectId);
+
+  /// Persists editable fields of [project] to remote storage.
+  ///
+  /// Checks [PermissionConstants.editProject] before delegating.
+  /// Returns [Left] with a [ProjectFailure] whose [errorType] is
+  /// [ProjectErrorType.permissionDenied] when the caller lacks the permission.
+  Future<Either<Failure, Project>> updateProject(Project project);
+
+  /// Permanently deletes the project identified by [projectId].
+  ///
+  /// Checks [PermissionConstants.deleteProject] before delegating.
+  /// Returns [Left] with a [ProjectFailure] whose [errorType] is
+  /// [ProjectErrorType.permissionDenied] when the caller lacks the permission.
+  Future<Either<Failure, void>> deleteProject(String projectId);
 
   /// Releases subscriptions and stream controllers held by this repository.
   void dispose();

--- a/lib/libraries/project/project_library_module.dart
+++ b/lib/libraries/project/project_library_module.dart
@@ -2,10 +2,14 @@ import 'package:construculator/app/app_bootstrap.dart';
 import 'package:construculator/libraries/project/data/current_project_notifier_impl.dart';
 import 'package:construculator/libraries/project/data/data_source/interfaces/permission_data_source.dart';
 import 'package:construculator/libraries/project/data/data_source/interfaces/project_data_source.dart';
+import 'package:construculator/libraries/project/data/data_source/interfaces/project_setting_data_source.dart';
 import 'package:construculator/libraries/project/data/data_source/local_jwt_project_permission_data_source.dart';
 import 'package:construculator/libraries/project/data/data_source/remote_project_data_source.dart';
+import 'package:construculator/libraries/project/data/data_source/remote_project_setting_data_source.dart';
 import 'package:construculator/libraries/project/data/repositories/project_repository_impl.dart';
+import 'package:construculator/libraries/project/data/repositories/project_setting_repository_impl.dart';
 import 'package:construculator/libraries/project/domain/repositories/project_repository.dart';
+import 'package:construculator/libraries/project/domain/repositories/project_setting_repository.dart';
 import 'package:construculator/libraries/project/interfaces/current_project_notifier.dart';
 import 'package:construculator/libraries/supabase/interfaces/supabase_wrapper.dart';
 import 'package:construculator/libraries/supabase/supabase_module.dart';
@@ -48,6 +52,20 @@ void _registerDependencies(Injector i) {
   i.addLazySingleton<ProjectRepository>(
     () => ProjectRepositoryImpl(
       projectDataSource: Modular.get<ProjectDataSource>(),
+      permissionDataSource: Modular.get<ProjectPermissionDataSource>(),
+    ),
+    config: BindConfig(onDispose: (repository) => repository.dispose()),
+  );
+
+  i.addLazySingleton<ProjectSettingDataSource>(
+    () => RemoteProjectSettingDataSource(
+      supabaseWrapper: Modular.get<SupabaseWrapper>(),
+    ),
+  );
+
+  i.addLazySingleton<ProjectSettingRepository>(
+    () => ProjectSettingRepositoryImpl(
+      dataSource: Modular.get<ProjectSettingDataSource>(),
       permissionDataSource: Modular.get<ProjectPermissionDataSource>(),
     ),
     config: BindConfig(onDispose: (repository) => repository.dispose()),

--- a/lib/libraries/project/testing/fake_project_setting_data_source.dart
+++ b/lib/libraries/project/testing/fake_project_setting_data_source.dart
@@ -51,8 +51,9 @@ class FakeProjectSettingDataSource implements ProjectSettingDataSource {
   Future<ProjectDto> fetchProjectSetting(String projectId) async {
     _methodCalls.add({'method': 'fetchProjectSetting', 'projectId': projectId});
 
-    if (exceptionToThrow != null) {
-      throw exceptionToThrow!;
+    final exception = exceptionToThrow;
+    if (exception != null) {
+      throw exception;
     }
 
     if (shouldThrowOnGet) {

--- a/test/libraries/project/units/data/repositories/project_setting_repository_impl_test.dart
+++ b/test/libraries/project/units/data/repositories/project_setting_repository_impl_test.dart
@@ -1,36 +1,45 @@
+import 'package:construculator/app/app_bootstrap.dart';
 import 'package:construculator/libraries/errors/exceptions.dart';
 import 'package:construculator/libraries/errors/failures.dart';
-import 'package:construculator/libraries/project/data/data_source/interfaces/project_setting_data_source.dart';
-import 'package:construculator/libraries/project/data/data_source/remote_project_setting_data_source.dart';
+import 'package:construculator/libraries/project/data/data_source/interfaces/permission_data_source.dart';
 import 'package:construculator/libraries/project/data/repositories/project_setting_repository_impl.dart';
 import 'package:construculator/libraries/project/domain/project_error_type.dart';
+import 'package:construculator/libraries/project/domain/repositories/project_setting_repository.dart';
+import 'package:construculator/libraries/project/project_library_module.dart';
 import 'package:construculator/libraries/project/testing/fake_project_setting_data_source.dart';
 import 'package:construculator/libraries/supabase/data/supabase_types.dart';
 import 'package:construculator/libraries/supabase/database_constants.dart';
+import 'package:construculator/libraries/supabase/interfaces/supabase_wrapper.dart';
 import 'package:construculator/libraries/supabase/testing/fake_supabase_wrapper.dart';
 import 'package:construculator/libraries/time/testing/fake_clock_impl.dart';
+import 'package:flutter_modular/flutter_modular.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:stack_trace/stack_trace.dart';
 
+import '../../../../../utils/fake_app_bootstrap_factory.dart';
+
 void main() {
   group('ProjectSettingRepositoryImpl', () {
-    late ProjectSettingDataSource dataSource;
     late ProjectSettingRepositoryImpl repository;
     late FakeSupabaseWrapper supabaseWrapper;
-    late FakeClockImpl clock;
 
     setUp(() {
-      clock = FakeClockImpl(DateTime(2025, 1, 1));
-      supabaseWrapper = FakeSupabaseWrapper(clock: clock);
-      dataSource = RemoteProjectSettingDataSource(
-        supabaseWrapper: supabaseWrapper,
+      final clock = FakeClockImpl(DateTime(2025, 1, 1));
+      Modular.init(
+        _TestAppModule(
+          FakeAppBootstrapFactory.create(
+            supabaseWrapper: FakeSupabaseWrapper(clock: clock),
+          ),
+        ),
       );
-      repository = ProjectSettingRepositoryImpl(dataSource: dataSource);
+      supabaseWrapper = Modular.get<SupabaseWrapper>() as FakeSupabaseWrapper;
+      repository =
+          Modular.get<ProjectSettingRepository>() as ProjectSettingRepositoryImpl;
+      supabaseWrapper.reset();
     });
 
     tearDown(() {
-      repository.dispose();
-      supabaseWrapper.dispose();
+      Modular.destroy();
     });
 
     group('getProjectSetting', () {
@@ -93,7 +102,11 @@ void main() {
       test('returns Left(UnexpectedFailure) on unknown error', () async {
         final fake = FakeProjectSettingDataSource()
           ..exceptionToThrow = Exception('unknown');
-        final repoWithFake = ProjectSettingRepositoryImpl(dataSource: fake);
+        // ignore: no_direct_instantiation, reason: FakeProjectSettingDataSource is injected to simulate an unclassified exception, which cannot be triggered via FakeSupabaseWrapper
+        final repoWithFake = ProjectSettingRepositoryImpl(
+          dataSource: fake,
+          permissionDataSource: Modular.get<ProjectPermissionDataSource>(),
+        );
 
         final result = await repoWithFake.getProjectSetting('p-1');
 
@@ -104,14 +117,9 @@ void main() {
       });
 
       test('returns Left(notFoundError) on NotFoundException', () async {
-        final fake = FakeProjectSettingDataSource()
-          ..exceptionToThrow = NotFoundException(
-            Trace.current(),
-            Exception('not found'),
-          );
-        final repoWithFake = ProjectSettingRepositoryImpl(dataSource: fake);
-
-        final result = await repoWithFake.getProjectSetting('p-1');
+        // No data added to supabaseWrapper → selectSingle returns null
+        // → RemoteProjectSettingDataSource throws NotFoundException
+        final result = await repository.getProjectSetting('p-1');
 
         expect(result.isLeft(), isTrue);
         result.fold((failure) {
@@ -149,7 +157,11 @@ void main() {
             Trace.current(),
             Exception('network error'),
           );
-        final repoWithFake = ProjectSettingRepositoryImpl(dataSource: fake);
+        // ignore: no_direct_instantiation, reason: FakeProjectSettingDataSource is injected to simulate NetworkException, which cannot be triggered via FakeSupabaseWrapper
+        final repoWithFake = ProjectSettingRepositoryImpl(
+          dataSource: fake,
+          permissionDataSource: Modular.get<ProjectPermissionDataSource>(),
+        );
 
         final result = await repoWithFake.getProjectSetting('p-1');
 
@@ -222,4 +234,12 @@ void main() {
       );
     });
   });
+}
+
+class _TestAppModule extends Module {
+  final AppBootstrap appBootstrap;
+  _TestAppModule(this.appBootstrap);
+
+  @override
+  List<Module> get imports => [ProjectLibraryModule(appBootstrap)];
 }

--- a/test/libraries/project/units/data/repositories/project_setting_repository_impl_test.dart
+++ b/test/libraries/project/units/data/repositories/project_setting_repository_impl_test.dart
@@ -37,7 +37,8 @@ void main() {
       );
       supabaseWrapper = Modular.get<SupabaseWrapper>() as FakeSupabaseWrapper;
       repository =
-          Modular.get<ProjectSettingRepository>() as ProjectSettingRepositoryImpl;
+          Modular.get<ProjectSettingRepository>()
+              as ProjectSettingRepositoryImpl;
       supabaseWrapper.reset();
     });
 
@@ -146,9 +147,7 @@ void main() {
           expect(
             failure,
             equals(
-              const ProjectFailure(
-                errorType: ProjectErrorType.connectionError,
-              ),
+              const ProjectFailure(errorType: ProjectErrorType.connectionError),
             ),
           );
         }, (_) => fail('Expected Left'));
@@ -173,9 +172,7 @@ void main() {
           expect(
             failure,
             equals(
-              const ProjectFailure(
-                errorType: ProjectErrorType.connectionError,
-              ),
+              const ProjectFailure(errorType: ProjectErrorType.connectionError),
             ),
           );
         }, (_) => fail('Expected Left'));
@@ -274,7 +271,7 @@ void main() {
             },
           ]);
 
-          permissionDataSource.setPermissions('p-1', [
+          supabaseWrapper.setProjectPermissions('p-1', [
             PermissionConstants.editProject,
           ]);
 
@@ -326,7 +323,7 @@ void main() {
             },
           ]);
 
-          permissionDataSource.setPermissions('p-1', [
+          supabaseWrapper.setProjectPermissions('p-1', [
             PermissionConstants.deleteProject,
           ]);
 
@@ -351,10 +348,6 @@ void main() {
 class _TestAppModule extends Module {
   final AppBootstrap appBootstrap;
   _TestAppModule(this.appBootstrap);
-
-  void setPermissions(String projectId, List<String> permissions) {
-    _permissions[projectId] = List<String>.from(permissions);
-  }
 
   @override
   List<Module> get imports => [ProjectLibraryModule(appBootstrap)];

--- a/test/libraries/project/units/data/repositories/project_setting_repository_impl_test.dart
+++ b/test/libraries/project/units/data/repositories/project_setting_repository_impl_test.dart
@@ -3,6 +3,9 @@ import 'package:construculator/libraries/errors/exceptions.dart';
 import 'package:construculator/libraries/errors/failures.dart';
 import 'package:construculator/libraries/project/data/data_source/interfaces/permission_data_source.dart';
 import 'package:construculator/libraries/project/data/repositories/project_setting_repository_impl.dart';
+import 'package:construculator/libraries/project/domain/entities/enums.dart';
+import 'package:construculator/libraries/project/domain/entities/project_entity.dart';
+import 'package:construculator/libraries/project/domain/permission_constants.dart';
 import 'package:construculator/libraries/project/domain/project_error_type.dart';
 import 'package:construculator/libraries/project/domain/repositories/project_setting_repository.dart';
 import 'package:construculator/libraries/project/project_library_module.dart';
@@ -233,12 +236,125 @@ void main() {
         },
       );
     });
+
+    group('updateProject', () {
+      test('returns Left(permissionDenied) when permission missing', () async {
+        final project = Project(
+          id: 'p-1',
+          projectName: 'Name',
+          creatorUserId: 'user-1',
+          createdAt: DateTime(2025, 1, 1),
+          updatedAt: DateTime(2025, 1, 1),
+          status: ProjectStatus.active,
+        );
+
+        final result = await repository.updateProject(project);
+
+        expect(result.isLeft(), isTrue);
+        result.fold((failure) {
+          expect(failure, isA<ProjectFailure>());
+          expect(
+            (failure as ProjectFailure).errorType,
+            equals(ProjectErrorType.permissionDenied),
+          );
+        }, (_) => fail('Expected Left'));
+      });
+
+      test(
+        'returns Right(project) when permission present and update succeeds',
+        () async {
+          supabaseWrapper.addTableData(DatabaseConstants.projectsTable, [
+            {
+              DatabaseConstants.idColumn: 'p-1',
+              DatabaseConstants.projectNameColumn: 'Old Name',
+              DatabaseConstants.creatorUserIdColumn: 'user-1',
+              DatabaseConstants.createdAtColumn: DateTime(2025, 1, 1),
+              DatabaseConstants.updatedAtColumn: DateTime(2025, 1, 2),
+              DatabaseConstants.statusColumn: 'active',
+            },
+          ]);
+
+          permissionDataSource.setPermissions('p-1', [
+            PermissionConstants.editProject,
+          ]);
+
+          final project = Project(
+            id: 'p-1',
+            projectName: 'New Name',
+            creatorUserId: 'user-1',
+            createdAt: DateTime(2025, 1, 1),
+            updatedAt: DateTime(2025, 1, 3),
+            status: ProjectStatus.active,
+          );
+
+          final result = await repository.updateProject(project);
+
+          expect(result.isRight(), isTrue);
+          result.fold((_) => fail('Expected Right'), (p) {
+            expect(p.id, equals('p-1'));
+            expect(p.projectName, equals('New Name'));
+          });
+        },
+      );
+    });
+
+    group('deleteProject', () {
+      test('returns Left(permissionDenied) when permission missing', () async {
+        final result = await repository.deleteProject('p-1');
+
+        expect(result.isLeft(), isTrue);
+        result.fold((failure) {
+          expect(failure, isA<ProjectFailure>());
+          expect(
+            (failure as ProjectFailure).errorType,
+            equals(ProjectErrorType.permissionDenied),
+          );
+        }, (_) => fail('Expected Left'));
+      });
+
+      test(
+        'returns Right(null) when permission present and delete succeeds',
+        () async {
+          supabaseWrapper.addTableData(DatabaseConstants.projectsTable, [
+            {
+              DatabaseConstants.idColumn: 'p-1',
+              DatabaseConstants.projectNameColumn: 'ToDelete',
+              DatabaseConstants.creatorUserIdColumn: 'user-1',
+              DatabaseConstants.createdAtColumn: DateTime(2025, 1, 1),
+              DatabaseConstants.updatedAtColumn: DateTime(2025, 1, 2),
+              DatabaseConstants.statusColumn: 'active',
+            },
+          ]);
+
+          permissionDataSource.setPermissions('p-1', [
+            PermissionConstants.deleteProject,
+          ]);
+
+          final result = await repository.deleteProject('p-1');
+
+          expect(result.isRight(), isTrue);
+          result.fold((_) => fail('Expected Right'), (_) => null);
+
+          // ensure row removed from fake supabase
+          final row = await supabaseWrapper.selectSingle(
+            table: DatabaseConstants.projectsTable,
+            filterColumn: DatabaseConstants.idColumn,
+            filterValue: 'p-1',
+          );
+          expect(row, isNull);
+        },
+      );
+    });
   });
 }
 
 class _TestAppModule extends Module {
   final AppBootstrap appBootstrap;
   _TestAppModule(this.appBootstrap);
+
+  void setPermissions(String projectId, List<String> permissions) {
+    _permissions[projectId] = List<String>.from(permissions);
+  }
 
   @override
   List<Module> get imports => [ProjectLibraryModule(appBootstrap)];


### PR DESCRIPTION
**PR SUMMARY**

- Adds write/delete methods to `ProjectSettingRepository` and implements them in project_setting_repository_impl.dart, introducing a `ProjectPermissionDataSource` permission check and DTO mapping.
- Updates the repository interface to declare `updateProject` and `deleteProject`.
- Adjusts unit tests to include a fake permission data source and small refactors to test setup.

**REVIEW — Key Findings & Recommendations**

- **Potential Async Bug:** The repo calls `_permissionDataSource.hasProjectPermission(...)` as a synchronous method. Confirm `ProjectPermissionDataSource.hasProjectPermission` is synchronous; if it is async (returns `Future<bool>`), change calls to `await _permissionDataSource.hasProjectPermission(...)` and make the methods `async` accordingly.
  - Files: project_setting_repository_impl.dart
- **Missing unit coverage for new behavior:** There are no tests exercising `updateProject` / `deleteProject` success and permission-denied branches. Add unit tests that:
  - Verify allowed path: permission present → dataSource called → returns Right.
  - Verify denied path: permission absent → returns Left(ProjectFailure with permissionDenied).
  - Verify unexpected data-source errors map to appropriate Failures.
  - File to update: project_setting_repository_impl_test.dart
- **Test double correctness & pattern:** Introduced `_FakeProjectPermissionDataSource` is appropriate (permission check is an external dependency). Ensure tests continue to follow the Test Double pattern: keep real `RemoteProjectSettingDataSource` where intended and only fake external systems (supabase wrapper, permission DS).
  - Verify the fake exposes helpers to set permissions per-project in tests (e.g., `permissionDataSource.allow(projectId, PermissionConstants.editProject)`).
- **Logging / Sentry usage:** Repository logs unexpected exceptions with `_logger.error(...)` which sends Sentry events. Confirm that underlying `DataSource` does not also call `error()` for the same unexpected exceptions to avoid duplicate Sentry events (rule 15). If DataSource already logs, prefer repository to use `warning()` or avoid duplicate logging.
  - File: project_setting_repository_impl.dart
- **DTO mapping sanity check:** `_toDtoFromEntity` maps `exportStorageProvider?.name`. Confirm enum-to-string mapping matches the DataSource expectation and nullability is correct for createdAt/updatedAt fields.
  - File: project_setting_repository_impl.dart
- **API contract & docs:** Public interface methods `updateProject`/`deleteProject` docstrings were added — good. Ensure callers of `ProjectSettingRepository` are updated where necessary and that permission semantics are documented for consumers.
  - File: project_setting_repository.dart
- **Test file structure:** The test file changes show reorganization and the addition of the fake permission DS. Verify the test file compiles: ensure no accidental trailing/removed tests (the diff removed several error-code mapping tests — confirm they were intentionally removed and covered elsewhere).

**Actionable Suggestions (small code examples)**

- If `hasProjectPermission` is async, update usage:
  - Suggested change in repository methods:
    - Make permission calls awaitable:
      - `final hasPermission = await _permissionDataSource.hasProjectPermission(...);`
- Add minimal tests (example test cases to add):
  - Permission denied for update → expect Left(ProjectFailure(permissionDenied))
  - Permission granted for update → verify `_dataSource.updateProject` called and Right(Project) returned
  - Same for `deleteProject`.

**REVIEW SUMMARY (issues to address)**

| Issue Name | Description | Status | Notes |
|------------|-------------|--------|-------|
| Potential async permission call | Repository treats permission check as synchronous; breakage if interface is async | :heavy_check_mark:  | Ensure `ProjectPermissionDataSource` signature matches usage or update calls to `await` |
| Missing unit tests for new flows | No tests exercising success and permission-denied branches for `updateProject` / `deleteProject` | :heavy_check_mark: | Add tests using `_FakeProjectPermissionDataSource` to cover both branches |
| Possible duplicate Sentry logging | Repository calls `error()` on catch; ensure DataSource does not also log same exception | :heavy_check_mark:  | If DataSource logs, avoid duplicating Sentry events; prefer `warning()` for expected API errors |
| Verify DTO mapping | Confirm `exportStorageProvider?.name` and timestamp nullability match DataSource contract | :heavy_check_mark:  | Small review with DataSource/DTO definitions recommended |