### PR TITLE
CA-250: feat: add watchProjectSetting live updates

### DIFF
--- a/lib/libraries/project/data/repositories/project_setting_repository_impl.dart
+++ b/lib/libraries/project/data/repositories/project_setting_repository_impl.dart
@@ -37,6 +37,8 @@ class ProjectSettingRepositoryImpl implements ProjectSettingRepository {
       final dto = await _dataSource.fetchProjectSetting(projectId);
       return Right(dto.toDomain());
     } catch (error, stackTrace) {
+      // Log raw error and stack trace before domain mapping so diagnostics
+      // keep the original exception details instead of only the mapped Failure.
       _logger.warning(
         'Error while getting project setting for projectId: $projectId',
         error,
@@ -63,6 +65,8 @@ class ProjectSettingRepositoryImpl implements ProjectSettingRepository {
       final result = await _dataSource.updateProject(dto);
       return Right(result.toDomain());
     } catch (error, stackTrace) {
+      // Log raw error and stack trace before domain mapping so diagnostics
+      // keep the original exception details instead of only the mapped Failure.
       _logger.warning(
         'Error while updating project with id: ${project.id}',
         error,
@@ -88,6 +92,8 @@ class ProjectSettingRepositoryImpl implements ProjectSettingRepository {
       await _dataSource.deleteProject(projectId);
       return const Right(null);
     } catch (error, stackTrace) {
+      // Log raw error and stack trace before domain mapping so diagnostics
+      // keep the original exception details instead of only the mapped Failure.
       _logger.warning(
         'Error while deleting project with id: $projectId',
         error,
@@ -100,15 +106,17 @@ class ProjectSettingRepositoryImpl implements ProjectSettingRepository {
   @override
   Stream<Either<Failure, Project>> watchProjectSetting(String projectId) {
     final existing = _settingControllers[projectId];
-    if (existing != null && !existing.isClosed) {
-      return existing.stream;
+    if (existing?.isClosed == true) {
+      _settingControllers.remove(projectId);
     }
 
-    final controller = StreamController<Either<Failure, Project>>.broadcast(
-      onListen: () => _startWatchingSettingChanges(projectId),
-      onCancel: () => _stopWatchingIfNoListeners(projectId),
+    final controller = _settingControllers.putIfAbsent(
+      projectId,
+      () => StreamController<Either<Failure, Project>>.broadcast(
+        onListen: () => _startWatchingSettingChanges(projectId),
+        onCancel: () => _stopWatchingIfNoListeners(projectId),
+      ),
     );
-    _settingControllers[projectId] = controller;
     return controller.stream;
   }
 
@@ -127,7 +135,10 @@ class ProjectSettingRepositoryImpl implements ProjectSettingRepository {
               error,
               stackTrace,
             );
-            _settingControllers[projectId]?.addError(error, stackTrace);
+            final controller = _settingControllers[projectId];
+            if (controller?.isClosed == false) {
+              controller?.addError(error, stackTrace);
+            }
           },
         );
 

--- a/lib/libraries/project/data/repositories/project_setting_repository_impl.dart
+++ b/lib/libraries/project/data/repositories/project_setting_repository_impl.dart
@@ -21,9 +21,9 @@ class ProjectSettingRepositoryImpl implements ProjectSettingRepository {
   final ProjectPermissionDataSource _permissionDataSource;
   static final _logger = AppLogger().tag('ProjectSettingRepositoryImpl');
 
-  StreamController<Either<Failure, Project>>? _settingController;
-  StreamSubscription<ProjectDto?>? _changesSubscription;
-  String? _watchedProjectId;
+  final Map<String, StreamController<Either<Failure, Project>>>
+  _settingControllers = {};
+  final Map<String, StreamSubscription<ProjectDto?>> _changesSubscriptions = {};
 
   ProjectSettingRepositoryImpl({
     required ProjectSettingDataSource dataSource,
@@ -99,59 +99,55 @@ class ProjectSettingRepositoryImpl implements ProjectSettingRepository {
 
   @override
   Stream<Either<Failure, Project>> watchProjectSetting(String projectId) {
-    _watchedProjectId = projectId;
-    final controller = _settingController ??=
-        StreamController<Either<Failure, Project>>.broadcast(
-          onListen: _startWatchingSettingChanges,
-          onCancel: _stopWatchingIfNoListeners,
-        );
+    final existing = _settingControllers[projectId];
+    if (existing != null && !existing.isClosed) {
+      return existing.stream;
+    }
+
+    final controller = StreamController<Either<Failure, Project>>.broadcast(
+      onListen: () => _startWatchingSettingChanges(projectId),
+      onCancel: () => _stopWatchingIfNoListeners(projectId),
+    );
+    _settingControllers[projectId] = controller;
     return controller.stream;
   }
 
-  void _startWatchingSettingChanges() {
-    if (_changesSubscription != null) {
+  void _startWatchingSettingChanges(String projectId) {
+    if (_changesSubscriptions.containsKey(projectId)) {
       return;
     }
 
-    final projectId = _watchedProjectId;
-    if (projectId == null || projectId.isEmpty) {
-      return;
-    }
-
-    _changesSubscription = _dataSource
+    _changesSubscriptions[projectId] = _dataSource
         .watchProjectChanges(projectId)
         .listen(
-          (_) => _refreshProjectSetting(),
+          (_) => _refreshProjectSetting(projectId),
           onError: (Object error, StackTrace stackTrace) {
-            _logger.error(
+            _logger.warning(
               'Error while watching project setting changes for projectId: $projectId',
               error,
               stackTrace,
             );
-            _settingController?.addError(error, stackTrace);
+            _settingControllers[projectId]?.addError(error, stackTrace);
           },
         );
 
-    _refreshProjectSetting();
+    _refreshProjectSetting(projectId);
   }
 
-  void _stopWatchingIfNoListeners() {
-    if (_settingController?.hasListener == true) {
+  void _stopWatchingIfNoListeners(String projectId) {
+    final controller = _settingControllers[projectId];
+    if (controller?.hasListener == true) {
       return;
     }
-    _changesSubscription?.cancel();
-    _changesSubscription = null;
-    _watchedProjectId = null;
+    _changesSubscriptions.remove(projectId)?.cancel();
+    _settingControllers.remove(projectId);
   }
 
-  Future<void> _refreshProjectSetting() async {
-    final projectId = _watchedProjectId;
-    if (projectId == null || projectId.isEmpty) {
-      return;
-    }
+  Future<void> _refreshProjectSetting(String projectId) async {
     final result = await getProjectSetting(projectId);
-    if (_settingController?.isClosed == false) {
-      _settingController?.add(result);
+    final controller = _settingControllers[projectId];
+    if (controller?.isClosed == false) {
+      controller?.add(result);
     }
   }
 
@@ -225,10 +221,13 @@ class ProjectSettingRepositoryImpl implements ProjectSettingRepository {
 
   @override
   void dispose() {
-    _changesSubscription?.cancel();
-    _changesSubscription = null;
-    _settingController?.close();
-    _settingController = null;
-    _watchedProjectId = null;
+    for (final subscription in _changesSubscriptions.values) {
+      subscription.cancel();
+    }
+    _changesSubscriptions.clear();
+    for (final controller in _settingControllers.values) {
+      controller.close();
+    }
+    _settingControllers.clear();
   }
 }

--- a/lib/libraries/project/data/repositories/project_setting_repository_impl.dart
+++ b/lib/libraries/project/data/repositories/project_setting_repository_impl.dart
@@ -21,6 +21,10 @@ class ProjectSettingRepositoryImpl implements ProjectSettingRepository {
   final ProjectPermissionDataSource _permissionDataSource;
   static final _logger = AppLogger().tag('ProjectSettingRepositoryImpl');
 
+  StreamController<Either<Failure, Project>>? _settingController;
+  StreamSubscription<ProjectDto?>? _changesSubscription;
+  String? _watchedProjectId;
+
   ProjectSettingRepositoryImpl({
     required ProjectSettingDataSource dataSource,
     required ProjectPermissionDataSource permissionDataSource,
@@ -33,13 +37,12 @@ class ProjectSettingRepositoryImpl implements ProjectSettingRepository {
       final dto = await _dataSource.fetchProjectSetting(projectId);
       return Right(dto.toDomain());
     } catch (error, stackTrace) {
-      return Left(
-        _handleError(
-          error,
-          'getting project setting for projectId: $projectId',
-          stackTrace,
-        ),
+      _logger.warning(
+        'Error while getting project setting for projectId: $projectId',
+        error,
+        stackTrace,
       );
+      return Left(_handleError(error, 'getting project setting'));
     }
   }
 
@@ -60,13 +63,12 @@ class ProjectSettingRepositoryImpl implements ProjectSettingRepository {
       final result = await _dataSource.updateProject(dto);
       return Right(result.toDomain());
     } catch (error, stackTrace) {
-      return Left(
-        _handleError(
-          error,
-          'updating project with id: ${project.id}',
-          stackTrace,
-        ),
+      _logger.warning(
+        'Error while updating project with id: ${project.id}',
+        error,
+        stackTrace,
       );
+      return Left(_handleError(error, 'updating project'));
     }
   }
 
@@ -86,9 +88,70 @@ class ProjectSettingRepositoryImpl implements ProjectSettingRepository {
       await _dataSource.deleteProject(projectId);
       return const Right(null);
     } catch (error, stackTrace) {
-      return Left(
-        _handleError(error, 'deleting project with id: $projectId', stackTrace),
+      _logger.warning(
+        'Error while deleting project with id: $projectId',
+        error,
+        stackTrace,
       );
+      return Left(_handleError(error, 'deleting project'));
+    }
+  }
+
+  @override
+  Stream<Either<Failure, Project>> watchProjectSetting(String projectId) {
+    _watchedProjectId = projectId;
+    final controller = _settingController ??=
+        StreamController<Either<Failure, Project>>.broadcast(
+          onListen: _startWatchingSettingChanges,
+          onCancel: _stopWatchingIfNoListeners,
+        );
+    return controller.stream;
+  }
+
+  void _startWatchingSettingChanges() {
+    if (_changesSubscription != null) {
+      return;
+    }
+
+    final projectId = _watchedProjectId;
+    if (projectId == null || projectId.isEmpty) {
+      return;
+    }
+
+    _changesSubscription = _dataSource
+        .watchProjectChanges(projectId)
+        .listen(
+          (_) => _refreshProjectSetting(),
+          onError: (Object error, StackTrace stackTrace) {
+            _logger.error(
+              'Error while watching project setting changes for projectId: $projectId',
+              error,
+              stackTrace,
+            );
+            _settingController?.addError(error, stackTrace);
+          },
+        );
+
+    _refreshProjectSetting();
+  }
+
+  void _stopWatchingIfNoListeners() {
+    if (_settingController?.hasListener == true) {
+      return;
+    }
+    _changesSubscription?.cancel();
+    _changesSubscription = null;
+    _watchedProjectId = null;
+  }
+
+  Future<void> _refreshProjectSetting() async {
+    final projectId = _watchedProjectId;
+    if (projectId == null || projectId.isEmpty) {
+      return;
+    }
+    final result = await getProjectSetting(projectId);
+    if (_settingController?.isClosed == false) {
+      _settingController?.add(result);
     }
   }
 
@@ -107,59 +170,39 @@ class ProjectSettingRepositoryImpl implements ProjectSettingRepository {
     );
   }
 
-  Failure _handleError(Object error, String operation, StackTrace stackTrace) {
+  Failure _handleError(Object error, String operation) {
     if (error is NotFoundException) {
-      _logger.warning(
-        'Not found $operation: ${error.exception}',
-        error,
-        stackTrace,
-      );
+      _logger.warning('Not found $operation: ${error.exception}');
       return const ProjectFailure(errorType: ProjectErrorType.notFoundError);
     }
 
     if (error is ServerException) {
-      _logger.warning(
-        'Server error $operation: ${error.exception}',
-        error,
-        stackTrace,
-      );
+      _logger.warning('Server error $operation: ${error.exception}');
       return const ProjectFailure(
         errorType: ProjectErrorType.unexpectedDatabaseError,
       );
     }
 
     if (error is TimeoutException) {
-      _logger.warning(
-        'Timeout error $operation: ${error.message}',
-        error,
-        stackTrace,
-      );
+      _logger.warning('Timeout error $operation: ${error.message}');
       return const ProjectFailure(errorType: ProjectErrorType.timeoutError);
     }
 
     if (error is SocketException || error is NetworkException) {
       _logger.warning(
         'Connection error $operation: ${error is SocketException ? (error).message : error.toString()}',
-        error,
-        stackTrace,
       );
       return const ProjectFailure(errorType: ProjectErrorType.connectionError);
     }
 
     if (error is TypeError) {
-      _logger.warning(
-        'Parsing error $operation: ${error.toString()}',
-        error,
-        stackTrace,
-      );
+      _logger.warning('Parsing error $operation: ${error.toString()}');
       return const ProjectFailure(errorType: ProjectErrorType.parsingError);
     }
 
     if (error is supabase.PostgrestException) {
       _logger.warning(
         'PostgreSQL error $operation: code=${error.code}, message=${error.message}',
-        error,
-        stackTrace,
       );
       final postgresErrorCode = PostgresErrorCode.fromCode(error.code);
       if (postgresErrorCode == PostgresErrorCode.noDataFound) {
@@ -176,12 +219,16 @@ class ProjectSettingRepositoryImpl implements ProjectSettingRepository {
       );
     }
 
-    _logger.error('Unexpected error $operation: $error', error, stackTrace);
+    _logger.error('Unexpected error $operation: $error');
     return UnexpectedFailure();
   }
 
   @override
   void dispose() {
-    // No subscriptions or stream controllers to release in the read-only MVP.
+    _changesSubscription?.cancel();
+    _changesSubscription = null;
+    _settingController?.close();
+    _settingController = null;
+    _watchedProjectId = null;
   }
 }

--- a/lib/libraries/project/domain/repositories/project_setting_repository.dart
+++ b/lib/libraries/project/domain/repositories/project_setting_repository.dart
@@ -30,6 +30,13 @@ abstract class ProjectSettingRepository {
   /// [ProjectErrorType.permissionDenied] when the caller lacks the permission.
   Future<Either<Failure, void>> deleteProject(String projectId);
 
+  /// Emits the current project state and re-emits on every remote change.
+  ///
+  /// Emits [Right] with the updated [Project] on each change, or [Left] with
+  /// a [Failure] if a fetch error occurs. Stream errors from the underlying
+  /// data source are forwarded to subscribers.
+  Stream<Either<Failure, Project>> watchProjectSetting(String projectId);
+
   /// Releases subscriptions and stream controllers held by this repository.
   void dispose();
 }

--- a/test/libraries/project/units/data/repositories/project_setting_repository_impl_test.dart
+++ b/test/libraries/project/units/data/repositories/project_setting_repository_impl_test.dart
@@ -1,63 +1,48 @@
-import 'package:construculator/app/app_bootstrap.dart';
+import 'dart:async';
+import 'dart:io';
+
 import 'package:construculator/libraries/errors/exceptions.dart';
 import 'package:construculator/libraries/errors/failures.dart';
 import 'package:construculator/libraries/project/data/data_source/interfaces/permission_data_source.dart';
+import 'package:construculator/libraries/project/data/data_source/interfaces/project_setting_data_source.dart';
+import 'package:construculator/libraries/project/data/models/project_dto.dart';
 import 'package:construculator/libraries/project/data/repositories/project_setting_repository_impl.dart';
 import 'package:construculator/libraries/project/domain/entities/enums.dart';
 import 'package:construculator/libraries/project/domain/entities/project_entity.dart';
 import 'package:construculator/libraries/project/domain/permission_constants.dart';
 import 'package:construculator/libraries/project/domain/project_error_type.dart';
 import 'package:construculator/libraries/project/domain/repositories/project_setting_repository.dart';
-import 'package:construculator/libraries/project/project_library_module.dart';
-import 'package:construculator/libraries/project/testing/fake_project_setting_data_source.dart';
 import 'package:construculator/libraries/supabase/data/supabase_types.dart';
-import 'package:construculator/libraries/supabase/database_constants.dart';
-import 'package:construculator/libraries/supabase/interfaces/supabase_wrapper.dart';
-import 'package:construculator/libraries/supabase/testing/fake_supabase_wrapper.dart';
-import 'package:construculator/libraries/time/testing/fake_clock_impl.dart';
 import 'package:flutter_modular/flutter_modular.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:stack_trace/stack_trace.dart';
-
-import '../../../../../utils/fake_app_bootstrap_factory.dart';
+import 'package:supabase_flutter/supabase_flutter.dart' as supabase;
 
 void main() {
   group('ProjectSettingRepositoryImpl', () {
-    late ProjectSettingRepositoryImpl repository;
-    late FakeSupabaseWrapper supabaseWrapper;
+    late _FakeProjectPermissionDataSource permissionDataSource;
+    late ProjectSettingRepository repository;
+    late _FakeProjectSettingDataSource fakeDataSource;
 
     setUp(() {
-      final clock = FakeClockImpl(DateTime(2025, 1, 1));
-      Modular.init(
-        _TestAppModule(
-          FakeAppBootstrapFactory.create(
-            supabaseWrapper: FakeSupabaseWrapper(clock: clock),
-          ),
-        ),
-      );
-      supabaseWrapper = Modular.get<SupabaseWrapper>() as FakeSupabaseWrapper;
-      repository =
-          Modular.get<ProjectSettingRepository>()
-              as ProjectSettingRepositoryImpl;
-      supabaseWrapper.reset();
+      Modular.init(_ProjectSettingRepositoryTestModule());
+      fakeDataSource = Modular.get<_FakeProjectSettingDataSource>();
+      permissionDataSource = Modular.get<_FakeProjectPermissionDataSource>();
+      repository = Modular.get<ProjectSettingRepository>();
     });
 
     tearDown(() {
+      repository.dispose();
+      fakeDataSource.dispose();
       Modular.destroy();
     });
 
     group('getProjectSetting', () {
       test('returns Right(project) when data source succeeds', () async {
-        supabaseWrapper.addTableData(DatabaseConstants.projectsTable, [
-          {
-            DatabaseConstants.idColumn: 'p-1',
-            DatabaseConstants.projectNameColumn: 'Test Project',
-            DatabaseConstants.creatorUserIdColumn: 'user-1',
-            DatabaseConstants.createdAtColumn: DateTime(2025, 1, 1),
-            DatabaseConstants.updatedAtColumn: DateTime(2025, 1, 2),
-            DatabaseConstants.statusColumn: 'active',
-          },
-        ]);
+        fakeDataSource.projectToReturn = _fakeDto(
+          id: 'p-1',
+          projectName: 'Test Project',
+        );
 
         final result = await repository.getProjectSetting('p-1');
 
@@ -71,7 +56,7 @@ void main() {
       test(
         'returns Left(unexpectedDatabaseError) on ServerException',
         () async {
-          supabaseWrapper.shouldThrowOnSelect = true;
+          fakeDataSource.shouldThrowOnGet = true;
 
           final result = await repository.getProjectSetting('p-1');
 
@@ -87,8 +72,8 @@ void main() {
       );
 
       test('returns Left(timeoutError) on TimeoutException', () async {
-        supabaseWrapper.shouldThrowOnSelect = true;
-        supabaseWrapper.selectExceptionType = SupabaseExceptionType.timeout;
+        fakeDataSource.shouldThrowOnGet = true;
+        fakeDataSource.exceptionToThrow = TimeoutException('Select failed');
 
         final result = await repository.getProjectSetting('p-1');
 
@@ -104,15 +89,9 @@ void main() {
       });
 
       test('returns Left(UnexpectedFailure) on unknown error', () async {
-        final fake = FakeProjectSettingDataSource()
-          ..exceptionToThrow = Exception('unknown');
-        // ignore: no_direct_instantiation, reason: FakeProjectSettingDataSource is injected to simulate an unclassified exception, which cannot be triggered via FakeSupabaseWrapper
-        final repoWithFake = ProjectSettingRepositoryImpl(
-          dataSource: fake,
-          permissionDataSource: Modular.get<ProjectPermissionDataSource>(),
-        );
+        fakeDataSource.exceptionToThrow = Exception('unknown');
 
-        final result = await repoWithFake.getProjectSetting('p-1');
+        final result = await repository.getProjectSetting('p-1');
 
         expect(result.isLeft(), isTrue);
         result.fold((failure) {
@@ -121,8 +100,11 @@ void main() {
       });
 
       test('returns Left(notFoundError) on NotFoundException', () async {
-        // No data added to supabaseWrapper → selectSingle returns null
-        // → RemoteProjectSettingDataSource throws NotFoundException
+        fakeDataSource.exceptionToThrow = NotFoundException(
+          Trace.current(),
+          Exception('not found'),
+        );
+
         final result = await repository.getProjectSetting('p-1');
 
         expect(result.isLeft(), isTrue);
@@ -137,8 +119,7 @@ void main() {
       });
 
       test('returns Left(connectionError) on SocketException', () async {
-        supabaseWrapper.shouldThrowOnSelect = true;
-        supabaseWrapper.selectExceptionType = SupabaseExceptionType.socket;
+        fakeDataSource.exceptionToThrow = const SocketException('socket error');
 
         final result = await repository.getProjectSetting('p-1');
 
@@ -154,18 +135,12 @@ void main() {
       });
 
       test('returns Left(connectionError) on NetworkException', () async {
-        final fake = FakeProjectSettingDataSource()
-          ..exceptionToThrow = NetworkException(
-            Trace.current(),
-            Exception('network error'),
-          );
-        // ignore: no_direct_instantiation, reason: FakeProjectSettingDataSource is injected to simulate NetworkException, which cannot be triggered via FakeSupabaseWrapper
-        final repoWithFake = ProjectSettingRepositoryImpl(
-          dataSource: fake,
-          permissionDataSource: Modular.get<ProjectPermissionDataSource>(),
+        fakeDataSource.exceptionToThrow = NetworkException(
+          Trace.current(),
+          Exception('network error'),
         );
 
-        final result = await repoWithFake.getProjectSetting('p-1');
+        final result = await repository.getProjectSetting('p-1');
 
         expect(result.isLeft(), isTrue);
         result.fold((failure) {
@@ -179,8 +154,7 @@ void main() {
       });
 
       test('returns Left(parsingError) on TypeError', () async {
-        supabaseWrapper.shouldThrowOnSelect = true;
-        supabaseWrapper.selectExceptionType = SupabaseExceptionType.type;
+        fakeDataSource.exceptionToThrow = _typeError();
 
         final result = await repository.getProjectSetting('p-1');
 
@@ -196,9 +170,10 @@ void main() {
       });
 
       test('maps PostgrestException PGRST116 to notFoundError', () async {
-        supabaseWrapper.shouldThrowOnSelect = true;
-        supabaseWrapper.selectExceptionType = SupabaseExceptionType.postgrest;
-        supabaseWrapper.postgrestErrorCode = PostgresErrorCode.noDataFound;
+        fakeDataSource.exceptionToThrow = supabase.PostgrestException(
+          message: 'Select failed',
+          code: PostgresErrorCode.noDataFound.toString(),
+        );
 
         final result = await repository.getProjectSetting('p-1');
 
@@ -215,10 +190,10 @@ void main() {
       test(
         'maps PostgrestException connection codes to connectionError',
         () async {
-          supabaseWrapper.shouldThrowOnSelect = true;
-          supabaseWrapper.selectExceptionType = SupabaseExceptionType.postgrest;
-          supabaseWrapper.postgrestErrorCode =
-              PostgresErrorCode.connectionFailure;
+          fakeDataSource.exceptionToThrow = supabase.PostgrestException(
+            message: 'Select failed',
+            code: PostgresErrorCode.connectionFailure.toString(),
+          );
 
           final result = await repository.getProjectSetting('p-1');
 
@@ -260,20 +235,14 @@ void main() {
       test(
         'returns Right(project) when permission present and update succeeds',
         () async {
-          supabaseWrapper.addTableData(DatabaseConstants.projectsTable, [
-            {
-              DatabaseConstants.idColumn: 'p-1',
-              DatabaseConstants.projectNameColumn: 'Old Name',
-              DatabaseConstants.creatorUserIdColumn: 'user-1',
-              DatabaseConstants.createdAtColumn: DateTime(2025, 1, 1),
-              DatabaseConstants.updatedAtColumn: DateTime(2025, 1, 2),
-              DatabaseConstants.statusColumn: 'active',
-            },
-          ]);
-
-          supabaseWrapper.setProjectPermissions('p-1', [
+          permissionDataSource.setPermissions('p-1', [
             PermissionConstants.editProject,
           ]);
+
+          fakeDataSource.projectToReturn = _fakeDto(
+            id: 'p-1',
+            projectName: 'New Name',
+          );
 
           final project = Project(
             id: 'p-1',
@@ -312,18 +281,7 @@ void main() {
       test(
         'returns Right(null) when permission present and delete succeeds',
         () async {
-          supabaseWrapper.addTableData(DatabaseConstants.projectsTable, [
-            {
-              DatabaseConstants.idColumn: 'p-1',
-              DatabaseConstants.projectNameColumn: 'ToDelete',
-              DatabaseConstants.creatorUserIdColumn: 'user-1',
-              DatabaseConstants.createdAtColumn: DateTime(2025, 1, 1),
-              DatabaseConstants.updatedAtColumn: DateTime(2025, 1, 2),
-              DatabaseConstants.statusColumn: 'active',
-            },
-          ]);
-
-          supabaseWrapper.setProjectPermissions('p-1', [
+          permissionDataSource.setPermissions('p-1', [
             PermissionConstants.deleteProject,
           ]);
 
@@ -331,24 +289,252 @@ void main() {
 
           expect(result.isRight(), isTrue);
           result.fold((_) => fail('Expected Right'), (_) => null);
-
-          // ensure row removed from fake supabase
-          final row = await supabaseWrapper.selectSingle(
-            table: DatabaseConstants.projectsTable,
-            filterColumn: DatabaseConstants.idColumn,
-            filterValue: 'p-1',
-          );
-          expect(row, isNull);
         },
       );
+    });
+
+    group('watchProjectSetting', () {
+      test('emits current project on subscribe', () async {
+        fakeDataSource.projectToReturn = _fakeDto(id: 'p-1', projectName: 'v1');
+
+        final emittedCompleter = Completer<Project>();
+        final subscription = repository.watchProjectSetting('p-1').listen((
+          result,
+        ) {
+          result.fold((_) {}, (project) {
+            if (!emittedCompleter.isCompleted) {
+              emittedCompleter.complete(project);
+            }
+          });
+        });
+
+        final project = await emittedCompleter.future;
+        expect(project.projectName, equals('v1'));
+        await subscription.cancel();
+      });
+
+      test('re-emits on data source change notification', () async {
+        fakeDataSource.projectToReturn = _fakeDto(id: 'p-1', projectName: 'v1');
+
+        final secondEmission = Completer<Project>();
+        var emissionCount = 0;
+        final subscription = repository.watchProjectSetting('p-1').listen((
+          result,
+        ) {
+          result.fold((_) {}, (project) {
+            emissionCount++;
+            if (emissionCount >= 2 && !secondEmission.isCompleted) {
+              secondEmission.complete(project);
+            }
+          });
+        });
+
+        await pumpEventQueue();
+
+        fakeDataSource.projectToReturn = _fakeDto(id: 'p-1', projectName: 'v2');
+        fakeDataSource.emitChange();
+
+        final project = await secondEmission.future;
+        expect(project.projectName, equals('v2'));
+        await subscription.cancel();
+      });
+
+      test('emits Left when getProjectSetting fails during watch', () async {
+        fakeDataSource.shouldThrowOnGet = true;
+
+        final failureCompleter = Completer<Failure>();
+        final subscription = repository.watchProjectSetting('p-1').listen((
+          result,
+        ) {
+          result.fold((failure) {
+            if (!failureCompleter.isCompleted) {
+              failureCompleter.complete(failure);
+            }
+          }, (_) {});
+        });
+
+        final failure = await failureCompleter.future;
+        expect(failure, isA<ProjectFailure>());
+        await subscription.cancel();
+      });
+
+      test('forwards stream error from data source to subscribers', () async {
+        fakeDataSource.projectToReturn = _fakeDto(id: 'p-1');
+
+        final errorCompleter = Completer<Object>();
+        final subscription = repository
+            .watchProjectSetting('p-1')
+            .listen(
+              (_) {},
+              onError: (Object error, StackTrace _) {
+                if (!errorCompleter.isCompleted) errorCompleter.complete(error);
+              },
+            );
+
+        await pumpEventQueue();
+        fakeDataSource.emitError(Exception('stream error'));
+
+        final receivedError = await errorCompleter.future;
+        expect(receivedError, isA<Exception>());
+        await subscription.cancel();
+      });
+
+      test('cleans up resources on dispose', () async {
+        fakeDataSource.projectToReturn = _fakeDto(id: 'p-1');
+
+        final subscription = repository
+            .watchProjectSetting('p-1')
+            .listen((_) {});
+        await pumpEventQueue();
+        await subscription.cancel();
+
+        repository.dispose();
+        expect(
+          fakeDataSource.getMethodCallsFor('watchProjectChanges'),
+          hasLength(1),
+        );
+      });
     });
   });
 }
 
-class _TestAppModule extends Module {
-  final AppBootstrap appBootstrap;
-  _TestAppModule(this.appBootstrap);
+ProjectDto _fakeDto({required String id, String? projectName}) {
+  return ProjectDto(
+    id: id,
+    projectName: projectName ?? 'Test Project',
+    creatorUserId: 'user-1',
+    createdAt: DateTime(2025, 1, 1),
+    updatedAt: DateTime(2025, 1, 2),
+    status: ProjectStatus.active,
+  );
+}
+
+TypeError _typeError() {
+  try {
+    final Object value = 'not an int';
+    value as int;
+  } on TypeError catch (error) {
+    return error;
+  }
+  throw StateError('Expected cast to throw TypeError');
+}
+
+class _FakeProjectSettingDataSource implements ProjectSettingDataSource {
+  final List<Map<String, dynamic>> _methodCalls = [];
+
+  ProjectDto? projectToReturn;
+  bool shouldThrowOnGet = false;
+  bool shouldThrowOnDelete = false;
+  Object? exceptionToThrow;
+
+  final StreamController<ProjectDto?> _changesController =
+      StreamController<ProjectDto?>.broadcast();
 
   @override
-  List<Module> get imports => [ProjectLibraryModule(appBootstrap)];
+  Future<ProjectDto> updateProject(ProjectDto projectDto) async {
+    _methodCalls.add({'method': 'updateProject', 'dto': projectDto});
+
+    final ex = exceptionToThrow;
+    if (ex != null) {
+      exceptionToThrow = null;
+      throw ex;
+    }
+
+    return projectToReturn ?? projectDto;
+  }
+
+  @override
+  Future<void> deleteProject(String projectId) async {
+    _methodCalls.add({'method': 'deleteProject', 'projectId': projectId});
+
+    final ex = exceptionToThrow;
+    if (ex != null) {
+      exceptionToThrow = null;
+      throw ex;
+    }
+
+    if (shouldThrowOnDelete) {
+      throw ServerException(Trace.current(), Exception('Delete failed'));
+    }
+  }
+
+  @override
+  Stream<ProjectDto?> watchProjectChanges(String projectId) {
+    _methodCalls.add({'method': 'watchProjectChanges', 'projectId': projectId});
+    return _changesController.stream;
+  }
+
+  void emitChange() => _changesController.add(projectToReturn);
+
+  void emitError(Object error) => _changesController.addError(error);
+
+  List<Map<String, dynamic>> getMethodCallsFor(String methodName) {
+    return _methodCalls.where((call) => call['method'] == methodName).toList();
+  }
+
+  void dispose() => _changesController.close();
+
+  @override
+  Future<ProjectDto> fetchProjectSetting(String projectId) {
+    _methodCalls.add({'method': 'fetchProjectSetting', 'projectId': projectId});
+
+    final ex = exceptionToThrow;
+    if (ex != null) {
+      exceptionToThrow = null;
+      throw ex;
+    }
+
+    if (shouldThrowOnGet) {
+      throw ServerException(Trace.current(), Exception('Select failed'));
+    }
+
+    if (projectToReturn != null) return Future.value(projectToReturn);
+
+    throw ServerException(
+      Trace.current(),
+      Exception('No project configured in FakeProjectSettingDataSource'),
+    );
+  }
+}
+
+class _FakeProjectPermissionDataSource implements ProjectPermissionDataSource {
+  final Map<String, List<String>> _permissions = {};
+
+  void setPermissions(String projectId, List<String> permissions) {
+    _permissions[projectId] = List<String>.from(permissions);
+  }
+
+  @override
+  List<String> getProjectPermissions(String projectId) {
+    return List.from(_permissions[projectId] ?? []);
+  }
+
+  @override
+  bool hasProjectPermission(String projectId, String permissionKey) {
+    return _permissions[projectId]?.contains(permissionKey) ?? false;
+  }
+}
+
+class _ProjectSettingRepositoryTestModule extends Module {
+  @override
+  void binds(Injector i) {
+    i.addLazySingleton<_FakeProjectSettingDataSource>(
+      () => _FakeProjectSettingDataSource(),
+    );
+    i.addLazySingleton<ProjectSettingDataSource>(
+      () => i.get<_FakeProjectSettingDataSource>(),
+    );
+    i.addLazySingleton<_FakeProjectPermissionDataSource>(
+      () => _FakeProjectPermissionDataSource(),
+    );
+    i.addLazySingleton<ProjectPermissionDataSource>(
+      () => i.get<_FakeProjectPermissionDataSource>(),
+    );
+    i.addLazySingleton<ProjectSettingRepository>(
+      () => ProjectSettingRepositoryImpl(
+        dataSource: i.get<ProjectSettingDataSource>(),
+        permissionDataSource: i.get<ProjectPermissionDataSource>(),
+      ),
+    );
+  }
 }

--- a/test/libraries/project/units/data/repositories/project_setting_repository_impl_test.dart
+++ b/test/libraries/project/units/data/repositories/project_setting_repository_impl_test.dart
@@ -1,11 +1,11 @@
 import 'dart:async';
-import 'dart:io';
 
-import 'package:construculator/libraries/errors/exceptions.dart';
+import 'package:construculator/app/app_bootstrap.dart';
 import 'package:construculator/libraries/errors/failures.dart';
 import 'package:construculator/libraries/project/data/data_source/interfaces/permission_data_source.dart';
 import 'package:construculator/libraries/project/data/data_source/interfaces/project_setting_data_source.dart';
-import 'package:construculator/libraries/project/data/models/project_dto.dart';
+import 'package:construculator/libraries/project/data/data_source/local_jwt_project_permission_data_source.dart';
+import 'package:construculator/libraries/project/data/data_source/remote_project_setting_data_source.dart';
 import 'package:construculator/libraries/project/data/repositories/project_setting_repository_impl.dart';
 import 'package:construculator/libraries/project/domain/entities/enums.dart';
 import 'package:construculator/libraries/project/domain/entities/project_entity.dart';
@@ -13,36 +13,49 @@ import 'package:construculator/libraries/project/domain/permission_constants.dar
 import 'package:construculator/libraries/project/domain/project_error_type.dart';
 import 'package:construculator/libraries/project/domain/repositories/project_setting_repository.dart';
 import 'package:construculator/libraries/supabase/data/supabase_types.dart';
+import 'package:construculator/libraries/supabase/database_constants.dart';
+import 'package:construculator/libraries/supabase/interfaces/supabase_wrapper.dart';
+import 'package:construculator/libraries/supabase/supabase_module.dart';
+import 'package:construculator/libraries/supabase/testing/fake_supabase_wrapper.dart';
+import 'package:construculator/libraries/time/testing/fake_clock_impl.dart';
 import 'package:flutter_modular/flutter_modular.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:stack_trace/stack_trace.dart';
-import 'package:supabase_flutter/supabase_flutter.dart' as supabase;
+
+import '../../../../../utils/fake_app_bootstrap_factory.dart';
 
 void main() {
   group('ProjectSettingRepositoryImpl', () {
-    late _FakeProjectPermissionDataSource permissionDataSource;
-    late ProjectSettingRepository repository;
-    late _FakeProjectSettingDataSource fakeDataSource;
+    late FakeSupabaseWrapper fakeSupabaseWrapper;
+    late FakeClockImpl fakeClock;
+    late ProjectSettingRepositoryImpl repository;
 
     setUp(() {
-      Modular.init(_ProjectSettingRepositoryTestModule());
-      fakeDataSource = Modular.get<_FakeProjectSettingDataSource>();
-      permissionDataSource = Modular.get<_FakeProjectPermissionDataSource>();
-      repository = Modular.get<ProjectSettingRepository>();
+      fakeClock = FakeClockImpl();
+      Modular.init(
+        _TestModule(
+          FakeAppBootstrapFactory.create(
+            supabaseWrapper: FakeSupabaseWrapper(clock: fakeClock),
+          ),
+        ),
+      );
+      fakeSupabaseWrapper =
+          Modular.get<SupabaseWrapper>() as FakeSupabaseWrapper;
+      repository =
+          Modular.get<ProjectSettingRepository>()
+              as ProjectSettingRepositoryImpl;
+      fakeSupabaseWrapper.reset();
     });
 
     tearDown(() {
-      repository.dispose();
-      fakeDataSource.dispose();
+      fakeSupabaseWrapper.reset();
       Modular.destroy();
     });
 
     group('getProjectSetting', () {
       test('returns Right(project) when data source succeeds', () async {
-        fakeDataSource.projectToReturn = _fakeDto(
-          id: 'p-1',
-          projectName: 'Test Project',
-        );
+        fakeSupabaseWrapper.addTableData(DatabaseConstants.projectsTable, [
+          _fakeProjectRow(id: 'p-1', projectName: 'Test Project'),
+        ]);
 
         final result = await repository.getProjectSetting('p-1');
 
@@ -53,27 +66,24 @@ void main() {
         });
       });
 
-      test(
-        'returns Left(unexpectedDatabaseError) on ServerException',
-        () async {
-          fakeDataSource.shouldThrowOnGet = true;
+      test('returns Left(unexpectedDatabaseError) on server error', () async {
+        fakeSupabaseWrapper.shouldThrowOnSelect = true;
 
-          final result = await repository.getProjectSetting('p-1');
+        final result = await repository.getProjectSetting('p-1');
 
-          expect(result.isLeft(), isTrue);
-          result.fold((failure) {
-            expect(failure, isA<ProjectFailure>());
-            expect(
-              (failure as ProjectFailure).errorType,
-              equals(ProjectErrorType.unexpectedDatabaseError),
-            );
-          }, (_) => fail('Expected Left'));
-        },
-      );
+        expect(result.isLeft(), isTrue);
+        result.fold((failure) {
+          expect(failure, isA<ProjectFailure>());
+          expect(
+            (failure as ProjectFailure).errorType,
+            equals(ProjectErrorType.unexpectedDatabaseError),
+          );
+        }, (_) => fail('Expected Left'));
+      });
 
       test('returns Left(timeoutError) on TimeoutException', () async {
-        fakeDataSource.shouldThrowOnGet = true;
-        fakeDataSource.exceptionToThrow = TimeoutException('Select failed');
+        fakeSupabaseWrapper.shouldThrowOnSelect = true;
+        fakeSupabaseWrapper.selectExceptionType = SupabaseExceptionType.timeout;
 
         final result = await repository.getProjectSetting('p-1');
 
@@ -88,92 +98,8 @@ void main() {
         }, (_) => fail('Expected Left'));
       });
 
-      test('returns Left(UnexpectedFailure) on unknown error', () async {
-        fakeDataSource.exceptionToThrow = Exception('unknown');
-
-        final result = await repository.getProjectSetting('p-1');
-
-        expect(result.isLeft(), isTrue);
-        result.fold((failure) {
-          expect(failure, isA<UnexpectedFailure>());
-        }, (_) => fail('Expected Left'));
-      });
-
-      test('returns Left(notFoundError) on NotFoundException', () async {
-        fakeDataSource.exceptionToThrow = NotFoundException(
-          Trace.current(),
-          Exception('not found'),
-        );
-
-        final result = await repository.getProjectSetting('p-1');
-
-        expect(result.isLeft(), isTrue);
-        result.fold((failure) {
-          expect(
-            failure,
-            equals(
-              const ProjectFailure(errorType: ProjectErrorType.notFoundError),
-            ),
-          );
-        }, (_) => fail('Expected Left'));
-      });
-
-      test('returns Left(connectionError) on SocketException', () async {
-        fakeDataSource.exceptionToThrow = const SocketException('socket error');
-
-        final result = await repository.getProjectSetting('p-1');
-
-        expect(result.isLeft(), isTrue);
-        result.fold((failure) {
-          expect(
-            failure,
-            equals(
-              const ProjectFailure(errorType: ProjectErrorType.connectionError),
-            ),
-          );
-        }, (_) => fail('Expected Left'));
-      });
-
-      test('returns Left(connectionError) on NetworkException', () async {
-        fakeDataSource.exceptionToThrow = NetworkException(
-          Trace.current(),
-          Exception('network error'),
-        );
-
-        final result = await repository.getProjectSetting('p-1');
-
-        expect(result.isLeft(), isTrue);
-        result.fold((failure) {
-          expect(
-            failure,
-            equals(
-              const ProjectFailure(errorType: ProjectErrorType.connectionError),
-            ),
-          );
-        }, (_) => fail('Expected Left'));
-      });
-
-      test('returns Left(parsingError) on TypeError', () async {
-        fakeDataSource.exceptionToThrow = _typeError();
-
-        final result = await repository.getProjectSetting('p-1');
-
-        expect(result.isLeft(), isTrue);
-        result.fold((failure) {
-          expect(
-            failure,
-            equals(
-              const ProjectFailure(errorType: ProjectErrorType.parsingError),
-            ),
-          );
-        }, (_) => fail('Expected Left'));
-      });
-
-      test('maps PostgrestException PGRST116 to notFoundError', () async {
-        fakeDataSource.exceptionToThrow = supabase.PostgrestException(
-          message: 'Select failed',
-          code: PostgresErrorCode.noDataFound.toString(),
-        );
+      test('returns Left(notFoundError) when project does not exist', () async {
+        fakeSupabaseWrapper.shouldReturnNullOnSelect = true;
 
         final result = await repository.getProjectSetting('p-1');
 
@@ -187,26 +113,19 @@ void main() {
         }, (_) => fail('Expected Left'));
       });
 
-      test(
-        'maps PostgrestException connection codes to connectionError',
-        () async {
-          fakeDataSource.exceptionToThrow = supabase.PostgrestException(
-            message: 'Select failed',
-            code: PostgresErrorCode.connectionFailure.toString(),
-          );
+      test('returns Left(UnexpectedFailure) on unexpected error', () async {
+        // AuthException is not handled by _handleError and falls through to
+        // UnexpectedFailure — the only reachable path via FakeSupabaseWrapper.
+        fakeSupabaseWrapper.shouldThrowOnSelect = true;
+        fakeSupabaseWrapper.selectExceptionType = SupabaseExceptionType.auth;
 
-          final result = await repository.getProjectSetting('p-1');
+        final result = await repository.getProjectSetting('p-1');
 
-          expect(result.isLeft(), isTrue);
-          result.fold((failure) {
-            expect(failure, isA<ProjectFailure>());
-            expect(
-              (failure as ProjectFailure).errorType,
-              equals(ProjectErrorType.connectionError),
-            );
-          }, (_) => fail('Expected Left'));
-        },
-      );
+        expect(result.isLeft(), isTrue);
+        result.fold((failure) {
+          expect(failure, isA<UnexpectedFailure>());
+        }, (_) => fail('Expected Left'));
+      });
     });
 
     group('updateProject', () {
@@ -235,14 +154,12 @@ void main() {
       test(
         'returns Right(project) when permission present and update succeeds',
         () async {
-          permissionDataSource.setPermissions('p-1', [
+          fakeSupabaseWrapper.setProjectPermissions('p-1', [
             PermissionConstants.editProject,
           ]);
-
-          fakeDataSource.projectToReturn = _fakeDto(
-            id: 'p-1',
-            projectName: 'New Name',
-          );
+          fakeSupabaseWrapper.addTableData(DatabaseConstants.projectsTable, [
+            _fakeProjectRow(id: 'p-1', projectName: 'Old Name'),
+          ]);
 
           final project = Project(
             id: 'p-1',
@@ -281,8 +198,11 @@ void main() {
       test(
         'returns Right(null) when permission present and delete succeeds',
         () async {
-          permissionDataSource.setPermissions('p-1', [
+          fakeSupabaseWrapper.setProjectPermissions('p-1', [
             PermissionConstants.deleteProject,
+          ]);
+          fakeSupabaseWrapper.addTableData(DatabaseConstants.projectsTable, [
+            _fakeProjectRow(id: 'p-1'),
           ]);
 
           final result = await repository.deleteProject('p-1');
@@ -295,7 +215,9 @@ void main() {
 
     group('watchProjectSetting', () {
       test('emits current project on subscribe', () async {
-        fakeDataSource.projectToReturn = _fakeDto(id: 'p-1', projectName: 'v1');
+        fakeSupabaseWrapper.addTableData(DatabaseConstants.projectsTable, [
+          _fakeProjectRow(id: 'p-1', projectName: 'v1'),
+        ]);
 
         final emittedCompleter = Completer<Project>();
         final subscription = repository.watchProjectSetting('p-1').listen((
@@ -314,33 +236,37 @@ void main() {
       });
 
       test('re-emits on data source change notification', () async {
-        fakeDataSource.projectToReturn = _fakeDto(id: 'p-1', projectName: 'v1');
+        fakeSupabaseWrapper.addTableData(DatabaseConstants.projectsTable, [
+          _fakeProjectRow(id: 'p-1', projectName: 'v1'),
+        ]);
 
-        final secondEmission = Completer<Project>();
-        var emissionCount = 0;
+        final v2Completer = Completer<Project>();
         final subscription = repository.watchProjectSetting('p-1').listen((
           result,
         ) {
           result.fold((_) {}, (project) {
-            emissionCount++;
-            if (emissionCount >= 2 && !secondEmission.isCompleted) {
-              secondEmission.complete(project);
+            if (project.projectName == 'v2' && !v2Completer.isCompleted) {
+              v2Completer.complete(project);
             }
           });
         });
 
         await pumpEventQueue();
 
-        fakeDataSource.projectToReturn = _fakeDto(id: 'p-1', projectName: 'v2');
-        fakeDataSource.emitChange();
+        fakeSupabaseWrapper.addTableData(DatabaseConstants.projectsTable, [
+          _fakeProjectRow(id: 'p-1', projectName: 'v2'),
+        ]);
 
-        final project = await secondEmission.future;
+        final project = await v2Completer.future;
         expect(project.projectName, equals('v2'));
         await subscription.cancel();
       });
 
       test('emits Left when getProjectSetting fails during watch', () async {
-        fakeDataSource.shouldThrowOnGet = true;
+        fakeSupabaseWrapper.addTableData(DatabaseConstants.projectsTable, [
+          _fakeProjectRow(id: 'p-1'),
+        ]);
+        fakeSupabaseWrapper.shouldThrowOnSelect = true;
 
         final failureCompleter = Completer<Failure>();
         final subscription = repository.watchProjectSetting('p-1').listen((
@@ -359,7 +285,9 @@ void main() {
       });
 
       test('forwards stream error from data source to subscribers', () async {
-        fakeDataSource.projectToReturn = _fakeDto(id: 'p-1');
+        fakeSupabaseWrapper.addTableData(DatabaseConstants.projectsTable, [
+          _fakeProjectRow(id: 'p-1'),
+        ]);
 
         final errorCompleter = Completer<Object>();
         final subscription = repository
@@ -372,15 +300,51 @@ void main() {
             );
 
         await pumpEventQueue();
-        fakeDataSource.emitError(Exception('stream error'));
+
+        fakeSupabaseWrapper.shouldEmitStreamErrors = true;
+        fakeSupabaseWrapper.addTableData(DatabaseConstants.projectsTable, [
+          _fakeProjectRow(id: 'p-1'),
+        ]);
 
         final receivedError = await errorCompleter.future;
         expect(receivedError, isA<Exception>());
         await subscription.cancel();
       });
 
+      test('can watch multiple projects concurrently', () async {
+        fakeSupabaseWrapper.addTableData(DatabaseConstants.projectsTable, [
+          _fakeProjectRow(id: 'p-1', projectName: 'Alpha'),
+          _fakeProjectRow(id: 'p-2', projectName: 'Beta'),
+        ]);
+
+        final alphaCompleter = Completer<Project>();
+        final betaCompleter = Completer<Project>();
+
+        final sub1 = repository.watchProjectSetting('p-1').listen((result) {
+          result.fold((_) {}, (p) {
+            if (!alphaCompleter.isCompleted) alphaCompleter.complete(p);
+          });
+        });
+        final sub2 = repository.watchProjectSetting('p-2').listen((result) {
+          result.fold((_) {}, (p) {
+            if (!betaCompleter.isCompleted) betaCompleter.complete(p);
+          });
+        });
+
+        final alpha = await alphaCompleter.future;
+        final beta = await betaCompleter.future;
+
+        expect(alpha.projectName, equals('Alpha'));
+        expect(beta.projectName, equals('Beta'));
+
+        await sub1.cancel();
+        await sub2.cancel();
+      });
+
       test('cleans up resources on dispose', () async {
-        fakeDataSource.projectToReturn = _fakeDto(id: 'p-1');
+        fakeSupabaseWrapper.addTableData(DatabaseConstants.projectsTable, [
+          _fakeProjectRow(id: 'p-1'),
+        ]);
 
         final subscription = repository
             .watchProjectSetting('p-1')
@@ -390,151 +354,56 @@ void main() {
 
         repository.dispose();
         expect(
-          fakeDataSource.getMethodCallsFor('watchProjectChanges'),
-          hasLength(1),
+          fakeSupabaseWrapper
+              .getMethodCalls()
+              .where((c) => c['method'] == 'watchTableFiltered')
+              .length,
+          equals(1),
         );
       });
     });
   });
 }
 
-ProjectDto _fakeDto({required String id, String? projectName}) {
-  return ProjectDto(
-    id: id,
-    projectName: projectName ?? 'Test Project',
-    creatorUserId: 'user-1',
-    createdAt: DateTime(2025, 1, 1),
-    updatedAt: DateTime(2025, 1, 2),
-    status: ProjectStatus.active,
-  );
+Map<String, dynamic> _fakeProjectRow({
+  required String id,
+  String? projectName,
+}) {
+  return {
+    DatabaseConstants.idColumn: id,
+    DatabaseConstants.projectNameColumn: projectName ?? 'Test Project',
+    DatabaseConstants.creatorUserIdColumn: 'user-1',
+    DatabaseConstants.createdAtColumn: '2025-01-01T00:00:00.000Z',
+    DatabaseConstants.updatedAtColumn: '2025-01-02T00:00:00.000Z',
+    DatabaseConstants.statusColumn: 'active',
+  };
 }
 
-TypeError _typeError() {
-  try {
-    final Object value = 'not an int';
-    value as int;
-  } on TypeError catch (error) {
-    return error;
-  }
-  throw StateError('Expected cast to throw TypeError');
-}
-
-class _FakeProjectSettingDataSource implements ProjectSettingDataSource {
-  final List<Map<String, dynamic>> _methodCalls = [];
-
-  ProjectDto? projectToReturn;
-  bool shouldThrowOnGet = false;
-  bool shouldThrowOnDelete = false;
-  Object? exceptionToThrow;
-
-  final StreamController<ProjectDto?> _changesController =
-      StreamController<ProjectDto?>.broadcast();
+class _TestModule extends Module {
+  final AppBootstrap _appBootstrap;
+  _TestModule(this._appBootstrap);
 
   @override
-  Future<ProjectDto> updateProject(ProjectDto projectDto) async {
-    _methodCalls.add({'method': 'updateProject', 'dto': projectDto});
+  List<Module> get imports => [SupabaseModule(_appBootstrap)];
 
-    final ex = exceptionToThrow;
-    if (ex != null) {
-      exceptionToThrow = null;
-      throw ex;
-    }
-
-    return projectToReturn ?? projectDto;
-  }
-
-  @override
-  Future<void> deleteProject(String projectId) async {
-    _methodCalls.add({'method': 'deleteProject', 'projectId': projectId});
-
-    final ex = exceptionToThrow;
-    if (ex != null) {
-      exceptionToThrow = null;
-      throw ex;
-    }
-
-    if (shouldThrowOnDelete) {
-      throw ServerException(Trace.current(), Exception('Delete failed'));
-    }
-  }
-
-  @override
-  Stream<ProjectDto?> watchProjectChanges(String projectId) {
-    _methodCalls.add({'method': 'watchProjectChanges', 'projectId': projectId});
-    return _changesController.stream;
-  }
-
-  void emitChange() => _changesController.add(projectToReturn);
-
-  void emitError(Object error) => _changesController.addError(error);
-
-  List<Map<String, dynamic>> getMethodCallsFor(String methodName) {
-    return _methodCalls.where((call) => call['method'] == methodName).toList();
-  }
-
-  void dispose() => _changesController.close();
-
-  @override
-  Future<ProjectDto> fetchProjectSetting(String projectId) {
-    _methodCalls.add({'method': 'fetchProjectSetting', 'projectId': projectId});
-
-    final ex = exceptionToThrow;
-    if (ex != null) {
-      exceptionToThrow = null;
-      throw ex;
-    }
-
-    if (shouldThrowOnGet) {
-      throw ServerException(Trace.current(), Exception('Select failed'));
-    }
-
-    if (projectToReturn != null) return Future.value(projectToReturn);
-
-    throw ServerException(
-      Trace.current(),
-      Exception('No project configured in FakeProjectSettingDataSource'),
-    );
-  }
-}
-
-class _FakeProjectPermissionDataSource implements ProjectPermissionDataSource {
-  final Map<String, List<String>> _permissions = {};
-
-  void setPermissions(String projectId, List<String> permissions) {
-    _permissions[projectId] = List<String>.from(permissions);
-  }
-
-  @override
-  List<String> getProjectPermissions(String projectId) {
-    return List.from(_permissions[projectId] ?? []);
-  }
-
-  @override
-  bool hasProjectPermission(String projectId, String permissionKey) {
-    return _permissions[projectId]?.contains(permissionKey) ?? false;
-  }
-}
-
-class _ProjectSettingRepositoryTestModule extends Module {
   @override
   void binds(Injector i) {
-    i.addLazySingleton<_FakeProjectSettingDataSource>(
-      () => _FakeProjectSettingDataSource(),
-    );
     i.addLazySingleton<ProjectSettingDataSource>(
-      () => i.get<_FakeProjectSettingDataSource>(),
-    );
-    i.addLazySingleton<_FakeProjectPermissionDataSource>(
-      () => _FakeProjectPermissionDataSource(),
+      () => RemoteProjectSettingDataSource(
+        supabaseWrapper: Modular.get<SupabaseWrapper>(),
+      ),
     );
     i.addLazySingleton<ProjectPermissionDataSource>(
-      () => i.get<_FakeProjectPermissionDataSource>(),
+      () => LocalJwtProjectPermissionDataSource(
+        supabaseWrapper: Modular.get<SupabaseWrapper>(),
+      ),
     );
     i.addLazySingleton<ProjectSettingRepository>(
       () => ProjectSettingRepositoryImpl(
-        dataSource: i.get<ProjectSettingDataSource>(),
-        permissionDataSource: i.get<ProjectPermissionDataSource>(),
+        dataSource: Modular.get<ProjectSettingDataSource>(),
+        permissionDataSource: Modular.get<ProjectPermissionDataSource>(),
       ),
+      config: BindConfig(onDispose: (r) => r.dispose()),
     );
   }
 }

--- a/test/libraries/project/units/data/repositories/project_setting_repository_impl_test.dart
+++ b/test/libraries/project/units/data/repositories/project_setting_repository_impl_test.dart
@@ -214,6 +214,47 @@ void main() {
     });
 
     group('watchProjectSetting', () {
+      test('reuses one stream controller per project', () async {
+        fakeSupabaseWrapper.addTableData(DatabaseConstants.projectsTable, [
+          _fakeProjectRow(id: 'p-1'),
+        ]);
+
+        final firstStream = repository.watchProjectSetting('p-1');
+        final secondStream = repository.watchProjectSetting('p-1');
+
+        final firstCompleter = Completer<Project>();
+        final secondCompleter = Completer<Project>();
+
+        final firstSubscription = firstStream.listen((result) {
+          result.fold((_) {}, (project) {
+            if (!firstCompleter.isCompleted) {
+              firstCompleter.complete(project);
+            }
+          });
+        });
+        final secondSubscription = secondStream.listen((result) {
+          result.fold((_) {}, (project) {
+            if (!secondCompleter.isCompleted) {
+              secondCompleter.complete(project);
+            }
+          });
+        });
+
+        await firstCompleter.future;
+        await secondCompleter.future;
+
+        expect(
+          fakeSupabaseWrapper
+              .getMethodCalls()
+              .where((c) => c['method'] == 'watchTableFiltered')
+              .length,
+          equals(1),
+        );
+
+        await firstSubscription.cancel();
+        await secondSubscription.cancel();
+      });
+
       test('emits current project on subscribe', () async {
         fakeSupabaseWrapper.addTableData(DatabaseConstants.projectsTable, [
           _fakeProjectRow(id: 'p-1', projectName: 'v1'),


### PR DESCRIPTION
**PR SUMMARY**
- Adds `watchProjectSetting` to `ProjectSettingRepository` and implements it in project_setting_repository_impl.dart, plus unit tests exercising the watch behavior in project_setting_repository_impl_test.dart.

**REVIEW FINDINGS**

- **Files reviewed**
  - project_setting_repository_impl.dart
  - project_setting_repository.dart
  - project_setting_repository_impl_test.dart

**ISSUES / RECOMMENDATIONS**

- Type mismatch on subscription (bug)
  - Description: `_changesSubscription` is declared as `StreamSubscription<void>?` but assigned from `_dataSource.watchProjectChanges(projectId).listen(...)` which yields a `StreamSubscription<T>` (e.g., `ProjectDto?`). This is a compile-time type mismatch and should be `StreamSubscription<dynamic>?` or, ideally, `StreamSubscription<ProjectDto?>?` (or the correct DTO type).
  - Suggested fix: change declaration to `StreamSubscription<dynamic>?` or `StreamSubscription<ProjectDto?>?` (prefer concrete DTO type).

- Single-watch limitation (design/behavior)
  - Description: Implementation uses a single `_settingController` and a single `_watchedProjectId`. Calling `watchProjectSetting` for different `projectId`s will overwrite `_watchedProjectId` and share the same stream — repository cannot support multiple concurrent project watches. This reduces API correctness/expectations.
  - Suggested fix: support per-project streams (map projectId → controller and subscription). Example approach:
    - Maintain `Map<String, StreamController<Either<Failure, Project>>> _controllers;`
    - Maintain `Map<String, StreamSubscription<ProjectDto?>> _subscriptions;`
    - Start/stop per-controller using their `onListen`/`onCancel`.
    - This preserves independent lifecycles and avoids races when multiple watches are active.

- Logging level and duplicate Sentry events (cost / semantics)
  - Description: In `_startWatchingSettingChanges` onError the code calls `_logger.error(...)` and forwards the error to the controller via `addError`. If the data source already logs/report errors, this can create duplicate Sentry events and unnecessary quota consumption.
  - Suggested fix: only call `error()` for genuinely unexpected failures (or when converting an internal invariant failure). For data-source stream errors that are expected to be handled by consumers, use `_logger.warning(...)` or avoid logging here. Add a comment documenting why this log is necessary to justify Sentry events.

- Tests violate "Test Double" guideline (policy / test quality)
  - Description: New tests replace `RemoteProjectSettingDataSource` with a fake `_FakeProjectSettingDataSource`. Per project testing rules, when testing Repository → DataSource, prefer using the real `RemoteProjectSettingDataSource` and fake only its external dependencies (e.g., `FakeSupabaseWrapper`), so the repository is validated with a real data-source implementation and only DB/network layers are faked.
  - Suggested fix: revert to using `RemoteProjectSettingDataSource` with `FakeSupabaseWrapper` (as the previous tests did) so the repository + data source integration is exercised. Keep the fake only for external connection points. If keeping the fake for faster unit tests, add an explicit test-case set that validates the integration using the real `RemoteProjectSettingDataSource` + fakes (so both styles are covered).

- Cleanup safety / minor improvement
  - Description: `dispose()` cancels `_changesSubscription` and closes `_settingController`. Consider guarding `close()` with `if (_settingController?.isClosed == false)` to avoid potential exceptions, and ensure cancelling subscriptions completes before closing controllers when there are inflight async callbacks.
  - Suggested fix: cancel subscription, `await` if needed (or at least cancel before close), and nullify fields. If making `_refreshProjectSetting` async and calling it during start, ensure any thrown errors are handled.

**SMALL SUGGESTIONS / NITS**
- In `_refreshProjectSetting` catch unexpected exceptions from `getProjectSetting` and forward as `addError` or map to a `Failure` (if appropriate) to make behavior explicit.
- Document the `watchProjectSetting` contract in `ProjectSettingRepository` javadoc (when it returns, whether it closes automatically, concurrency expectations) — currently doc is present but add note about whether multiple watchers are supported.
- Tests: prefer asserting behaviors (Right/Left) rather than internal calls count where possible; keep one integration-style test that uses the real data source + fake DB.

**REVIEW SUMMARY TABLE**

| Issue Name | Description | Status | Notes |
|------------|-------------|--------|-------|
| Subscription type mismatch | `_changesSubscription` typed `StreamSubscription<void>?` but assigned from `.listen(...)` of a typed stream. | :heavy_check_mark:  | Change to `StreamSubscription<ProjectDto?>?` or `dynamic`. |
| Single-project watch limitation | Repo uses single controller + `_watchedProjectId` — cannot concurrently watch multiple projectIds. | :heavy_check_mark:  | Use per-project controller/subscription maps. |
| Sentry / duplicate logging risk | `_logger.error()` on data-source stream errors may double-report; use warning or avoid duplicated logging. | :heavy_check_mark:  | Log only unexpected errors; document reason. |
| Test Double pattern deviation | Tests use a fake data source instead of the real remote data source with faked external deps. | :heavy_check_mark:  | Prefer real `RemoteProjectSettingDataSource` + `FakeSupabaseWrapper` for integration-style unit tests. |