### PR TITLE
feat: implement initial tab module loading in AppShellBloc

### DIFF
--- a/lib/app/shell/app_shell_bloc/app_shell_bloc.dart
+++ b/lib/app/shell/app_shell_bloc/app_shell_bloc.dart
@@ -24,9 +24,8 @@ class AppShellBloc extends Bloc<AppShellEvent, AppShellState> {
     AppShellInitialized event,
     Emitter<AppShellState> emit,
   ) async {
-    final initialTab = ShellTab.values[state.selectedTabIndex];
-    await _moduleLoader.ensureTabModuleLoaded(initialTab);
-    emit(state.copyWith(loadedTabIndexes: {state.selectedTabIndex}));
+    await _moduleLoader.ensureTabModuleLoaded(ShellTab.home);
+    emit(state.copyWith(loadedTabIndexes: {0}, selectedTabIndex: 0));
   }
 
   Future<void> _onTabSelected(

--- a/lib/app/shell/app_shell_bloc/app_shell_event.dart
+++ b/lib/app/shell/app_shell_bloc/app_shell_event.dart
@@ -8,7 +8,7 @@ sealed class AppShellEvent extends Equatable {
   List<Object> get props => [];
 }
 
-/// Event triggered once on startup to load the initial tab's module.
+/// Event triggered once when the shell first mounts, to load the initial tab module.
 class AppShellInitialized extends AppShellEvent {
   const AppShellInitialized();
 }

--- a/lib/app/shell/shell_module.dart
+++ b/lib/app/shell/shell_module.dart
@@ -3,6 +3,7 @@ import 'package:construculator/app/shell/app_shell_bloc/app_shell_bloc.dart';
 import 'package:construculator/app/shell/app_shell_page.dart';
 import 'package:construculator/app/shell/tab_module_manager.dart';
 import 'package:construculator/features/estimation/estimation_routes_module.dart';
+import 'package:construculator/libraries/router/guards/auth_guard.dart';
 import 'package:construculator/libraries/router/routes/estimation_routes.dart';
 import 'package:flutter_modular/flutter_modular.dart';
 
@@ -14,7 +15,9 @@ class ShellModule extends Module {
   @override
   void binds(Injector i) {
     i.addSingleton<TabModuleManager>(() => TabModuleManager(appBootstrap));
-    i.add<AppShellBloc>(() => AppShellBloc(moduleLoader: i.get()));
+    i.add<AppShellBloc>(
+      () => AppShellBloc(moduleLoader: i.get())..add(AppShellInitialized()),
+    );
   }
 
   @override
@@ -22,6 +25,7 @@ class ShellModule extends Module {
     r.child(
       '/',
       child: (_) => const AppShellPage(),
+      guards: [AuthGuard()],
       children: [
         ModuleRoute(
           estimationBaseRoute,

--- a/test/app/shell/app_shell_page_test.dart
+++ b/test/app/shell/app_shell_page_test.dart
@@ -1,28 +1,15 @@
-import 'package:construculator/app/app_bootstrap.dart';
-import 'package:construculator/app/shell/app_shell_bloc/app_shell_bloc.dart';
 import 'package:construculator/app/shell/app_shell_page.dart';
-import 'package:construculator/app/shell/default_tab_providers.dart';
-import 'package:construculator/app/shell/module_model.dart';
-import 'package:construculator/app/shell/tab_module_manager.dart';
+import 'package:construculator/app/shell/shell_module.dart';
 import 'package:construculator/features/calculations/presentation/pages/calculations_page.dart';
 import 'package:construculator/features/dashboard/presentation/pages/dashboard_page.dart';
-import 'package:construculator/features/estimation/estimation_module.dart';
 import 'package:construculator/features/estimation/presentation/pages/cost_estimation_landing_page.dart';
 import 'package:construculator/features/members/presentation/pages/members_page.dart';
 import 'package:construculator/l10n/generated/app_localizations.dart';
-import 'package:construculator/libraries/auth/interfaces/auth_manager.dart';
-import 'package:construculator/libraries/auth/interfaces/auth_notifier.dart';
-import 'package:construculator/libraries/auth/testing/fake_auth_manager.dart';
-import 'package:construculator/libraries/auth/testing/fake_auth_notifier.dart';
-import 'package:construculator/libraries/auth/testing/fake_auth_repository.dart';
-import 'package:construculator/libraries/config/testing/fake_app_config.dart';
-import 'package:construculator/libraries/config/testing/fake_env_loader.dart';
+import 'package:construculator/libraries/auth/data/models/auth_user.dart';
+import 'package:construculator/libraries/auth/domain/types/auth_types.dart';
 import 'package:construculator/libraries/project/interfaces/current_project_notifier.dart';
-import 'package:construculator/libraries/project/presentation/project_ui_provider.dart';
 import 'package:construculator/libraries/project/testing/fake_current_project_notifier.dart';
-import 'package:construculator/libraries/router/interfaces/app_router.dart';
-import 'package:construculator/libraries/router/testing/fake_router.dart';
-import 'package:construculator/libraries/sentry/fake_sentry_wrapper.dart';
+import 'package:construculator/libraries/supabase/testing/fake_supabase_user.dart';
 import 'package:construculator/libraries/supabase/testing/fake_supabase_wrapper.dart';
 import 'package:construculator/libraries/time/testing/fake_clock_impl.dart';
 import 'package:flutter/material.dart';
@@ -30,63 +17,11 @@ import 'package:flutter_modular/flutter_modular.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:ripplearc_coreui/ripplearc_coreui.dart';
 
-class _FakeProjectUiProvider extends ProjectUIProvider {
-  @override
-  PreferredSizeWidget buildProjectHeaderAppbar({
-    required String projectId,
-    VoidCallback? onProjectTap,
-    VoidCallback? onSearchTap,
-    VoidCallback? onNotificationTap,
-    ImageProvider<Object>? avatarImage,
-  }) {
-    return AppBar(title: Text(projectId));
-  }
-}
-
-class _TestEstimationTabModuleProvider implements TabModuleProvider {
-  const _TestEstimationTabModuleProvider();
-
-  @override
-  Future<void> load(AppBootstrap appBootstrap) async {
-    Modular.bindModule(EstimationModule(appBootstrap));
-  }
-}
-
-class _AppShellTestModule extends Module {
-  final FakeAuthManager authManager;
-  final FakeAuthNotifier authNotifier;
-  final FakeCurrentProjectNotifier currentProjectNotifier;
-  final AppBootstrap appBootstrap;
-
-  _AppShellTestModule({
-    required this.authManager,
-    required this.authNotifier,
-    required this.currentProjectNotifier,
-    required this.appBootstrap,
-  });
-
-  @override
-  void binds(Injector i) {
-    i.addLazySingleton<AuthManager>(() => authManager);
-    i.addLazySingleton<AuthNotifier>(() => authNotifier);
-    i.addLazySingleton<AppRouter>(FakeAppRouter.new);
-    i.addLazySingleton<CurrentProjectNotifier>(() => currentProjectNotifier);
-    i.addLazySingleton<ProjectUIProvider>(() => _FakeProjectUiProvider());
-    i.addLazySingleton<TabModuleManager>(
-      () => TabModuleManager(
-        appBootstrap,
-        providers: {
-          for (final tab in ShellTab.values) tab: const NoOpTabModuleProvider(),
-          ShellTab.estimation: const _TestEstimationTabModuleProvider(),
-        },
-      ),
-    );
-    i.add<AppShellBloc>(() => AppShellBloc(moduleLoader: i.get()));
-  }
-}
+import '../../utils/fake_app_bootstrap_factory.dart';
 
 void main() {
   late FakeCurrentProjectNotifier fakeProjectNotifier;
+  late FakeSupabaseWrapper fakeSupabaseWrapper;
 
   setUpAll(() {
     CoreToast.disableTimers();
@@ -97,35 +32,38 @@ void main() {
   });
 
   setUp(() {
-    final clock = FakeClockImpl();
-    final fakeSupabase = FakeSupabaseWrapper(clock: clock);
-    final authNotifier = FakeAuthNotifier();
-    final authRepository = FakeAuthRepository(clock: clock);
-    final authManager = FakeAuthManager(
-      authNotifier: authNotifier,
-      authRepository: authRepository,
-      wrapper: fakeSupabase,
-      clock: clock,
-    );
     fakeProjectNotifier = FakeCurrentProjectNotifier(
       initialProjectId: '950e8400-e29b-41d4-a716-446655440001',
     );
+    final fakeClock = FakeClockImpl();
+    fakeSupabaseWrapper = FakeSupabaseWrapper(clock: fakeClock);
 
-    final appBootstrap = AppBootstrap(
-      config: FakeAppConfig(),
-      envLoader: FakeEnvLoader(),
-      supabaseWrapper: fakeSupabase,
-      sentryWrapper: FakeSentryWrapper(),
+    fakeSupabaseWrapper.setCurrentUser(
+      FakeUser(id: 'fake-id', createdAt: fakeClock.now().toIso8601String()),
     );
+
+    final fakeUser = User(
+      id: '1',
+      credentialId: 'fake-id',
+      email: 'test@example.com',
+      firstName: 'Test',
+      lastName: 'User',
+      professionalRole: 'Engineer',
+      createdAt: fakeClock.now(),
+      updatedAt: fakeClock.now(),
+      userStatus: UserProfileStatus.active,
+      userPreferences: {},
+    );
+
+    fakeSupabaseWrapper.addTableData('users', [fakeUser.toJson()]);
 
     Modular.init(
-      _AppShellTestModule(
-        authManager: authManager,
-        authNotifier: authNotifier,
-        currentProjectNotifier: fakeProjectNotifier,
-        appBootstrap: appBootstrap,
+      ShellModule(
+        FakeAppBootstrapFactory.create(supabaseWrapper: fakeSupabaseWrapper),
       ),
     );
+
+    Modular.replaceInstance<CurrentProjectNotifier>(fakeProjectNotifier);
   });
 
   tearDown(() {
@@ -304,16 +242,17 @@ void main() {
   });
 
   group('Cost Estimation Tab', () {
-    testWidgets('shows CostEstimationLandingPage when estimation tab is tapped', (
-      tester,
-    ) async {
-      await tester.pumpWidget(makeApp());
-      await tester.pumpAndSettle();
+    testWidgets(
+      'shows CostEstimationLandingPage when estimation tab is tapped',
+      (tester) async {
+        await tester.pumpWidget(makeApp());
+        await tester.pumpAndSettle();
 
-      await tapTabByLabel(tester, l10n().costEstimation);
+        await tapTabByLabel(tester, l10n().costEstimation);
 
-      expect(find.byType(CostEstimationLandingPage), findsOneWidget);
-    });
+        expect(find.byType(CostEstimationLandingPage), findsOneWidget);
+      },
+    );
   });
 
   group('App Bar', () {

--- a/test/app/shell/units/app_shell_bloc_test.dart
+++ b/test/app/shell/units/app_shell_bloc_test.dart
@@ -1,32 +1,20 @@
 import 'package:bloc_test/bloc_test.dart';
 import 'package:construculator/app/shell/app_shell_bloc/app_shell_bloc.dart';
-import 'package:construculator/app/shell/default_tab_providers.dart';
+import 'package:construculator/app/shell/shell_module.dart';
 import 'package:construculator/app/shell/tab_module_manager.dart';
-import 'package:construculator/libraries/supabase/testing/fake_supabase_wrapper.dart';
-import 'package:construculator/libraries/time/testing/fake_clock_impl.dart';
 import 'package:flutter_modular/flutter_modular.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import '../../../utils/fake_app_bootstrap_factory.dart';
 
-TabModuleManager _noOpLoader() {
-  final clock = FakeClockImpl();
-  return TabModuleManager(
-    FakeAppBootstrapFactory.create(
-      supabaseWrapper: FakeSupabaseWrapper(clock: clock),
-    ),
-    providers: {
-      for (final tab in ShellTab.values) tab: const NoOpTabModuleProvider(),
-    },
-  );
-}
-
 void main() {
   late AppShellBloc bloc;
+  late TabModuleManager tabModuleManager;
 
   setUp(() {
-    Modular.init(_AppShellBlocTestModule());
+    Modular.init(ShellModule(FakeAppBootstrapFactory.create()));
     bloc = Modular.get<AppShellBloc>();
+    tabModuleManager = Modular.get<TabModuleManager>();
   });
 
   tearDown(() async {
@@ -35,10 +23,15 @@ void main() {
   });
 
   group('AppShellBloc', () {
-    test('initial state has tab 0 loaded', () {
-      expect(bloc.state.selectedTabIndex, 0);
-      expect(bloc.state.loadedTabIndexes, {0});
-    });
+    blocTest<AppShellBloc, AppShellState>(
+      'emits home tab loaded after AppShellInitialized',
+      build: () => AppShellBloc(moduleLoader: tabModuleManager),
+      act: (b) => b.add(const AppShellInitialized()),
+      expect: () => [
+        const AppShellState(selectedTabIndex: 0, loadedTabIndexes: {0}),
+      ],
+      verify: (_) => expect(tabModuleManager.isLoaded(ShellTab.home), isTrue),
+    );
 
     test('events expose value equality through props', () {
       expect(
@@ -69,8 +62,24 @@ void main() {
     });
 
     blocTest<AppShellBloc, AppShellState>(
+      'processes AppShellTabSelected then AppShellInitialized: loads the selected tab, then initializes home',
+      build: () => bloc,
+      act: (bloc) {
+        bloc.add(const AppShellTabSelected(1));
+        bloc.add(const AppShellInitialized());
+      },
+      expect: () => [
+        const AppShellState(selectedTabIndex: 1, loadedTabIndexes: {0, 1}),
+        const AppShellState(selectedTabIndex: 0, loadedTabIndexes: {0}),
+      ],
+      verify: (bloc) {
+        expect(tabModuleManager.isLoaded(ShellTab.home), isTrue);
+      },
+    );
+
+    blocTest<AppShellBloc, AppShellState>(
       'updates selected tab and tracks lazy-loaded tabs',
-      build: () => Modular.get<AppShellBloc>(),
+      build: () => bloc,
       act: (bloc) {
         bloc.add(const AppShellTabSelected(1));
         bloc.add(const AppShellTabSelected(3));
@@ -79,21 +88,19 @@ void main() {
         const AppShellState(selectedTabIndex: 1, loadedTabIndexes: {0, 1}),
         const AppShellState(selectedTabIndex: 3, loadedTabIndexes: {0, 1, 3}),
       ],
+      verify: (bloc) {
+        expect(tabModuleManager.isLoaded(ShellTab.home), isTrue);
+        expect(tabModuleManager.isLoaded(ShellTab.calculations), isTrue);
+        expect(tabModuleManager.isLoaded(ShellTab.estimation), isFalse);
+        expect(tabModuleManager.isLoaded(ShellTab.members), isTrue);
+      },
     );
 
     blocTest<AppShellBloc, AppShellState>(
       'does not emit when selecting current tab',
-      build: () => Modular.get<AppShellBloc>(),
+      build: () => bloc,
       act: (bloc) => bloc.add(const AppShellTabSelected(0)),
       expect: () => <AppShellState>[],
     );
   });
-}
-
-class _AppShellBlocTestModule extends Module {
-  @override
-  void binds(Injector i) {
-    i.add<TabModuleManager>(_noOpLoader);
-    i.add<AppShellBloc>(() => AppShellBloc(moduleLoader: i.get()));
-  }
 }


### PR DESCRIPTION
# PR Review: `bugfix/fix-appshell-bloc-initialization` → `feat/custom_animated_splash_screen`

**Date:** Wed May 27, 2026
**Reviewer:** Automated Code Review
**PR Size Classification:** XS (~18 net lines of production code) ✅

---

## 1. PR Summary

This PR fixes a bug where the `AppShellBloc` initialised with `loadedTabIndexes: {0}` in its constructor, marking the home tab as loaded in state without actually loading the underlying module. The fix defers that work to a new `AppShellInitialized` event, which is dispatched immediately at BLoC creation in `ShellModule.binds()`. The event handler calls `_moduleLoader.ensureTabModuleLoaded(ShellTab.home)` before emitting the loaded state. An `AuthGuard` is also added to the shell route. The tests are significantly simplified by replacing the custom `_AppShellTestModule` and `_AppShellBlocTestModule` with the real `ShellModule` backed by `FakeAppBootstrapFactory`, which is a clean RULE_3 improvement.

---

## 2. Review Summary Table

| Issue Name | Description | Status | Notes |
|---|---|---|---|
| **Dead code `NoOpTabModuleProvider()` in page test** | `NoOpTabModuleProvider()` is instantiated with no assignment in `setUp()`. It has no effect and is a refactoring artefact. Remove it. | ✅ | I have removed it because I believe we can use `TabModuleManager` |
| **Synchronous assertion on async `AppShellInitialized` in bloc test** | `'initial state has tab 0 loaded'` is a plain `test()` that checks `loadedTabIndexes == {0}` synchronously. Since `_onInitialized` is `async`, this could be flaky if `ensureTabModuleLoaded` doesn't resolve synchronously in the fake. Verify the fake's behaviour or convert to a `blocTest` with `wait`. | ✅ |  |