### PR TITLE
fix: correct Dart repo architecture constraint and resolve FVM kernel binary mismatch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN apt-get update && \
     gnupg \
     openjdk-17-jdk \
     && wget -qO- https://dl-ssl.google.com/linux/linux_signing_key.pub | gpg --dearmor -o /usr/share/keyrings/dart.gpg && \
-    echo 'deb [signed-by=/usr/share/keyrings/dart.gpg arch=amd64] https://storage.googleapis.com/download.dartlang.org/linux/debian stable main' | tee /etc/apt/sources.list.d/dart_stable.list && \
+    echo 'deb [signed-by=/usr/share/keyrings/dart.gpg] https://storage.googleapis.com/download.dartlang.org/linux/debian stable main' | tee /etc/apt/sources.list.d/dart_stable.list && \
     apt-get update && \
     apt-get install -y dart && \
     rm -rf /var/lib/apt/lists/*
@@ -69,6 +69,9 @@ COPY --chown=flutter:flutter .fvmrc ./
 # Install Flutter using FVM based on .fvmrc and set it as default
 RUN fvm install && \
     fvm global ${FLUTTER_VERSION}
+
+# Re-activate fvm using the Flutter-bundled Dart (3.8.0) to avoid kernel binary mismatch
+RUN /home/flutter/fvm/default/bin/dart pub global activate fvm
 
 # Ensure PATH and SSH alias are exported in interactive shells
 RUN echo 'export PATH="$PATH:$HOME/.pub-cache/bin:$HOME/fvm/default/bin:$ANDROID_HOME/cmdline-tools/latest/bin:$ANDROID_HOME/platform-tools"' >> ~/.bashrc


### PR DESCRIPTION
## Summary

Fixes two Docker build issues related to Dart/FVM version mismatches.

## Changes

**1. Remove `arch=amd64` from Dart APT source**
Prevents Dart installation from being silently skipped on non-amd64 runners (e.g. ARM/Apple Silicon).

**2. Re-activate FVM using Flutter's bundled Dart**
FVM is first installed via the system Dart, but Flutter ships its own Dart SDK. Without re-activation, this causes a kernel binary mismatch at runtime.

```dockerfile
# Re-activate fvm using Flutter-bundled Dart to avoid kernel binary mismatch
RUN /home/flutter/fvm/default/bin/dart pub global activate fvm
```

## Testing
- Docker image builds successfully end-to-end
- `fvm flutter doctor` passes without kernel binary mismatch errors