### PR TITLE
CA-263: feat: implement RemoteProjectSettingDataSource

### DIFF
--- a/lib/libraries/errors/exceptions.dart
+++ b/lib/libraries/errors/exceptions.dart
@@ -45,6 +45,14 @@ class ServerException extends AppException {
   ServerException(super.stackTrace, super.exception);
 }
 
+/// Exception thrown when a requested resource does not exist.
+///
+/// Use this exception for expected not-found outcomes so callers can map it to
+/// a not-found failure without treating it as a Sentry-level error.
+class NotFoundException extends AppException {
+  NotFoundException(super.stackTrace, super.exception);
+}
+
 /// Exception thrown when a client error occurs.
 ///
 /// Throw this exception when status of an upstream request

--- a/lib/libraries/project/data/data_source/interfaces/project_setting_data_source.dart
+++ b/lib/libraries/project/data/data_source/interfaces/project_setting_data_source.dart
@@ -6,6 +6,11 @@ import 'package:construculator/libraries/project/data/models/project_dto.dart';
 /// Methods throw on failure — callers are responsible for converting exceptions
 /// to domain [Failure] objects.
 abstract class ProjectSettingDataSource {
+  /// Creates a new project from [projectDto] and returns the persisted row.
+  ///
+  /// Throws on network or database errors.
+  Future<ProjectDto> createProject(ProjectDto projectDto);
+
   /// Fetches the current state of a single project by its [projectId].
   ///
   /// Throws if the project does not exist or if a network error occurs.
@@ -21,10 +26,4 @@ abstract class ProjectSettingDataSource {
   ///
   /// Throws on network or database errors.
   Future<void> deleteProject(String projectId);
-
-  /// Emits the latest project snapshot whenever the project row identified by
-  /// [projectId] changes in remote storage.
-  ///
-  /// Errors from the underlying stream are forwarded to subscribers.
-  Stream<ProjectDto?> watchProjectChanges(String projectId);
 }

--- a/lib/libraries/project/data/data_source/interfaces/project_setting_data_source.dart
+++ b/lib/libraries/project/data/data_source/interfaces/project_setting_data_source.dart
@@ -1,3 +1,4 @@
+// coverage:ignore-file
 import 'package:construculator/libraries/project/data/models/project_dto.dart';
 
 /// Provides raw data access for project setting mutations and single-project reads.

--- a/lib/libraries/project/data/data_source/interfaces/project_setting_data_source.dart
+++ b/lib/libraries/project/data/data_source/interfaces/project_setting_data_source.dart
@@ -1,0 +1,30 @@
+import 'package:construculator/libraries/project/data/models/project_dto.dart';
+
+/// Provides raw data access for project setting mutations and single-project reads.
+///
+/// Implementations communicate directly with a remote data store (e.g., Supabase).
+/// Methods throw on failure — callers are responsible for converting exceptions
+/// to domain [Failure] objects.
+abstract class ProjectSettingDataSource {
+  /// Fetches the current state of a single project by its [projectId].
+  ///
+  /// Throws if the project does not exist or if a network error occurs.
+  Future<ProjectDto> fetchProjectSetting(String projectId);
+
+  /// Persists the editable fields of [projectDto] to remote storage.
+  ///
+  /// Returns the updated [ProjectDto] as stored after the write.
+  /// Throws on network or database errors.
+  Future<ProjectDto> updateProject(ProjectDto projectDto);
+
+  /// Permanently deletes the project identified by [projectId].
+  ///
+  /// Throws on network or database errors.
+  Future<void> deleteProject(String projectId);
+
+  /// Emits the latest project snapshot whenever the project row identified by
+  /// [projectId] changes in remote storage.
+  ///
+  /// Errors from the underlying stream are forwarded to subscribers.
+  Stream<ProjectDto?> watchProjectChanges(String projectId);
+}

--- a/lib/libraries/project/data/data_source/remote_project_setting_data_source.dart
+++ b/lib/libraries/project/data/data_source/remote_project_setting_data_source.dart
@@ -44,7 +44,7 @@ class RemoteProjectSettingDataSource implements ProjectSettingDataSource {
 
       return ProjectDto.fromJson(row);
     } on NotFoundException {
-      rethrow;
+      rethrow; // Prevents double-logging in the catch below.
     } catch (error, stackTrace) {
       _logger.warning(
         'Error while getting project setting for projectId: $projectId, error: $error',
@@ -66,6 +66,7 @@ class RemoteProjectSettingDataSource implements ProjectSettingDataSource {
 
       // Editable columns are always sent (including nulls) so the edit form
       // can clear an optional field. project_name is NOT NULL, so it is always set.
+      // updated_at is omitted because it is managed server-side by a DB trigger.
       final data = <String, dynamic>{
         DatabaseConstants.projectNameColumn: projectDto.projectName,
         DatabaseConstants.descriptionColumn: projectDto.description,
@@ -102,6 +103,9 @@ class RemoteProjectSettingDataSource implements ProjectSettingDataSource {
 
       // Hard remote delete by id. Offline-queued / soft deletion will be
       // handled by the local data source.
+      // Note: Supabase DELETE is a no-op for non-existent rows — callers that
+      // need to distinguish "deleted" vs "never existed" must check rows-affected
+      // at the repository layer.
       // TODO: https://ripplearc.youtrack.cloud/issue/CA-262
       await _supabaseWrapper.delete(
         table: DatabaseConstants.projectsTable,

--- a/lib/libraries/project/data/data_source/remote_project_setting_data_source.dart
+++ b/lib/libraries/project/data/data_source/remote_project_setting_data_source.dart
@@ -19,6 +19,41 @@ class RemoteProjectSettingDataSource implements ProjectSettingDataSource {
     required SupabaseWrapper supabaseWrapper,
   }) : _supabaseWrapper = supabaseWrapper;
 
+  /// Creates a new project row from [projectDto] and returns the persisted row.
+  ///
+  /// Throws on network or database errors.
+  @override
+  Future<ProjectDto> createProject(ProjectDto projectDto) async {
+    try {
+      _logger.debug('Creating project with name: ${projectDto.projectName}');
+
+      final data = <String, dynamic>{
+        DatabaseConstants.projectNameColumn: projectDto.projectName,
+        DatabaseConstants.descriptionColumn: projectDto.description,
+        DatabaseConstants.creatorUserIdColumn: projectDto.creatorUserId,
+        DatabaseConstants.owningCompanyIdColumn: projectDto.owningCompanyId,
+        DatabaseConstants.exportFolderLinkColumn: projectDto.exportFolderLink,
+        DatabaseConstants.exportStorageProviderColumn:
+            projectDto.exportStorageProvider,
+        DatabaseConstants.statusColumn: projectDto.status.name,
+      };
+
+      final result = await _supabaseWrapper.insert(
+        table: DatabaseConstants.projectsTable,
+        data: data,
+      );
+
+      return ProjectDto.fromJson(result);
+    } catch (error, stackTrace) {
+      _logger.warning(
+        'Error while creating project: $error',
+        error,
+        stackTrace,
+      );
+      rethrow;
+    }
+  }
+
   /// Fetches a single project setting row by [projectId].
   ///
   /// Throws [NotFoundException] when the project does not exist and rethrows
@@ -122,27 +157,4 @@ class RemoteProjectSettingDataSource implements ProjectSettingDataSource {
     }
   }
 
-  /// Streams the latest project setting snapshot whenever the project row changes.
-  ///
-  /// Emits `null` when the project is deleted or temporarily missing and
-  /// forwards stream errors to subscribers.
-  @override
-  Stream<ProjectDto?> watchProjectChanges(String projectId) {
-    return _supabaseWrapper
-        .watchTableFiltered(
-          table: DatabaseConstants.projectsTable,
-          primaryKey: const [DatabaseConstants.idColumn],
-          filterColumn: DatabaseConstants.idColumn,
-          filterValue: projectId,
-        )
-        .map((rows) => rows.isEmpty ? null : ProjectDto.fromJson(rows.first))
-        .handleError((Object error, StackTrace stackTrace) {
-          _logger.warning(
-            'Error while watching project changes for projectId: $projectId, error: $error',
-            error,
-            stackTrace,
-          );
-          Error.throwWithStackTrace(error, stackTrace);
-        });
-  }
 }

--- a/lib/libraries/project/data/data_source/remote_project_setting_data_source.dart
+++ b/lib/libraries/project/data/data_source/remote_project_setting_data_source.dart
@@ -19,11 +19,11 @@ class RemoteProjectSettingDataSource implements ProjectSettingDataSource {
     required SupabaseWrapper supabaseWrapper,
   }) : _supabaseWrapper = supabaseWrapper;
 
-  @override
   /// Fetches a single project setting row by [projectId].
   ///
   /// Throws [NotFoundException] when the project does not exist and rethrows
   /// unexpected Supabase or parsing errors.
+  @override
   Future<ProjectDto> fetchProjectSetting(String projectId) async {
     try {
       _logger.debug('Getting project setting for projectId: $projectId');
@@ -55,11 +55,11 @@ class RemoteProjectSettingDataSource implements ProjectSettingDataSource {
     }
   }
 
-  @override
   /// Persists the editable project settings in remote storage.
   ///
   /// Returns the updated project row as stored remotely and rethrows
   /// unexpected Supabase or parsing errors.
+  @override
   Future<ProjectDto> updateProject(ProjectDto projectDto) async {
     try {
       _logger.debug('Updating project with id: ${projectDto.id}');
@@ -92,10 +92,10 @@ class RemoteProjectSettingDataSource implements ProjectSettingDataSource {
     }
   }
 
-  @override
   /// Deletes the project row identified by [projectId].
   ///
   /// Throws on unexpected Supabase errors.
+  @override
   Future<void> deleteProject(String projectId) async {
     try {
       _logger.debug('Deleting project with id: $projectId');
@@ -118,11 +118,11 @@ class RemoteProjectSettingDataSource implements ProjectSettingDataSource {
     }
   }
 
-  @override
   /// Streams the latest project setting snapshot whenever the project row changes.
   ///
   /// Emits `null` when the project is deleted or temporarily missing and
   /// forwards stream errors to subscribers.
+  @override
   Stream<ProjectDto?> watchProjectChanges(String projectId) {
     return _supabaseWrapper
         .watchTableFiltered(

--- a/lib/libraries/project/data/data_source/remote_project_setting_data_source.dart
+++ b/lib/libraries/project/data/data_source/remote_project_setting_data_source.dart
@@ -1,0 +1,144 @@
+import 'package:construculator/libraries/errors/exceptions.dart';
+import 'package:construculator/libraries/logging/app_logger.dart';
+import 'package:construculator/libraries/project/data/data_source/interfaces/project_setting_data_source.dart';
+import 'package:construculator/libraries/project/data/models/project_dto.dart';
+import 'package:construculator/libraries/supabase/database_constants.dart';
+import 'package:construculator/libraries/supabase/interfaces/supabase_wrapper.dart';
+import 'package:stack_trace/stack_trace.dart';
+
+/// Remote data source for reading and mutating a single project's settings.
+///
+/// This layer talks directly to Supabase and throws low-level exceptions that
+/// higher layers map into project failures.
+class RemoteProjectSettingDataSource implements ProjectSettingDataSource {
+  final SupabaseWrapper _supabaseWrapper;
+  static final _logger = AppLogger().tag('RemoteProjectSettingDataSource');
+
+  /// Creates a remote project setting data source.
+  const RemoteProjectSettingDataSource({
+    required SupabaseWrapper supabaseWrapper,
+  }) : _supabaseWrapper = supabaseWrapper;
+
+  @override
+  /// Fetches a single project setting row by [projectId].
+  ///
+  /// Throws [NotFoundException] when the project does not exist and rethrows
+  /// unexpected Supabase or parsing errors.
+  Future<ProjectDto> fetchProjectSetting(String projectId) async {
+    try {
+      _logger.debug('Getting project setting for projectId: $projectId');
+
+      final row = await _supabaseWrapper.selectSingle(
+        table: DatabaseConstants.projectsTable,
+        filterColumn: DatabaseConstants.idColumn,
+        filterValue: projectId,
+      );
+
+      if (row == null) {
+        _logger.warning('Project not found for projectId: $projectId');
+        throw NotFoundException(
+          Trace.current(),
+          Exception('Project not found for id: $projectId'),
+        );
+      }
+
+      return ProjectDto.fromJson(row);
+    } on NotFoundException {
+      rethrow;
+    } catch (error, stackTrace) {
+      _logger.warning(
+        'Error while getting project setting for projectId: $projectId, error: $error',
+        error,
+        stackTrace,
+      );
+      rethrow;
+    }
+  }
+
+  @override
+  /// Persists the editable project settings in remote storage.
+  ///
+  /// Returns the updated project row as stored remotely and rethrows
+  /// unexpected Supabase or parsing errors.
+  Future<ProjectDto> updateProject(ProjectDto projectDto) async {
+    try {
+      _logger.debug('Updating project with id: ${projectDto.id}');
+
+      // Editable columns are always sent (including nulls) so the edit form
+      // can clear an optional field. project_name is NOT NULL, so it is always set.
+      final data = <String, dynamic>{
+        DatabaseConstants.projectNameColumn: projectDto.projectName,
+        DatabaseConstants.descriptionColumn: projectDto.description,
+        DatabaseConstants.exportFolderLinkColumn: projectDto.exportFolderLink,
+        DatabaseConstants.exportStorageProviderColumn:
+            projectDto.exportStorageProvider,
+      };
+
+      final result = await _supabaseWrapper.update(
+        table: DatabaseConstants.projectsTable,
+        data: data,
+        filterColumn: DatabaseConstants.idColumn,
+        filterValue: projectDto.id,
+      );
+
+      return ProjectDto.fromJson(result);
+    } catch (error, stackTrace) {
+      _logger.warning(
+        'Error while updating project with id: ${projectDto.id}, error: $error',
+        error,
+        stackTrace,
+      );
+      rethrow;
+    }
+  }
+
+  @override
+  /// Deletes the project row identified by [projectId].
+  ///
+  /// Throws on unexpected Supabase errors.
+  Future<void> deleteProject(String projectId) async {
+    try {
+      _logger.debug('Deleting project with id: $projectId');
+
+      // Hard remote delete by id. Offline-queued / soft deletion will be
+      // handled by the local data source.
+      // TODO: https://ripplearc.youtrack.cloud/issue/CA-262
+      await _supabaseWrapper.delete(
+        table: DatabaseConstants.projectsTable,
+        filterColumn: DatabaseConstants.idColumn,
+        filterValue: projectId,
+      );
+    } catch (error, stackTrace) {
+      _logger.warning(
+        'Error while deleting project with id: $projectId, error: $error',
+        error,
+        stackTrace,
+      );
+      rethrow;
+    }
+  }
+
+  @override
+  /// Streams the latest project setting snapshot whenever the project row changes.
+  ///
+  /// Emits `null` when the project is deleted or temporarily missing and
+  /// forwards stream errors to subscribers.
+  Stream<ProjectDto?> watchProjectChanges(String projectId) {
+    return _supabaseWrapper
+        .watchTableFiltered(
+          table: DatabaseConstants.projectsTable,
+          primaryKey: const [DatabaseConstants.idColumn],
+          filterColumn: DatabaseConstants.idColumn,
+          filterValue: projectId,
+        )
+        .map((rows) => rows.isEmpty ? null : ProjectDto.fromJson(rows.first))
+        .handleError((Object error, StackTrace stackTrace) {
+          _logger.warning(
+            'Error while watching project changes for projectId: $projectId, error: $error',
+            error,
+            stackTrace,
+          );
+          Error.throwWithStackTrace(error, stackTrace);
+        });
+  }
+}

--- a/test/libraries/project/units/data/data_source/remote_project_setting_data_source_test.dart
+++ b/test/libraries/project/units/data/data_source/remote_project_setting_data_source_test.dart
@@ -1,0 +1,291 @@
+import 'dart:async';
+
+import 'package:construculator/libraries/errors/exceptions.dart';
+import 'package:construculator/libraries/project/data/data_source/remote_project_setting_data_source.dart';
+import 'package:construculator/libraries/project/data/models/project_dto.dart';
+import 'package:construculator/libraries/project/domain/entities/enums.dart';
+import 'package:construculator/libraries/supabase/data/supabase_types.dart';
+import 'package:construculator/libraries/supabase/database_constants.dart';
+import 'package:construculator/libraries/supabase/testing/fake_supabase_wrapper.dart';
+import 'package:construculator/libraries/time/testing/fake_clock_impl.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:supabase_flutter/supabase_flutter.dart' as supabase;
+
+void main() {
+  group('RemoteProjectSettingDataSource', () {
+    late FakeClockImpl clock;
+    late FakeSupabaseWrapper supabaseWrapper;
+    late RemoteProjectSettingDataSource dataSource;
+
+    setUp(() {
+      clock = FakeClockImpl(DateTime(2025, 1, 1, 8, 0));
+      supabaseWrapper = FakeSupabaseWrapper(clock: clock);
+      dataSource = RemoteProjectSettingDataSource(
+        supabaseWrapper: supabaseWrapper,
+      );
+    });
+
+    tearDown(() {
+      supabaseWrapper.reset();
+    });
+
+    group('fetchProjectSetting', () {
+      test('returns ProjectDto when project exists', () async {
+        supabaseWrapper.addTableData(DatabaseConstants.projectsTable, [
+          _projectRow(id: 'project-1', projectName: 'My Project'),
+        ]);
+
+        final result = await dataSource.fetchProjectSetting('project-1');
+
+        expect(result.id, equals('project-1'));
+        expect(result.projectName, equals('My Project'));
+      });
+
+      test('throws NotFoundException when project does not exist', () async {
+        await expectLater(
+          dataSource.fetchProjectSetting('non-existent'),
+          throwsA(isA<NotFoundException>()),
+        );
+      });
+
+      test(
+        'rethrows when selectSingle throws due to shouldReturnNullOnSelect',
+        () async {
+          supabaseWrapper.shouldReturnNullOnSelect = true;
+
+          await expectLater(
+            dataSource.fetchProjectSetting('project-1'),
+            throwsA(isA<NotFoundException>()),
+          );
+        },
+      );
+
+      test('rethrows PostgrestException from supabaseWrapper', () async {
+        supabaseWrapper.shouldThrowOnSelect = true;
+        supabaseWrapper.selectExceptionType = SupabaseExceptionType.postgrest;
+
+        await expectLater(
+          dataSource.fetchProjectSetting('project-1'),
+          throwsA(isA<supabase.PostgrestException>()),
+        );
+      });
+    });
+
+    group('updateProject', () {
+      test('calls update with correct table, data map, and filter', () async {
+        supabaseWrapper.addTableData(DatabaseConstants.projectsTable, [
+          _projectRow(id: 'project-1', projectName: 'Old Name'),
+        ]);
+
+        final dto = _projectDto(id: 'project-1', projectName: 'New Name');
+        final result = await dataSource.updateProject(dto);
+
+        expect(result.id, equals('project-1'));
+        expect(result.projectName, equals('New Name'));
+
+        final updateCalls = supabaseWrapper.getMethodCallsFor('update');
+        expect(updateCalls, hasLength(1));
+        expect(
+          updateCalls.first['table'],
+          equals(DatabaseConstants.projectsTable),
+        );
+        expect(
+          updateCalls.first['filterColumn'],
+          equals(DatabaseConstants.idColumn),
+        );
+        expect(updateCalls.first['filterValue'], equals('project-1'));
+      });
+
+      test('includes description in data map when provided', () async {
+        supabaseWrapper.addTableData(DatabaseConstants.projectsTable, [
+          _projectRow(
+            id: 'project-1',
+            projectName: 'Project',
+            description: 'Old desc',
+          ),
+        ]);
+
+        final dto = _projectDto(
+          id: 'project-1',
+          projectName: 'Project',
+          description: 'New desc',
+        );
+        await dataSource.updateProject(dto);
+
+        final updateCalls = supabaseWrapper.getMethodCallsFor('update');
+        final data = updateCalls.first['data'] as Map<String, dynamic>;
+        expect(data[DatabaseConstants.descriptionColumn], equals('New desc'));
+      });
+
+      test(
+        'includes nullable editable fields even when null so they can be cleared',
+        () async {
+          supabaseWrapper.addTableData(DatabaseConstants.projectsTable, [
+            _projectRow(
+              id: 'project-1',
+              projectName: 'Project',
+              description: 'Old desc',
+            ),
+          ]);
+
+          final dto = _projectDto(id: 'project-1', projectName: 'Project');
+          await dataSource.updateProject(dto);
+
+          final data =
+              supabaseWrapper.getMethodCallsFor('update').first['data']
+                  as Map<String, dynamic>;
+          expect(data.containsKey(DatabaseConstants.descriptionColumn), isTrue);
+          expect(data[DatabaseConstants.descriptionColumn], isNull);
+          expect(
+            data.containsKey(DatabaseConstants.exportFolderLinkColumn),
+            isTrue,
+          );
+          expect(data[DatabaseConstants.exportFolderLinkColumn], isNull);
+          expect(
+            data.containsKey(DatabaseConstants.exportStorageProviderColumn),
+            isTrue,
+          );
+          expect(data[DatabaseConstants.exportStorageProviderColumn], isNull);
+        },
+      );
+
+      test('rethrows PostgrestException on shouldThrowOnUpdate', () async {
+        supabaseWrapper.shouldThrowOnUpdate = true;
+        supabaseWrapper.updateExceptionType = SupabaseExceptionType.postgrest;
+
+        final dto = _projectDto(id: 'project-1', projectName: 'Name');
+        await expectLater(
+          dataSource.updateProject(dto),
+          throwsA(isA<supabase.PostgrestException>()),
+        );
+      });
+    });
+
+    group('deleteProject', () {
+      test(
+        'calls delete with correct table, filterColumn, and filterValue',
+        () async {
+          supabaseWrapper.addTableData(DatabaseConstants.projectsTable, [
+            _projectRow(id: 'project-1', projectName: 'To Delete'),
+          ]);
+
+          await dataSource.deleteProject('project-1');
+
+          final deleteCalls = supabaseWrapper.getMethodCallsFor('delete');
+          expect(deleteCalls, hasLength(1));
+          expect(
+            deleteCalls.first['table'],
+            equals(DatabaseConstants.projectsTable),
+          );
+          expect(
+            deleteCalls.first['filterColumn'],
+            equals(DatabaseConstants.idColumn),
+          );
+          expect(deleteCalls.first['filterValue'], equals('project-1'));
+        },
+      );
+
+      test('rethrows on shouldThrowOnDelete', () async {
+        supabaseWrapper.shouldThrowOnDelete = true;
+        supabaseWrapper.deleteExceptionType = SupabaseExceptionType.postgrest;
+
+        await expectLater(
+          dataSource.deleteProject('project-1'),
+          throwsA(isA<supabase.PostgrestException>()),
+        );
+      });
+    });
+
+    group('watchProjectChanges', () {
+      test('emits when project row changes', () async {
+        supabaseWrapper.addTableData(DatabaseConstants.projectsTable, [
+          _projectRow(id: 'project-1', projectName: 'Initial'),
+        ]);
+
+        final emissions = <ProjectDto?>[];
+        final emissionCompleter = Completer<void>();
+        var emissionCount = 0;
+        final subscription = dataSource.watchProjectChanges('project-1').listen(
+          (projectDto) {
+            emissions.add(projectDto);
+            emissionCount++;
+            if (emissionCount >= 2 && !emissionCompleter.isCompleted) {
+              emissionCompleter.complete();
+            }
+          },
+        );
+
+        await pumpEventQueue();
+
+        supabaseWrapper.addTableData(DatabaseConstants.projectsTable, [
+          _projectRow(id: 'project-1', projectName: 'Updated'),
+        ]);
+
+        await expectLater(emissionCompleter.future, completes);
+        expect(emissions.first?.projectName, equals('Initial'));
+        expect(emissions.last?.projectName, equals('Updated'));
+        await subscription.cancel();
+      });
+
+      test('forwards stream errors to subscribers', () async {
+        final errorCompleter = Completer<Object>();
+        final subscription = dataSource
+            .watchProjectChanges('project-1')
+            .listen(
+              (_) {},
+              onError: (Object error, StackTrace _) {
+                if (!errorCompleter.isCompleted) errorCompleter.complete(error);
+              },
+            );
+
+        await pumpEventQueue();
+
+        supabaseWrapper.shouldEmitStreamErrors = true;
+        supabaseWrapper.addTableData(DatabaseConstants.projectsTable, [
+          _projectRow(id: 'project-1', projectName: 'Trigger'),
+        ]);
+
+        final receivedError = await errorCompleter.future;
+        expect(receivedError, isA<ServerException>());
+        await subscription.cancel();
+      });
+    });
+  });
+}
+
+Map<String, dynamic> _projectRow({
+  required String id,
+  required String projectName,
+  String? description,
+}) {
+  return {
+    DatabaseConstants.idColumn: id,
+    DatabaseConstants.projectNameColumn: projectName,
+    DatabaseConstants.descriptionColumn:
+        description ?? '$projectName description',
+    DatabaseConstants.creatorUserIdColumn: 'user-1',
+    DatabaseConstants.owningCompanyIdColumn: 'company-1',
+    DatabaseConstants.exportFolderLinkColumn: null,
+    DatabaseConstants.exportStorageProviderColumn: null,
+    DatabaseConstants.createdAtColumn: DateTime(2025, 1, 1).toIso8601String(),
+    DatabaseConstants.updatedAtColumn: DateTime(2025, 1, 2).toIso8601String(),
+    DatabaseConstants.statusColumn: 'active',
+  };
+}
+
+ProjectDto _projectDto({
+  required String id,
+  required String projectName,
+  String? description,
+}) {
+  return ProjectDto(
+    id: id,
+    projectName: projectName,
+    description: description,
+    creatorUserId: 'user-1',
+    owningCompanyId: 'company-1',
+    createdAt: DateTime(2025, 1, 1),
+    updatedAt: DateTime(2025, 1, 2),
+    status: ProjectStatus.active,
+  );
+}

--- a/test/libraries/project/units/data/data_source/remote_project_setting_data_source_test.dart
+++ b/test/libraries/project/units/data/data_source/remote_project_setting_data_source_test.dart
@@ -1,4 +1,5 @@
 import 'package:construculator/libraries/errors/exceptions.dart';
+import 'package:construculator/libraries/project/data/data_source/interfaces/project_setting_data_source.dart';
 import 'package:construculator/libraries/project/data/data_source/remote_project_setting_data_source.dart';
 import 'package:construculator/libraries/project/data/models/project_dto.dart';
 import 'package:construculator/libraries/project/domain/entities/enums.dart';
@@ -13,7 +14,7 @@ void main() {
   group('RemoteProjectSettingDataSource', () {
     late FakeClockImpl clock;
     late FakeSupabaseWrapper supabaseWrapper;
-    late RemoteProjectSettingDataSource dataSource;
+    late ProjectSettingDataSource dataSource;
 
     setUp(() {
       clock = FakeClockImpl(DateTime(2025, 1, 1, 8, 0));

--- a/test/libraries/project/units/data/data_source/remote_project_setting_data_source_test.dart
+++ b/test/libraries/project/units/data/data_source/remote_project_setting_data_source_test.dart
@@ -167,6 +167,16 @@ void main() {
           throwsA(isA<ServerException>()),
         );
       });
+
+      test('rethrows generic (non-PostgrestException) error as-is', () async {
+        supabaseWrapper.shouldThrowOnUpdate = true;
+
+        final dto = _projectDto(id: 'project-1', projectName: 'Name');
+        await expectLater(
+          dataSource.updateProject(dto),
+          throwsA(isA<ServerException>()),
+        );
+      });
     });
 
     group('deleteProject', () {

--- a/test/libraries/project/units/data/data_source/remote_project_setting_data_source_test.dart
+++ b/test/libraries/project/units/data/data_source/remote_project_setting_data_source_test.dart
@@ -1,5 +1,4 @@
 import 'package:construculator/libraries/errors/exceptions.dart';
-import 'package:construculator/libraries/project/data/data_source/interfaces/project_setting_data_source.dart';
 import 'package:construculator/libraries/project/data/data_source/remote_project_setting_data_source.dart';
 import 'package:construculator/libraries/project/data/models/project_dto.dart';
 import 'package:construculator/libraries/project/domain/entities/enums.dart';
@@ -14,7 +13,7 @@ void main() {
   group('RemoteProjectSettingDataSource', () {
     late FakeClockImpl clock;
     late FakeSupabaseWrapper supabaseWrapper;
-    late ProjectSettingDataSource dataSource;
+    late RemoteProjectSettingDataSource dataSource;
 
     setUp(() {
       clock = FakeClockImpl(DateTime(2025, 1, 1, 8, 0));

--- a/test/libraries/project/units/data/data_source/remote_project_setting_data_source_test.dart
+++ b/test/libraries/project/units/data/data_source/remote_project_setting_data_source_test.dart
@@ -49,7 +49,7 @@ void main() {
       });
 
       test(
-        'rethrows when selectSingle throws due to shouldReturnNullOnSelect',
+        'throws NotFoundException when selectSingle returns null (shouldReturnNullOnSelect)',
         () async {
           supabaseWrapper.shouldReturnNullOnSelect = true;
 
@@ -159,6 +159,14 @@ void main() {
           throwsA(isA<supabase.PostgrestException>()),
         );
       });
+
+      test('throws ServerException when updating a non-existent row', () async {
+        final dto = _projectDto(id: 'non-existent', projectName: 'Name');
+        await expectLater(
+          dataSource.updateProject(dto),
+          throwsA(isA<ServerException>()),
+        );
+      });
     });
 
     group('deleteProject', () {
@@ -214,6 +222,7 @@ void main() {
             }
           },
         );
+        addTearDown(subscription.cancel);
 
         await pumpEventQueue();
 
@@ -224,7 +233,32 @@ void main() {
         await expectLater(emissionCompleter.future, completes);
         expect(emissions.first?.projectName, equals('Initial'));
         expect(emissions.last?.projectName, equals('Updated'));
-        await subscription.cancel();
+      });
+
+      test('emits null when the project row is deleted', () async {
+        supabaseWrapper.addTableData(DatabaseConstants.projectsTable, [
+          _projectRow(id: 'project-1', projectName: 'Existing'),
+        ]);
+
+        final emissions = <ProjectDto?>[];
+        final deletionCompleter = Completer<void>();
+        final subscription = dataSource.watchProjectChanges('project-1').listen(
+          (projectDto) {
+            emissions.add(projectDto);
+            if (projectDto == null && !deletionCompleter.isCompleted) {
+              deletionCompleter.complete();
+            }
+          },
+        );
+        addTearDown(subscription.cancel);
+
+        await pumpEventQueue();
+
+        supabaseWrapper.addTableData(DatabaseConstants.projectsTable, []);
+
+        await expectLater(deletionCompleter.future, completes);
+        expect(emissions.first?.projectName, equals('Existing'));
+        expect(emissions.last, isNull);
       });
 
       test('forwards stream errors to subscribers', () async {
@@ -237,6 +271,7 @@ void main() {
                 if (!errorCompleter.isCompleted) errorCompleter.complete(error);
               },
             );
+        addTearDown(subscription.cancel);
 
         await pumpEventQueue();
 
@@ -247,7 +282,6 @@ void main() {
 
         final receivedError = await errorCompleter.future;
         expect(receivedError, isA<ServerException>());
-        await subscription.cancel();
       });
     });
   });

--- a/test/libraries/project/units/data/data_source/remote_project_setting_data_source_test.dart
+++ b/test/libraries/project/units/data/data_source/remote_project_setting_data_source_test.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:construculator/libraries/errors/exceptions.dart';
 import 'package:construculator/libraries/project/data/data_source/remote_project_setting_data_source.dart';
 import 'package:construculator/libraries/project/data/models/project_dto.dart';
@@ -214,84 +212,46 @@ void main() {
       });
     });
 
-    group('watchProjectChanges', () {
-      test('emits when project row changes', () async {
-        supabaseWrapper.addTableData(DatabaseConstants.projectsTable, [
-          _projectRow(id: 'project-1', projectName: 'Initial'),
-        ]);
-
-        final emissions = <ProjectDto?>[];
-        final emissionCompleter = Completer<void>();
-        var emissionCount = 0;
-        final subscription = dataSource.watchProjectChanges('project-1').listen(
-          (projectDto) {
-            emissions.add(projectDto);
-            emissionCount++;
-            if (emissionCount >= 2 && !emissionCompleter.isCompleted) {
-              emissionCompleter.complete();
-            }
-          },
-        );
-        addTearDown(subscription.cancel);
-
-        await pumpEventQueue();
-
-        supabaseWrapper.addTableData(DatabaseConstants.projectsTable, [
-          _projectRow(id: 'project-1', projectName: 'Updated'),
-        ]);
-
-        await expectLater(emissionCompleter.future, completes);
-        expect(emissions.first?.projectName, equals('Initial'));
-        expect(emissions.last?.projectName, equals('Updated'));
-      });
-
-      test('emits null when the project row is deleted', () async {
-        supabaseWrapper.addTableData(DatabaseConstants.projectsTable, [
-          _projectRow(id: 'project-1', projectName: 'Existing'),
-        ]);
-
-        final emissions = <ProjectDto?>[];
-        final deletionCompleter = Completer<void>();
-        final subscription = dataSource.watchProjectChanges('project-1').listen(
-          (projectDto) {
-            emissions.add(projectDto);
-            if (projectDto == null && !deletionCompleter.isCompleted) {
-              deletionCompleter.complete();
-            }
-          },
-        );
-        addTearDown(subscription.cancel);
-
-        await pumpEventQueue();
-
+    group('createProject', () {
+      test('returns ProjectDto with persisted fields on success', () async {
         supabaseWrapper.addTableData(DatabaseConstants.projectsTable, []);
 
-        await expectLater(deletionCompleter.future, completes);
-        expect(emissions.first?.projectName, equals('Existing'));
-        expect(emissions.last, isNull);
+        final dto = _projectDto(
+          id: 'project-1',
+          projectName: 'New Project',
+          description: 'A description',
+        );
+        final result = await dataSource.createProject(dto);
+
+        expect(result.projectName, equals('New Project'));
+        expect(result.description, equals('A description'));
+
+        final insertCalls = supabaseWrapper.getMethodCallsFor('insert');
+        expect(insertCalls, hasLength(1));
+        expect(
+          insertCalls.first['table'],
+          equals(DatabaseConstants.projectsTable),
+        );
+        final data = insertCalls.first['data'] as Map<String, dynamic>;
+        expect(
+          data[DatabaseConstants.projectNameColumn],
+          equals('New Project'),
+        );
+        expect(
+          data[DatabaseConstants.descriptionColumn],
+          equals('A description'),
+        );
       });
 
-      test('forwards stream errors to subscribers', () async {
-        final errorCompleter = Completer<Object>();
-        final subscription = dataSource
-            .watchProjectChanges('project-1')
-            .listen(
-              (_) {},
-              onError: (Object error, StackTrace _) {
-                if (!errorCompleter.isCompleted) errorCompleter.complete(error);
-              },
-            );
-        addTearDown(subscription.cancel);
+      test('rethrows exception when supabaseWrapper.insert throws', () async {
+        supabaseWrapper.shouldThrowOnInsert = true;
+        supabaseWrapper.insertExceptionType = SupabaseExceptionType.postgrest;
 
-        await pumpEventQueue();
-
-        supabaseWrapper.shouldEmitStreamErrors = true;
-        supabaseWrapper.addTableData(DatabaseConstants.projectsTable, [
-          _projectRow(id: 'project-1', projectName: 'Trigger'),
-        ]);
-
-        final receivedError = await errorCompleter.future;
-        expect(receivedError, isA<ServerException>());
+        final dto = _projectDto(id: 'project-1', projectName: 'New Project');
+        await expectLater(
+          dataSource.createProject(dto),
+          throwsA(isA<supabase.PostgrestException>()),
+        );
       });
     });
   });


### PR DESCRIPTION
**REVIEW SUMMARY**

| Issue Name | Description | Status | Notes |
|------------|-------------|--------|-------|
| PR Size / Scope | PR adds an interface, implementation, exception, and 1 full test file (~450+ lines total). This crosses the "L" size threshold. | Production code in this PR is 182 lines across 3 files (interface 30, impl 144, NotFoundException 8); the ~291 test lines are excluded per our digestible-PR rule (one logic per PR; prod < 100 ideal, ≤ 200 max, tests uncapped). This is one cohesive logical change; the remote data source plus the single exception its not-found path throws. The work is already split at the stack level: the FakeProjectSettingDataSource is a separate PR on top, and the repository/error-mapper layers are separate CA-250 PRs above that. Splitting the interface from its only implementation would create non-compiling/no-op intermediate PRs and violate "one logic per PR," so they stay together. | The change is cohesive, but consider splitting into (1) exception + interface, (2) implementation, (3) tests if you want smaller reviewable units. |
| Stream error handling dependency | `watchProjectChanges` uses `rxdart`'s `doOnError`. This brings a dependency-specific operator for a simple logging side-effect. | Addressed| Prefer `stream.handleError(...)` or `.transform(...)` to avoid forcing rxdart here unless the project already relies on rxdart widely. If rxdart is accepted, keep as-is. |
| Duplicate Sentry logging risk | Data source logs warnings; ensure upper layers (repository/usecases) do not also log the same errors with `error()`/`omg()`, which would double-report to Sentry. | Verified - no duplicate Sentry events.| Confirm logging policy: data-source should avoid `error()` for expected API conditions. Current code uses `warning()` — good — but ask reviewers to confirm no duplicate logging upstream. |