### PR TITLE
CA-263: feat: add FakeProjectSettingDataSource for testing

### DIFF
--- a/lib/libraries/project/testing/fake_project_setting_data_source.dart
+++ b/lib/libraries/project/testing/fake_project_setting_data_source.dart
@@ -24,9 +24,8 @@ class FakeProjectSettingDataSource implements ProjectSettingDataSource {
 
   /// If non-null, this exception/object will be thrown directly by
   /// [fetchProjectSetting] to allow tests to simulate different failures
-  /// (e.g., [TimeoutException]). This takes precedence over
-  /// [shouldThrowOnGet].
-  Object? exceptionToThrow;
+  /// (e.g., [TimeoutException]). This takes precedence over [shouldThrowOnGet].
+  Object? fetchExceptionToThrow;
 
   /// Controls whether [updateProject] throws a [ServerException].
   bool shouldThrowOnUpdate = false;
@@ -54,7 +53,7 @@ class FakeProjectSettingDataSource implements ProjectSettingDataSource {
   Future<ProjectDto> fetchProjectSetting(String projectId) async {
     _methodCalls.add({'method': 'fetchProjectSetting', 'projectId': projectId});
 
-    final exception = exceptionToThrow;
+    final exception = fetchExceptionToThrow;
     if (exception != null) {
       throw exception;
     }
@@ -77,8 +76,8 @@ class FakeProjectSettingDataSource implements ProjectSettingDataSource {
     return project;
   }
 
-  /// Persists [projectDto] (or [projectToReturn] if set) and updates stored
-  /// state so subsequent reads reflect the mutation.
+  /// Persists [projectDto] and updates stored state so subsequent reads and
+  /// watch streams reflect the mutation.
   @override
   Future<ProjectDto> updateProject(ProjectDto projectDto) async {
     _methodCalls.add({'method': 'updateProject', 'projectDto': projectDto});
@@ -90,13 +89,13 @@ class FakeProjectSettingDataSource implements ProjectSettingDataSource {
       );
     }
 
-    final result = projectToReturn ?? projectDto;
-    projectToReturn = result;
-    return result;
+    projectToReturn = projectDto;
+    _getOrCreateController(projectDto.id).add(projectDto);
+    return projectDto;
   }
 
-  /// Records deletion and clears stored state so subsequent reads and watches
-  /// reflect the removal.
+  /// Records deletion, clears stored state, and closes the project's stream so
+  /// subsequent reads, watches, and stream completions reflect the removal.
   @override
   Future<void> deleteProject(String projectId) async {
     _methodCalls.add({'method': 'deleteProject', 'projectId': projectId});
@@ -109,6 +108,11 @@ class FakeProjectSettingDataSource implements ProjectSettingDataSource {
     }
 
     projectToReturn = null;
+    final controller = _projectControllers.remove(projectId);
+    if (controller != null) {
+      controller.add(null);
+      controller.close();
+    }
   }
 
   /// Returns a per-project stream that immediately emits the current snapshot
@@ -163,7 +167,7 @@ class FakeProjectSettingDataSource implements ProjectSettingDataSource {
     deleteErrorMessage = null;
     projectToReturn = null;
     _methodCalls.clear();
-    exceptionToThrow = null;
+    fetchExceptionToThrow = null;
     for (final controller in _projectControllers.values) {
       controller.close();
     }

--- a/lib/libraries/project/testing/fake_project_setting_data_source.dart
+++ b/lib/libraries/project/testing/fake_project_setting_data_source.dart
@@ -3,12 +3,18 @@ import 'dart:async';
 import 'package:construculator/libraries/errors/exceptions.dart';
 import 'package:construculator/libraries/project/data/data_source/interfaces/project_setting_data_source.dart';
 import 'package:construculator/libraries/project/data/models/project_dto.dart';
+import 'package:rxdart/rxdart.dart';
 import 'package:stack_trace/stack_trace.dart';
 
 /// Fake implementation of [ProjectSettingDataSource] for testing.
 class FakeProjectSettingDataSource implements ProjectSettingDataSource {
   /// Tracks method calls for boundary assertions.
   final List<Map<String, dynamic>> _methodCalls = [];
+
+  /// Per-project stream controllers. Each project gets its own [BehaviorSubject]
+  /// so cross-project isolation can be verified and subscriptions receive the
+  /// current snapshot immediately on listen.
+  final Map<String, BehaviorSubject<ProjectDto?>> _projectControllers = {};
 
   /// Project returned by [fetchProjectSetting] and [updateProject].
   ProjectDto? projectToReturn;
@@ -39,9 +45,6 @@ class FakeProjectSettingDataSource implements ProjectSettingDataSource {
 
   /// Error message for [deleteProject] when [shouldThrowOnDelete] is true.
   String? deleteErrorMessage;
-
-  final StreamController<ProjectDto?> _changesController =
-      StreamController<ProjectDto?>.broadcast();
 
   /// Creates a [FakeProjectSettingDataSource].
   FakeProjectSettingDataSource();
@@ -74,7 +77,8 @@ class FakeProjectSettingDataSource implements ProjectSettingDataSource {
     return project;
   }
 
-  /// Updates a project and returns either [projectToReturn] or [projectDto].
+  /// Persists [projectDto] (or [projectToReturn] if set) and updates stored
+  /// state so subsequent reads reflect the mutation.
   @override
   Future<ProjectDto> updateProject(ProjectDto projectDto) async {
     _methodCalls.add({'method': 'updateProject', 'projectDto': projectDto});
@@ -86,10 +90,13 @@ class FakeProjectSettingDataSource implements ProjectSettingDataSource {
       );
     }
 
-    return projectToReturn ?? projectDto;
+    final result = projectToReturn ?? projectDto;
+    projectToReturn = result;
+    return result;
   }
 
-  /// Records deletion of the project with the given [projectId].
+  /// Records deletion and clears stored state so subsequent reads and watches
+  /// reflect the removal.
   @override
   Future<void> deleteProject(String projectId) async {
     _methodCalls.add({'method': 'deleteProject', 'projectId': projectId});
@@ -100,9 +107,12 @@ class FakeProjectSettingDataSource implements ProjectSettingDataSource {
         Exception(deleteErrorMessage ?? 'Delete project failed'),
       );
     }
+
+    projectToReturn = null;
   }
 
-  /// Watches project changes emitted through [emitChange] and [emitError].
+  /// Returns a per-project stream that immediately emits the current snapshot
+  /// on subscription, then emits on each [emitChange] call.
   @override
   Stream<ProjectDto?> watchProjectChanges(String projectId) {
     _methodCalls.add({'method': 'watchProjectChanges', 'projectId': projectId});
@@ -114,17 +124,24 @@ class FakeProjectSettingDataSource implements ProjectSettingDataSource {
       );
     }
 
-    return _changesController.stream;
+    return _getOrCreateController(projectId).stream;
   }
 
-  /// Emits a change event to active [watchProjectChanges] subscribers.
-  void emitChange() {
-    _changesController.add(projectToReturn);
+  /// Emits [projectToReturn] to subscribers watching [projectId].
+  void emitChange(String projectId) {
+    _getOrCreateController(projectId).add(projectToReturn);
   }
 
-  /// Emits an error to active [watchProjectChanges] subscribers.
-  void emitError(Object error, [StackTrace? stackTrace]) {
-    _changesController.addError(error, stackTrace);
+  /// Emits an error to subscribers watching [projectId].
+  void emitError(Object error, String projectId, [StackTrace? stackTrace]) {
+    _getOrCreateController(projectId).addError(error, stackTrace);
+  }
+
+  BehaviorSubject<ProjectDto?> _getOrCreateController(String projectId) {
+    return _projectControllers.putIfAbsent(
+      projectId,
+      () => BehaviorSubject<ProjectDto?>.seeded(projectToReturn),
+    );
   }
 
   /// Returns a copy of all recorded method calls.
@@ -135,7 +152,7 @@ class FakeProjectSettingDataSource implements ProjectSettingDataSource {
     return _methodCalls.where((call) => call['method'] == methodName).toList();
   }
 
-  /// Resets all flags, error messages, data, and recorded calls.
+  /// Resets all flags, error messages, data, recorded calls, and stream state.
   void reset() {
     shouldThrowOnGet = false;
     shouldThrowOnUpdate = false;
@@ -147,10 +164,17 @@ class FakeProjectSettingDataSource implements ProjectSettingDataSource {
     projectToReturn = null;
     _methodCalls.clear();
     exceptionToThrow = null;
+    for (final controller in _projectControllers.values) {
+      controller.close();
+    }
+    _projectControllers.clear();
   }
 
   /// Releases resources held by this fake.
   void dispose() {
-    _changesController.close();
+    for (final controller in _projectControllers.values) {
+      controller.close();
+    }
+    _projectControllers.clear();
   }
 }

--- a/lib/libraries/project/testing/fake_project_setting_data_source.dart
+++ b/lib/libraries/project/testing/fake_project_setting_data_source.dart
@@ -1,0 +1,156 @@
+import 'dart:async';
+
+import 'package:construculator/libraries/errors/exceptions.dart';
+import 'package:construculator/libraries/project/data/data_source/interfaces/project_setting_data_source.dart';
+import 'package:construculator/libraries/project/data/models/project_dto.dart';
+import 'package:stack_trace/stack_trace.dart';
+
+/// Fake implementation of [ProjectSettingDataSource] for testing.
+class FakeProjectSettingDataSource implements ProjectSettingDataSource {
+  /// Tracks method calls for boundary assertions.
+  final List<Map<String, dynamic>> _methodCalls = [];
+
+  /// Project returned by [fetchProjectSetting] and [updateProject].
+  ProjectDto? projectToReturn;
+
+  /// Controls whether [fetchProjectSetting] throws a [ServerException].
+  bool shouldThrowOnGet = false;
+
+  /// If non-null, this exception/object will be thrown directly by
+  /// [fetchProjectSetting] to allow tests to simulate different failures
+  /// (e.g., [TimeoutException]). This takes precedence over
+  /// [shouldThrowOnGet].
+  Object? exceptionToThrow;
+
+  /// Controls whether [updateProject] throws a [ServerException].
+  bool shouldThrowOnUpdate = false;
+
+  /// Controls whether [deleteProject] throws a [ServerException].
+  bool shouldThrowOnDelete = false;
+
+  /// Controls whether [watchProjectChanges] throws a [ServerException].
+  bool shouldThrowOnWatch = false;
+
+  /// Error message for [fetchProjectSetting] when [shouldThrowOnGet] is true.
+  String? getErrorMessage;
+
+  /// Error message for [updateProject] when [shouldThrowOnUpdate] is true.
+  String? updateErrorMessage;
+
+  /// Error message for [deleteProject] when [shouldThrowOnDelete] is true.
+  String? deleteErrorMessage;
+
+  final StreamController<ProjectDto?> _changesController =
+      StreamController<ProjectDto?>.broadcast();
+
+  /// Creates a [FakeProjectSettingDataSource].
+  FakeProjectSettingDataSource();
+
+  /// Returns the configured [projectToReturn] for the given [projectId].
+  @override
+  Future<ProjectDto> fetchProjectSetting(String projectId) async {
+    _methodCalls.add({'method': 'fetchProjectSetting', 'projectId': projectId});
+
+    final exception = exceptionToThrow;
+    if (exception != null) {
+      throw exception;
+    }
+
+    if (shouldThrowOnGet) {
+      throw ServerException(
+        Trace.current(),
+        Exception(getErrorMessage ?? 'Get project setting failed'),
+      );
+    }
+
+    final project = projectToReturn;
+    if (project == null) {
+      throw ServerException(
+        Trace.current(),
+        Exception('No project configured in FakeProjectSettingDataSource'),
+      );
+    }
+
+    return project;
+  }
+
+  /// Updates a project and returns either [projectToReturn] or [projectDto].
+  @override
+  Future<ProjectDto> updateProject(ProjectDto projectDto) async {
+    _methodCalls.add({'method': 'updateProject', 'projectDto': projectDto});
+
+    if (shouldThrowOnUpdate) {
+      throw ServerException(
+        Trace.current(),
+        Exception(updateErrorMessage ?? 'Update project failed'),
+      );
+    }
+
+    return projectToReturn ?? projectDto;
+  }
+
+  /// Records deletion of the project with the given [projectId].
+  @override
+  Future<void> deleteProject(String projectId) async {
+    _methodCalls.add({'method': 'deleteProject', 'projectId': projectId});
+
+    if (shouldThrowOnDelete) {
+      throw ServerException(
+        Trace.current(),
+        Exception(deleteErrorMessage ?? 'Delete project failed'),
+      );
+    }
+  }
+
+  /// Watches project changes emitted through [emitChange] and [emitError].
+  @override
+  Stream<ProjectDto?> watchProjectChanges(String projectId) {
+    _methodCalls.add({'method': 'watchProjectChanges', 'projectId': projectId});
+
+    if (shouldThrowOnWatch) {
+      throw ServerException(
+        Trace.current(),
+        Exception('Watch project changes failed'),
+      );
+    }
+
+    return _changesController.stream;
+  }
+
+  /// Emits a change event to active [watchProjectChanges] subscribers.
+  void emitChange() {
+    _changesController.add(projectToReturn);
+  }
+
+  /// Emits an error to active [watchProjectChanges] subscribers.
+  void emitError(Object error, [StackTrace? stackTrace]) {
+    _changesController.addError(error, stackTrace);
+  }
+
+  /// Returns a copy of all recorded method calls.
+  List<Map<String, dynamic>> getMethodCalls() => List.from(_methodCalls);
+
+  /// Returns all calls for the given [methodName].
+  List<Map<String, dynamic>> getMethodCallsFor(String methodName) {
+    return _methodCalls.where((call) => call['method'] == methodName).toList();
+  }
+
+  /// Resets all flags, error messages, data, and recorded calls.
+  void reset() {
+    shouldThrowOnGet = false;
+    shouldThrowOnUpdate = false;
+    shouldThrowOnDelete = false;
+    shouldThrowOnWatch = false;
+    getErrorMessage = null;
+    updateErrorMessage = null;
+    deleteErrorMessage = null;
+    projectToReturn = null;
+    _methodCalls.clear();
+    exceptionToThrow = null;
+  }
+
+  /// Releases resources held by this fake.
+  void dispose() {
+    _changesController.close();
+  }
+}

--- a/lib/libraries/project/testing/fake_project_setting_data_source.dart
+++ b/lib/libraries/project/testing/fake_project_setting_data_source.dart
@@ -3,7 +3,6 @@ import 'dart:async';
 import 'package:construculator/libraries/errors/exceptions.dart';
 import 'package:construculator/libraries/project/data/data_source/interfaces/project_setting_data_source.dart';
 import 'package:construculator/libraries/project/data/models/project_dto.dart';
-import 'package:rxdart/rxdart.dart';
 import 'package:stack_trace/stack_trace.dart';
 
 /// Fake implementation of [ProjectSettingDataSource] for testing.
@@ -11,13 +10,14 @@ class FakeProjectSettingDataSource implements ProjectSettingDataSource {
   /// Tracks method calls for boundary assertions.
   final List<Map<String, dynamic>> _methodCalls = [];
 
-  /// Per-project stream controllers. Each project gets its own [BehaviorSubject]
-  /// so cross-project isolation can be verified and subscriptions receive the
-  /// current snapshot immediately on listen.
-  final Map<String, BehaviorSubject<ProjectDto?>> _projectControllers = {};
-
   /// Project returned by [fetchProjectSetting] and [updateProject].
   ProjectDto? projectToReturn;
+
+  /// Controls whether [createProject] throws a [ServerException].
+  bool shouldThrowOnCreate = false;
+
+  /// Error message for [createProject] when [shouldThrowOnCreate] is true.
+  String? createErrorMessage;
 
   /// Controls whether [fetchProjectSetting] throws a [ServerException].
   bool shouldThrowOnGet = false;
@@ -33,9 +33,6 @@ class FakeProjectSettingDataSource implements ProjectSettingDataSource {
   /// Controls whether [deleteProject] throws a [ServerException].
   bool shouldThrowOnDelete = false;
 
-  /// Controls whether [watchProjectChanges] throws a [ServerException].
-  bool shouldThrowOnWatch = false;
-
   /// Error message for [fetchProjectSetting] when [shouldThrowOnGet] is true.
   String? getErrorMessage;
 
@@ -47,6 +44,21 @@ class FakeProjectSettingDataSource implements ProjectSettingDataSource {
 
   /// Creates a [FakeProjectSettingDataSource].
   FakeProjectSettingDataSource();
+
+  /// Returns [projectDto] as-is, simulating a successful create.
+  @override
+  Future<ProjectDto> createProject(ProjectDto projectDto) async {
+    _methodCalls.add({'method': 'createProject', 'projectDto': projectDto});
+
+    if (shouldThrowOnCreate) {
+      throw ServerException(
+        Trace.current(),
+        Exception(createErrorMessage ?? 'Create project failed'),
+      );
+    }
+
+    return projectDto;
+  }
 
   /// Returns the configured [projectToReturn] for the given [projectId].
   @override
@@ -76,8 +88,8 @@ class FakeProjectSettingDataSource implements ProjectSettingDataSource {
     return project;
   }
 
-  /// Persists [projectDto] and updates stored state so subsequent reads and
-  /// watch streams reflect the mutation.
+  /// Persists [projectDto] and updates [projectToReturn] so subsequent reads
+  /// reflect the mutation.
   @override
   Future<ProjectDto> updateProject(ProjectDto projectDto) async {
     _methodCalls.add({'method': 'updateProject', 'projectDto': projectDto});
@@ -90,12 +102,10 @@ class FakeProjectSettingDataSource implements ProjectSettingDataSource {
     }
 
     projectToReturn = projectDto;
-    _getOrCreateController(projectDto.id).add(projectDto);
     return projectDto;
   }
 
-  /// Records deletion, clears stored state, and closes the project's stream so
-  /// subsequent reads, watches, and stream completions reflect the removal.
+  /// Records deletion and clears stored state.
   @override
   Future<void> deleteProject(String projectId) async {
     _methodCalls.add({'method': 'deleteProject', 'projectId': projectId});
@@ -108,44 +118,6 @@ class FakeProjectSettingDataSource implements ProjectSettingDataSource {
     }
 
     projectToReturn = null;
-    final controller = _projectControllers.remove(projectId);
-    if (controller != null) {
-      controller.add(null);
-      controller.close();
-    }
-  }
-
-  /// Returns a per-project stream that immediately emits the current snapshot
-  /// on subscription, then emits on each [emitChange] call.
-  @override
-  Stream<ProjectDto?> watchProjectChanges(String projectId) {
-    _methodCalls.add({'method': 'watchProjectChanges', 'projectId': projectId});
-
-    if (shouldThrowOnWatch) {
-      throw ServerException(
-        Trace.current(),
-        Exception('Watch project changes failed'),
-      );
-    }
-
-    return _getOrCreateController(projectId).stream;
-  }
-
-  /// Emits [projectToReturn] to subscribers watching [projectId].
-  void emitChange(String projectId) {
-    _getOrCreateController(projectId).add(projectToReturn);
-  }
-
-  /// Emits an error to subscribers watching [projectId].
-  void emitError(Object error, String projectId, [StackTrace? stackTrace]) {
-    _getOrCreateController(projectId).addError(error, stackTrace);
-  }
-
-  BehaviorSubject<ProjectDto?> _getOrCreateController(String projectId) {
-    return _projectControllers.putIfAbsent(
-      projectId,
-      () => BehaviorSubject<ProjectDto?>.seeded(projectToReturn),
-    );
   }
 
   /// Returns a copy of all recorded method calls.
@@ -156,29 +128,21 @@ class FakeProjectSettingDataSource implements ProjectSettingDataSource {
     return _methodCalls.where((call) => call['method'] == methodName).toList();
   }
 
-  /// Resets all flags, error messages, data, recorded calls, and stream state.
+  /// Resets all flags, error messages, data, and recorded calls.
   void reset() {
+    shouldThrowOnCreate = false;
     shouldThrowOnGet = false;
     shouldThrowOnUpdate = false;
     shouldThrowOnDelete = false;
-    shouldThrowOnWatch = false;
+    createErrorMessage = null;
     getErrorMessage = null;
     updateErrorMessage = null;
     deleteErrorMessage = null;
     projectToReturn = null;
-    _methodCalls.clear();
     fetchExceptionToThrow = null;
-    for (final controller in _projectControllers.values) {
-      controller.close();
-    }
-    _projectControllers.clear();
+    _methodCalls.clear();
   }
 
   /// Releases resources held by this fake.
-  void dispose() {
-    for (final controller in _projectControllers.values) {
-      controller.close();
-    }
-    _projectControllers.clear();
-  }
+  void dispose() {}
 }

--- a/test/libraries/project/units/fakes/fake_project_setting_data_source_test.dart
+++ b/test/libraries/project/units/fakes/fake_project_setting_data_source_test.dart
@@ -1,0 +1,220 @@
+import 'dart:async';
+
+import 'package:construculator/libraries/errors/exceptions.dart';
+import 'package:construculator/libraries/project/data/models/project_dto.dart';
+import 'package:construculator/libraries/project/domain/entities/enums.dart';
+import 'package:construculator/libraries/project/testing/fake_project_setting_data_source.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('FakeProjectSettingDataSource', () {
+    late FakeProjectSettingDataSource fake;
+
+    setUp(() {
+      fake = FakeProjectSettingDataSource();
+    });
+
+    tearDown(() {
+      fake.reset();
+      fake.dispose();
+    });
+
+    group('fetchProjectSetting', () {
+      test('records method call with projectId', () async {
+        fake.projectToReturn = _fakeDto(id: 'p-1');
+
+        await fake.fetchProjectSetting('p-1');
+
+        final calls = fake.getMethodCallsFor('fetchProjectSetting');
+        expect(calls, hasLength(1));
+        expect(calls.first['projectId'], equals('p-1'));
+      });
+
+      test('returns projectToReturn when set', () async {
+        final dto = _fakeDto(id: 'p-1', projectName: 'My Project');
+        fake.projectToReturn = dto;
+
+        final result = await fake.fetchProjectSetting('p-1');
+
+        expect(result.id, equals('p-1'));
+        expect(result.projectName, equals('My Project'));
+      });
+
+      test('throws ServerException when shouldThrowOnGet is true', () async {
+        fake.shouldThrowOnGet = true;
+
+        await expectLater(
+          fake.fetchProjectSetting('p-1'),
+          throwsA(isA<ServerException>()),
+        );
+      });
+
+      test(
+        'throws ServerException with custom message when getErrorMessage is set',
+        () async {
+          fake.shouldThrowOnGet = true;
+          fake.getErrorMessage = 'Custom get error';
+
+          await expectLater(
+            fake.fetchProjectSetting('p-1'),
+            throwsA(isA<ServerException>()),
+          );
+        },
+      );
+
+      test(
+        'throws ServerException when projectToReturn is null and no error flag',
+        () async {
+          await expectLater(
+            fake.fetchProjectSetting('p-1'),
+            throwsA(isA<ServerException>()),
+          );
+        },
+      );
+    });
+
+    group('updateProject', () {
+      test('records method call with projectDto', () async {
+        final dto = _fakeDto(id: 'p-1', projectName: 'Updated');
+        fake.projectToReturn = dto;
+
+        await fake.updateProject(dto);
+
+        final calls = fake.getMethodCallsFor('updateProject');
+        expect(calls, hasLength(1));
+        expect(calls.first['projectDto'], equals(dto));
+      });
+
+      test('returns projectToReturn when set', () async {
+        final updated = _fakeDto(id: 'p-1', projectName: 'Returned Name');
+        fake.projectToReturn = updated;
+
+        final result = await fake.updateProject(_fakeDto(id: 'p-1'));
+
+        expect(result.projectName, equals('Returned Name'));
+      });
+
+      test('returns the passed dto when projectToReturn is null', () async {
+        final dto = _fakeDto(id: 'p-1', projectName: 'Fallback');
+
+        final result = await fake.updateProject(dto);
+
+        expect(result.projectName, equals('Fallback'));
+      });
+
+      test('throws ServerException when shouldThrowOnUpdate is true', () async {
+        fake.shouldThrowOnUpdate = true;
+
+        await expectLater(
+          fake.updateProject(_fakeDto(id: 'p-1')),
+          throwsA(isA<ServerException>()),
+        );
+      });
+    });
+
+    group('deleteProject', () {
+      test('records method call with projectId', () async {
+        await fake.deleteProject('p-1');
+
+        final calls = fake.getMethodCallsFor('deleteProject');
+        expect(calls, hasLength(1));
+        expect(calls.first['projectId'], equals('p-1'));
+      });
+
+      test('completes successfully by default', () async {
+        await expectLater(fake.deleteProject('p-1'), completes);
+      });
+
+      test('throws ServerException when shouldThrowOnDelete is true', () async {
+        fake.shouldThrowOnDelete = true;
+
+        await expectLater(
+          fake.deleteProject('p-1'),
+          throwsA(isA<ServerException>()),
+        );
+      });
+    });
+
+    group('watchProjectChanges', () {
+      test('records method call with projectId', () {
+        fake.watchProjectChanges('p-1').listen((_) {});
+
+        final calls = fake.getMethodCallsFor('watchProjectChanges');
+        expect(calls, hasLength(1));
+        expect(calls.first['projectId'], equals('p-1'));
+      });
+
+      test('emits when emitChange is called', () async {
+        final emittedCompleter = Completer<ProjectDto?>();
+        final subscription = fake.watchProjectChanges('p-1').listen((dto) {
+          if (!emittedCompleter.isCompleted) emittedCompleter.complete(dto);
+        });
+
+        fake.projectToReturn = _fakeDto(id: 'p-1');
+        fake.emitChange();
+
+        final emitted = await emittedCompleter.future;
+        expect(emitted, isA<ProjectDto>());
+        await subscription.cancel();
+      });
+
+      test('forwards errors when emitError is called', () async {
+        final errorCompleter = Completer<Object>();
+        final subscription = fake
+            .watchProjectChanges('p-1')
+            .listen(
+              (_) {},
+              onError: (Object error, StackTrace _) {
+                if (!errorCompleter.isCompleted) errorCompleter.complete(error);
+              },
+            );
+
+        fake.emitError(Exception('test error'));
+
+        final receivedError = await errorCompleter.future;
+        expect(receivedError, isA<Exception>());
+        await subscription.cancel();
+      });
+
+      test('throws ServerException when shouldThrowOnWatch is true', () {
+        fake.shouldThrowOnWatch = true;
+
+        expect(
+          () => fake.watchProjectChanges('p-1'),
+          throwsA(isA<ServerException>()),
+        );
+      });
+    });
+
+    group('reset', () {
+      test('clears all flags and recorded calls', () async {
+        fake.shouldThrowOnGet = true;
+        fake.shouldThrowOnUpdate = true;
+        fake.shouldThrowOnDelete = true;
+        fake.getErrorMessage = 'error';
+        fake.projectToReturn = _fakeDto(id: 'p-1');
+        fake.getMethodCallsFor('deleteProject');
+
+        fake.reset();
+
+        expect(fake.shouldThrowOnGet, isFalse);
+        expect(fake.shouldThrowOnUpdate, isFalse);
+        expect(fake.shouldThrowOnDelete, isFalse);
+        expect(fake.getErrorMessage, isNull);
+        expect(fake.projectToReturn, isNull);
+        expect(fake.getMethodCalls(), isEmpty);
+      });
+    });
+  });
+}
+
+ProjectDto _fakeDto({required String id, String? projectName}) {
+  return ProjectDto(
+    id: id,
+    projectName: projectName ?? 'Test Project',
+    creatorUserId: 'user-1',
+    createdAt: DateTime(2025, 1, 1),
+    updatedAt: DateTime(2025, 1, 2),
+    status: ProjectStatus.active,
+  );
+}

--- a/test/libraries/project/units/fakes/fake_project_setting_data_source_test.dart
+++ b/test/libraries/project/units/fakes/fake_project_setting_data_source_test.dart
@@ -102,15 +102,17 @@ void main() {
         expect(result.projectName, equals('Fallback'));
       });
 
-      test('persists result so subsequent fetchProjectSetting returns it',
-          () async {
-        final dto = _fakeDto(id: 'p-1', projectName: 'Written');
+      test(
+        'persists result so subsequent fetchProjectSetting returns it',
+        () async {
+          final dto = _fakeDto(id: 'p-1', projectName: 'Written');
 
-        await fake.updateProject(dto);
-        final fetched = await fake.fetchProjectSetting('p-1');
+          await fake.updateProject(dto);
+          final fetched = await fake.fetchProjectSetting('p-1');
 
-        expect(fetched.projectName, equals('Written'));
-      });
+          expect(fetched.projectName, equals('Written'));
+        },
+      );
 
       test('throws ServerException when shouldThrowOnUpdate is true', () async {
         fake.shouldThrowOnUpdate = true;
@@ -185,14 +187,18 @@ void main() {
         fake.projectToReturn = _fakeDto(id: 'p-1', projectName: 'Initial');
         final emittedValues = <ProjectDto?>[];
 
-        final subscription =
-            fake.watchProjectChanges('p-1').listen(emittedValues.add);
-        await Future.microtask(() {});
+        final subscription = fake
+            .watchProjectChanges('p-1')
+            .listen(emittedValues.add);
+        await expectLater(
+          fake.watchProjectChanges('p-1'),
+          emits(_fakeDto(id: 'p-1', projectName: 'Initial')),
+        );
 
         final updated = _fakeDto(id: 'p-1', projectName: 'Updated');
         fake.projectToReturn = updated;
         fake.emitChange('p-1');
-        await Future.microtask(() {});
+        await expectLater(fake.watchProjectChanges('p-1'), emits(updated));
 
         expect(emittedValues, contains(updated));
         await subscription.cancel();
@@ -205,11 +211,14 @@ void main() {
 
         final s1 = fake.watchProjectChanges('p-1').listen(p1Values.add);
         final s2 = fake.watchProjectChanges('p-2').listen(p2Values.add);
-        await Future.microtask(() {});
+        await expectLater(
+          fake.watchProjectChanges('p-1'),
+          emits(_fakeDto(id: 'p-1')),
+        );
 
         final countBefore = p2Values.length;
         fake.emitChange('p-1');
-        await Future.microtask(() {});
+        await expectLater(fake.watchProjectChanges('p-1'), emits(anything));
 
         expect(p1Values.length, greaterThan(countBefore));
         expect(p2Values.length, equals(countBefore));

--- a/test/libraries/project/units/fakes/fake_project_setting_data_source_test.dart
+++ b/test/libraries/project/units/fakes/fake_project_setting_data_source_test.dart
@@ -102,6 +102,16 @@ void main() {
         expect(result.projectName, equals('Fallback'));
       });
 
+      test('persists result so subsequent fetchProjectSetting returns it',
+          () async {
+        final dto = _fakeDto(id: 'p-1', projectName: 'Written');
+
+        await fake.updateProject(dto);
+        final fetched = await fake.fetchProjectSetting('p-1');
+
+        expect(fetched.projectName, equals('Written'));
+      });
+
       test('throws ServerException when shouldThrowOnUpdate is true', () async {
         fake.shouldThrowOnUpdate = true;
 
@@ -125,6 +135,17 @@ void main() {
         await expectLater(fake.deleteProject('p-1'), completes);
       });
 
+      test('clears projectToReturn so subsequent fetch throws', () async {
+        fake.projectToReturn = _fakeDto(id: 'p-1');
+
+        await fake.deleteProject('p-1');
+
+        await expectLater(
+          fake.fetchProjectSetting('p-1'),
+          throwsA(isA<ServerException>()),
+        );
+      });
+
       test('throws ServerException when shouldThrowOnDelete is true', () async {
         fake.shouldThrowOnDelete = true;
 
@@ -137,6 +158,7 @@ void main() {
 
     group('watchProjectChanges', () {
       test('records method call with projectId', () {
+        fake.projectToReturn = _fakeDto(id: 'p-1');
         fake.watchProjectChanges('p-1').listen((_) {});
 
         final calls = fake.getMethodCallsFor('watchProjectChanges');
@@ -144,22 +166,62 @@ void main() {
         expect(calls.first['projectId'], equals('p-1'));
       });
 
-      test('emits when emitChange is called', () async {
-        final emittedCompleter = Completer<ProjectDto?>();
-        final subscription = fake.watchProjectChanges('p-1').listen((dto) {
-          if (!emittedCompleter.isCompleted) emittedCompleter.complete(dto);
-        });
+      test('emits current snapshot immediately on subscription', () async {
+        final dto = _fakeDto(id: 'p-1');
+        fake.projectToReturn = dto;
 
-        fake.projectToReturn = _fakeDto(id: 'p-1');
-        fake.emitChange();
+        final first = await fake.watchProjectChanges('p-1').first;
 
-        final emitted = await emittedCompleter.future;
-        expect(emitted, isA<ProjectDto>());
+        expect(first, equals(dto));
+      });
+
+      test('emits null snapshot when projectToReturn is null', () async {
+        final first = await fake.watchProjectChanges('p-1').first;
+
+        expect(first, isNull);
+      });
+
+      test('emits updated value when emitChange is called', () async {
+        fake.projectToReturn = _fakeDto(id: 'p-1', projectName: 'Initial');
+        final emittedValues = <ProjectDto?>[];
+
+        final subscription =
+            fake.watchProjectChanges('p-1').listen(emittedValues.add);
+        await Future.microtask(() {});
+
+        final updated = _fakeDto(id: 'p-1', projectName: 'Updated');
+        fake.projectToReturn = updated;
+        fake.emitChange('p-1');
+        await Future.microtask(() {});
+
+        expect(emittedValues, contains(updated));
         await subscription.cancel();
       });
 
+      test('isolates streams per project', () async {
+        fake.projectToReturn = _fakeDto(id: 'p-1');
+        final p1Values = <ProjectDto?>[];
+        final p2Values = <ProjectDto?>[];
+
+        final s1 = fake.watchProjectChanges('p-1').listen(p1Values.add);
+        final s2 = fake.watchProjectChanges('p-2').listen(p2Values.add);
+        await Future.microtask(() {});
+
+        final countBefore = p2Values.length;
+        fake.emitChange('p-1');
+        await Future.microtask(() {});
+
+        expect(p1Values.length, greaterThan(countBefore));
+        expect(p2Values.length, equals(countBefore));
+
+        await s1.cancel();
+        await s2.cancel();
+      });
+
       test('forwards errors when emitError is called', () async {
+        fake.projectToReturn = _fakeDto(id: 'p-1');
         final errorCompleter = Completer<Object>();
+
         final subscription = fake
             .watchProjectChanges('p-1')
             .listen(
@@ -169,7 +231,7 @@ void main() {
               },
             );
 
-        fake.emitError(Exception('test error'));
+        fake.emitError(Exception('test error'), 'p-1');
 
         final receivedError = await errorCompleter.future;
         expect(receivedError, isA<Exception>());

--- a/test/libraries/project/units/fakes/fake_project_setting_data_source_test.dart
+++ b/test/libraries/project/units/fakes/fake_project_setting_data_source_test.dart
@@ -134,7 +134,7 @@ void main() {
         final result = await fake.updateProject(newDto);
 
         expect(result.projectName, equals('New Name'));
-        expect(fake.projectToReturn?.projectName, equals('New Name'));
+        expect(fake.projectToReturn!.projectName, equals('New Name'));
       });
 
       test('returns the passed dto when projectToReturn is null', () async {

--- a/test/libraries/project/units/fakes/fake_project_setting_data_source_test.dart
+++ b/test/libraries/project/units/fakes/fake_project_setting_data_source_test.dart
@@ -19,6 +19,35 @@ void main() {
       fake.dispose();
     });
 
+    group('createProject', () {
+      test('returns the provided ProjectDto', () async {
+        final dto = _fakeDto(id: 'p-1', projectName: 'New Project');
+
+        final result = await fake.createProject(dto);
+
+        expect(result, equals(dto));
+      });
+
+      test('records method call', () async {
+        final dto = _fakeDto(id: 'p-1', projectName: 'New Project');
+
+        await fake.createProject(dto);
+
+        final calls = fake.getMethodCallsFor('createProject');
+        expect(calls, hasLength(1));
+        expect(calls.first['projectDto'], equals(dto));
+      });
+
+      test('throws ServerException when shouldThrowOnCreate is true', () async {
+        fake.shouldThrowOnCreate = true;
+
+        await expectLater(
+          fake.createProject(_fakeDto(id: 'p-1')),
+          throwsA(isA<ServerException>()),
+        );
+      });
+    });
+
     group('fetchProjectSetting', () {
       test('records method call with projectId', () async {
         fake.projectToReturn = _fakeDto(id: 'p-1');
@@ -128,18 +157,6 @@ void main() {
         },
       );
 
-      test('propagates the updated dto to the watch stream', () async {
-        fake.projectToReturn = _fakeDto(id: 'p-1', projectName: 'Initial');
-        final updated = _fakeDto(id: 'p-1', projectName: 'Updated');
-
-        final future = expectLater(
-          fake.watchProjectChanges('p-1'),
-          emitsThrough(updated),
-        );
-        await fake.updateProject(updated);
-        await future;
-      });
-
       test('throws ServerException when shouldThrowOnUpdate is true', () async {
         fake.shouldThrowOnUpdate = true;
 
@@ -174,30 +191,6 @@ void main() {
         );
       });
 
-      test('emits null to the watch stream before closing it', () async {
-        fake.projectToReturn = _fakeDto(id: 'p-1');
-
-        final future = expectLater(
-          fake.watchProjectChanges('p-1'),
-          emitsThrough(isNull),
-        );
-        await fake.deleteProject('p-1');
-        await future;
-      });
-
-      test('closes the project stream on deletion', () async {
-        fake.projectToReturn = _fakeDto(id: 'p-1');
-        final isDone = Completer<void>();
-
-        fake
-            .watchProjectChanges('p-1')
-            .listen((_) {}, onDone: isDone.complete);
-
-        await fake.deleteProject('p-1');
-
-        await expectLater(isDone.future, completes);
-      });
-
       test('throws ServerException when shouldThrowOnDelete is true', () async {
         fake.shouldThrowOnDelete = true;
 
@@ -208,118 +201,23 @@ void main() {
       });
     });
 
-    group('watchProjectChanges', () {
-      test('records method call with projectId', () {
-        fake.projectToReturn = _fakeDto(id: 'p-1');
-        fake.watchProjectChanges('p-1').listen((_) {});
-
-        final calls = fake.getMethodCallsFor('watchProjectChanges');
-        expect(calls, hasLength(1));
-        expect(calls.first['projectId'], equals('p-1'));
-      });
-
-      test('emits current snapshot immediately on subscription', () async {
-        final dto = _fakeDto(id: 'p-1');
-        fake.projectToReturn = dto;
-
-        final first = await fake.watchProjectChanges('p-1').first;
-
-        expect(first, equals(dto));
-      });
-
-      test('emits null snapshot when projectToReturn is null', () async {
-        final first = await fake.watchProjectChanges('p-1').first;
-
-        expect(first, isNull);
-      });
-
-      test('emits updated value when emitChange is called', () async {
-        fake.projectToReturn = _fakeDto(id: 'p-1', projectName: 'Initial');
-        final emittedValues = <ProjectDto?>[];
-
-        final subscription = fake
-            .watchProjectChanges('p-1')
-            .listen(emittedValues.add);
-        await expectLater(
-          fake.watchProjectChanges('p-1'),
-          emits(_fakeDto(id: 'p-1', projectName: 'Initial')),
-        );
-
-        final updated = _fakeDto(id: 'p-1', projectName: 'Updated');
-        fake.projectToReturn = updated;
-        fake.emitChange('p-1');
-        await expectLater(fake.watchProjectChanges('p-1'), emits(updated));
-
-        expect(emittedValues, contains(updated));
-        await subscription.cancel();
-      });
-
-      test('isolates streams per project', () async {
-        fake.projectToReturn = _fakeDto(id: 'p-1');
-        final p1Values = <ProjectDto?>[];
-        final p2Values = <ProjectDto?>[];
-
-        final s1 = fake.watchProjectChanges('p-1').listen(p1Values.add);
-        final s2 = fake.watchProjectChanges('p-2').listen(p2Values.add);
-        await expectLater(
-          fake.watchProjectChanges('p-1'),
-          emits(_fakeDto(id: 'p-1')),
-        );
-
-        fake.emitChange('p-1');
-        await expectLater(fake.watchProjectChanges('p-1'), emits(anything));
-
-        expect(p1Values.length, greaterThan(1)); // seed + emitChange emission
-        expect(p2Values, hasLength(1)); // only the BehaviorSubject seed, never p1's emit
-
-        await s1.cancel();
-        await s2.cancel();
-      });
-
-      test('forwards errors when emitError is called', () async {
-        fake.projectToReturn = _fakeDto(id: 'p-1');
-        final errorCompleter = Completer<Object>();
-
-        final subscription = fake
-            .watchProjectChanges('p-1')
-            .listen(
-              (_) {},
-              onError: (Object error, StackTrace _) {
-                if (!errorCompleter.isCompleted) errorCompleter.complete(error);
-              },
-            );
-
-        fake.emitError(Exception('test error'), 'p-1');
-
-        final receivedError = await errorCompleter.future;
-        expect(receivedError, isA<Exception>());
-        await subscription.cancel();
-      });
-
-      test('throws ServerException when shouldThrowOnWatch is true', () {
-        fake.shouldThrowOnWatch = true;
-
-        expect(
-          () => fake.watchProjectChanges('p-1'),
-          throwsA(isA<ServerException>()),
-        );
-      });
-    });
-
     group('reset', () {
       test('clears all flags and recorded calls', () async {
+        fake.shouldThrowOnCreate = true;
         fake.shouldThrowOnGet = true;
         fake.shouldThrowOnUpdate = true;
         fake.shouldThrowOnDelete = true;
-        fake.getErrorMessage = 'error';
+        fake.createErrorMessage = 'create error';
+        fake.getErrorMessage = 'get error';
         fake.projectToReturn = _fakeDto(id: 'p-1');
-        fake.getMethodCallsFor('deleteProject');
 
         fake.reset();
 
+        expect(fake.shouldThrowOnCreate, isFalse);
         expect(fake.shouldThrowOnGet, isFalse);
         expect(fake.shouldThrowOnUpdate, isFalse);
         expect(fake.shouldThrowOnDelete, isFalse);
+        expect(fake.createErrorMessage, isNull);
         expect(fake.getErrorMessage, isNull);
         expect(fake.projectToReturn, isNull);
         expect(fake.getMethodCalls(), isEmpty);

--- a/test/libraries/project/units/fakes/fake_project_setting_data_source_test.dart
+++ b/test/libraries/project/units/fakes/fake_project_setting_data_source_test.dart
@@ -71,6 +71,17 @@ void main() {
           );
         },
       );
+
+      test('fetchExceptionToThrow takes precedence over shouldThrowOnGet',
+          () async {
+        fake.shouldThrowOnGet = true;
+        fake.fetchExceptionToThrow = TimeoutException('timed out');
+
+        await expectLater(
+          fake.fetchProjectSetting('p-1'),
+          throwsA(isA<TimeoutException>()),
+        );
+      });
     });
 
     group('updateProject', () {
@@ -85,13 +96,16 @@ void main() {
         expect(calls.first['projectDto'], equals(dto));
       });
 
-      test('returns projectToReturn when set', () async {
-        final updated = _fakeDto(id: 'p-1', projectName: 'Returned Name');
-        fake.projectToReturn = updated;
+      test('always returns the passed dto, overriding pre-set projectToReturn',
+          () async {
+        final preExisting = _fakeDto(id: 'p-1', projectName: 'Old Name');
+        fake.projectToReturn = preExisting;
+        final newDto = _fakeDto(id: 'p-1', projectName: 'New Name');
 
-        final result = await fake.updateProject(_fakeDto(id: 'p-1'));
+        final result = await fake.updateProject(newDto);
 
-        expect(result.projectName, equals('Returned Name'));
+        expect(result.projectName, equals('New Name'));
+        expect(fake.projectToReturn?.projectName, equals('New Name'));
       });
 
       test('returns the passed dto when projectToReturn is null', () async {
@@ -113,6 +127,18 @@ void main() {
           expect(fetched.projectName, equals('Written'));
         },
       );
+
+      test('propagates the updated dto to the watch stream', () async {
+        fake.projectToReturn = _fakeDto(id: 'p-1', projectName: 'Initial');
+        final updated = _fakeDto(id: 'p-1', projectName: 'Updated');
+
+        final future = expectLater(
+          fake.watchProjectChanges('p-1'),
+          emitsThrough(updated),
+        );
+        await fake.updateProject(updated);
+        await future;
+      });
 
       test('throws ServerException when shouldThrowOnUpdate is true', () async {
         fake.shouldThrowOnUpdate = true;
@@ -146,6 +172,30 @@ void main() {
           fake.fetchProjectSetting('p-1'),
           throwsA(isA<ServerException>()),
         );
+      });
+
+      test('emits null to the watch stream before closing it', () async {
+        fake.projectToReturn = _fakeDto(id: 'p-1');
+
+        final future = expectLater(
+          fake.watchProjectChanges('p-1'),
+          emitsThrough(isNull),
+        );
+        await fake.deleteProject('p-1');
+        await future;
+      });
+
+      test('closes the project stream on deletion', () async {
+        fake.projectToReturn = _fakeDto(id: 'p-1');
+        final isDone = Completer<void>();
+
+        fake
+            .watchProjectChanges('p-1')
+            .listen((_) {}, onDone: isDone.complete);
+
+        await fake.deleteProject('p-1');
+
+        await expectLater(isDone.future, completes);
       });
 
       test('throws ServerException when shouldThrowOnDelete is true', () async {
@@ -216,12 +266,11 @@ void main() {
           emits(_fakeDto(id: 'p-1')),
         );
 
-        final countBefore = p2Values.length;
         fake.emitChange('p-1');
         await expectLater(fake.watchProjectChanges('p-1'), emits(anything));
 
-        expect(p1Values.length, greaterThan(countBefore));
-        expect(p2Values.length, equals(countBefore));
+        expect(p1Values.length, greaterThan(1)); // seed + emitChange emission
+        expect(p2Values, hasLength(1)); // only the BehaviorSubject seed, never p1's emit
 
         await s1.cancel();
         await s2.cancel();


### PR DESCRIPTION
### 1. PR SUMMARY
This PR adds a new testing fake for `ProjectSettingDataSource` plus unit tests for its CRUD and watch helpers.

### 2. REVIEW SUMMARY

| Issue Name | Description | Status | Notes |
|------------|-------------|--------|-------|
| Mutations are not persisted in the fake | The fake returns values from `projectToReturn`, but `updateProject()` does not write the updated DTO back to that stored state and `deleteProject()` does not clear it. That means a write-then-read or delete-then-watch flow can still behave as if the old project exists, which diverges from the real data source and can hide integration bugs. See fake_project_setting_data_source.dart and fake_project_setting_data_source.dart. | Addressed| `updateProject()` now assigns `projectToReturn` = `result` and `deleteProject()` now sets `projectToReturn` = `null` |
| Watch stream does not mirror the real per-project contract | `watchProjectChanges()` uses one shared broadcast controller for every `projectId`, and it only emits when `emitChange()` is called. The real implementation is project-scoped and emits the current snapshot on subscription, so this fake cannot catch bugs around initial load or cross-project isolation. See fake_project_setting_data_source.dart and fake_project_setting_data_source.dart. | addressed| Replaced the single shared `StreamController` with a `Map<String, BehaviorSubject<ProjectDto?>>`|