### PR TITLE
CA-250: repository watch

### DIFF
--- a/lib/libraries/project/data/repositories/project_setting_repository_impl.dart
+++ b/lib/libraries/project/data/repositories/project_setting_repository_impl.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 
 import 'package:construculator/libraries/either/either.dart';
 import 'package:construculator/libraries/errors/failures.dart';
-import 'package:construculator/libraries/logging/app_logger.dart';
 import 'package:construculator/libraries/project/data/data_source/interfaces/permission_data_source.dart';
 import 'package:construculator/libraries/project/data/data_source/interfaces/project_setting_data_source.dart';
 import 'package:construculator/libraries/project/data/models/project_dto.dart';
@@ -16,7 +15,6 @@ import 'package:construculator/libraries/project/domain/repositories/project_set
 class ProjectSettingRepositoryImpl implements ProjectSettingRepository {
   final ProjectSettingDataSource _dataSource;
   final ProjectPermissionDataSource _permissionDataSource;
-  static final _logger = AppLogger().tag('ProjectSettingRepositoryImpl');
 
   final Map<String, StreamController<Either<Failure, Project>>>
   _settingControllers = {};
@@ -34,14 +32,7 @@ class ProjectSettingRepositoryImpl implements ProjectSettingRepository {
     try {
       final dto = await _dataSource.fetchProjectSetting(projectId);
       return Right(dto.toDomain());
-    } catch (error, stackTrace) {
-      // Log raw error and stack trace before domain mapping so diagnostics
-      // keep the original exception details instead of only the mapped Failure.
-      _logger.warning(
-        'Error while getting project setting for projectId: $projectId',
-        error,
-        stackTrace,
-      );
+    } catch (error) {
       return Left(_handleError(error));
     }
   }
@@ -62,14 +53,7 @@ class ProjectSettingRepositoryImpl implements ProjectSettingRepository {
       final dto = _toDtoFromEntity(project);
       final result = await _dataSource.updateProject(dto);
       return Right(result.toDomain());
-    } catch (error, stackTrace) {
-      // Log raw error and stack trace before domain mapping so diagnostics
-      // keep the original exception details instead of only the mapped Failure.
-      _logger.warning(
-        'Error while updating project with id: ${project.id}',
-        error,
-        stackTrace,
-      );
+    } catch (error) {
       return Left(_handleError(error));
     }
   }
@@ -89,14 +73,7 @@ class ProjectSettingRepositoryImpl implements ProjectSettingRepository {
     try {
       await _dataSource.deleteProject(projectId);
       return const Right(null);
-    } catch (error, stackTrace) {
-      // Log raw error and stack trace before domain mapping so diagnostics
-      // keep the original exception details instead of only the mapped Failure.
-      _logger.warning(
-        'Error while deleting project with id: $projectId',
-        error,
-        stackTrace,
-      );
+    } catch (error) {
       return Left(_handleError(error));
     }
   }
@@ -128,11 +105,6 @@ class ProjectSettingRepositoryImpl implements ProjectSettingRepository {
         .listen(
           (_) => _refreshProjectSetting(projectId),
           onError: (Object error, StackTrace stackTrace) {
-            _logger.warning(
-              'Error while watching project setting changes for projectId: $projectId',
-              error,
-              stackTrace,
-            );
             final controller = _settingControllers[projectId];
             if (controller?.isClosed == false) {
               controller?.addError(error, stackTrace);

--- a/lib/libraries/project/data/repositories/project_setting_repository_impl.dart
+++ b/lib/libraries/project/data/repositories/project_setting_repository_impl.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:construculator/libraries/either/either.dart';
 import 'package:construculator/libraries/errors/failures.dart';
 import 'package:construculator/libraries/logging/app_logger.dart';
@@ -16,6 +18,10 @@ class ProjectSettingRepositoryImpl implements ProjectSettingRepository {
   final ProjectPermissionDataSource _permissionDataSource;
   static final _logger = AppLogger().tag('ProjectSettingRepositoryImpl');
 
+  StreamController<Either<Failure, Project>>? _settingController;
+  StreamSubscription<ProjectDto?>? _changesSubscription;
+  String? _watchedProjectId;
+
   ProjectSettingRepositoryImpl({
     required ProjectSettingDataSource dataSource,
     required ProjectPermissionDataSource permissionDataSource,
@@ -28,13 +34,12 @@ class ProjectSettingRepositoryImpl implements ProjectSettingRepository {
       final dto = await _dataSource.fetchProjectSetting(projectId);
       return Right(dto.toDomain());
     } catch (error, stackTrace) {
-      return Left(
-        _handleError(
-          error,
-          'getting project setting for projectId: $projectId',
-          stackTrace,
-        ),
+      _logger.warning(
+        'Error while getting project setting for projectId: $projectId',
+        error,
+        stackTrace,
       );
+      return Left(_handleError(error));
     }
   }
 
@@ -55,13 +60,12 @@ class ProjectSettingRepositoryImpl implements ProjectSettingRepository {
       final result = await _dataSource.updateProject(dto);
       return Right(result.toDomain());
     } catch (error, stackTrace) {
-      return Left(
-        _handleError(
-          error,
-          'updating project with id: ${project.id}',
-          stackTrace,
-        ),
+      _logger.warning(
+        'Error while updating project with id: ${project.id}',
+        error,
+        stackTrace,
       );
+      return Left(_handleError(error));
     }
   }
 
@@ -81,9 +85,70 @@ class ProjectSettingRepositoryImpl implements ProjectSettingRepository {
       await _dataSource.deleteProject(projectId);
       return const Right(null);
     } catch (error, stackTrace) {
-      return Left(
-        _handleError(error, 'deleting project with id: $projectId', stackTrace),
+      _logger.warning(
+        'Error while deleting project with id: $projectId',
+        error,
+        stackTrace,
       );
+      return Left(_handleError(error));
+    }
+  }
+
+  @override
+  Stream<Either<Failure, Project>> watchProjectSetting(String projectId) {
+    _watchedProjectId = projectId;
+    final controller = _settingController ??=
+        StreamController<Either<Failure, Project>>.broadcast(
+          onListen: _startWatchingSettingChanges,
+          onCancel: _stopWatchingIfNoListeners,
+        );
+    return controller.stream;
+  }
+
+  void _startWatchingSettingChanges() {
+    if (_changesSubscription != null) {
+      return;
+    }
+
+    final projectId = _watchedProjectId;
+    if (projectId == null || projectId.isEmpty) {
+      return;
+    }
+
+    _changesSubscription = _dataSource
+        .watchProjectChanges(projectId)
+        .listen(
+          (_) => _refreshProjectSetting(),
+          onError: (Object error, StackTrace stackTrace) {
+            _logger.error(
+              'Error while watching project setting changes for projectId: $projectId',
+              error,
+              stackTrace,
+            );
+            _settingController?.addError(error, stackTrace);
+          },
+        );
+
+    _refreshProjectSetting();
+  }
+
+  void _stopWatchingIfNoListeners() {
+    if (_settingController?.hasListener == true) {
+      return;
+    }
+    _changesSubscription?.cancel();
+    _changesSubscription = null;
+    _watchedProjectId = null;
+  }
+
+  Future<void> _refreshProjectSetting() async {
+    final projectId = _watchedProjectId;
+    if (projectId == null || projectId.isEmpty) {
+      return;
+    }
+    final result = await getProjectSetting(projectId);
+    if (_settingController?.isClosed == false) {
+      _settingController?.add(result);
     }
   }
 
@@ -102,32 +167,16 @@ class ProjectSettingRepositoryImpl implements ProjectSettingRepository {
     );
   }
 
-  static const _unexpectedErrorTypes = {
-    ProjectErrorType.unexpectedError,
-    ProjectErrorType.unexpectedDatabaseError,
-    ProjectErrorType.parsingError,
-  };
-
-  ProjectFailure _handleError(
-    Object error,
-    String operation,
-    StackTrace stackTrace,
-  ) {
-    final failure = ProjectErrorMapper.toFailure(error);
-    if (_unexpectedErrorTypes.contains(failure.errorType)) {
-      _logger.error('Error $operation: $error', error, stackTrace);
-    } else {
-      _logger.warning(
-        'Error $operation: ${failure.errorType.name}',
-        error,
-        stackTrace,
-      );
-    }
-    return failure;
+  ProjectFailure _handleError(Object error) {
+    return ProjectErrorMapper.toFailure(error);
   }
 
   @override
   void dispose() {
-    // No subscriptions or stream controllers to release in this PR's scope.
+    _changesSubscription?.cancel();
+    _changesSubscription = null;
+    _settingController?.close();
+    _settingController = null;
+    _watchedProjectId = null;
   }
 }

--- a/lib/libraries/project/data/repositories/project_setting_repository_impl.dart
+++ b/lib/libraries/project/data/repositories/project_setting_repository_impl.dart
@@ -34,6 +34,8 @@ class ProjectSettingRepositoryImpl implements ProjectSettingRepository {
       final dto = await _dataSource.fetchProjectSetting(projectId);
       return Right(dto.toDomain());
     } catch (error, stackTrace) {
+      // Log raw error and stack trace before domain mapping so diagnostics
+      // keep the original exception details instead of only the mapped Failure.
       _logger.warning(
         'Error while getting project setting for projectId: $projectId',
         error,
@@ -60,6 +62,8 @@ class ProjectSettingRepositoryImpl implements ProjectSettingRepository {
       final result = await _dataSource.updateProject(dto);
       return Right(result.toDomain());
     } catch (error, stackTrace) {
+      // Log raw error and stack trace before domain mapping so diagnostics
+      // keep the original exception details instead of only the mapped Failure.
       _logger.warning(
         'Error while updating project with id: ${project.id}',
         error,
@@ -85,6 +89,8 @@ class ProjectSettingRepositoryImpl implements ProjectSettingRepository {
       await _dataSource.deleteProject(projectId);
       return const Right(null);
     } catch (error, stackTrace) {
+      // Log raw error and stack trace before domain mapping so diagnostics
+      // keep the original exception details instead of only the mapped Failure.
       _logger.warning(
         'Error while deleting project with id: $projectId',
         error,
@@ -97,15 +103,17 @@ class ProjectSettingRepositoryImpl implements ProjectSettingRepository {
   @override
   Stream<Either<Failure, Project>> watchProjectSetting(String projectId) {
     final existing = _settingControllers[projectId];
-    if (existing != null && !existing.isClosed) {
-      return existing.stream;
+    if (existing?.isClosed == true) {
+      _settingControllers.remove(projectId);
     }
 
-    final controller = StreamController<Either<Failure, Project>>.broadcast(
-      onListen: () => _startWatchingSettingChanges(projectId),
-      onCancel: () => _stopWatchingIfNoListeners(projectId),
+    final controller = _settingControllers.putIfAbsent(
+      projectId,
+      () => StreamController<Either<Failure, Project>>.broadcast(
+        onListen: () => _startWatchingSettingChanges(projectId),
+        onCancel: () => _stopWatchingIfNoListeners(projectId),
+      ),
     );
-    _settingControllers[projectId] = controller;
     return controller.stream;
   }
 
@@ -124,7 +132,10 @@ class ProjectSettingRepositoryImpl implements ProjectSettingRepository {
               error,
               stackTrace,
             );
-            _settingControllers[projectId]?.addError(error, stackTrace);
+            final controller = _settingControllers[projectId];
+            if (controller?.isClosed == false) {
+              controller?.addError(error, stackTrace);
+            }
           },
         );
 

--- a/lib/libraries/project/data/repositories/project_setting_repository_impl.dart
+++ b/lib/libraries/project/data/repositories/project_setting_repository_impl.dart
@@ -21,6 +21,7 @@ class ProjectSettingRepositoryImpl implements ProjectSettingRepository {
   final Map<String, StreamController<Either<Failure, Project>>>
   _settingControllers = {};
   final Map<String, StreamSubscription<ProjectDto?>> _changesSubscriptions = {};
+  final Map<String, int> _refreshSequences = {};
 
   ProjectSettingRepositoryImpl({
     required ProjectSettingDataSource dataSource,
@@ -149,10 +150,17 @@ class ProjectSettingRepositoryImpl implements ProjectSettingRepository {
     }
     _changesSubscriptions.remove(projectId)?.cancel();
     _settingControllers.remove(projectId);
+    _refreshSequences.remove(projectId);
   }
 
   Future<void> _refreshProjectSetting(String projectId) async {
+    final sequence = (_refreshSequences[projectId] ?? 0) + 1;
+    _refreshSequences[projectId] = sequence;
+
     final result = await getProjectSetting(projectId);
+
+    if (_refreshSequences[projectId] != sequence) return;
+
     final controller = _settingControllers[projectId];
     if (controller?.isClosed == false) {
       controller?.add(result);
@@ -188,5 +196,6 @@ class ProjectSettingRepositoryImpl implements ProjectSettingRepository {
       controller.close();
     }
     _settingControllers.clear();
+    _refreshSequences.clear();
   }
 }

--- a/lib/libraries/project/data/repositories/project_setting_repository_impl.dart
+++ b/lib/libraries/project/data/repositories/project_setting_repository_impl.dart
@@ -18,9 +18,9 @@ class ProjectSettingRepositoryImpl implements ProjectSettingRepository {
   final ProjectPermissionDataSource _permissionDataSource;
   static final _logger = AppLogger().tag('ProjectSettingRepositoryImpl');
 
-  StreamController<Either<Failure, Project>>? _settingController;
-  StreamSubscription<ProjectDto?>? _changesSubscription;
-  String? _watchedProjectId;
+  final Map<String, StreamController<Either<Failure, Project>>>
+  _settingControllers = {};
+  final Map<String, StreamSubscription<ProjectDto?>> _changesSubscriptions = {};
 
   ProjectSettingRepositoryImpl({
     required ProjectSettingDataSource dataSource,
@@ -96,59 +96,55 @@ class ProjectSettingRepositoryImpl implements ProjectSettingRepository {
 
   @override
   Stream<Either<Failure, Project>> watchProjectSetting(String projectId) {
-    _watchedProjectId = projectId;
-    final controller = _settingController ??=
-        StreamController<Either<Failure, Project>>.broadcast(
-          onListen: _startWatchingSettingChanges,
-          onCancel: _stopWatchingIfNoListeners,
-        );
+    final existing = _settingControllers[projectId];
+    if (existing != null && !existing.isClosed) {
+      return existing.stream;
+    }
+
+    final controller = StreamController<Either<Failure, Project>>.broadcast(
+      onListen: () => _startWatchingSettingChanges(projectId),
+      onCancel: () => _stopWatchingIfNoListeners(projectId),
+    );
+    _settingControllers[projectId] = controller;
     return controller.stream;
   }
 
-  void _startWatchingSettingChanges() {
-    if (_changesSubscription != null) {
+  void _startWatchingSettingChanges(String projectId) {
+    if (_changesSubscriptions.containsKey(projectId)) {
       return;
     }
 
-    final projectId = _watchedProjectId;
-    if (projectId == null || projectId.isEmpty) {
-      return;
-    }
-
-    _changesSubscription = _dataSource
+    _changesSubscriptions[projectId] = _dataSource
         .watchProjectChanges(projectId)
         .listen(
-          (_) => _refreshProjectSetting(),
+          (_) => _refreshProjectSetting(projectId),
           onError: (Object error, StackTrace stackTrace) {
-            _logger.error(
+            _logger.warning(
               'Error while watching project setting changes for projectId: $projectId',
               error,
               stackTrace,
             );
-            _settingController?.addError(error, stackTrace);
+            _settingControllers[projectId]?.addError(error, stackTrace);
           },
         );
 
-    _refreshProjectSetting();
+    _refreshProjectSetting(projectId);
   }
 
-  void _stopWatchingIfNoListeners() {
-    if (_settingController?.hasListener == true) {
+  void _stopWatchingIfNoListeners(String projectId) {
+    final controller = _settingControllers[projectId];
+    if (controller?.hasListener == true) {
       return;
     }
-    _changesSubscription?.cancel();
-    _changesSubscription = null;
-    _watchedProjectId = null;
+    _changesSubscriptions.remove(projectId)?.cancel();
+    _settingControllers.remove(projectId);
   }
 
-  Future<void> _refreshProjectSetting() async {
-    final projectId = _watchedProjectId;
-    if (projectId == null || projectId.isEmpty) {
-      return;
-    }
+  Future<void> _refreshProjectSetting(String projectId) async {
     final result = await getProjectSetting(projectId);
-    if (_settingController?.isClosed == false) {
-      _settingController?.add(result);
+    final controller = _settingControllers[projectId];
+    if (controller?.isClosed == false) {
+      controller?.add(result);
     }
   }
 
@@ -173,10 +169,13 @@ class ProjectSettingRepositoryImpl implements ProjectSettingRepository {
 
   @override
   void dispose() {
-    _changesSubscription?.cancel();
-    _changesSubscription = null;
-    _settingController?.close();
-    _settingController = null;
-    _watchedProjectId = null;
+    for (final subscription in _changesSubscriptions.values) {
+      subscription.cancel();
+    }
+    _changesSubscriptions.clear();
+    for (final controller in _settingControllers.values) {
+      controller.close();
+    }
+    _settingControllers.clear();
   }
 }

--- a/lib/libraries/project/domain/repositories/project_setting_repository.dart
+++ b/lib/libraries/project/domain/repositories/project_setting_repository.dart
@@ -30,6 +30,13 @@ abstract class ProjectSettingRepository {
   /// [ProjectErrorType.permissionDenied] when the caller lacks the permission.
   Future<Either<Failure, void>> deleteProject(String projectId);
 
+  /// Emits the current project state and re-emits on every remote change.
+  ///
+  /// Emits [Right] with the updated [Project] on each change, or [Left] with
+  /// a [Failure] if a fetch error occurs. Stream errors from the underlying
+  /// data source are forwarded to subscribers.
+  Stream<Either<Failure, Project>> watchProjectSetting(String projectId);
+
   /// Releases subscriptions and stream controllers held by this repository.
   void dispose();
 }

--- a/test/libraries/project/units/data/repositories/project_setting_repository_impl_test.dart
+++ b/test/libraries/project/units/data/repositories/project_setting_repository_impl_test.dart
@@ -1,59 +1,48 @@
-import 'package:construculator/app/app_bootstrap.dart';
+import 'dart:async';
+import 'dart:io';
+
+import 'package:construculator/libraries/errors/exceptions.dart';
 import 'package:construculator/libraries/errors/failures.dart';
+import 'package:construculator/libraries/project/data/data_source/interfaces/permission_data_source.dart';
+import 'package:construculator/libraries/project/data/data_source/interfaces/project_setting_data_source.dart';
+import 'package:construculator/libraries/project/data/models/project_dto.dart';
 import 'package:construculator/libraries/project/data/repositories/project_setting_repository_impl.dart';
 import 'package:construculator/libraries/project/domain/entities/enums.dart';
 import 'package:construculator/libraries/project/domain/entities/project_entity.dart';
 import 'package:construculator/libraries/project/domain/permission_constants.dart';
 import 'package:construculator/libraries/project/domain/project_error_type.dart';
 import 'package:construculator/libraries/project/domain/repositories/project_setting_repository.dart';
-import 'package:construculator/libraries/project/project_library_module.dart';
 import 'package:construculator/libraries/supabase/data/supabase_types.dart';
-import 'package:construculator/libraries/supabase/database_constants.dart';
-import 'package:construculator/libraries/supabase/interfaces/supabase_wrapper.dart';
-import 'package:construculator/libraries/supabase/testing/fake_supabase_wrapper.dart';
-import 'package:construculator/libraries/time/testing/fake_clock_impl.dart';
 import 'package:flutter_modular/flutter_modular.dart';
 import 'package:flutter_test/flutter_test.dart';
-
-import '../../../../../utils/fake_app_bootstrap_factory.dart';
+import 'package:stack_trace/stack_trace.dart';
+import 'package:supabase_flutter/supabase_flutter.dart' as supabase;
 
 void main() {
   group('ProjectSettingRepositoryImpl', () {
-    late ProjectSettingRepositoryImpl repository;
-    late FakeSupabaseWrapper supabaseWrapper;
+    late _FakeProjectPermissionDataSource permissionDataSource;
+    late ProjectSettingRepository repository;
+    late _FakeProjectSettingDataSource fakeDataSource;
 
     setUp(() {
-      final clock = FakeClockImpl(DateTime(2025, 1, 1));
-      Modular.init(
-        _TestAppModule(
-          FakeAppBootstrapFactory.create(
-            supabaseWrapper: FakeSupabaseWrapper(clock: clock),
-          ),
-        ),
-      );
-      supabaseWrapper = Modular.get<SupabaseWrapper>() as FakeSupabaseWrapper;
-      repository =
-          Modular.get<ProjectSettingRepository>()
-              as ProjectSettingRepositoryImpl;
-      supabaseWrapper.reset();
+      Modular.init(_ProjectSettingRepositoryTestModule());
+      fakeDataSource = Modular.get<_FakeProjectSettingDataSource>();
+      permissionDataSource = Modular.get<_FakeProjectPermissionDataSource>();
+      repository = Modular.get<ProjectSettingRepository>();
     });
 
     tearDown(() {
+      repository.dispose();
+      fakeDataSource.dispose();
       Modular.destroy();
     });
 
     group('getProjectSetting', () {
       test('returns Right(project) when data source succeeds', () async {
-        supabaseWrapper.addTableData(DatabaseConstants.projectsTable, [
-          {
-            DatabaseConstants.idColumn: 'p-1',
-            DatabaseConstants.projectNameColumn: 'Test Project',
-            DatabaseConstants.creatorUserIdColumn: 'user-1',
-            DatabaseConstants.createdAtColumn: DateTime(2025, 1, 1),
-            DatabaseConstants.updatedAtColumn: DateTime(2025, 1, 2),
-            DatabaseConstants.statusColumn: 'active',
-          },
-        ]);
+        fakeDataSource.projectToReturn = _fakeDto(
+          id: 'p-1',
+          projectName: 'Test Project',
+        );
 
         final result = await repository.getProjectSetting('p-1');
 
@@ -67,7 +56,7 @@ void main() {
       test(
         'returns Left(unexpectedDatabaseError) on ServerException',
         () async {
-          supabaseWrapper.shouldThrowOnSelect = true;
+          fakeDataSource.shouldThrowOnGet = true;
 
           final result = await repository.getProjectSetting('p-1');
 
@@ -83,8 +72,8 @@ void main() {
       );
 
       test('returns Left(timeoutError) on TimeoutException', () async {
-        supabaseWrapper.shouldThrowOnSelect = true;
-        supabaseWrapper.selectExceptionType = SupabaseExceptionType.timeout;
+        fakeDataSource.shouldThrowOnGet = true;
+        fakeDataSource.exceptionToThrow = TimeoutException('Select failed');
 
         final result = await repository.getProjectSetting('p-1');
 
@@ -100,8 +89,7 @@ void main() {
       });
 
       test('returns Left(unexpectedError) on unknown error', () async {
-        supabaseWrapper.shouldThrowOnSelect = true;
-        supabaseWrapper.selectExceptionType = SupabaseExceptionType.auth;
+        fakeDataSource.exceptionToThrow = Exception('unknown');
 
         final result = await repository.getProjectSetting('p-1');
 
@@ -116,7 +104,10 @@ void main() {
       });
 
       test('returns Left(notFoundError) on NotFoundException', () async {
-        supabaseWrapper.shouldReturnNullOnSelect = true;
+        fakeDataSource.exceptionToThrow = NotFoundException(
+          Trace.current(),
+          Exception('not found'),
+        );
 
         final result = await repository.getProjectSetting('p-1');
 
@@ -132,8 +123,7 @@ void main() {
       });
 
       test('returns Left(connectionError) on SocketException', () async {
-        supabaseWrapper.shouldThrowOnSelect = true;
-        supabaseWrapper.selectExceptionType = SupabaseExceptionType.socket;
+        fakeDataSource.exceptionToThrow = const SocketException('socket error');
 
         final result = await repository.getProjectSetting('p-1');
 
@@ -149,8 +139,10 @@ void main() {
       });
 
       test('returns Left(connectionError) on NetworkException', () async {
-        supabaseWrapper.shouldThrowOnSelect = true;
-        supabaseWrapper.selectExceptionType = SupabaseExceptionType.network;
+        fakeDataSource.exceptionToThrow = NetworkException(
+          Trace.current(),
+          Exception('network error'),
+        );
 
         final result = await repository.getProjectSetting('p-1');
 
@@ -166,8 +158,7 @@ void main() {
       });
 
       test('returns Left(parsingError) on TypeError', () async {
-        supabaseWrapper.shouldThrowOnSelect = true;
-        supabaseWrapper.selectExceptionType = SupabaseExceptionType.type;
+        fakeDataSource.exceptionToThrow = _typeError();
 
         final result = await repository.getProjectSetting('p-1');
 
@@ -183,9 +174,10 @@ void main() {
       });
 
       test('maps PostgrestException PGRST116 to notFoundError', () async {
-        supabaseWrapper.shouldThrowOnSelect = true;
-        supabaseWrapper.selectExceptionType = SupabaseExceptionType.postgrest;
-        supabaseWrapper.postgrestErrorCode = PostgresErrorCode.noDataFound;
+        fakeDataSource.exceptionToThrow = supabase.PostgrestException(
+          message: 'Select failed',
+          code: PostgresErrorCode.noDataFound.toString(),
+        );
 
         final result = await repository.getProjectSetting('p-1');
 
@@ -202,10 +194,10 @@ void main() {
       test(
         'maps PostgrestException connection codes to connectionError',
         () async {
-          supabaseWrapper.shouldThrowOnSelect = true;
-          supabaseWrapper.selectExceptionType = SupabaseExceptionType.postgrest;
-          supabaseWrapper.postgrestErrorCode =
-              PostgresErrorCode.connectionFailure;
+          fakeDataSource.exceptionToThrow = supabase.PostgrestException(
+            message: 'Select failed',
+            code: PostgresErrorCode.connectionFailure.toString(),
+          );
 
           final result = await repository.getProjectSetting('p-1');
 
@@ -223,10 +215,10 @@ void main() {
       test(
         'maps PostgrestException unableToConnect to connectionError',
         () async {
-          supabaseWrapper.shouldThrowOnSelect = true;
-          supabaseWrapper.selectExceptionType = SupabaseExceptionType.postgrest;
-          supabaseWrapper.postgrestErrorCode =
-              PostgresErrorCode.unableToConnect;
+          fakeDataSource.exceptionToThrow = supabase.PostgrestException(
+            message: 'connection refused',
+            code: PostgresErrorCode.unableToConnect.toString(),
+          );
 
           final result = await repository.getProjectSetting('p-1');
 
@@ -244,10 +236,10 @@ void main() {
       test(
         'maps PostgrestException connectionDoesNotExist to connectionError',
         () async {
-          supabaseWrapper.shouldThrowOnSelect = true;
-          supabaseWrapper.selectExceptionType = SupabaseExceptionType.postgrest;
-          supabaseWrapper.postgrestErrorCode =
-              PostgresErrorCode.connectionDoesNotExist;
+          fakeDataSource.exceptionToThrow = supabase.PostgrestException(
+            message: 'connection does not exist',
+            code: PostgresErrorCode.connectionDoesNotExist.toString(),
+          );
 
           final result = await repository.getProjectSetting('p-1');
 
@@ -265,10 +257,10 @@ void main() {
       test(
         'maps PostgrestException unknown code to unexpectedDatabaseError',
         () async {
-          supabaseWrapper.shouldThrowOnSelect = true;
-          supabaseWrapper.selectExceptionType = SupabaseExceptionType.postgrest;
-          supabaseWrapper.postgrestErrorCode =
-              PostgresErrorCode.uniqueViolation;
+          fakeDataSource.exceptionToThrow = supabase.PostgrestException(
+            message: 'unique violation',
+            code: PostgresErrorCode.uniqueViolation.toString(),
+          );
 
           final result = await repository.getProjectSetting('p-1');
 
@@ -310,20 +302,14 @@ void main() {
       test(
         'returns Right(project) when permission present and update succeeds',
         () async {
-          supabaseWrapper.addTableData(DatabaseConstants.projectsTable, [
-            {
-              DatabaseConstants.idColumn: 'p-1',
-              DatabaseConstants.projectNameColumn: 'Old Name',
-              DatabaseConstants.creatorUserIdColumn: 'user-1',
-              DatabaseConstants.createdAtColumn: DateTime(2025, 1, 1),
-              DatabaseConstants.updatedAtColumn: DateTime(2025, 1, 2),
-              DatabaseConstants.statusColumn: 'active',
-            },
-          ]);
-
-          supabaseWrapper.setProjectPermissions('p-1', [
+          permissionDataSource.setPermissions('p-1', [
             PermissionConstants.editProject,
           ]);
+
+          fakeDataSource.projectToReturn = _fakeDto(
+            id: 'p-1',
+            projectName: 'New Name',
+          );
 
           final project = Project(
             id: 'p-1',
@@ -362,18 +348,7 @@ void main() {
       test(
         'returns Right(null) when permission present and delete succeeds',
         () async {
-          supabaseWrapper.addTableData(DatabaseConstants.projectsTable, [
-            {
-              DatabaseConstants.idColumn: 'p-1',
-              DatabaseConstants.projectNameColumn: 'ToDelete',
-              DatabaseConstants.creatorUserIdColumn: 'user-1',
-              DatabaseConstants.createdAtColumn: DateTime(2025, 1, 1),
-              DatabaseConstants.updatedAtColumn: DateTime(2025, 1, 2),
-              DatabaseConstants.statusColumn: 'active',
-            },
-          ]);
-
-          supabaseWrapper.setProjectPermissions('p-1', [
+          permissionDataSource.setPermissions('p-1', [
             PermissionConstants.deleteProject,
           ]);
 
@@ -381,24 +356,252 @@ void main() {
 
           expect(result.isRight(), isTrue);
           result.fold((_) => fail('Expected Right'), (_) => null);
-
-          // ensure row removed from fake supabase
-          final row = await supabaseWrapper.selectSingle(
-            table: DatabaseConstants.projectsTable,
-            filterColumn: DatabaseConstants.idColumn,
-            filterValue: 'p-1',
-          );
-          expect(row, isNull);
         },
       );
+    });
+
+    group('watchProjectSetting', () {
+      test('emits current project on subscribe', () async {
+        fakeDataSource.projectToReturn = _fakeDto(id: 'p-1', projectName: 'v1');
+
+        final emittedCompleter = Completer<Project>();
+        final subscription = repository.watchProjectSetting('p-1').listen((
+          result,
+        ) {
+          result.fold((_) {}, (project) {
+            if (!emittedCompleter.isCompleted) {
+              emittedCompleter.complete(project);
+            }
+          });
+        });
+
+        final project = await emittedCompleter.future;
+        expect(project.projectName, equals('v1'));
+        await subscription.cancel();
+      });
+
+      test('re-emits on data source change notification', () async {
+        fakeDataSource.projectToReturn = _fakeDto(id: 'p-1', projectName: 'v1');
+
+        final secondEmission = Completer<Project>();
+        var emissionCount = 0;
+        final subscription = repository.watchProjectSetting('p-1').listen((
+          result,
+        ) {
+          result.fold((_) {}, (project) {
+            emissionCount++;
+            if (emissionCount >= 2 && !secondEmission.isCompleted) {
+              secondEmission.complete(project);
+            }
+          });
+        });
+
+        await pumpEventQueue();
+
+        fakeDataSource.projectToReturn = _fakeDto(id: 'p-1', projectName: 'v2');
+        fakeDataSource.emitChange();
+
+        final project = await secondEmission.future;
+        expect(project.projectName, equals('v2'));
+        await subscription.cancel();
+      });
+
+      test('emits Left when getProjectSetting fails during watch', () async {
+        fakeDataSource.shouldThrowOnGet = true;
+
+        final failureCompleter = Completer<Failure>();
+        final subscription = repository.watchProjectSetting('p-1').listen((
+          result,
+        ) {
+          result.fold((failure) {
+            if (!failureCompleter.isCompleted) {
+              failureCompleter.complete(failure);
+            }
+          }, (_) {});
+        });
+
+        final failure = await failureCompleter.future;
+        expect(failure, isA<ProjectFailure>());
+        await subscription.cancel();
+      });
+
+      test('forwards stream error from data source to subscribers', () async {
+        fakeDataSource.projectToReturn = _fakeDto(id: 'p-1');
+
+        final errorCompleter = Completer<Object>();
+        final subscription = repository
+            .watchProjectSetting('p-1')
+            .listen(
+              (_) {},
+              onError: (Object error, StackTrace _) {
+                if (!errorCompleter.isCompleted) errorCompleter.complete(error);
+              },
+            );
+
+        await pumpEventQueue();
+        fakeDataSource.emitError(Exception('stream error'));
+
+        final receivedError = await errorCompleter.future;
+        expect(receivedError, isA<Exception>());
+        await subscription.cancel();
+      });
+
+      test('cleans up resources on dispose', () async {
+        fakeDataSource.projectToReturn = _fakeDto(id: 'p-1');
+
+        final subscription = repository
+            .watchProjectSetting('p-1')
+            .listen((_) {});
+        await pumpEventQueue();
+        await subscription.cancel();
+
+        repository.dispose();
+        expect(
+          fakeDataSource.getMethodCallsFor('watchProjectChanges'),
+          hasLength(1),
+        );
+      });
     });
   });
 }
 
-class _TestAppModule extends Module {
-  final AppBootstrap appBootstrap;
-  _TestAppModule(this.appBootstrap);
+ProjectDto _fakeDto({required String id, String? projectName}) {
+  return ProjectDto(
+    id: id,
+    projectName: projectName ?? 'Test Project',
+    creatorUserId: 'user-1',
+    createdAt: DateTime(2025, 1, 1),
+    updatedAt: DateTime(2025, 1, 2),
+    status: ProjectStatus.active,
+  );
+}
+
+TypeError _typeError() {
+  try {
+    final Object value = 'not an int';
+    value as int;
+  } on TypeError catch (error) {
+    return error;
+  }
+  throw StateError('Expected cast to throw TypeError');
+}
+
+class _FakeProjectSettingDataSource implements ProjectSettingDataSource {
+  final List<Map<String, dynamic>> _methodCalls = [];
+
+  ProjectDto? projectToReturn;
+  bool shouldThrowOnGet = false;
+  bool shouldThrowOnDelete = false;
+  Object? exceptionToThrow;
+
+  final StreamController<ProjectDto?> _changesController =
+      StreamController<ProjectDto?>.broadcast();
 
   @override
-  List<Module> get imports => [ProjectLibraryModule(appBootstrap)];
+  Future<ProjectDto> updateProject(ProjectDto projectDto) async {
+    _methodCalls.add({'method': 'updateProject', 'dto': projectDto});
+
+    final ex = exceptionToThrow;
+    if (ex != null) {
+      exceptionToThrow = null;
+      throw ex;
+    }
+
+    return projectToReturn ?? projectDto;
+  }
+
+  @override
+  Future<void> deleteProject(String projectId) async {
+    _methodCalls.add({'method': 'deleteProject', 'projectId': projectId});
+
+    final ex = exceptionToThrow;
+    if (ex != null) {
+      exceptionToThrow = null;
+      throw ex;
+    }
+
+    if (shouldThrowOnDelete) {
+      throw ServerException(Trace.current(), Exception('Delete failed'));
+    }
+  }
+
+  @override
+  Stream<ProjectDto?> watchProjectChanges(String projectId) {
+    _methodCalls.add({'method': 'watchProjectChanges', 'projectId': projectId});
+    return _changesController.stream;
+  }
+
+  void emitChange() => _changesController.add(projectToReturn);
+
+  void emitError(Object error) => _changesController.addError(error);
+
+  List<Map<String, dynamic>> getMethodCallsFor(String methodName) {
+    return _methodCalls.where((call) => call['method'] == methodName).toList();
+  }
+
+  void dispose() => _changesController.close();
+
+  @override
+  Future<ProjectDto> fetchProjectSetting(String projectId) {
+    _methodCalls.add({'method': 'fetchProjectSetting', 'projectId': projectId});
+
+    final ex = exceptionToThrow;
+    if (ex != null) {
+      exceptionToThrow = null;
+      throw ex;
+    }
+
+    if (shouldThrowOnGet) {
+      throw ServerException(Trace.current(), Exception('Select failed'));
+    }
+
+    if (projectToReturn != null) return Future.value(projectToReturn);
+
+    throw ServerException(
+      Trace.current(),
+      Exception('No project configured in FakeProjectSettingDataSource'),
+    );
+  }
+}
+
+class _FakeProjectPermissionDataSource implements ProjectPermissionDataSource {
+  final Map<String, List<String>> _permissions = {};
+
+  void setPermissions(String projectId, List<String> permissions) {
+    _permissions[projectId] = List<String>.from(permissions);
+  }
+
+  @override
+  List<String> getProjectPermissions(String projectId) {
+    return List.from(_permissions[projectId] ?? []);
+  }
+
+  @override
+  bool hasProjectPermission(String projectId, String permissionKey) {
+    return _permissions[projectId]?.contains(permissionKey) ?? false;
+  }
+}
+
+class _ProjectSettingRepositoryTestModule extends Module {
+  @override
+  void binds(Injector i) {
+    i.addLazySingleton<_FakeProjectSettingDataSource>(
+      () => _FakeProjectSettingDataSource(),
+    );
+    i.addLazySingleton<ProjectSettingDataSource>(
+      () => i.get<_FakeProjectSettingDataSource>(),
+    );
+    i.addLazySingleton<_FakeProjectPermissionDataSource>(
+      () => _FakeProjectPermissionDataSource(),
+    );
+    i.addLazySingleton<ProjectPermissionDataSource>(
+      () => i.get<_FakeProjectPermissionDataSource>(),
+    );
+    i.addLazySingleton<ProjectSettingRepository>(
+      () => ProjectSettingRepositoryImpl(
+        dataSource: i.get<ProjectSettingDataSource>(),
+        permissionDataSource: i.get<ProjectPermissionDataSource>(),
+      ),
+    );
+  }
 }

--- a/test/libraries/project/units/data/repositories/project_setting_repository_impl_test.dart
+++ b/test/libraries/project/units/data/repositories/project_setting_repository_impl_test.dart
@@ -1,11 +1,11 @@
 import 'dart:async';
-import 'dart:io';
 
-import 'package:construculator/libraries/errors/exceptions.dart';
+import 'package:construculator/app/app_bootstrap.dart';
 import 'package:construculator/libraries/errors/failures.dart';
 import 'package:construculator/libraries/project/data/data_source/interfaces/permission_data_source.dart';
 import 'package:construculator/libraries/project/data/data_source/interfaces/project_setting_data_source.dart';
-import 'package:construculator/libraries/project/data/models/project_dto.dart';
+import 'package:construculator/libraries/project/data/data_source/local_jwt_project_permission_data_source.dart';
+import 'package:construculator/libraries/project/data/data_source/remote_project_setting_data_source.dart';
 import 'package:construculator/libraries/project/data/repositories/project_setting_repository_impl.dart';
 import 'package:construculator/libraries/project/domain/entities/enums.dart';
 import 'package:construculator/libraries/project/domain/entities/project_entity.dart';
@@ -13,36 +13,49 @@ import 'package:construculator/libraries/project/domain/permission_constants.dar
 import 'package:construculator/libraries/project/domain/project_error_type.dart';
 import 'package:construculator/libraries/project/domain/repositories/project_setting_repository.dart';
 import 'package:construculator/libraries/supabase/data/supabase_types.dart';
+import 'package:construculator/libraries/supabase/database_constants.dart';
+import 'package:construculator/libraries/supabase/interfaces/supabase_wrapper.dart';
+import 'package:construculator/libraries/supabase/supabase_module.dart';
+import 'package:construculator/libraries/supabase/testing/fake_supabase_wrapper.dart';
+import 'package:construculator/libraries/time/testing/fake_clock_impl.dart';
 import 'package:flutter_modular/flutter_modular.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:stack_trace/stack_trace.dart';
-import 'package:supabase_flutter/supabase_flutter.dart' as supabase;
+
+import '../../../../../utils/fake_app_bootstrap_factory.dart';
 
 void main() {
   group('ProjectSettingRepositoryImpl', () {
-    late _FakeProjectPermissionDataSource permissionDataSource;
-    late ProjectSettingRepository repository;
-    late _FakeProjectSettingDataSource fakeDataSource;
+    late FakeSupabaseWrapper fakeSupabaseWrapper;
+    late FakeClockImpl fakeClock;
+    late ProjectSettingRepositoryImpl repository;
 
     setUp(() {
-      Modular.init(_ProjectSettingRepositoryTestModule());
-      fakeDataSource = Modular.get<_FakeProjectSettingDataSource>();
-      permissionDataSource = Modular.get<_FakeProjectPermissionDataSource>();
-      repository = Modular.get<ProjectSettingRepository>();
+      fakeClock = FakeClockImpl();
+      Modular.init(
+        _TestModule(
+          FakeAppBootstrapFactory.create(
+            supabaseWrapper: FakeSupabaseWrapper(clock: fakeClock),
+          ),
+        ),
+      );
+      fakeSupabaseWrapper =
+          Modular.get<SupabaseWrapper>() as FakeSupabaseWrapper;
+      repository =
+          Modular.get<ProjectSettingRepository>()
+              as ProjectSettingRepositoryImpl;
+      fakeSupabaseWrapper.reset();
     });
 
     tearDown(() {
-      repository.dispose();
-      fakeDataSource.dispose();
+      fakeSupabaseWrapper.reset();
       Modular.destroy();
     });
 
     group('getProjectSetting', () {
       test('returns Right(project) when data source succeeds', () async {
-        fakeDataSource.projectToReturn = _fakeDto(
-          id: 'p-1',
-          projectName: 'Test Project',
-        );
+        fakeSupabaseWrapper.addTableData(DatabaseConstants.projectsTable, [
+          _fakeProjectRow(id: 'p-1', projectName: 'Test Project'),
+        ]);
 
         final result = await repository.getProjectSetting('p-1');
 
@@ -53,27 +66,24 @@ void main() {
         });
       });
 
-      test(
-        'returns Left(unexpectedDatabaseError) on ServerException',
-        () async {
-          fakeDataSource.shouldThrowOnGet = true;
+      test('returns Left(unexpectedDatabaseError) on server error', () async {
+        fakeSupabaseWrapper.shouldThrowOnSelect = true;
 
-          final result = await repository.getProjectSetting('p-1');
+        final result = await repository.getProjectSetting('p-1');
 
-          expect(result.isLeft(), isTrue);
-          result.fold((failure) {
-            expect(failure, isA<ProjectFailure>());
-            expect(
-              (failure as ProjectFailure).errorType,
-              equals(ProjectErrorType.unexpectedDatabaseError),
-            );
-          }, (_) => fail('Expected Left'));
-        },
-      );
+        expect(result.isLeft(), isTrue);
+        result.fold((failure) {
+          expect(failure, isA<ProjectFailure>());
+          expect(
+            (failure as ProjectFailure).errorType,
+            equals(ProjectErrorType.unexpectedDatabaseError),
+          );
+        }, (_) => fail('Expected Left'));
+      });
 
       test('returns Left(timeoutError) on TimeoutException', () async {
-        fakeDataSource.shouldThrowOnGet = true;
-        fakeDataSource.exceptionToThrow = TimeoutException('Select failed');
+        fakeSupabaseWrapper.shouldThrowOnSelect = true;
+        fakeSupabaseWrapper.selectExceptionType = SupabaseExceptionType.timeout;
 
         final result = await repository.getProjectSetting('p-1');
 
@@ -88,8 +98,24 @@ void main() {
         }, (_) => fail('Expected Left'));
       });
 
-      test('returns Left(unexpectedError) on unknown error', () async {
-        fakeDataSource.exceptionToThrow = Exception('unknown');
+      test('returns Left(notFoundError) when project does not exist', () async {
+        fakeSupabaseWrapper.shouldReturnNullOnSelect = true;
+
+        final result = await repository.getProjectSetting('p-1');
+
+        expect(result.isLeft(), isTrue);
+        result.fold((failure) {
+          expect(failure, isA<ProjectFailure>());
+          expect(
+            (failure as ProjectFailure).errorType,
+            equals(ProjectErrorType.notFoundError),
+          );
+        }, (_) => fail('Expected Left'));
+      });
+
+      test('returns Left(unexpectedError) on unexpected error', () async {
+        fakeSupabaseWrapper.shouldThrowOnSelect = true;
+        fakeSupabaseWrapper.selectExceptionType = SupabaseExceptionType.auth;
 
         final result = await repository.getProjectSetting('p-1');
 
@@ -103,27 +129,9 @@ void main() {
         }, (_) => fail('Expected Left'));
       });
 
-      test('returns Left(notFoundError) on NotFoundException', () async {
-        fakeDataSource.exceptionToThrow = NotFoundException(
-          Trace.current(),
-          Exception('not found'),
-        );
-
-        final result = await repository.getProjectSetting('p-1');
-
-        expect(result.isLeft(), isTrue);
-        result.fold((failure) {
-          expect(
-            failure,
-            equals(
-              const ProjectFailure(errorType: ProjectErrorType.notFoundError),
-            ),
-          );
-        }, (_) => fail('Expected Left'));
-      });
-
       test('returns Left(connectionError) on SocketException', () async {
-        fakeDataSource.exceptionToThrow = const SocketException('socket error');
+        fakeSupabaseWrapper.shouldThrowOnSelect = true;
+        fakeSupabaseWrapper.selectExceptionType = SupabaseExceptionType.socket;
 
         final result = await repository.getProjectSetting('p-1');
 
@@ -139,10 +147,8 @@ void main() {
       });
 
       test('returns Left(connectionError) on NetworkException', () async {
-        fakeDataSource.exceptionToThrow = NetworkException(
-          Trace.current(),
-          Exception('network error'),
-        );
+        fakeSupabaseWrapper.shouldThrowOnSelect = true;
+        fakeSupabaseWrapper.selectExceptionType = SupabaseExceptionType.network;
 
         final result = await repository.getProjectSetting('p-1');
 
@@ -158,7 +164,8 @@ void main() {
       });
 
       test('returns Left(parsingError) on TypeError', () async {
-        fakeDataSource.exceptionToThrow = _typeError();
+        fakeSupabaseWrapper.shouldThrowOnSelect = true;
+        fakeSupabaseWrapper.selectExceptionType = SupabaseExceptionType.type;
 
         final result = await repository.getProjectSetting('p-1');
 
@@ -174,10 +181,9 @@ void main() {
       });
 
       test('maps PostgrestException PGRST116 to notFoundError', () async {
-        fakeDataSource.exceptionToThrow = supabase.PostgrestException(
-          message: 'Select failed',
-          code: PostgresErrorCode.noDataFound.toString(),
-        );
+        fakeSupabaseWrapper.shouldThrowOnSelect = true;
+        fakeSupabaseWrapper.selectExceptionType = SupabaseExceptionType.postgrest;
+        fakeSupabaseWrapper.postgrestErrorCode = PostgresErrorCode.noDataFound;
 
         final result = await repository.getProjectSetting('p-1');
 
@@ -194,10 +200,11 @@ void main() {
       test(
         'maps PostgrestException connection codes to connectionError',
         () async {
-          fakeDataSource.exceptionToThrow = supabase.PostgrestException(
-            message: 'Select failed',
-            code: PostgresErrorCode.connectionFailure.toString(),
-          );
+          fakeSupabaseWrapper.shouldThrowOnSelect = true;
+          fakeSupabaseWrapper.selectExceptionType =
+              SupabaseExceptionType.postgrest;
+          fakeSupabaseWrapper.postgrestErrorCode =
+              PostgresErrorCode.connectionFailure;
 
           final result = await repository.getProjectSetting('p-1');
 
@@ -215,10 +222,11 @@ void main() {
       test(
         'maps PostgrestException unableToConnect to connectionError',
         () async {
-          fakeDataSource.exceptionToThrow = supabase.PostgrestException(
-            message: 'connection refused',
-            code: PostgresErrorCode.unableToConnect.toString(),
-          );
+          fakeSupabaseWrapper.shouldThrowOnSelect = true;
+          fakeSupabaseWrapper.selectExceptionType =
+              SupabaseExceptionType.postgrest;
+          fakeSupabaseWrapper.postgrestErrorCode =
+              PostgresErrorCode.unableToConnect;
 
           final result = await repository.getProjectSetting('p-1');
 
@@ -236,10 +244,11 @@ void main() {
       test(
         'maps PostgrestException connectionDoesNotExist to connectionError',
         () async {
-          fakeDataSource.exceptionToThrow = supabase.PostgrestException(
-            message: 'connection does not exist',
-            code: PostgresErrorCode.connectionDoesNotExist.toString(),
-          );
+          fakeSupabaseWrapper.shouldThrowOnSelect = true;
+          fakeSupabaseWrapper.selectExceptionType =
+              SupabaseExceptionType.postgrest;
+          fakeSupabaseWrapper.postgrestErrorCode =
+              PostgresErrorCode.connectionDoesNotExist;
 
           final result = await repository.getProjectSetting('p-1');
 
@@ -257,10 +266,11 @@ void main() {
       test(
         'maps PostgrestException unknown code to unexpectedDatabaseError',
         () async {
-          fakeDataSource.exceptionToThrow = supabase.PostgrestException(
-            message: 'unique violation',
-            code: PostgresErrorCode.uniqueViolation.toString(),
-          );
+          fakeSupabaseWrapper.shouldThrowOnSelect = true;
+          fakeSupabaseWrapper.selectExceptionType =
+              SupabaseExceptionType.postgrest;
+          fakeSupabaseWrapper.postgrestErrorCode =
+              PostgresErrorCode.uniqueViolation;
 
           final result = await repository.getProjectSetting('p-1');
 
@@ -302,14 +312,12 @@ void main() {
       test(
         'returns Right(project) when permission present and update succeeds',
         () async {
-          permissionDataSource.setPermissions('p-1', [
+          fakeSupabaseWrapper.setProjectPermissions('p-1', [
             PermissionConstants.editProject,
           ]);
-
-          fakeDataSource.projectToReturn = _fakeDto(
-            id: 'p-1',
-            projectName: 'New Name',
-          );
+          fakeSupabaseWrapper.addTableData(DatabaseConstants.projectsTable, [
+            _fakeProjectRow(id: 'p-1', projectName: 'Old Name'),
+          ]);
 
           final project = Project(
             id: 'p-1',
@@ -348,8 +356,11 @@ void main() {
       test(
         'returns Right(null) when permission present and delete succeeds',
         () async {
-          permissionDataSource.setPermissions('p-1', [
+          fakeSupabaseWrapper.setProjectPermissions('p-1', [
             PermissionConstants.deleteProject,
+          ]);
+          fakeSupabaseWrapper.addTableData(DatabaseConstants.projectsTable, [
+            _fakeProjectRow(id: 'p-1'),
           ]);
 
           final result = await repository.deleteProject('p-1');
@@ -362,7 +373,9 @@ void main() {
 
     group('watchProjectSetting', () {
       test('emits current project on subscribe', () async {
-        fakeDataSource.projectToReturn = _fakeDto(id: 'p-1', projectName: 'v1');
+        fakeSupabaseWrapper.addTableData(DatabaseConstants.projectsTable, [
+          _fakeProjectRow(id: 'p-1', projectName: 'v1'),
+        ]);
 
         final emittedCompleter = Completer<Project>();
         final subscription = repository.watchProjectSetting('p-1').listen((
@@ -381,33 +394,37 @@ void main() {
       });
 
       test('re-emits on data source change notification', () async {
-        fakeDataSource.projectToReturn = _fakeDto(id: 'p-1', projectName: 'v1');
+        fakeSupabaseWrapper.addTableData(DatabaseConstants.projectsTable, [
+          _fakeProjectRow(id: 'p-1', projectName: 'v1'),
+        ]);
 
-        final secondEmission = Completer<Project>();
-        var emissionCount = 0;
+        final v2Completer = Completer<Project>();
         final subscription = repository.watchProjectSetting('p-1').listen((
           result,
         ) {
           result.fold((_) {}, (project) {
-            emissionCount++;
-            if (emissionCount >= 2 && !secondEmission.isCompleted) {
-              secondEmission.complete(project);
+            if (project.projectName == 'v2' && !v2Completer.isCompleted) {
+              v2Completer.complete(project);
             }
           });
         });
 
         await pumpEventQueue();
 
-        fakeDataSource.projectToReturn = _fakeDto(id: 'p-1', projectName: 'v2');
-        fakeDataSource.emitChange();
+        fakeSupabaseWrapper.addTableData(DatabaseConstants.projectsTable, [
+          _fakeProjectRow(id: 'p-1', projectName: 'v2'),
+        ]);
 
-        final project = await secondEmission.future;
+        final project = await v2Completer.future;
         expect(project.projectName, equals('v2'));
         await subscription.cancel();
       });
 
       test('emits Left when getProjectSetting fails during watch', () async {
-        fakeDataSource.shouldThrowOnGet = true;
+        fakeSupabaseWrapper.addTableData(DatabaseConstants.projectsTable, [
+          _fakeProjectRow(id: 'p-1'),
+        ]);
+        fakeSupabaseWrapper.shouldThrowOnSelect = true;
 
         final failureCompleter = Completer<Failure>();
         final subscription = repository.watchProjectSetting('p-1').listen((
@@ -426,7 +443,9 @@ void main() {
       });
 
       test('forwards stream error from data source to subscribers', () async {
-        fakeDataSource.projectToReturn = _fakeDto(id: 'p-1');
+        fakeSupabaseWrapper.addTableData(DatabaseConstants.projectsTable, [
+          _fakeProjectRow(id: 'p-1'),
+        ]);
 
         final errorCompleter = Completer<Object>();
         final subscription = repository
@@ -439,15 +458,51 @@ void main() {
             );
 
         await pumpEventQueue();
-        fakeDataSource.emitError(Exception('stream error'));
+
+        fakeSupabaseWrapper.shouldEmitStreamErrors = true;
+        fakeSupabaseWrapper.addTableData(DatabaseConstants.projectsTable, [
+          _fakeProjectRow(id: 'p-1'),
+        ]);
 
         final receivedError = await errorCompleter.future;
         expect(receivedError, isA<Exception>());
         await subscription.cancel();
       });
 
+      test('can watch multiple projects concurrently', () async {
+        fakeSupabaseWrapper.addTableData(DatabaseConstants.projectsTable, [
+          _fakeProjectRow(id: 'p-1', projectName: 'Alpha'),
+          _fakeProjectRow(id: 'p-2', projectName: 'Beta'),
+        ]);
+
+        final alphaCompleter = Completer<Project>();
+        final betaCompleter = Completer<Project>();
+
+        final sub1 = repository.watchProjectSetting('p-1').listen((result) {
+          result.fold((_) {}, (p) {
+            if (!alphaCompleter.isCompleted) alphaCompleter.complete(p);
+          });
+        });
+        final sub2 = repository.watchProjectSetting('p-2').listen((result) {
+          result.fold((_) {}, (p) {
+            if (!betaCompleter.isCompleted) betaCompleter.complete(p);
+          });
+        });
+
+        final alpha = await alphaCompleter.future;
+        final beta = await betaCompleter.future;
+
+        expect(alpha.projectName, equals('Alpha'));
+        expect(beta.projectName, equals('Beta'));
+
+        await sub1.cancel();
+        await sub2.cancel();
+      });
+
       test('cleans up resources on dispose', () async {
-        fakeDataSource.projectToReturn = _fakeDto(id: 'p-1');
+        fakeSupabaseWrapper.addTableData(DatabaseConstants.projectsTable, [
+          _fakeProjectRow(id: 'p-1'),
+        ]);
 
         final subscription = repository
             .watchProjectSetting('p-1')
@@ -457,151 +512,56 @@ void main() {
 
         repository.dispose();
         expect(
-          fakeDataSource.getMethodCallsFor('watchProjectChanges'),
-          hasLength(1),
+          fakeSupabaseWrapper
+              .getMethodCalls()
+              .where((c) => c['method'] == 'watchTableFiltered')
+              .length,
+          equals(1),
         );
       });
     });
   });
 }
 
-ProjectDto _fakeDto({required String id, String? projectName}) {
-  return ProjectDto(
-    id: id,
-    projectName: projectName ?? 'Test Project',
-    creatorUserId: 'user-1',
-    createdAt: DateTime(2025, 1, 1),
-    updatedAt: DateTime(2025, 1, 2),
-    status: ProjectStatus.active,
-  );
+Map<String, dynamic> _fakeProjectRow({
+  required String id,
+  String? projectName,
+}) {
+  return {
+    DatabaseConstants.idColumn: id,
+    DatabaseConstants.projectNameColumn: projectName ?? 'Test Project',
+    DatabaseConstants.creatorUserIdColumn: 'user-1',
+    DatabaseConstants.createdAtColumn: '2025-01-01T00:00:00.000Z',
+    DatabaseConstants.updatedAtColumn: '2025-01-02T00:00:00.000Z',
+    DatabaseConstants.statusColumn: 'active',
+  };
 }
 
-TypeError _typeError() {
-  try {
-    final Object value = 'not an int';
-    value as int;
-  } on TypeError catch (error) {
-    return error;
-  }
-  throw StateError('Expected cast to throw TypeError');
-}
-
-class _FakeProjectSettingDataSource implements ProjectSettingDataSource {
-  final List<Map<String, dynamic>> _methodCalls = [];
-
-  ProjectDto? projectToReturn;
-  bool shouldThrowOnGet = false;
-  bool shouldThrowOnDelete = false;
-  Object? exceptionToThrow;
-
-  final StreamController<ProjectDto?> _changesController =
-      StreamController<ProjectDto?>.broadcast();
+class _TestModule extends Module {
+  final AppBootstrap _appBootstrap;
+  _TestModule(this._appBootstrap);
 
   @override
-  Future<ProjectDto> updateProject(ProjectDto projectDto) async {
-    _methodCalls.add({'method': 'updateProject', 'dto': projectDto});
+  List<Module> get imports => [SupabaseModule(_appBootstrap)];
 
-    final ex = exceptionToThrow;
-    if (ex != null) {
-      exceptionToThrow = null;
-      throw ex;
-    }
-
-    return projectToReturn ?? projectDto;
-  }
-
-  @override
-  Future<void> deleteProject(String projectId) async {
-    _methodCalls.add({'method': 'deleteProject', 'projectId': projectId});
-
-    final ex = exceptionToThrow;
-    if (ex != null) {
-      exceptionToThrow = null;
-      throw ex;
-    }
-
-    if (shouldThrowOnDelete) {
-      throw ServerException(Trace.current(), Exception('Delete failed'));
-    }
-  }
-
-  @override
-  Stream<ProjectDto?> watchProjectChanges(String projectId) {
-    _methodCalls.add({'method': 'watchProjectChanges', 'projectId': projectId});
-    return _changesController.stream;
-  }
-
-  void emitChange() => _changesController.add(projectToReturn);
-
-  void emitError(Object error) => _changesController.addError(error);
-
-  List<Map<String, dynamic>> getMethodCallsFor(String methodName) {
-    return _methodCalls.where((call) => call['method'] == methodName).toList();
-  }
-
-  void dispose() => _changesController.close();
-
-  @override
-  Future<ProjectDto> fetchProjectSetting(String projectId) {
-    _methodCalls.add({'method': 'fetchProjectSetting', 'projectId': projectId});
-
-    final ex = exceptionToThrow;
-    if (ex != null) {
-      exceptionToThrow = null;
-      throw ex;
-    }
-
-    if (shouldThrowOnGet) {
-      throw ServerException(Trace.current(), Exception('Select failed'));
-    }
-
-    if (projectToReturn != null) return Future.value(projectToReturn);
-
-    throw ServerException(
-      Trace.current(),
-      Exception('No project configured in FakeProjectSettingDataSource'),
-    );
-  }
-}
-
-class _FakeProjectPermissionDataSource implements ProjectPermissionDataSource {
-  final Map<String, List<String>> _permissions = {};
-
-  void setPermissions(String projectId, List<String> permissions) {
-    _permissions[projectId] = List<String>.from(permissions);
-  }
-
-  @override
-  List<String> getProjectPermissions(String projectId) {
-    return List.from(_permissions[projectId] ?? []);
-  }
-
-  @override
-  bool hasProjectPermission(String projectId, String permissionKey) {
-    return _permissions[projectId]?.contains(permissionKey) ?? false;
-  }
-}
-
-class _ProjectSettingRepositoryTestModule extends Module {
   @override
   void binds(Injector i) {
-    i.addLazySingleton<_FakeProjectSettingDataSource>(
-      () => _FakeProjectSettingDataSource(),
-    );
     i.addLazySingleton<ProjectSettingDataSource>(
-      () => i.get<_FakeProjectSettingDataSource>(),
-    );
-    i.addLazySingleton<_FakeProjectPermissionDataSource>(
-      () => _FakeProjectPermissionDataSource(),
+      () => RemoteProjectSettingDataSource(
+        supabaseWrapper: Modular.get<SupabaseWrapper>(),
+      ),
     );
     i.addLazySingleton<ProjectPermissionDataSource>(
-      () => i.get<_FakeProjectPermissionDataSource>(),
+      () => LocalJwtProjectPermissionDataSource(
+        supabaseWrapper: Modular.get<SupabaseWrapper>(),
+      ),
     );
     i.addLazySingleton<ProjectSettingRepository>(
       () => ProjectSettingRepositoryImpl(
-        dataSource: i.get<ProjectSettingDataSource>(),
-        permissionDataSource: i.get<ProjectPermissionDataSource>(),
+        dataSource: Modular.get<ProjectSettingDataSource>(),
+        permissionDataSource: Modular.get<ProjectPermissionDataSource>(),
       ),
+      config: BindConfig(onDispose: (r) => r.dispose()),
     );
   }
 }

--- a/test/libraries/project/units/data/repositories/project_setting_repository_impl_test.dart
+++ b/test/libraries/project/units/data/repositories/project_setting_repository_impl_test.dart
@@ -372,6 +372,47 @@ void main() {
     });
 
     group('watchProjectSetting', () {
+      test('reuses one stream controller per project', () async {
+        fakeSupabaseWrapper.addTableData(DatabaseConstants.projectsTable, [
+          _fakeProjectRow(id: 'p-1'),
+        ]);
+
+        final firstStream = repository.watchProjectSetting('p-1');
+        final secondStream = repository.watchProjectSetting('p-1');
+
+        final firstCompleter = Completer<Project>();
+        final secondCompleter = Completer<Project>();
+
+        final firstSubscription = firstStream.listen((result) {
+          result.fold((_) {}, (project) {
+            if (!firstCompleter.isCompleted) {
+              firstCompleter.complete(project);
+            }
+          });
+        });
+        final secondSubscription = secondStream.listen((result) {
+          result.fold((_) {}, (project) {
+            if (!secondCompleter.isCompleted) {
+              secondCompleter.complete(project);
+            }
+          });
+        });
+
+        await firstCompleter.future;
+        await secondCompleter.future;
+
+        expect(
+          fakeSupabaseWrapper
+              .getMethodCalls()
+              .where((c) => c['method'] == 'watchTableFiltered')
+              .length,
+          equals(1),
+        );
+
+        await firstSubscription.cancel();
+        await secondSubscription.cancel();
+      });
+
       test('emits current project on subscribe', () async {
         fakeSupabaseWrapper.addTableData(DatabaseConstants.projectsTable, [
           _fakeProjectRow(id: 'p-1', projectName: 'v1'),

--- a/test/libraries/project/units/data/repositories/project_setting_repository_impl_test.dart
+++ b/test/libraries/project/units/data/repositories/project_setting_repository_impl_test.dart
@@ -182,7 +182,8 @@ void main() {
 
       test('maps PostgrestException PGRST116 to notFoundError', () async {
         fakeSupabaseWrapper.shouldThrowOnSelect = true;
-        fakeSupabaseWrapper.selectExceptionType = SupabaseExceptionType.postgrest;
+        fakeSupabaseWrapper.selectExceptionType =
+            SupabaseExceptionType.postgrest;
         fakeSupabaseWrapper.postgrestErrorCode = PostgresErrorCode.noDataFound;
 
         final result = await repository.getProjectSetting('p-1');
@@ -538,6 +539,50 @@ void main() {
 
         await sub1.cancel();
         await sub2.cancel();
+      });
+
+      test('discards out-of-order refresh when a later refresh wins', () async {
+        fakeSupabaseWrapper.addTableData(DatabaseConstants.projectsTable, [
+          _fakeProjectRow(id: 'p-1', projectName: 'v1'),
+        ]);
+
+        final emitted = <String>[];
+        final v1Received = Completer<void>();
+        final v3Received = Completer<void>();
+
+        final subscription = repository.watchProjectSetting('p-1').listen((
+          result,
+        ) {
+          result.fold((_) {}, (project) {
+            emitted.add(project.projectName);
+            if (project.projectName == 'v1' && !v1Received.isCompleted) {
+              v1Received.complete();
+            }
+            if (project.projectName == 'v3' && !v3Received.isCompleted) {
+              v3Received.complete();
+            }
+          });
+        });
+
+        await v1Received.future;
+
+        final refreshCompleter = Completer<void>();
+        fakeSupabaseWrapper.shouldDelayOperations = true;
+        fakeSupabaseWrapper.completer = refreshCompleter;
+
+        fakeSupabaseWrapper.addTableData(DatabaseConstants.projectsTable, [
+          _fakeProjectRow(id: 'p-1', projectName: 'v2'),
+        ]);
+        fakeSupabaseWrapper.addTableData(DatabaseConstants.projectsTable, [
+          _fakeProjectRow(id: 'p-1', projectName: 'v3'),
+        ]);
+
+        refreshCompleter.complete();
+
+        await expectLater(v3Received.future, completes);
+
+        expect(emitted, equals(['v1', 'v3']));
+        await subscription.cancel();
       });
 
       test('cleans up resources on dispose', () async {


### PR DESCRIPTION
**PR Summary**

This adds a watch API to project settings, wiring the repository to realtime row changes and expanding tests around the new stream lifecycle.

**Review Summary**

| Issue Name | Description | Status | Notes |
|------------|-------------|--------|-------|
| Out-of-order watch refreshes | `watchProjectSetting()` starts a new async refresh on every row-change event, but there is no in-flight refresh guard or coalescing. A burst of updates can therefore emit stale project state if an earlier fetch completes after a later one. The risky path is the change listener and refresh call in project_setting_repository_impl.dart and project_setting_repository_impl.dart. | Addressed |Added a per-project sequence counter (`_refreshSequences: Map<String, int>`). Each ` _refreshProjectSetting` call increments and captures the sequence before awaiting, then silently discards its result if a newer refresh has since started. The counter is cleaned up in `_stopWatchingIfNoListeners` and `dispose`. |
| Unexpected failures lose exception context | The unexpected-error branch now logs only a message via `error(...)` without passing the caught exception or stack trace, so Sentry loses the actual failure context. The previous implementation preserved both. See project_setting_repository_impl.dart. | Addressed |Added `StackTrace stackTrace` as a third parameter to `_handleError` and updated all three call sites (`getProjectSetting`, `updateProject`, `deleteProject`) to pass their local `stackTrace`. The unexpected-error branch now calls `_logger.error('Unexpected error  $operation', error, stackTrace)`, restoring full exception and stack-trace capture in Sentry. |