### PR TITLE
CA-691: optimize skills

### DIFF
--- a/skills/code-data/SKILL.md
+++ b/skills/code-data/SKILL.md
@@ -28,24 +28,11 @@ disable-model-invocation: false
 
 ## 2. RemoteDataSource Pattern
 
-**Purpose:** Fetch data from external source (Supabase); log debug on success; rethrow errors.
-
-**Logging:**
-- Log debug on success: `_logger.debug('Fetched N items')`
-- **Do NOT log errors** — RepositoryImpl is the error boundary (RULE_15)
-
-**Error handling:**
-- **Always rethrow** — Let RepositoryImpl handle error mapping and logging
+Fetch from external source. Log `_logger.debug('Fetched N items')` on success; **always rethrow on error** — RepositoryImpl is the error boundary (RULE_15); do NOT log errors here.
 
 ## 3. RepositoryImpl Pattern
 
-**Purpose:** Implement domain repository interface; delegate to DataSource; map exceptions to Failures.
-
-**Required imports:**
-```dart
-import 'package:construculator/libraries/either/either.dart';
-import 'package:construculator/libraries/errors/failures.dart';
-```
+Implement domain repository interface; delegate to DataSource; map exceptions to Failures.
 
 **Error mapping (at RepositoryImpl boundary):**
 
@@ -61,9 +48,13 @@ import 'package:construculator/libraries/errors/failures.dart';
 - **Warning level:** Expected errors; no Sentry event
 - **Error level:** Critical/unexpected errors; sends Sentry event
 
-**Pattern:** Wrap datasource call in try-catch; return `Either<Failure, T>` (never throw).
+**Failure identification (before writing try-catch):**
+1. List every failure case the repository method can produce (network, not-found, auth, validation, etc.)
+2. Search `lib/features/{feature}/domain/` for an existing `{Feature}Failure` class — if it covers the case, **reuse it**
+3. If no matching Failure exists, create `lib/features/{feature}/domain/failures/{feature}_failure.dart` with the new cases
+4. Never invent a Failure inline — it must live in its own file and be importable by domain and data layers
 
-**AppLogger signature:** `_logger.error('message', error, stackTrace)` or `_logger.warning('message', error, stackTrace)`
+**Pattern:** Wrap datasource call in try-catch; return `Either<Failure, T>` (never throw).
 
 ## 4. DTO Pattern
 
@@ -76,14 +67,7 @@ import 'package:construculator/libraries/errors/failures.dart';
 
 ## 5. Dependency Registration
 
-Add to `lib/features/{feature}/{feature}_module.dart`:
-
-```dart
-void _registerDependencies(Injector i) {
-  i.addLazySingleton<{Noun}DataSource>(() => Remote{Noun}DataSource(supabaseWrapper: i()));
-  i.addLazySingleton<{Noun}Repository>(() => {Noun}RepositoryImpl(dataSource: i()));
-}
-```
+In `{feature}_module.dart`, register DataSource as `addLazySingleton` (inject `SupabaseWrapper`) and RepositoryImpl as `addLazySingleton` (inject DataSource). See `code-domain` skill for the canonical `_registerDependencies` shape.
 
 ## 6. Layer Boundaries (RULE_5)
 
@@ -108,7 +92,7 @@ void _registerDependencies(Injector i) {
 2. **Error boundary** — RemoteDataSource rethrows without logging; RepositoryImpl is the error boundary where exceptions become Failures
 3. **DTO ↔ Entity** — DTOs for JSON; Entities for domain; validate/handle invalid JSON
 4. **RULE_15: Log once** — At RepositoryImpl boundary only (don't re-log as errors propagate)
-5. **Never throw from repository** — Always `Either<Failure, T>`
+5. **Never throw from repository** — Always `Either<Failure, T>`. Use `package:construculator/libraries/either/either.dart` for `Either` and `package:construculator/libraries/errors/failures.dart` for `Failure` — **do NOT import `dartz`**.
 
 ## References
 

--- a/skills/code-domain/SKILL.md
+++ b/skills/code-domain/SKILL.md
@@ -36,18 +36,6 @@ Prefer `Equatable` for all entities to enable value equality without boilerplate
 - ✅ Extend `Equatable` and override `props`
 - ❌ Don't manually override `==` and `hashCode`
 
-## Enums
-
-Document each enum case with dartdoc comments explaining business meaning.
-
-
-## Required Imports
-
-```dart
-import 'package:construculator/libraries/either/either.dart';
-import 'package:construculator/libraries/errors/failures.dart';
-```
-
 ## Dependency Registration
 
 Add to `lib/features/{feature}/{feature}_module.dart`:
@@ -80,7 +68,7 @@ void _registerDependencies(Injector i) {
 ### 🔴 Non-Negotiable (Must Follow)
 1. **Pure business logic** — No UI, no data source knowledge
 2. **No layer violations** — Domain MUST NOT import Flutter, data layer, or presentation layer (see RULE_5)
-3. **Either, never throw** — Always return `Either<Failure, T>`, never throw exceptions
+3. **Either, never throw** — Always return `Either<Failure, T>`, never throw exceptions. Use `package:construculator/libraries/either/either.dart` for `Either` and `package:construculator/libraries/errors/failures.dart` for `Failure` — **do NOT import `dartz`**. Before writing interface signatures, identify all failure cases: search `lib/features/{feature}/domain/` for an existing `{Feature}Failure` — reuse it if found, otherwise note that `code-data` must create it.
 
 ### 🟡 Core Patterns (Always Apply)
 4. **UseCases orchestrate** — Delegate to repositories; don't implement business rules

--- a/skills/code-integration/SKILL.md
+++ b/skills/code-integration/SKILL.md
@@ -20,17 +20,11 @@ disable-model-invocation: false
 
 ## Gate Check
 
-| ✅ Use This Skill | ❌ Use `code-data` Instead |
-|------------------|---------------------------|
-| NEW payment provider (Stripe, PayPal) | Existing Supabase (use `SupabaseWrapper`) |
-| NEW analytics SDK (Mixpanel, Amplitude) | Existing auth (use `AuthManager`) |
-| NEW cloud service (AWS S3, Firebase Storage) | Regular data sources |
-| NEW push notification provider | |
-| NEW OAuth provider | |
+- ✅ Use this skill for NEW SDKs/services not yet in the codebase (payment, analytics, cloud storage, push, OAuth).
+- ❌ Use `code-data` for existing integrations (`SupabaseWrapper`, `AuthManager`) or regular data sources.
+- ⚠️ **Gate failure:** If the SDK already exists, **stop immediately** — point the user to `code-data` and the existing wrapper.
 
 **Input:** Context from `plan-implementation` — SDK name, wrapper interface (if needed), operations needed.
-
-⚠️ **Gate failure:** If the SDK already exists in the codebase, **stop immediately** — do not write any code. Tell the user to use `code-data` instead and point to the existing wrapper (e.g. `SupabaseWrapper`, `AuthManager`).
 
 ## Wrapper Pattern Classes
 
@@ -54,25 +48,9 @@ disable-model-invocation: false
 
 ## Dependency Registration
 
-Create `lib/libraries/{sdk}/_{sdk}_module.dart`:
-
-```dart
-import 'package:flutter_modular/flutter_modular.dart';
-import 'package:{sdk_package}/{sdk_package}.dart' as sdk;
-
-class {SDK}Module extends Module {
-  @override
-  void binds(Injector i) {
-    i.addLazySingleton<sdk.{SDK}Client>(() => sdk.{SDK}Client(apiKey: i.get<EnvLoader>().get('{SDK}_API_KEY') ?? ''));
-    i.addLazySingleton<{SDK}Wrapper>(() => {SDK}Wrapper(client: i()));
-    // Or with interface: i.addLazySingleton<{SDK}WrapperInterface>(() => {SDK}Wrapper(client: i()));
-  }
-}
-```
+Create `lib/libraries/{sdk}/_{sdk}_module.dart` extending `Module`. In `binds(Injector i)`, register the SDK client (`sdk.{SDK}Client` with API key from `EnvLoader`) and the wrapper (`{SDK}Wrapper`) as `addLazySingleton`. Use a `{SDK}WrapperInterface` binding if domain depends on an interface. Import the module in `lib/app/app_module.dart`.
 
 **Config pattern:** Keys are read from `assets/env/.env.{dev|qa|prod}` via `EnvLoader` (already in DI — inject with `i.get<EnvLoader>()`). Never hardcode credentials. Add the key to all three `.env` files.
-
-Then import in `lib/app/app_module.dart`.
 
 ## Output Files
 
@@ -88,7 +66,7 @@ Then import in `lib/app/app_module.dart`.
 
 1. **Domain isolation** — Wrapper is boundary; domain never imports SDK directly
 2. **Wrapper is type translation layer** — SDK types → Domain types
-3. **Error translation** — SDK exceptions → Domain Failures at wrapper boundary
+3. **Error translation** — SDK exceptions → Domain Failures at wrapper boundary. `{SDK}Failure extends Failure` and `UnexpectedFailure` both come from `package:construculator/libraries/errors/failures.dart`
 4. **Testability** — Fake SDK client (RULE_3), test wrapper mapping logic
 
 ## References
@@ -99,6 +77,4 @@ Then import in `lib/app/app_module.dart`.
 - **Clean Architecture:** Domain depends on wrappers, not SDKs
 - **Example:** `lib/libraries/supabase/supabase_wrapper.dart`
 - `write-tests` skill — Wrapper tests with fake SDK clients
-
-⚠️ **Use sparingly** — Most data access uses existing wrappers (`SupabaseWrapper`, `AuthManager`). Only for external services or SDKs that are not previously implemented or integrated in the codebase.
 

--- a/skills/code-presentation/SKILL.md
+++ b/skills/code-presentation/SKILL.md
@@ -31,93 +31,31 @@ If the input context from `plan-implementation` is incomplete or missing, respon
 
 ## 2. Page Pattern
 
-**Purpose:** Top-level screen that provides BLoC and builds UI tree.
+Top-level screen; provides BLoC; builds UI tree. Pages are **passive** — they display state, they don't decide what it means.
 
-**Access via BuildContext extension:**
-- **Localization (RULE_10):** `context.l10n.keyName` (not `S.of(context)`)
-- **Colors:** `context.colorTheme.primary`, `context.colorTheme.pageBackground`
-- **Typography:** `context.textTheme.bodyMediumRegular`, `context.textTheme.titleLargeBold`
+**BuildContext extensions** (always use these — never hardcode):
+- Localization (RULE_10): `context.l10n.keyName` (not `S.of(context)`)
+- Colors: `context.colorTheme.primary` / `.pageBackground`
+- Typography: `context.textTheme.bodyMediumRegular` / `.titleLargeBold`
 
-**UI Rules:**
-- **RULE_4:** Use CoreUI components ONLY — never `Material` widgets directly
-- **RULE_10:** All text via `context.l10n.keyName` — no hardcoded strings
-- Pages are **passive** — they display state from BLoC; they don't decide what state means
-
-**BLoC access (preferred):** Prefer resolving BLoCs via `BuildContext` instead of `Modular.get`. This keeps wiring explicit and works well with `BlocProvider`.
-
-Two recommended approaches:
-
-1. Inline usage for simple callbacks:
-
-```dart
-onTabSelected: (index) => context.read<AppShellBloc>().add(AppShellTabSelected(index)),
-```
-
-2. Field resolution in `didChangeDependencies` (preferred when a `BlocProvider` is above the Page):
-
-Resolve the BLoC in `didChangeDependencies` (not in `build`) to avoid repeated lookups and to satisfy lints that forbid resolving dependencies during build.
-
-If your app does not provide the BLoC via `BlocProvider`, fall back to module
-registration and resolve as a class field:
-  `final _bloc = Modular.get<FeatureBloc>();`
-Never call `Modular.get` inside `build()` — violates `forbid_modular_get_outside_module`.
-
-**Routing (three-tier model):**
-- **Tab switching** (within shell): Dispatch BLoC events (e.g. `context.read<AppShellBloc>().add(AppShellTabSelected(index))`) — handled by the shell's BLoC; widgets do not have to call `Navigator.push/pop` to switch tabs
-- **Full-screen navigation** (above shell): `Modular.get<AppRouter>().push(...)` / `.pop()` — replaces entire shell
-- **In-tab drill-downs** (within tab): `Navigator.of(context).push(...)` / `.pop()` — preserves tab state and other tabs
-  ⚠️ Never use AppRouter for tab-switching or in-tab navigation — it resets tab state and navigators.
+**BLoC access:** Prefer `context.read<FeatureBloc>()` (inline callbacks) or resolve as a field in `didChangeDependencies` when a `BlocProvider` is above the Page. Fall back to `final _bloc = Modular.get<FeatureBloc>();` as a class field only if no `BlocProvider` exists. **Never call `Modular.get` inside `build()`** — violates `forbid_modular_get_outside_module`.
 
 ## 3. BLoC Pattern
 
-**Purpose:** Coordinate UI state; handle events; emit states. BLoC is NOT a business rule engine.
+Coordinate UI state; handle events; emit states. BLoC is **not** a business rule engine.
 
-**Structure:**
-```
-bloc/{feature}_bloc/
-├── {feature}_bloc.dart       # BLoC class with event handlers
-├── {feature}_event.dart       # Sealed event classes
-└── {feature}_state.dart       # Sealed state classes
-```
-
-**State Management Rules:**
-- **RULE_12:** State derivation happens HERE, not in widgets (e.g., `total`, `isValid`, `filteredItems`)
-- **RULE_5:** BLoC orchestrates UseCases; doesn't implement business logic
-- Events: User actions (`SubmitPressed`, `FieldChanged`) or lifecycle (`PageLoaded`)
-- States: UI representations (`Loading`, `Success`, `Error`)
-- Use `emit()` to transition states
-
-**Error handling:** Catch UseCase failures; emit error states with user-friendly messages (via RULE_10 localization).
+- **RULE_12:** State derivation lives here, not in widgets (`total`, `isValid`, `filteredItems`).
+- **RULE_5:** BLoC orchestrates UseCases; never implements business logic.
+- Events = user actions (`SubmitPressed`) or lifecycle (`PageLoaded`); States = UI representations (`Loading`, `Success`, `Error`). Transition with `emit()`.
+- **Error handling:** Catch UseCase failures; emit error states with localized messages (RULE_10).
 
 ## 4. Widget Pattern
 
-**Purpose:** Reusable UI components; receive data via constructor; no state management.
-
-**Widget Rules:**
-- **RULE_4:** CoreUI components only (from `ripplearc_coreui` package)
-- **RULE_10:** Localized text via `context.l10n.keyName`
-- **RULE_5:** Zero logic — widgets are **dumb presenters**
-- Use `context.colorTheme` for colors, `context.textTheme` for typography
-- Prefer `const` constructors for performance
-- Extract complex UI trees into named widgets for readability
-
-**Forbidden in widgets:**
-- Business validation (`if (id != null) { bloc.add(...) }`)
-- State derivation (`total = items.fold(...)`)
-- Cross-field coordination
-- Direct UseCase calls
-- Hardcoded colors/text (use `context.colorTheme`, `context.l10n`)
+Reusable UI components; data via constructor; no state management. Widgets are **dumb presenters** (RULE_5) — zero business logic, no state derivation, no UseCase calls. Use CoreUI only (RULE_4), `context.l10n` for text (RULE_10), `context.colorTheme` / `context.textTheme` for styling. Prefer `const` constructors.
 
 ## 5. Dependency Registration
 
-Add to `lib/features/{feature}/{feature}_module.dart`:
-
-```dart
-void _registerDependencies(Injector i) {
-  // BLoCs (transient — new instance per request)
-  i.add<{Feature}Bloc>(() => {Feature}Bloc(useCase: i()));
-}
-```
+In `{feature}_module.dart`, register BLoCs as transient: `i.add<{Feature}Bloc>(() => {Feature}Bloc(useCase: i()));`. See `code-domain` skill for canonical module pattern.
 
 ## 6. Layer Boundaries (RULE_5)
 
@@ -152,6 +90,7 @@ void _registerDependencies(Injector i) {
    - Tab switching (within shell): `context.read<AppShellBloc>().add(AppShellTabSelected(index))`
    - Full-screen (above shell): `_router.push(...)` — resolve as `final _router = Modular.get<AppRouter>();` class field
    - In-tab drill-downs: `Navigator.of(context).push(...)` / `.pop()` — never AppRouter here
+   - ⚠️ **Never use AppRouter for tab-switching or in-tab navigation** — it resets tab state and navigators.
 7. **Testable widgets** — Widgets are dumb presenters; prefer `const` constructors and constructor-based inputs
 
 ## References

--- a/skills/write-tests-golden/SKILL.md
+++ b/skills/write-tests-golden/SKILL.md
@@ -24,48 +24,18 @@ disable-model-invocation: false
 
 ## Golden Test Pattern
 
-**File location:** `test/features/{feature}/screenshots/{widget}_screenshot_test.dart`
+**File:** `test/features/{feature}/screenshots/{widget}_screenshot_test.dart`
 
-**Basic structure:**
+In `setUp`, call `await loadAppFonts()` (from `test/utils/screenshot/font_loader.dart`). Pump the widget inside a `MaterialApp(theme: createTestTheme(), home: Material(child: ...))`. Set `tester.view.physicalSize` and `devicePixelRatio = 1.0` before pumping, `pumpAndSettle()` after, then assert:
+
 ```dart
-import 'package:flutter/material.dart';
-import 'package:flutter_test/flutter_test.dart';
-import 'package:ripplearc_coreui/ripplearc_coreui.dart';
-import '../../../utils/screenshot/font_loader.dart';
-
-void main() {
-  final size = const Size(390, 844); // adjust to the widget's expected dimensions
-  TestWidgetsFlutterBinding.ensureInitialized();
-
-  setUp(() async {
-    await loadAppFonts();
-  });
-
-  group('{Widget} Screenshot Tests', () {
-    Future<void> pump{Widget}({required WidgetTester tester}) async {
-      await tester.pumpWidget(
-        MaterialApp(
-          theme: createTestTheme(),
-          home: Material(child: {WidgetToTest}()),
-        ),
-      );
-      await tester.pumpAndSettle();
-    }
-
-    testWidgets('renders default state correctly', (tester) async {
-      tester.view.physicalSize = size;
-      tester.view.devicePixelRatio = 1.0;
-
-      await pump{Widget}(tester: tester);
-
-      await expectLater(
-        find.byType({WidgetToTest}),
-        matchesGoldenFile('goldens/{widget}/${size.width}x${size.height}/{widget}_default.png'),
-      );
-    });
-  });
-}
+await expectLater(
+  find.byType({WidgetToTest}),
+  matchesGoldenFile('goldens/{widget}/${size.width}x${size.height}/{widget}_default.png'),
+);
 ```
+
+See `test/features/auth/screenshots/` for a complete example.
 
 ## Key Scenarios to Test
 
@@ -82,8 +52,7 @@ void main() {
 
 ## Running Golden Tests
 
-- Generate/update: `flutter test --update-goldens test/features/{feature}/screenshots/`
-- Verify: `flutter test test/features/{feature}/screenshots/`
+Use `flutter test --update-goldens <path>` to generate/update, plain `flutter test <path>` to verify.
 
 ## Anti-Patterns
 

--- a/skills/write-tests-mutation/SKILL.md
+++ b/skills/write-tests-mutation/SKILL.md
@@ -28,37 +28,41 @@ disable-model-invocation: false
 
 ## Logic Classification
 
-**Critical Logic** (requires 85% mutation score):
-- Authentication/authorization systems
-- Payment processing and financial calculations
-- Access control and data validation affecting security/correctness
-
-**Non-Critical Logic** (70% mutation score acceptable):
-- Display formatting, sorting/filtering for UI
-- Non-essential calculations and secondary features
+- **Critical (85% score):** auth/authorization, payments, financial calculations, access control, security-relevant validation.
+- **Non-critical (70% score):** display formatting, UI-side sorting/filtering, secondary features.
 
 ## Running Mutation Tests
 
+**Tool:** Dart package `mutation_test` (declared as `dev_dependency` in `pubspec.yaml`, currently `mutation_test: 1.7.0`). Not `mutant`.
+
 **Step 1: Create mutation config**
 
-Copy `test/features/estimations/mutations/add_cost_estimation_usecase.xml` as a template. Key attributes:
-- `timeout` on `<command>` — **per-mutation timeout in seconds**; set to ~2× your normal test run time (prevents infinite loops caused by mutations)
-- `threshold failure` — `85` for critical logic, `70` for non-critical
-- `<exclude>` — exclude logger calls and try/catch blocks (noise mutations)
+Copy `test/features/estimations/mutations/add_cost_estimation_usecase.xml` as a template. The XML schema:
+- `<files>` — single source file under test.
+- `<exclude>` — regex patterns for noise mutations (logger calls, try/catch structure).
+- `<rules>` — hand-authored `<regex pattern="..." id="..."><mutation text="..."/></regex>` entries. With `--no-builtin`, ONLY these custom rules run.
+- `<commands>` — `<command group="..." expected-return="0">flutter test <test-file></command>`. No `timeout` attribute is used.
+- `<threshold failure="N">` — score threshold inside the XML. Convention: `85` for critical paths (auth, payments, security), `70` for non-critical.
 
-Location: `test/features/{feature}/mutations/{file}_mutations.xml`
+Location: `test/features/{feature}/mutations/{file}.xml` or `test/libraries/{lib}/mutations/{file}.xml`.
 
 **Step 2: Run**
 
+Direct invocation:
+
 ```bash
-dart run mutant --config test/features/{feature}/mutations/{file}_mutations.xml
+dart run mutation_test <config1.xml> [<config2.xml> ...] --no-builtin
 ```
+
+CI invocation (preferred for PR work): mutation tests run automatically when XML config files change. Trigger via:
+- Local: `./scripts/run_check.sh --mutations` (see `run_mutation_tests()` in `scripts/run_check.sh:202`).
+- Codemagic: comment `#runcheck` on the PR — the CI workflow runs the mutation check on changed XML configs.
 
 **Step 3: Check the score**
 
 Read `mutation-test-report/mutation-test-report.html` — it is small (~8KB) and contains the overall score, detected/total counts, and quality rating.
 
-If score ≥ 85% → done. If score < 85%, grep each detail file in `mutation-test-report/lib/` for `Undetected` to identify survived mutation IDs. Add a test for each that asserts the specific behavior the mutation changes, then re-run.
+If score ≥ threshold (`<threshold failure>` from the XML) → done. If score is below, grep each detail file under `mutation-test-report/lib/` for `Undetected` to identify survived mutation IDs. Add a test for each that asserts the specific behavior the mutation changes, then re-run.
 
 ⚠️ Do NOT read per-file detail HTML files in full — they can be 75KB+.
 
@@ -75,24 +79,26 @@ If score ≥ 85% → done. If score < 85%, grep each detail file in `mutation-te
 **✅ Run for:**
 - `lib/features/**/domain/usecases/*.dart`
 - `lib/features/**/domain/services/*.dart`
-- `lib/features/**/data/repositories/*_impl.dart` — if contains logic
-- `lib/features/**/data/data_source/*.dart` — if contains transformation logic
+- `lib/features/**/data/repositories/*_impl.dart` — if it contains logic
+- `lib/features/**/data/data_source/*.dart` — if it contains transformation logic
+- `lib/libraries/**/...` — many existing configs live under `test/libraries/**/mutations/`
 
 **❌ Skip:**
-- `lib/features/**/presentation/**`
 - `lib/features/**/data/models/**`
 - Generated code
 
+**Note on presentation:** the repo *does* have mutation configs for presentation BLoCs and pages (e.g. `test/features/auth/mutations/login_with_email_bloc.xml`, `login_with_email_page_mutations.xml`). Apply the gate per-file based on logic density, not blanket layer exclusion.
+
 ## Best Practices
 
-1. Run during PR review, not on every commit (mutation testing is slow)
-2. Target changed files only
-3. Include mutation score in PR description
-4. Focus on critical paths: auth, authorization, payment, validation
-5. Read `mutation-test-report.html` for score; grep detail HTML for survived mutation IDs — never read detail files in full
+1. Run during PR review, not on every commit (slow).
+2. Target changed files only; focus on critical paths.
+3. Read `mutation-test-report/mutation-test-report.html` for the score; grep detail HTML under `mutation-test-report/lib/` for survived mutation IDs — never read detail files in full (75KB+).
 
 ## References
 
 - **RULE_13:** `skills/rules/13-mutation-testing.md`
 - **Example config:** `test/features/estimations/mutations/add_cost_estimation_usecase.xml`
-- **Package:** `dart pub global activate mutant`
+- **CI runner:** `scripts/run_check.sh` (`run_mutation_tests` function, line 202)
+- **CI docs:** `docs/Testing/CI-Scripts.md` — "Mutation testing behavior" section
+- **Package:** `mutation_test` on pub.dev — already declared as `dev_dependency` in `pubspec.yaml` (currently 1.7.0)


### PR DESCRIPTION
## Summary

  Optimizes the 7 agent SKILL.md files in `skills/` to reduce repository-wide agent context overhead
  per CA-691. Cuts verbose explanations, heavy code blocks, and redundant structural diagrams while
  preserving load-bearing architectural constraints as explicit single-sentence rules.

  **Net change:** 804 → 645 lines (-159, ~20% reduction).

  ## Per-file changes

  | Skill | Before | After | Target | Primary cuts |
  |---|---:|---:|---:|---|
  | `code-domain` | 96 | 84 | 70 | Enums section, duplicate Required Imports block |
  | `code-data` | 120 | 98 | 90 | `_registerDependencies` Dart block (now cross-refs `code-domain`),
  Required Imports, AppLogger signature, compressed RemoteDataSource prose |
  | `code-integration` | 104 | 80 | 80 | `{SDK}Module` Dart block → prose, Gate Check table →
  checklist, trailing "Use sparingly" duplicate |
  | `code-presentation` | 167 | 105 | 100 | BLoC directory tree, "Forbidden in widgets" list, 19-line
   BLoC-access prose → 5 lines, §3/§4 prose, §5 Dart block → cross-ref |
  | `write-tests` | 117 | 117 | 120 | Already at target — verified ticket excisions present |
  | `write-tests-golden` | 102 | 71 | 60 | 39-line basic-structure Dart block → 6-line prose +
  minimal `matchesGoldenFile` snippet, bash run-commands block → one line |
  | `write-tests-mutation` | 98 | 90 | 80 | Compressed Logic Classification and Best Practices;
  verified excisions (educational section, mutation-types table, CLI output, multi-line Dart
  examples) already removed |
  | **Total** | **804** | **645** | — | **-159 lines** |

  ## Notable decisions

  - **`Either` import preserved.** Trimming the Required Imports blocks risked the agent defaulting
  to `dartz`. Added an explicit "use `package:construculator/libraries/either/either.dart` — do NOT
  import `dartz`" callout to `code-domain` Priority Rule #3 and `code-data` Key Principle #5.
  - **Canonical `_registerDependencies` lives in `code-domain`.** `code-data` and `code-presentation`
   now cross-reference it instead of duplicating the Dart block.
  - **Load-bearing tables kept.** Class Overview, Layer Boundaries, error-mapping, and Priority Rules
   tables were preserved everywhere — per the ticket's note that "hard architectural expectations 
  remain clear as explicit, single-sentence constraints."
  - **Two files landed slightly above target** (`code-domain` 84 vs 70; `code-presentation` 105 vs 
  100). Closing the remaining gap would require cutting the Priority Rules sections, which the ticket
   explicitly asks to preserve.