### PR TITLE
CA-691: optimize the context size of rules

### DIFF
--- a/skills/rules/02-naming-conventions.md
+++ b/skills/rules/02-naming-conventions.md
@@ -7,38 +7,37 @@ RULE_2
 Architecture & Design
 
 ## Severity Levels
-- **Critical:** Using forbidden suffixes (`Helper`, `Util`, `Manager` without Service)
+- **Critical:** Forbidden suffixes (`Helper`, `Util`, `Manager` alone)
 - **Major:** Wrong suffix for layer (e.g., `Service` in data layer, missing `Local/Remote` prefix on DataSource)
-- **Minor:** Name doesn't follow verb-noun pattern for UseCase
-- **Suggestion:** Name could be more descriptive or follow abstraction principle better
+- **Minor:** UseCase doesn't follow verb-noun pattern
+- **Suggestion:** Name could be more descriptive
 
 ## Description
 
-Class naming must follow two principles:
-1. **Suffix Conventions:** Use correct suffixes that indicate responsibility and layer
-2. **Abstraction Levels:** Name precision inversely proportional to abstraction level
-   - High level (UI/Domain): Abstract names (e.g., `getEstimations`)
-   - Low level (Data/Repository): Concrete, explicit names (e.g., `fetchInitialProjectEstimations`)
+Class naming follows two principles:
+
+1. **Suffix conventions** — suffixes indicate responsibility and layer.
+2. **Abstraction levels** — name precision is **inversely** proportional to abstraction level. High level (UI/Domain) uses abstract names (`getEstimations`); low level (Data) uses concrete, explicit names (`fetchInitialEstimationsByProjectId`).
 
 ## Applicability
 
-Applies to all production code in `lib/` directory across all architecture layers.
+All production code in `lib/` across all architecture layers.
 
 ---
 
 ## Part 1: Class Suffix Conventions
 
-### Quick Reference Table
+### Quick Reference
 
 | Suffix | Pattern | Purpose | Layer | Example |
 |--------|---------|---------|-------|---------|
 | **UseCase** | `VerbNounUseCase` | Single business operation | Domain | `GetUserEstimationsUseCase` |
-| **Service** | `NounService` | Complex domain logic, multiple operations | Domain | `AuthenticationService` |
+| **Service** | `NounService` | Coordinates multiple operations | Domain | `AuthenticationService` |
 | **Repository** | `NounRepository` | Data access abstraction (interface) | Domain | `EstimationRepository` |
 | **RepositoryImpl** | `NounRepositoryImpl` | Repository implementation | Data | `EstimationRepositoryImpl` |
-| **DataSource** | `(Local\|Remote)NounDataSource` | Raw data handling (API, DB, cache) | Data | `RemoteEstimationDataSource` |
+| **DataSource** | `(Local\|Remote)NounDataSource` | Raw data (API, DB, cache) | Data | `RemoteEstimationDataSource` |
 | **BLoC** | `NounBloc` + `NounEvent` + `NounState` | UI state coordination | Presentation | `AuthBloc`, `AuthEvent`, `AuthState` |
-| **Formatter** | `NounFormatter` | Data formatting/transformation | Helper | `CurrencyFormatter`, `DateFormatter` |
+| **Formatter** | `NounFormatter` | Data formatting | Helper | `CurrencyFormatter` |
 | **Validator** | `NounValidator` | Input validation | Helper | `EmailValidator` |
 | **Parser** | `NounParser` | String/data parsing | Helper | `JsonParser` |
 | **Mapper** | `NounMapper` | Object-to-object mapping | Helper | `UserDtoMapper` |
@@ -46,188 +45,97 @@ Applies to all production code in `lib/` directory across all architecture layer
 
 ### 🚫 Forbidden Suffixes
 
-- ❌ **`Helper`** - Too generic, doesn't indicate responsibility
-- ❌ **`Util`** or **`Utils`** - Too generic, doesn't indicate responsibility
-- ❌ **`Manager`** alone - Use `Service` instead (unless managing stateful resources)
+- ❌ `Helper` — too generic; pick a specific role (Formatter / Validator / Mapper / …).
+- ❌ `Util` / `Utils` — same problem.
+- ❌ `Manager` alone — use `Service` (unless it manages a stateful resource like a `ConnectionManager`).
 
----
-
-## For Coding Agents (Prescriptive)
-
-### Decision Tree: What Should I Name This Class?
+### Decision Tree
 
 ```
 What is the class responsibility?
 
-├─ Single business operation?
-│  └─ YES → UseCase
-│     └─ Pattern: VerbNounUseCase
-│     └─ Example: GetUserProfileUseCase, CreateProjectUseCase
-│
-├─ Multiple coordinated business operations?
-│  └─ YES → Service
-│     └─ Pattern: NounService
-│     └─ Example: AuthenticationService, ValidationService
-│
-├─ Abstracts data access?
-│  └─ YES → Repository (interface) + RepositoryImpl (implementation)
-│     └─ Pattern: NounRepository, NounRepositoryImpl
-│     └─ Example: UserRepository, UserRepositoryImpl
-│
-├─ Handles raw data (API/DB/Cache)?
-│  └─ YES → DataSource
-│     └─ Pattern: (Local|Remote)NounDataSource
-│     └─ Example: RemoteUserDataSource, LocalEstimationDataSource
-│
-├─ Manages UI state?
-│  └─ YES → BLoC
-│     └─ Pattern: NounBloc + NounEvent + NounState
-│     └─ Example: AuthBloc, AuthEvent, AuthState
-│
-└─ Transforms/validates/parses data?
-   └─ YES → Specific Helper
-      ├─ Formats data? → NounFormatter
-      ├─ Validates input? → NounValidator
-      ├─ Parses strings? → NounParser
-      ├─ Maps objects? → NounMapper
-      └─ Converts types? → NounConverter
+├─ Single business operation?           → UseCase           (VerbNounUseCase)
+├─ Multiple coordinated operations?     → Service           (NounService)
+├─ Abstracts data access?               → Repository + RepositoryImpl
+├─ Handles raw data (API/DB/Cache)?     → DataSource        ((Local|Remote)NounDataSource)
+├─ Manages UI state?                    → BLoC + Event + State
+└─ Transforms/validates/parses?         → Formatter / Validator / Parser / Mapper / Converter
 ```
 
-### When Naming Classes
-
-**Step 1: Identify the layer**
-- Presentation: `lib/features/**/presentation/`
-- Domain: `lib/features/**/domain/`
-- Data: `lib/features/**/data/`
-
-**Step 2: Identify the responsibility**
-- Use the decision tree above
-
-**Step 3: Apply naming pattern**
-- Follow the table above
-
-**Step 4: Apply abstraction principle** (see Part 2 below)
-
-### Examples - What to Create
-
-| Scenario | Layer | Correct Name | Wrong Name ❌ |
-|----------|-------|--------------|---------------|
-| Fetch user profile from API | Domain | `GetUserProfileUseCase` | `UserService`, `ProfileFetcher`, `UserHelper` |
-| Handle authentication flow | Domain | `AuthenticationService` | `AuthUseCase`, `LoginHelper` |
-| Abstract cost estimation data | Domain | `EstimationRepository` (interface) | `EstimationService`, `EstimationHelper` |
-| Call Supabase API | Data | `RemoteEstimationDataSource` | `EstimationApiService`, `SupabaseHelper`, `EstimationDataSource` |
-| Cache user data locally | Data | `LocalUserDataSource` | `UserCache`, `UserCacheHelper` |
-| Format currency for display | Helper | `CurrencyFormatter` | `CurrencyHelper`, `CurrencyUtil` |
-| Validate email format | Helper | `EmailValidator` | `ValidationHelper`, `EmailUtil` |
-| Coordinate login UI state | Presentation | `AuthBloc` + `AuthEvent` + `AuthState` | `LoginManager`, `AuthHelper` |
+Layer is determined by directory: `presentation/` / `domain/` / `data/`. Apply the suffix table once layer + responsibility are decided.
 
 ---
 
 ## Part 2: Abstraction-Level Naming
 
-### Core Principle
-
-**Naming precision is inversely proportional to abstraction level.**
-
-- **High Level (UI/Domain):** Focus on *what* → Abstract, business-oriented names
-- **Low Level (Data/Repository):** Focus on *how* and *scope* → Concrete, explicit names
-
-### The Abstraction Scale
+**Core principle:** name precision is inversely proportional to abstraction level.
 
 ```
-HIGH ABSTRACTION (Abstract Names)
+HIGH ABSTRACTION (abstract names)
 ↑
-│  UI/Domain Layer
-│  └─ getEstimations
-│  └─ fetchUser
-│  └─ saveProject
-│
-│  Repository Interface
-│  └─ getEstimationsByProjectId
-│  └─ fetchUserById
-│  └─ saveProjectWithMetadata
-│
-│  Repository Implementation
-│  └─ fetchInitialEstimationsByProjectId
-│  └─ fetchUserFromCacheOrNetwork
-│  └─ saveProjectAndCreateDefaultEstimation
-│
-↓  DataSource Layer
-LOW ABSTRACTION (Explicit Names)
+│  UI / Domain                  → getEstimations, fetchUser, saveProject
+│  Repository interface         → getEstimationsByProjectId, fetchUserById
+│  Repository implementation    → fetchInitialEstimationsByProjectId, fetchUserFromCacheOrNetwork
+│  DataSource                   → fetchInitialEstimationsByProjectId (explicit op + scope + lookup key)
+↓
+LOW ABSTRACTION (explicit names)
 ```
 
-### Examples by Layer
-
-#### ✅ Good: Abstract names at high levels, explicit at low levels
+### Canonical Pair
 
 ```dart
-// UI/Domain - Abstract (focuses on "what")
+// ❌ Bad — high level too explicit, low level too vague
+class FetchInitialEstimationsFromSupabaseUseCase { } // exposes SDK
+abstract class EstimationDataSource {
+  Future<List<EstimationDto>> getEstimations(String id);  // hides pagination/reset semantics
+}
+
+// ✅ Good — abstract at high level, explicit at low level
 class GetEstimationsUseCase {
-  Stream<List<Estimation>> execute(String projectId) {
-    return repository.getEstimations(projectId);
-  }
+  Stream<List<Estimation>> execute(String projectId) => repository.getEstimations(projectId);
 }
-
-// Data - Explicit (specifies "how" and "scope")
-class RemoteEstimationDataSource {
-  Future<List<EstimationDto>> fetchInitialEstimationsByProjectId(String id) {
-    // fetch = network, Initial = resets pagination, ByProjectId = lookup key
-  }
+abstract class EstimationDataSource {
+  Future<List<EstimationDto>> fetchInitialEstimationsByProjectId(String id);
+  // fetch = network · Initial = resets pagination · ByProjectId = lookup key
 }
 ```
 
-#### ❌ Bad: Wrong abstraction level
+### Data-Layer Naming Requirements
 
-```dart
-// High level too explicit
-class FetchInitialEstimationsFromSupabaseUseCase { } // ❌ Exposes implementation
-class GetEstimationsUseCase { } // ✅
+✅ **Explicit names must encode:**
+- **Operation type:** `fetch` (network), `load` (cache), `find` (search), `ensure` (get-or-create).
+- **Scope/intent:** `Initial` (resets pagination), `Next` (paginates), `ByProjectId` (lookup key).
+- **Side effects:** if the method creates/resets state, make it explicit.
 
-// Low level too vague
-class RemoteEstimationDataSource {
-  Future<List<EstimationDto>> getEstimations(String id); // ❌ Hides complexity
-  Future<List<EstimationDto>> fetchInitialEstimationsByProjectId(String id); // ✅
-}
-```
-
-### Key Requirements for Data Layer
-
-✅ **Explicit names must include:**
-- **Operation type:** `fetch` (network), `load` (cache), `find` (search), `ensure` (get-or-create)
-- **Scope/Intent:** `Initial` (reset pagination), `Next` (pagination), `ByProjectId` (lookup key)
-- **Side effects:** If method has side effects (create, reset), make it explicit
-
-❌ **Avoid hiding logic behind generic names:**
-- Never hide initialization or state-reset logic behind generic `get` names in Data Layer
-- Never hide "get-or-create" behavior behind `get` or `find`
+❌ **Avoid:** hiding init / state-reset / get-or-create behind a bare `get…` in the data layer.
 
 ---
 
 ## For Review Agents (Detective)
 
-### Detection Patterns
+### Check For
 
-**Check for:**
-1. **Forbidden suffixes:** `Helper`, `Util`, `Utils`, `Manager` (without Service)
-2. **Wrong suffix for layer:** UseCases not in domain/usecases/, DataSources not in data/data_source/, etc.
-3. **Missing DataSource prefix:** DataSources must start with `Local` or `Remote`
-4. **UseCase naming:** Must follow `VerbNounUseCase` pattern
-5. **Vague Data layer names:** Methods using generic `get` without scope, not indicating operation type (`fetch`/`load`/`find`), hiding side effects
+1. Forbidden suffixes: `Helper`, `Util`, `Utils`, bare `Manager`.
+2. Wrong suffix for layer (UseCase outside `domain/usecases/`, DataSource outside `data/data_source/`, etc.).
+3. DataSource missing `Local` / `Remote` prefix.
+4. UseCase not in `VerbNounUseCase` form.
+5. Vague data-layer methods: generic `get…` without operation type or scope; hidden side effects.
 
 ### Common Violations
 
 | ❌ Violation | ✅ Fix | Severity | Layer |
-|-------------|--------|----------|-------|
+|---|---|---|---|
 | `class AuthHelper` | `class AuthenticationService` | Critical | Domain |
-| `class DataUtil` | `class DataFormatter` | Critical | Helper |
+| `class DataUtil` | `class CurrencyFormatter` (or specific role) | Critical | Helper |
 | `class UserUseCase` | `class GetUserUseCase` | Major | Domain |
 | `class ApiDataSource` | `class RemoteUserDataSource` | Major | Data |
-| `class EstimationDataSource` | `class RemoteEstimationDataSource` or `LocalEstimationDataSource` | Major | Data |
-| `getEstimations(id)` in DataSource | `fetchInitialEstimationsByProjectId(id)` | Major | Data |
-| `loadUser(id)` without specifying source | `loadUserFromCache(id)` or `fetchUserFromNetwork(id)` | Minor | Data |
+| `class EstimationDataSource` (no prefix) | `class RemoteEstimationDataSource` / `class LocalEstimationDataSource` | Major | Data |
+| `getEstimations(id)` on a DataSource | `fetchInitialEstimationsByProjectId(id)` | Major | Data |
+| `loadUser(id)` (source unspecified) | `loadUserFromCache(id)` or `fetchUserFromNetwork(id)` | Minor | Data |
 
 ---
 
 ## References
+
 - [RULE_2 Gist: Class Naming Convention](https://gist.github.com/ripplearcgit/89f05e4f83e087f63148bbbb1d99a178)
-- Related: RULE_5 (UI/Business Separation) - ensures classes in right layer
+- Related: RULE_5 (UI/Business Separation) — places classes in the right layer.

--- a/skills/rules/03-test-double-pattern.md
+++ b/skills/rules/03-test-double-pattern.md
@@ -9,180 +9,136 @@ Testing Strategy
 ## Severity Levels
 - **Critical:** Using mocks or stubs (forbidden in this codebase)
 - **Major:** Faking business logic components instead of using real implementations
-- **Minor:** Test structure could be improved to test real integration
-- **Suggestion:** Consider using Test Double pattern for better integration testing
+- **Minor:** Test structure could exercise more real integration
+- **Suggestion:** Consider Test Double pattern for better integration testing
 
 ## Description
 
-Test real integration between components. Only fake external dependencies (database, network, 3rd party libraries). Never fake your own business logic.
+Test real integration between components. Only fake external dependencies (database, network, 3rd-party libraries). Never fake your own business logic.
 
-**Core Principle:** Test Double pattern ensures tests verify real component interaction and real business logic, catching integration bugs that unit tests with mocks would miss.
+**Core Principle:** Test Double pattern ensures tests verify real component interaction and real business logic, catching integration bugs that mocked unit tests would miss.
 
 ## Applicability
 
-Applies to all tests in `test/` directory, particularly unit tests for BLoCs, Services, UseCases, and Repositories.
+All tests in `test/`, particularly unit tests for BLoCs, Services, UseCases, and Repositories.
 
 ---
 
 ## For Coding Agents (Prescriptive)
 
-### The Test Double Pattern
+### The Pattern
 
-**When testing Class A that depends on Class B:**
+When testing class A that depends on class B:
 
-```
-✅ CORRECT (Test Double Pattern):
-┌─────────────────────────────────────┐
-│          Test Suite                  │
-│                                      │
-│  ┌──────────┐      ┌──────────┐    │
-│  │ Real A   │─────▶│  Real B  │    │
-│  └──────────┘      └──────────┘    │
-│                          │          │
-│                          ▼          │
-│                    ┌──────────┐    │
-│                    │  Fake    │    │
-│                    │ External │    │
-│                    │   Dep    │    │
-│                    └──────────┘    │
-└─────────────────────────────────────┘
+| Class under test | Inner project dependencies | External dependencies |
+|---|---|---|
+| BLoC / UseCase / Service / Repository | **Real** implementation | **Fake** (Supabase, HTTP, Clock, …) |
 
-❌ WRONG (Fake Everything):
-┌─────────────────────────────────────┐
-│          Test Suite                  │
-│                                      │
-│  ┌──────────┐      ┌──────────┐    │
-│  │ Real A   │─────▶│  Fake B  │    │
-│  └──────────┘      └──────────┘    │
-│                                      │
-│  (Not testing real integration!)    │
-└─────────────────────────────────────┘
-```
+The chain is wired up with real implementations; only the outermost boundary (the SDK / network / DB / clock) is replaced with a hand-written fake.
 
-### Decision Tree: Should I Fake This?
+### Decision Tree
 
 ```
 Is this dependency MY code (in this codebase)?
-  ├─ YES → Use REAL implementation
-  │        └─ Examples: BLoC → Real UseCase, UseCase → Real Service
+  ├─ YES
+  │   ├─ Same feature?             → Use REAL implementation
+  │   │    (BLoC → real UseCase → real Service → real RepositoryImpl → real DataSource)
+  │   │
+  │   └─ From another library/feature? → Use FAKE repository for isolation
+  │        (prevents cascading test failures when the library changes)
   │
-  └─ NO → Is it an external dependency?
-         └─ YES → Use FAKE implementation
-                  └─ Examples: Supabase, Database, File System, HTTP client
+  └─ NO  → External dependency
+           → Use FAKE wrapper  (FakeSupabaseWrapper, FakeClock, HTTP fake, …)
 ```
 
-### What to Fake (External Boundaries Only)
+### What to Fake — and What Not to Fake
 
-✅ **Always Fake:**
-- Database (Supabase, local DB)
-- Network (HTTP clients, API calls)
-- File system
-- Device sensors
-- Time/Clock
-- Random generators
-- 3rd party SDKs
+✅ **Always fake** — external boundaries via wrappers: `FakeSupabaseWrapper`, HTTP fakes, `FakeClock`, random generators, 3rd-party SDKs.
 
-❌ **Never Fake:**
-- Your UseCases
-- Your Services
-- Your Repositories (the interface)
-- Your BLoCs
-- Your domain logic
-- Your mappers/formatters
+✅ **Fake repository when** it belongs to another library/feature (e.g., `FakeProjectRepository` in estimation tests) — prevents coupling across features.
 
-### How to Write Tests
+❌ **Never fake** — your own same-feature code: UseCases, Services, RepositoryImpls, DataSources, BLoCs, domain logic, mappers/formatters.
 
-#### ✅ Correct: Chain real components, fake only external dependencies
+### Canonical Integration Test
+
+The project fakes at the **wrapper level**: `FakeSupabaseWrapper` replaces all Supabase I/O while the entire real chain above it (DataSource → RepositoryImpl → UseCase → BLoC) runs as-is. Wire the module with the fake wrapper and get real objects from DI:
 
 ```dart
 void main() {
-  late AuthBloc bloc;
-  late FakeAuthDataSource fakeDataSource;
+  late FakeSupabaseWrapper fakeSupabase;
+  late OtpVerificationBloc bloc;
 
-  setUp(() {
-    fakeDataSource = FakeAuthDataSource(); // Fake external (Supabase)
-    final authRepository = AuthRepositoryImpl(remoteDataSource: fakeDataSource); // Real
-    final authService = AuthenticationService(repository: authRepository); // Real
-    bloc = AuthBloc(authService: authService); // Real
+  setUpAll(() {
+    fakeSupabase = FakeSupabaseWrapper(clock: FakeClockImpl()); // ✅ fake at I/O boundary
+    Modular.init(AuthTestModule(AppBootstrap(supabaseWrapper: fakeSupabase)));
+    bloc = Modular.get<OtpVerificationBloc>();                  // ✅ real chain from DI
   });
 
-  test('should emit authenticated state when login succeeds', () {
-    fakeDataSource.mockLoginSuccess(userId: '123');
-    bloc.add(LoginRequested(email: 'test@example.com', password: 'pass123'));
-    expect(bloc.stream, emitsInOrder([AuthLoading(), AuthAuthenticated(userId: '123')]));
+  tearDown(() {
+    fakeSupabase.reset();
+    Modular.destroy();
   });
-}
-```
 
-#### ❌ Wrong: Mocking internal business logic
-
-```dart
-void main() {
-  late MockAuthService mockAuthService; // ❌ Don't mock your own code
-
-  test('should emit authenticated state', () {
-    when(mockAuthService.login(any, any)).thenReturn(...); // ❌ Doesn't test real logic
-    // Test passes even if AuthService implementation is broken!
-  });
+  blocTest<OtpVerificationBloc, OtpVerificationState>(
+    'emits [Loading, Success] when OTP is correct',
+    build: () {
+      fakeSupabase.shouldThrowOnVerifyOtp = false; // ✅ configure via fake wrapper
+      return bloc;
+    },
+    act: (bloc) => bloc.add(OtpVerificationSubmitted(contact: 'test@example.com', otp: '123456')),
+    expect: () => [OtpVerificationLoading(), OtpVerificationSuccess(email: 'test@example.com')],
+  );
 }
 ```
 
 ### Implementing Fakes
 
-**Create fakes for external dependencies:**
+**At the I/O boundary** — the project maintains `FakeSupabaseWrapper` as the single re-usable fake for all Supabase operations. Tests inject it via `AppBootstrap`. See `docs/Testing/Fakes.md` for full usage.
+
+**For library repository dependencies** — when your feature depends on a repository from *another* library/feature, create a fake repository implementing the interface. Expose setup methods and call counters; keep the implementation minimal:
 
 ```dart
-// Fake Supabase DataSource
-class FakeAuthDataSource implements RemoteAuthDataSource {
-  User? _mockUser;
-  Exception? _mockException;
+class FakeProjectRepository implements ProjectRepository {
+  Project? _project;
+  int getProjectByIdCallCount = 0;
 
-  void mockLoginSuccess({required String userId}) {
-    _mockUser = User(id: userId);
-    _mockException = null;
-  }
-
-  void mockLoginFailure(Exception exception) {
-    _mockUser = null;
-    _mockException = exception;
-  }
+  void setProject(Project project) => _project = project;
+  void reset() { _project = null; getProjectByIdCallCount = 0; }
 
   @override
-  Future<Either<Failure, User>> login(String email, String password) async {
-    if (_mockException != null) {
-      return Left(ServerFailure(message: _mockException.toString()));
-    }
-    if (_mockUser != null) {
-      return Right(_mockUser!);
-    }
-    return Left(ServerFailure(message: 'Unknown error'));
+  Future<Either<Failure, Project>> getProjectById(String id) async {
+    getProjectByIdCallCount++;
+    return _project != null ? Right(_project!) : Left(NotFoundFailure());
   }
 }
 ```
+
+See `docs/Testing/Fakes.md` for the full decision matrix and `FakeSupabaseWrapper` API.
 
 ---
 
 ## For Review Agents (Detective)
 
-### Detection Patterns
+### Detection
 
-**Check for:**
-1. **Forbidden mocks/stubs:** `Mock<`, `when(`, `verify(`, `@GenerateMocks` (Critical)
-2. **Faking business logic:** Mock UseCases, Services, Repositories, BLoCs (Major)
-3. **Missing integration:** Tests only exercising one layer in isolation (Major)
+1. Forbidden tooling: `Mock<…>`, `when(…)`, `verify(…)`, `@GenerateMocks`, imports of `mockito`. **Critical.**
+2. Faking business logic: `MockAuthService`, `MockUseCase`, `MockRepository`, `MockBloc`. **Major.**
+3. Test exercises a single layer in isolation while the rest is mocked. **Major.**
 
 ### Common Violations
 
 | ❌ Violation | ✅ Fix | Severity |
-|-------------|--------|----------|
-| `MockAuthService` in BLoC test | Use real `AuthService` + fake `AuthDataSource` | Major |
-| `when(useCase.execute()).thenReturn(...)` | Use real `UseCase` + fake external dependencies | Major |
+|---|---|---|
+| `MockAuthService` in a BLoC test | Use real `AuthService` wired via `FakeSupabaseWrapper` | Major |
+| `when(useCase.execute()).thenReturn(...)` | Use real `UseCase` + `FakeSupabaseWrapper` at I/O boundary | Major |
 | `verify(repository.save(any))` | Assert on observable outputs, not method calls | Major |
-| `MockEstimationRepository` | Use real `EstimationRepositoryImpl` + fake `DataSource` | Major |
-| Using `mockito` package | Use hand-written fakes for external dependencies | Critical |
+| `MockEstimationRepository` | Use real `EstimationRepositoryImpl` + `FakeSupabaseWrapper`; or `FakeEstimationRepository` only if it's a cross-library dependency | Major |
+| Using `mockito` package | Use `FakeSupabaseWrapper` or hand-written fake repositories | Critical |
 
 ---
 
 ## References
+
 - [Test Double Pattern Gist](https://gist.github.com/ripplearcgit/89687b7414f62a8c042b16b52e9ceb0b)
 - Related: RULE_8 (Widget Test Finders), RULE_9 (Unit Test Behavior)
+- Existing fakes: `test/utils/fake_app_bootstrap_factory.dart`, `test/utils/a11y/` (helpers).

--- a/skills/rules/04-coreui-components.md
+++ b/skills/rules/04-coreui-components.md
@@ -7,18 +7,18 @@ RULE_4
 UI Components
 
 ## Severity Levels
-- Critical: Material components are used directly in new UI code.
-- Major: Hardcoded spacing, colors, or typography appear instead of CoreUI tokens.
-- Minor: CoreUI imports are missing where they should be present.
-- Suggestion: Prefer CoreUI components for new work.
+- **Critical:** Material components used directly in new UI code
+- **Major:** Hardcoded spacing, colors, or typography appear instead of CoreUI tokens
+- **Minor:** CoreUI imports missing where they should be present
+- **Suggestion:** Prefer CoreUI components for new work
 
 ## Description
 
-All UI components, styling, and design tokens should use CoreUI rather than ad hoc Material usage.
+All UI components, styling, and design tokens use CoreUI rather than ad-hoc Material.
 
 ## Applicability
 
-This rule applies to all presentation code under `lib/features/**/presentation/` and `lib/app/`.
+All presentation code under `lib/features/**/presentation/` and `lib/app/`.
 
 ---
 
@@ -26,41 +26,26 @@ This rule applies to all presentation code under `lib/features/**/presentation/`
 
 ### Core Principle
 
-**Never use Material components or hardcoded design tokens directly.** Always use CoreUI's design system for consistency and maintainability.
+**Never use Material components or hardcoded design tokens directly.** Use CoreUI's design system for consistency.
 
-### When Writing UI Code
-
-Before writing any UI code, consult the CoreUI design system:
-- **Reference:** https://github.com/ripplearc/coreui#readme
-- **API Docs:** Check `skills/references/coreui-api.md` for available components
-
-### Decision Tree: What Should I Use?
+### Decision Tree
 
 ```
-Need spacing/padding?
-  └─ Use: CoreSpacing.space{4|8|12|16|20|24|32|40|48|64}
-     Example: EdgeInsets.all(CoreSpacing.space16)
+What do I need?
 
-Need an icon?
-  └─ Use: CoreIconWidget(icon: CoreIcons.{name})
-     Example: CoreIconWidget(icon: CoreIcons.search)
-
-Need typography/text style?
-  └─ Use: context.textTheme.{variant}
-     Example: context.textTheme.bodyMediumRegular
-
-Need colors?
-  └─ Use: context.colorTheme.{variant}
-     Example: context.colorTheme.primary, context.colorTheme.pageBackground
-
-Need a UI component?
-  └─ Check CoreUI equivalents below
+├─ Spacing/padding?  → CoreSpacing.space{4|8|12|16|20|24|32|40|48|64}
+├─ Icon?             → CoreIconWidget(icon: CoreIcons.<name>, size: CoreIconSize.<size>)
+├─ Typography?       → context.textTheme.<variant>  (e.g. bodyMediumRegular, headlineLargeBold)
+├─ Color?            → context.colorTheme.<variant> (e.g. primary, pageBackground, textHeadline)
+└─ UI component?     → See component reference below
 ```
 
-### CoreUI Component Reference
+Complete token tables (spacing values, typography variants, color names) live in **`skills/references/coreui-api.md`** — consult it before writing UI code.
+
+### Component Reference
 
 | Need | ❌ Don't Use | ✅ Use Instead |
-|------|-------------|---------------|
+|---|---|---|
 | **Buttons** | `ElevatedButton`, `TextButton`, `OutlinedButton` | `CoreButton` |
 | **Text Input** | `TextField`, `TextFormField` | `CoreTextField` |
 | **App Bar** | `AppBar` | `CoreAppBar` |
@@ -75,176 +60,11 @@ Need a UI component?
 | **Slider** | `Slider` | `CoreSlider` |
 | **FAB** | `FloatingActionButton` | `CoreFAB` |
 
-### Common Patterns
+### What If CoreUI Doesn't Have It?
 
-#### ✅ Spacing
+**Never silently substitute Material components.** Surface to the developer:
 
-```dart
-// Good: Using CoreSpacing
-Padding(
-  padding: EdgeInsets.all(CoreSpacing.space16),
-  child: Column(
-    spacing: CoreSpacing.space12,  // ✅ Column spacing
-    children: [
-      Text('Title'),
-      SizedBox(height: CoreSpacing.space8),  // ✅ Explicit gap
-      Text('Subtitle'),
-    ],
-  ),
-)
-
-// Bad: Hardcoded values
-Padding(
-  padding: EdgeInsets.all(16.0),  // ❌ Magic number
-  child: Column(
-    children: [
-      Text('Title'),
-      SizedBox(height: 8),  // ❌ Magic number
-      Text('Subtitle'),
-    ],
-  ),
-)
-```
-
-**Available Spacing:**
-- `CoreSpacing.space4` → 4.0
-- `CoreSpacing.space8` → 8.0
-- `CoreSpacing.space12` → 12.0
-- `CoreSpacing.space16` → 16.0
-- `CoreSpacing.space20` → 20.0
-- `CoreSpacing.space24` → 24.0
-- `CoreSpacing.space32` → 32.0
-- `CoreSpacing.space40` → 40.0
-- `CoreSpacing.space48` → 48.0
-- `CoreSpacing.space64` → 64.0
-
-#### ✅ Icons
-
-```dart
-// Good: Using CoreIcons
-CoreIconWidget(
-  icon: CoreIcons.search,
-  size: CoreIconSize.medium,
-  color: context.colorTheme.primary,
-)
-
-// Bad: Material icons
-Icon(Icons.search)  // ❌ Material icon
-```
-
-#### ✅ Typography
-
-```dart
-// Good: Using CoreTypography
-Text(
-  'Welcome',
-  style: context.textTheme.headlineLargeBold,
-)
-
-Text(
-  'Description text',
-  style: context.textTheme.bodyMediumRegular,
-)
-
-// Bad: Hardcoded TextStyle
-Text(
-  'Welcome',
-  style: TextStyle(  // ❌ Hardcoded
-    fontSize: 24,
-    fontWeight: FontWeight.bold,
-  ),
-)
-```
-
-**Available Typography Properties (via `context.textTheme`):**
-- `context.textTheme.displayLargeBold` - Large display text
-- `context.textTheme.headlineLargeBold` - Page titles
-- `context.textTheme.headlineMediumBold` - Section headers
-- `context.textTheme.bodyLargeRegular` - Large body text
-- `context.textTheme.bodyMediumRegular` - Standard body text
-- `context.textTheme.bodySmallRegular` - Small body text
-- `context.textTheme.labelLargeBold` - Button labels
-- `context.textTheme.labelMediumBold` - Small labels
-
-#### ✅ Colors
-
-```dart
-// Good: Using CoreUI colors via extension
-Container(
-  color: context.colorTheme.pageBackground,
-  child: Text(
-    'Hello',
-    style: context.textTheme.bodyMediumRegular.copyWith(
-      color: context.colorTheme.primary,  // ✅ CoreUI color via extension
-    ),
-  ),
-)
-
-// Bad: Material colors
-Container(
-  color: Colors.white,  // ❌ Material color
-  child: Text(
-    'Hello',
-    style: TextStyle(color: Colors.black),  // ❌ Material color
-  ),
-)
-
-// Bad: Theme lookup
-Container(
-  color: Theme.of(context).primaryColor,  // ❌ Theme lookup
-)
-
-// Bad: Hex colors
-Container(
-  color: Color(0xFFFFFFFF),  // ❌ Hardcoded hex
-)
-```
-
-**Available Color Properties (via `context.colorTheme`):**
-
-Access colors through the extension pattern:
-- `context.colorTheme.pageBackground` - Page background color
-- `context.colorTheme.textHeadline` - Headline text color
-- `context.colorTheme.primary` - Primary brand color
-- `context.colorTheme.orientMid` - Mid-tone color
-
-> **Note:** See `lib/libraries/extensions/build_context_extensions.dart` and CoreUI's `AppColorsExtension` for the complete list of available color properties.
-
-#### ✅ Buttons
-
-```dart
-// Good: Using CoreButton
-CoreButton(
-  label: 'Continue',
-  onPressed: () => handlePress(),
-  variant: CoreButtonVariant.primary,
-)
-
-// Bad: Material button
-ElevatedButton(  // ❌ Material component
-  onPressed: () => handlePress(),
-  child: Text('Continue'),
-)
-```
-
-### What If CoreUI Doesn't Have What I Need?
-
-**Decision Gate:**
-
-```
-Does the component I need exist in CoreUI?
-  ├─ YES → Use it
-  │
-  └─ NO → STOP and ask the developer
-           "CoreUI doesn't have {ComponentName}. Options:
-           1. Use existing CoreUI component with custom layout
-           2. Request CoreUI team to add it
-           3. Build custom component following CoreUI patterns
-
-           What would you like to do?"
-```
-
-**Never substitute silently with Material components.** Always surface missing components to the developer.
+> CoreUI doesn't have `{ComponentName}`. Options: (1) compose existing CoreUI components, (2) request CoreUI team to add it, (3) build a custom component following CoreUI patterns. Which do you want?
 
 ---
 
@@ -252,118 +72,33 @@ Does the component I need exist in CoreUI?
 
 ### Detection Patterns
 
-Search for violations using these grep patterns:
+| # | Indicator | Regex | Severity | Fix |
+|---|---|---|---|---|
+| 1 | Hardcoded spacing in `EdgeInsets`/`SizedBox`/`Padding` | `(EdgeInsets\|SizedBox\|Padding).*\(\s*[0-9]+(\.[0-9]+)?\s*\)` | Major | `CoreSpacing.space<N>` |
+| 2 | Material icons | `Icons\.[a-zA-Z_]+` | Critical | `CoreIconWidget(icon: CoreIcons.<name>)` |
+| 3 | Hardcoded `TextStyle(...)` | `TextStyle\s*\(` | Major | `context.textTheme.<variant>` |
+| 4 | Material colors / theme lookups / hex | `Colors\.[a-zA-Z_]+\|Theme\.of\(context\)\.\w*[Cc]olor\|Color\(0x[0-9A-Fa-f]{8}\)` | Major | `context.colorTheme.<variant>` |
+| 5 | Material components | `(ElevatedButton\|TextFormField\|TextField\|AppBar\|BottomNavigationBar\|FloatingActionButton\|Checkbox\|Switch\|Slider\|LinearProgressIndicator\|CircularProgressIndicator\|Dialog\|ModalBottomSheet\|SnackBar)\s*\(` | Critical | Use the CoreUI equivalent from the component table |
 
-### Pattern 1: Hardcoded Spacing
-
-**Regex:** `(EdgeInsets|SizedBox|Padding).*\((([0-9]+\.[0-9]*)|([0-9]+))\)`
-
-**Examples to catch:**
-- `EdgeInsets.all(24.0)` → should be `EdgeInsets.all(CoreSpacing.space24)`
-- `SizedBox(height: 16)` → should be `SizedBox(height: CoreSpacing.space16)`
-- `Padding(padding: EdgeInsets.symmetric(horizontal: 20))` → should use `CoreSpacing.space20`
-
-**Severity:** Major
-
-**Fix:** Replace literal values with `CoreSpacing.space*` constants per [CoreUI API Reference](../references/coreui-api.md#spacing)
-
----
-
-### Pattern 2: Material Icons
-
-**Regex:** `Icons\.[a-zA-Z_]+`
-
-**Examples to catch:**
-- `Icon(Icons.search)`
-- `IconButton(icon: Icon(Icons.close))`
-- `leading: Icon(Icons.menu)`
-
-**Severity:** Critical
-
-**Fix:** Replace with `CoreIconWidget(icon: CoreIcons.<name>)`. Reference available icons: [CoreUI API Reference](../references/coreui-api.md#icons)
-
----
-
-### Pattern 3: Hardcoded Typography
-
-**Regex:** `TextStyle\s*\(`
-
-**Examples to catch:**
-- `TextStyle(fontSize: 16, fontWeight: FontWeight.bold)`
-- `Text('Hello', style: TextStyle(color: Colors.black))`
-- `TextStyle(fontSize: 14, height: 1.5)`
-
-**Severity:** Major
-
-**Fix:** Use `context.textTheme.<property>` instead. Example: `context.textTheme.bodyMediumRegular` for body text
-
----
-
-### Pattern 4: Material Colors
-
-**Regex:** `(Colors\.[a-zA-Z_]+|Theme\.of\(context\)\.\w*[Cc]olor|Color\(0x[0-9A-Fa-f]{8}\))`
-
-**Examples to catch:**
-- `Colors.blue`, `Colors.black`, `Colors.white`
-- `Theme.of(context).primaryColor`
-- `Color(0xFF000000)`
-
-**Severity:** Major
-
-**Fix:** Use `context.colorTheme.<property>` for colors. Examples:
-- `context.colorTheme.primary` - Primary brand color
-- `context.colorTheme.pageBackground` - Page background
-- `context.colorTheme.textHeadline` - Headline text color
-
----
-
-### Pattern 5: Material Components
-
-**Regex:** `(ElevatedButton|TextFormField|TextField|AppBar|BottomNavigationBar|FloatingActionButton|Checkbox|Switch|Slider|LinearProgressIndicator|CircularProgressIndicator|Dialog|ModalBottomSheet|SnackBar)\s*\(`
-
-**Examples to catch:**
-- `ElevatedButton(onPressed: () {}, child: Text('Click'))`
-- `TextFormField(decoration: InputDecoration(...))`
-- `AppBar(title: Text('Title'))`
-- `FloatingActionButton(onPressed: () {})`
-
-**Severity:** Critical
-
-**Fix:** Replace with CoreUI equivalents:
-- `ElevatedButton` → `CoreButton`
-- `TextFormField` / `TextField` → `CoreTextField`
-- `AppBar` → `CoreAppBar`
-- `FloatingActionButton` → `CoreFAB`
-- `Checkbox` → `CoreCheckbox`
-- `Switch` → `CoreSwitch`
-- `Slider` → `CoreSlider`
-- `CircularProgressIndicator` → `CoreLoadingIndicator`
-- `LinearProgressIndicator` → `CoreProgressBar`
-- `Dialog` → `CoreDialog`
-- `ModalBottomSheet` → `CoreBottomSheet`
-- `SnackBar` → `CoreSnackBar`
-
----
-
-**Agent Workflow:**
+### Agent Workflow
 
 ```
 For each applicable file:
-  1. Read file content
-  2. For each pattern above:
-     a. Search using grep with provided regex
-     b. Extract line numbers and surrounding context
-     c. Determine severity based on pattern
-     d. Create issue object with (id, name, description, severity, file, line, snippet, suggested_fix, references)
-  3. Compile all issues and return
+  1. Grep each pattern above.
+  2. For each match: capture line, surrounding context, severity.
+  3. Suggest the CoreUI replacement from the tables above (or coreui-api.md).
+  4. Return issues with (id, severity, file:line, snippet, suggested fix, reference).
 ```
+
+---
 
 ## Summary: Suggested Fixes
 
-Replace all literal styling and Material components with CoreUI design tokens and widgets. If a needed component doesn't exist in CoreUI, surface this to the developer rather than substituting with Material.
+Replace all literal styling and Material components with CoreUI design tokens and widgets. If a needed component doesn't exist in CoreUI, surface to the developer rather than substituting Material.
 
 ## References
 
-- [CoreUI GitHub README](https://github.com/ripplearc/coreui#readme) - Latest design system documentation
-- [CoreUI API Reference](../references/coreui-api.md) - Local API reference
+- [CoreUI GitHub README](https://github.com/ripplearc/coreui#readme) — latest design system docs
+- **Token tables:** `skills/references/coreui-api.md` (spacing, typography, colors, icons)
+- Extension: `lib/libraries/extensions/build_context_extensions.dart` (defines `context.textTheme`, `context.colorTheme`)
 - Review Script Lines: 273-294 in `scripts/review_pr.sh`

--- a/skills/rules/07-self-documenting-code.md
+++ b/skills/rules/07-self-documenting-code.md
@@ -14,15 +14,15 @@ Code Quality & Maintainability
 
 ## Description
 
-Code must be expressive and self-explanatory. Use documentation for contracts and public APIs, but avoid implementation comments that explain logic. If you need a comment to explain *what* code does, the code should be refactored to be clearer.
+Code must be expressive and self-explanatory. Use documentation for contracts and public APIs; avoid implementation comments that explain logic. If you need a comment to explain *what* code does, refactor the code to be clearer.
 
 **Two Types of Comments:**
-1. **Code Documentation** ✅ - Explains *purpose* and *usage* of APIs
-2. **Implementation Comments** ❌ - Explains *what* each line does
+1. **Code Documentation** ✅ — explains *purpose* and *usage* of public APIs (dartdoc on classes, methods, fields).
+2. **Implementation Comments** ❌ — explains *what* each line does.
 
 ## Applicability
 
-Applies to all production code in `lib/` directory.
+All production code in `lib/`.
 
 ---
 
@@ -30,303 +30,71 @@ Applies to all production code in `lib/` directory.
 
 ### Core Principle
 
-**Write code that reads like a story.** Variable names, function names, and structure should make the code's intent obvious without requiring comments.
+**Write code that reads like a story.** Names and structure carry intent; comments are reserved for what code cannot say.
 
-### What TO Write (Code Documentation)
+### What TO Write — Documentation
 
-✅ **Document Public APIs:**
+- **Public APIs:** dartdoc with purpose, contract, return shape (`Either<Failure, T>`), and an example. Document inputs that are not obvious from the type.
+- **Class purpose:** one paragraph at the top of every public class — what it does, what it abstracts, lifecycle notes (e.g. dispose).
+- **Non-obvious state:** brief dartdoc on private fields whose meaning isn't obvious from the name.
 
-```dart
-/// Fetches initial estimations for a project and resets pagination state.
-///
-/// This method performs a network request and clears any existing
-/// pagination cursors. Use [fetchNextEstimations] for subsequent pages.
-///
-/// Returns a [Future] that completes with [Either]:
-/// - [Right]: List of estimations if successful
-/// - [Left]: [Failure] if network error or parsing fails
-///
-/// Example:
-/// ```dart
-/// final result = await repository.fetchInitialEstimations('project-123');
-/// result.fold(
-///   (failure) => print('Error: ${failure.message}'),
-///   (estimations) => print('Loaded ${estimations.length} items'),
-/// );
-/// ```
-Future<Either<Failure, List<Estimation>>> fetchInitialEstimations(String projectId);
-```
+### What NOT to Write — Implementation Comments
 
-✅ **Document Class Purpose:**
+- AI residuals (`// <-- ADD THIS`, `// TODO: implement`, `// Fix:`).
+- Step-by-step narration (`// Initialize total to zero`, `// Loop through items`).
+- Comments that restate the code (`// Increment counter` above `counter++`).
+- Obscure names patched with comments (`var val // user info`) — rename instead.
+- Commented-out code — delete it; git keeps history.
+- Inline changelogs (`// Updated 2024-01-15: …`) — commit messages own history.
+
+**Canonical bad/good pair (AI residuals):**
 
 ```dart
-/// Repository for managing cost estimation data.
-///
-/// Provides access to estimation CRUD operations and real-time updates
-/// via streams. Abstracts the underlying data source (Supabase) from
-/// the domain layer.
-///
-/// **Lifecycle:** Call [dispose] when no longer needed to clean up stream
-/// controllers and prevent memory leaks.
-abstract class EstimationRepository {
-  // ...
-}
-```
-
-✅ **Document Non-Obvious State:**
-
-```dart
-class EstimationBloc {
-  /// Tracks the last scroll position to implement infinite scroll pagination.
-  ///
-  /// Reset to 0.0 when user navigates away or refreshes the list.
-  double _lastScrollPosition = 0.0;
-}
-```
-
-### What NOT TO Write (Implementation Comments)
-
-❌ **AI Residuals:**
-
-```dart
-// Bad: AI-generated placeholders
+// ❌ Bad
 void login(String email, String password) {
   // <-- ADD THIS
-  validateEmail(email);  // ❌
-
-  // TODO: implementation here  // ❌
-
-  // Fix: removed hardcoded value  // ❌
+  validateEmail(email);
+  // TODO: implementation here
 }
 
-// Good: Just the code
+// ✅ Good
 void login(String email, String password) {
-  validateEmail(email);  // ✅ No comment needed
+  validateEmail(email);
   authenticateUser(email, password);
 }
 ```
 
-❌ **Step-by-Step Narratives:**
+### Refactor Instead of Commenting
 
-```dart
-// Bad: Explaining what each line does
-void calculateTotal(List<Item> items) {
-  // Initialize total to zero  // ❌
-  double total = 0.0;
+When you reach for a comment, refactor instead:
 
-  // Loop through all items  // ❌
-  for (final item in items) {
-    // Add item price to total  // ❌
-    total += item.price;
-
-    // Apply tax if item is taxable  // ❌
-    if (item.isTaxable) {
-      total += item.price * 0.08;  // ❌ What is 0.08?
-    }
-  }
-
-  return total;
-}
-
-// Good: Self-documenting with constants and extraction
-void calculateTotal(List<Item> items) {
-  return items.fold(0.0, (total, item) => total + _itemTotal(item));
-}
-
-double _itemTotal(Item item) {
-  final basePrice = item.price;
-  final tax = item.isTaxable ? basePrice * _taxRate : 0.0;
-  return basePrice + tax;
-}
-
-static const double _taxRate = 0.08;  // ✅ Named constant
-```
-
-❌ **Obscure Naming with Comments:**
-
-```dart
-// Bad: Generic names requiring comments
-void processData(Map<String, dynamic> data) {
-  // Extract user information  // ❌
-  final val = data['user'];
-
-  // Convert to user model  // ❌
-  final info = UserMapper.fromJson(val);
-
-  // Save to database  // ❌
-  repo.save(info);
-}
-
-// Good: Descriptive names, no comments needed
-void saveUserFromApiResponse(Map<String, dynamic> apiResponse) {
-  final userJson = apiResponse['user'];
-  final userModel = UserMapper.fromJson(userJson);
-  repository.saveUser(userModel);
-}
-```
-
-### Refactor vs. Comment
-
-**When you feel the urge to add a comment, refactor instead:**
-
-#### Example 1: Extract Complex Condition
-
-```dart
-// Bad: Comment explains condition
-if (user != null && user.isActive && user.subscriptionExpiry.isAfter(DateTime.now())) {  // Check if user has valid subscription  ❌
-  grantAccess();
-}
-
-// Good: Extract to descriptive method
-if (_hasValidSubscription(user)) {  // ✅ Self-explanatory
-  grantAccess();
-}
-
-bool _hasValidSubscription(User? user) {
-  return user != null &&
-         user.isActive &&
-         user.subscriptionExpiry.isAfter(DateTime.now());
-}
-```
-
-#### Example 2: Extract Magic Numbers
-
-```dart
-// Bad: Comment explains magic number
-await Future.delayed(Duration(milliseconds: 500));  // Wait for animation to complete  ❌
-
-// Good: Named constant
-static const _animationDuration = Duration(milliseconds: 500);
-await Future.delayed(_animationDuration);  // ✅
-```
-
-#### Example 3: Extract Complex Calculation
-
-```dart
-// Bad: Comment explains calculation
-final discount = price * 0.1 + (loyaltyPoints > 1000 ? price * 0.05 : 0);  // Calculate total discount  ❌
-
-// Good: Extract method with clear name
-final discount = _calculateTotalDiscount(price, loyaltyPoints);  // ✅
-
-double _calculateTotalDiscount(double price, int loyaltyPoints) {
-  final baseDiscount = price * 0.1;
-  final loyaltyDiscount = loyaltyPoints > 1000 ? price * 0.05 : 0;
-  return baseDiscount + loyaltyDiscount;
-}
-```
+- **Complex condition →** extract to a predicate method (`_hasValidSubscription(user)`).
+- **Magic number →** extract to a named `static const` (`_animationDuration`, `_taxRate`).
+- **Long calculation →** extract to a private helper with a descriptive verb name.
 
 ### Naming Guidelines
 
-**Use names that eliminate the need for comments:**
-
 | ❌ Requires Comment | ✅ Self-Documenting |
-|---------------------|---------------------|
-| `int c`  // count | `int estimationCount` |
-| `bool f`  // flag for processing | `bool isProcessingPayment` |
-| `var data`  // user information | `User user` or `UserData userData` |
-| `void process()`  // saves to DB | `void saveToDatabase()` |
-| `double calc()`  // calculates tax | `double calculateSalesTax()` |
+|---|---|
+| `int c` // count | `int estimationCount` |
+| `bool f` // is processing | `bool isProcessingPayment` |
+| `var data` // user info | `User user` / `UserData userData` |
+| `void process()` // saves to DB | `void saveToDatabase()` |
+| `double calc()` // tax | `double calculateSalesTax()` |
 
-**Naming Patterns:**
-
-- **Booleans:** `is...`, `has...`, `should...`, `can...`
-  - `isLoading`, `hasValidCredentials`, `shouldShowError`, `canEdit`
-
-- **Collections:** Plural nouns
-  - `estimations`, `users`, `errors` (not `estimationList`, `userArray`)
-
-- **Methods:** Verb phrases
-  - `fetchEstimations()`, `calculateTotal()`, `validateEmail()`
-
-- **Classes:** Nouns describing responsibility
-  - `EstimationCalculator`, `EmailValidator`, `UserRepository`
+**Patterns:**
+- Booleans: `is…` / `has…` / `should…` / `can…`
+- Collections: plural nouns (`estimations`, not `estimationList`)
+- Methods: verb phrases (`fetchEstimations()`, `calculateTotal()`)
+- Classes: noun describing responsibility (`EstimationCalculator`, `UserRepository`)
 
 ### When Comments ARE Appropriate
 
-✅ **Non-Obvious Business Rules:**
+Comments earn their place when they explain **why**, not **what**:
 
-```dart
-// ✅ Good: Explains WHY, not WHAT
-// Tax rate changes to 9% for commercial properties per 2024 tax law
-static const _commercialTaxRate = 0.09;
-```
-
-✅ **Workarounds or Known Issues:**
-
-```dart
-// ✅ Good: Documents technical constraint
-// Supabase doesn't support nested transactions, so we commit each stage separately
-// See: https://github.com/supabase/supabase/issues/1234
-await _commitStageOne();
-await _commitStageTwo();
-```
-
-✅ **Complex Algorithms (when extraction isn't enough):**
-
-```dart
-/// Implements binary search with early termination optimization.
-///
-/// Time complexity: O(log n)
-/// Space complexity: O(1)
-///
-/// Returns index of item, or -1 if not found.
-int binarySearch(List<int> sorted, int target) {
-  // Implementation follows...
-}
-```
-
-### Common Anti-Patterns
-
-❌ **Commented-Out Code:**
-
-```dart
-// Bad: Dead code left in
-void login(String email, String password) {
-  // Old implementation
-  // await authenticateWithFirebase(email, password);
-
-  // New implementation
-  await authenticateWithSupabase(email, password);
-}
-
-// Good: Remove dead code, use git for history
-void login(String email, String password) {
-  await authenticateWithSupabase(email, password);
-}
-```
-
-❌ **Changelog Comments:**
-
-```dart
-// Bad: Inline changelog
-void calculateDiscount(double price) {
-  // Updated 2024-01-15: Changed from 10% to 15%
-  // Updated 2024-02-01: Added loyalty bonus
-  return price * 0.15 + _loyaltyBonus();
-}
-
-// Good: Use git commit messages for history
-void calculateDiscount(double price) {
-  return price * _standardDiscountRate + _loyaltyBonus();
-}
-
-static const double _standardDiscountRate = 0.15;
-```
-
-❌ **Redundant Comments:**
-
-```dart
-// Bad: Comment repeats what code says
-// Get user by ID  ❌
-final user = await getUserById(id);
-
-// Increment counter  ❌
-counter++;
-
-// Return true  ❌
-return true;
-```
+- **Non-obvious business rules:** `// Tax rate changes to 9% for commercial properties per 2024 tax law`
+- **Workarounds:** `// Supabase doesn't support nested transactions; commit stages separately. https://github.com/supabase/supabase/issues/1234`
+- **Algorithm intent** that survives extraction: complexity notes, contract on non-trivial private helpers.
 
 ---
 
@@ -334,104 +102,55 @@ return true;
 
 ### Detection Patterns
 
-**Pattern 1: AI Residuals**
-
-```bash
-# Search for common AI artifacts
-grep -rn "// <--" lib/
-grep -rn "// ADD THIS" lib/
-grep -rn "// implementation here" lib/
-grep -rn "// TODO: implement" lib/
-grep -rn "// Fix:" lib/
-```
-
-**Regex:** `//\s*(<--|ADD THIS|implementation here|TODO: implement|Fix:)`
-
-**Severity:** Critical
-
-**Pattern 2: Step-by-Step Narratives**
-
-Look for methods with multiple consecutive single-line comments:
-
-**Indicator:** 3+ consecutive lines with `//` comments inside a method
-
-**Severity:** Major
-
-**Pattern 3: Obscure Naming**
-
-Variables with generic names (`data`, `info`, `val`, `tmp`, `x`, `y`) followed by comments:
-
-**Regex:** `(var|final|const)\s+(data|info|val|tmp|temp|x|y|i|j|k)\s*=.*//`
-
-**Severity:** Minor
-
-**Pattern 4: Commented-Out Code**
-
-```bash
-# Find commented-out code blocks
-grep -rn "^[[:space:]]*//.*await\|^[[:space:]]*//.*return\|^[[:space:]]*//.*if\|^[[:space:]]*//.*for" lib/
-```
-
-**Severity:** Major
-
-**Pattern 5: Magic Numbers Without Constants**
-
-Numeric literals (except 0, 1, -1) without named constants:
-
-**Regex:** `(?<![a-zA-Z_])[2-9]\d*(?:\.\d+)?(?![a-zA-Z_0-9])` (excluding 0, 1, common loop indices)
-
-**Context needed:** Check if number appears multiple times or has semantic meaning
-
-**Severity:** Minor
+| Pattern | Grep / Regex | Severity |
+|---|---|---|
+| AI residuals | `grep -rn "// <--\\|// ADD THIS\\|// implementation here\\|// TODO: implement\\|// Fix:" lib/` | Critical |
+| Step-by-step narration | 3+ consecutive `//` lines inside a method body | Major |
+| Obscure name + comment | `(var\\|final\\|const)\\s+(data\\|info\\|val\\|tmp\\|temp\\|x\\|y)\\s*=.*//` | Minor |
+| Commented-out code | `grep -rn "^[[:space:]]*//.*\\(await\\|return\\|if\\|for\\)" lib/` | Major |
+| Magic numbers | numeric literal ≥ 2 with no named constant context, used > once | Minor |
+| Inline changelog | `grep -rn "// Updated 20[0-9][0-9]-" lib/` | Minor |
 
 ### Common Violations
 
 | ❌ Violation | ✅ Fix | Severity |
-|-------------|--------|----------|
-| `// <-- ADD THIS` | Delete AI placeholder | Critical |
-| `// Loop through items` | Remove redundant comment | Major |
-| `var data // user info` | Rename to `userData` or `userInfo` | Minor |
-| Commented-out code block | Delete (use git for history) | Major |
-| `0.08` without constant name | Extract to `static const _taxRate = 0.08;` | Minor |
-| 5+ single-line comments in method | Extract complex logic to helper methods | Major |
+|---|---|---|
+| `// <-- ADD THIS` / `// TODO: implement` | Delete the placeholder | Critical |
+| `// Loop through items` above a `for` | Delete the comment | Major |
+| `var data // user info` | Rename to `userData` | Minor |
+| Commented-out code block | Delete; use git for history | Major |
+| `0.08` repeated without a constant | Extract to `static const _taxRate = 0.08;` | Minor |
+| 5+ single-line comments in one method | Extract complex logic into helpers | Major |
+| Inline changelog comment | Delete; commit messages own history | Minor |
 
 ### Review Questions
 
-1. **Can this code be understood without the comments?**
-   - If NO → Refactor, don't just add comments
-
-2. **Does this comment explain WHY, or just WHAT?**
-   - WHAT → Remove or refactor
-   - WHY → Keep if non-obvious
-
-3. **Is this comment up-to-date with the code?**
-   - If NO → Critical issue (misleading documentation)
-
-4. **Would a better variable/method name eliminate this comment?**
-   - If YES → Rename, remove comment
+1. Can this code be understood without the comments? → if no, refactor (don't just comment more).
+2. Does the comment explain WHY or WHAT? → WHAT → remove; WHY → keep if non-obvious.
+3. Is the comment up to date with the code? → if no, it's misleading; remove or fix.
+4. Would a better name eliminate the comment? → rename, remove comment.
 
 ---
 
 ## Summary: Suggested Fixes
 
-1. **Remove AI artifacts:** Delete all `<-- ADD THIS`, `TODO: implement`, `Fix:` comments
-2. **Refactor narrative comments:** Extract complex logic into descriptive methods
-3. **Rename obscure variables:** Use meaningful names that don't need comments
-4. **Delete commented-out code:** Use git for code history, not inline comments
-5. **Extract magic numbers:** Create named constants for semantic values
-6. **Keep contracts clear:** Document public APIs, class purposes, and non-obvious business rules
+1. Delete AI artifacts (`<-- ADD THIS`, `TODO: implement`, `Fix:`).
+2. Refactor narrative comments — extract logic into named helpers.
+3. Rename obscure variables — eliminate the comment by renaming.
+4. Delete commented-out code; use git for history.
+5. Extract magic numbers into named `static const`s.
+6. Keep dartdoc on contracts: public APIs, class purpose, non-obvious business rules.
 
 ## References
 
-- Clean Code by Robert C. Martin - Chapter 4: Comments
+- *Clean Code* by Robert C. Martin — Chapter 4: Comments
 - [Effective Dart: Documentation](https://dart.dev/guides/language/effective-dart/documentation)
 - Review Script Lines: 339-355 in `scripts/review_pr.sh`
 
 ## Notes
 
-**The Prime Directive:** Code should read like well-written prose. Comments are a necessary evil when code cannot express intent alone—minimize them by writing better code.
+**The prime directive:** code reads like prose; comments are a necessary evil when code cannot express intent alone. Minimize them by writing better code.
 
-**Good Documentation ≠ Good Comments:**
-- Documentation explains contracts and usage (external view)
-- Comments explain implementation (internal view)
-- Prioritize the former, avoid the latter
+**Documentation ≠ Comments:**
+- Documentation explains contracts and usage (external view) — prioritize.
+- Comments explain implementation (internal view) — avoid.

--- a/skills/rules/08-widget-test-finders.md
+++ b/skills/rules/08-widget-test-finders.md
@@ -7,20 +7,20 @@ RULE_8
 Testing - Widget Tests
 
 ## Severity Levels
-- **Critical:** Using fragile finders like `findsNWidgets` with `byType` for implementation-specific widgets
+- **Critical:** `findsNWidgets` + `byType` on implementation-specific widgets
 - **Major:** Tests rely on exact widget counts, tree structure, or internal implementation
-- **Minor:** Finders use positional access (`.first`, `.last`) without semantic context
-- **Suggestion:** Consider using Keys or semantic finders for better test resilience
+- **Minor:** Positional access (`.first`, `.last`) without semantic context
+- **Suggestion:** Prefer Keys or semantic finders for resilience
 
 ## Description
 
-Widget tests should focus on user-observable behavior, not implementation details. Use semantic finders (Keys, text, semantics) that remain stable across refactoring, rather than fragile finders that break when widget structure changes.
+Widget tests focus on user-observable behavior, not implementation structure. Use semantic finders (Keys, text, semantics) that survive refactoring, not fragile finders that break when widget structure changes.
 
 **Core Principle:** Test what the user sees and does, not how widgets are internally structured.
 
 ## Applicability
 
-Applies to all widget tests in `test/features/**/widgets/` and `test/` directories.
+All widget tests in `test/features/**/widgets/` and `test/`.
 
 ---
 
@@ -28,331 +28,61 @@ Applies to all widget tests in `test/features/**/widgets/` and `test/` directori
 
 ### Core Principle
 
-**Write tests that survive refactoring.** Tests should verify user-facing behavior, not internal widget composition. If you refactor a widget without changing its behavior, tests should still pass.
+**Write tests that survive refactoring.** If you refactor a widget without changing behavior, tests should still pass.
 
 ### Decision Tree: Which Finder Should I Use?
 
 ```
 What am I trying to find?
 
-├─ User-visible text?
-│  └─ Use: find.text('Button Label')
-│     └─ Or: find.widgetWithText(CoreButton, 'Continue')
-│
-├─ Interactive element with specific purpose?
-│  └─ Use: find.byKey(Key('login_button'))
-│     └─ Add Key to widget in production code
-│
-├─ Icon visible to user?
-│  └─ Use: find.byKey(Key('search_icon'))
-│     └─ Or: find.byIcon(Icons.search) if testing Material
-│
-├─ Semantically labeled element?
-│  └─ Use: find.bySemanticsLabel('Close dialog')
-│
-└─ Specific widget TYPE for interaction?
-   └─ Use: find.byType(SpecificWidget) ONLY if:
-      - It's a leaf widget you're directly testing
-      - Not counting instances (no findsNWidgets)
-      - Not using positional access (.first, .last)
+├─ User-visible text?                  → find.text('Continue')  or  find.widgetWithText(CoreButton, 'Continue')
+├─ Interactive element (specific role)? → find.byKey(Key('login_button'))  (add Key in production code)
+├─ Icon visible to user?               → find.byKey(Key('search_icon'))  (or find.byIcon for Material)
+├─ Semantically labeled element?       → find.bySemanticsLabel('Close dialog')
+└─ Specific widget TYPE?               → find.byType(LeafWidget)
+                                          ONLY if: leaf widget under test, no findsNWidgets,
+                                          no .first/.last/.at(...)
 ```
 
-### What Finders to Use
+### Fragile Finder → Stable Finder
 
-#### ✅ Good: Semantic Finders
-
-**Keys (Preferred):**
-
-```dart
-// Production code: Add Keys to important widgets
-CoreButton(
-  key: const Key('submit_button'),  // ✅ Semantic, stable
-  label: 'Submit',
-  onPressed: () => handleSubmit(),
-)
-
-// Test code: Find by Key
-testWidgets('should submit form when button tapped', (tester) async {
-  await tester.pumpWidget(MyApp());
-
-  final submitButton = find.byKey(const Key('submit_button'));  // ✅
-  expect(submitButton, findsOneWidget);
-
-  await tester.tap(submitButton);
-  await tester.pumpAndSettle();
-
-  // Assert on behavior
-  expect(find.text('Success'), findsOneWidget);
-});
-```
-
-**Text-based (For User-Visible Content):**
-
-```dart
-testWidgets('should display welcome message', (tester) async {
-  await tester.pumpWidget(MyApp());
-
-  // ✅ Tests what user sees
-  expect(find.text('Welcome back'), findsOneWidget);
-  expect(find.text('Logout'), findsOneWidget);
-});
-```
-
-**Combined (Widget + Text):**
-
-```dart
-testWidgets('should render login button', (tester) async {
-  await tester.pumpWidget(MyApp());
-
-  // ✅ Semantic: finds button with specific text
-  final loginButton = find.widgetWithText(CoreButton, 'Login');
-  expect(loginButton, findsOneWidget);
-});
-```
-
-**Semantics (For Accessibility):**
-
-```dart
-testWidgets('should have semantic label for screen readers', (tester) async {
-  await tester.pumpWidget(MyApp());
-
-  // ✅ Tests accessibility
-  expect(find.bySemanticsLabel('Close dialog'), findsOneWidget);
-});
-```
-
-#### ❌ Bad: Fragile Finders
-
-**Type-based counting (Forbidden):**
-
-```dart
-// ❌ CRITICAL: Breaks if you add/remove any icon
-expect(find.byType(CoreIconWidget), findsNWidgets(3));
-
-// Why bad: If you add a 4th icon elsewhere, test breaks
-// even though behavior is unchanged
-```
-
-**Positional access:**
-
-```dart
-// ❌ MAJOR: Fragile, order-dependent
-final firstButton = find.byType(CoreButton).first;
-await tester.tap(firstButton);
-
-// Why bad: If button order changes, test breaks
-// even though each button still works correctly
-```
-
-**Generic type finders:**
-
-```dart
-// ❌ MINOR: Too generic, may match unintended widgets
-expect(find.byType(Row), findsOneWidget);
-expect(find.byType(Container), findsWidgets);
-
-// Why bad: Internal layout widgets shouldn't be test targets
-```
-
-### How to Write Widget Tests
-
-#### Pattern 1: Test User Interactions
-
-```dart
-testWidgets('should navigate to settings when icon tapped', (tester) async {
-  await tester.pumpWidget(MyApp());
-
-  // ✅ Find by semantic Key
-  final settingsIcon = find.byKey(const Key('settings_icon'));
-  expect(settingsIcon, findsOneWidget);
-
-  // ✅ Test user action
-  await tester.tap(settingsIcon);
-  await tester.pumpAndSettle();
-
-  // ✅ Assert on observable result
-  expect(find.text('Settings'), findsOneWidget);
-  expect(find.byType(SettingsScreen), findsOneWidget);
-});
-```
-
-#### Pattern 2: Test Displayed Content
-
-```dart
-testWidgets('should display estimation list', (tester) async {
-  await tester.pumpWidget(MyApp());
-
-  // ✅ Test user-visible content
-  expect(find.text('Kitchen Remodel'), findsOneWidget);
-  expect(find.text('\$25,000'), findsOneWidget);
-  expect(find.text('Bathroom Renovation'), findsOneWidget);
-
-  // ❌ Don't test internal structure
-  // expect(find.byType(ListView), findsOneWidget);  // ❌
-  // expect(find.byType(EstimationCard), findsNWidgets(2));  // ❌
-});
-```
-
-#### Pattern 3: Test State Changes
-
-```dart
-testWidgets('should show error message on invalid input', (tester) async {
-  await tester.pumpWidget(MyApp());
-
-  // ✅ Find input field by Key
-  final emailField = find.byKey(const Key('email_input'));
-
-  // ✅ Simulate user input
-  await tester.enterText(emailField, 'invalid-email');
-
-  // ✅ Trigger validation
-  final submitButton = find.byKey(const Key('submit_button'));
-  await tester.tap(submitButton);
-  await tester.pumpAndSettle();
-
-  // ✅ Assert on user-visible feedback
-  expect(find.text('Invalid email format'), findsOneWidget);
-});
-```
+| ❌ Fragile | ✅ Stable | Why |
+|---|---|---|
+| `find.byType(CoreIconWidget), findsNWidgets(3)` | `find.byKey(Key('home_icon')) // …` per icon | Adding/removing an unrelated icon breaks the count |
+| `find.byType(CoreButton).first` | `find.byKey(Key('submit_button'))` | Order-dependent; first button changes with refactor |
+| `find.byType(IconButton).at(1)` | `find.byKey(Key('action_<purpose>'))` | Same as above |
+| `find.byType(Row)` / `byType(Column)` / `byType(Padding)` | `find.text(...)` or `find.byKey(...)` | Internal layout widgets aren't user-observable |
+| `find.text('Submit').first` (multiple submits) | `find.byKey(Key('login_submit'))` | Disambiguates by purpose, not order |
+| `tester.tap(find.byType(CoreButton))` | `tester.tap(find.byKey(Key('submit_button')))` | Without a Key, the test can't say *which* button |
 
 ### Adding Keys to Production Code
 
-**When to add Keys:**
+Add Keys to interactive elements, navigation targets, dynamic list items, and conditionally rendered state markers (loading, empty, content).
 
-- ✅ Interactive elements (buttons, inputs, icons)
-- ✅ Navigation targets (tabs, menu items)
-- ✅ Dynamic content that needs testing (lists, cards)
-- ✅ Elements with important state changes
+**Naming pattern:** `Key('{purpose}_{element_type}')` — descriptive, purpose-driven.
 
-**How to name Keys:**
-
-Use descriptive, purpose-driven names:
-
-| Element | ❌ Bad Key | ✅ Good Key |
-|---------|-----------|------------|
-| Submit button | `Key('button')` | `Key('submit_button')` or `Key('login_submit')` |
+| Element | ❌ Bad | ✅ Good |
+|---|---|---|
+| Submit button | `Key('button')` | `Key('submit_button')` / `Key('login_submit')` |
 | Email input | `Key('input1')` | `Key('email_input')` |
 | Search icon | `Key('icon')` | `Key('search_icon')` |
-| Estimation card | `Key('card_0')` | `Key('estimation_$id')` or `Key('estimation_list_item_$index')` |
+| Dynamic list item | `Key('card_0')` | `Key('estimation_$id')` |
 
-**Pattern:** `Key('{purpose}_{element_type}')` or `Key('{feature}_{action}')`
-
-### What NOT to Test
-
-❌ **Internal Widget Structure:**
+### Canonical Test Pattern
 
 ```dart
-// Bad: Tests implementation
-testWidgets('should have correct widget tree', (tester) async {
-  await tester.pumpWidget(MyApp());
+testWidgets('shows error message on invalid email', (tester) async {
+  await tester.pumpWidget(makeTestableWidget(child: LoginPage()));
 
-  expect(find.byType(Column), findsOneWidget);  // ❌ Internal layout
-  expect(find.byType(Padding), findsWidgets);  // ❌ Internal styling
-  expect(find.byType(SizedBox), findsNWidgets(3));  // ❌ Spacers
-});
-
-// Good: Tests behavior
-testWidgets('should display login form elements', (tester) async {
-  await tester.pumpWidget(MyApp());
-
-  expect(find.text('Email'), findsOneWidget);  // ✅ User-facing
-  expect(find.text('Password'), findsOneWidget);  // ✅ User-facing
-  expect(find.text('Login'), findsOneWidget);  // ✅ User-facing
-});
-```
-
-❌ **Widget Count Assertions:**
-
-```dart
-// Bad: Fragile count assertion
-expect(find.byType(CoreIconWidget), findsNWidgets(3));  // ❌
-
-// Good: Test each icon has purpose
-expect(find.byKey(const Key('home_icon')), findsOneWidget);  // ✅
-expect(find.byKey(const Key('search_icon')), findsOneWidget);  // ✅
-expect(find.byKey(const Key('profile_icon')), findsOneWidget);  // ✅
-```
-
-### Special Cases
-
-#### Testing Lists with Dynamic Content
-
-```dart
-// ✅ Good: Use Keys with identifiers
-ListView.builder(
-  itemCount: estimations.length,
-  itemBuilder: (context, index) {
-    final estimation = estimations[index];
-    return EstimationCard(
-      key: Key('estimation_${estimation.id}'),  // ✅ Unique, stable key
-      estimation: estimation,
-    );
-  },
-)
-
-// Test
-testWidgets('should display specific estimation', (tester) async {
-  await tester.pumpWidget(MyApp());
-
-  final estimationCard = find.byKey(const Key('estimation_abc123'));  // ✅
-  expect(estimationCard, findsOneWidget);
-});
-```
-
-#### Testing Conditional Rendering
-
-```dart
-testWidgets('should show loading indicator when loading', (tester) async {
-  await tester.pumpWidget(MyApp());
-
-  // ✅ Test state-specific widget presence
-  expect(find.byKey(const Key('loading_indicator')), findsOneWidget);
-  expect(find.byKey(const Key('content_view')), findsNothing);
-
-  // Simulate data load
+  await tester.enterText(find.byKey(const Key('email_input')), 'invalid');
+  await tester.tap(find.byKey(const Key('submit_button')));
   await tester.pumpAndSettle();
 
-  // ✅ Test state changed
-  expect(find.byKey(const Key('loading_indicator')), findsNothing);
-  expect(find.byKey(const Key('content_view')), findsOneWidget);
+  expect(find.text(l10n().invalidEmailError), findsOneWidget); // RULE_10
 });
 ```
 
-### Common Patterns
-
-#### ✅ Scrolling to Find Widgets
-
-```dart
-testWidgets('should find widget by scrolling', (tester) async {
-  await tester.pumpWidget(MyApp());
-
-  // ✅ Scroll to specific item by Key
-  await tester.scrollUntilVisible(
-    find.byKey(const Key('estimation_xyz789')),
-    100.0,
-  );
-
-  expect(find.byKey(const Key('estimation_xyz789')), findsOneWidget);
-});
-```
-
-#### ✅ Testing Gestures
-
-```dart
-testWidgets('should dismiss item on swipe', (tester) async {
-  await tester.pumpWidget(MyApp());
-
-  final item = find.byKey(const Key('dismissible_item'));
-
-  // ✅ Test gesture
-  await tester.drag(item, const Offset(-500.0, 0.0));
-  await tester.pumpAndSettle();
-
-  // ✅ Assert item removed
-  expect(item, findsNothing);
-  expect(find.text('Item deleted'), findsOneWidget);
-});
-```
+Test inputs by Key, taps by Key, assertions on user-visible text (always via `l10n`). Never assert on internal layout widgets (`Row`, `Column`, `Padding`) or widget counts.
 
 ---
 
@@ -360,95 +90,46 @@ testWidgets('should dismiss item on swipe', (tester) async {
 
 ### Detection Patterns
 
-**Pattern 1: Fragile findsNWidgets with byType**
-
-```bash
-grep -rn "findsNWidgets" test/ | grep "byType"
-```
-
-**Regex:** `find\.byType\([^)]+\).*findsNWidgets\(|findsNWidgets\(.*find\.byType`
-
-**Severity:** Critical
-
-**Examples to catch:**
-- `expect(find.byType(CoreIconWidget), findsNWidgets(3))`
-- `expect(find.byType(EstimationCard), findsNWidgets(2))`
-
-**Pattern 2: Positional Access**
-
-```bash
-grep -rn "\.first\|\.last\|\.at(" test/
-```
-
-**Regex:** `find\.[a-zA-Z]+\([^)]*\)\.(first|last|at\()`
-
-**Severity:** Major
-
-**Examples to catch:**
-- `find.byType(CoreButton).first`
-- `find.byType(IconButton).at(1)`
-
-**Pattern 3: Generic Type Finders**
-
-```bash
-grep -rn "byType(Row)\|byType(Column)\|byType(Container)\|byType(Padding)" test/
-```
-
-**Severity:** Minor
-
-**Pattern 4: Missing Keys on Interactive Elements**
-
-Check if test tries to find interactive widgets without Keys:
-
-```dart
-await tester.tap(find.byType(CoreButton));  // ❌ Which button?
-```
-
-**Severity:** Major
+| Pattern | Grep | Severity |
+|---|---|---|
+| `findsNWidgets` with `byType` | `grep -rn "findsNWidgets" test/ \| grep "byType"` | Critical |
+| Positional access | `grep -rn "find\\.[a-zA-Z]\\+([^)]*)\\.\\(first\\|last\\|at(\\)" test/` | Major |
+| Generic type finders | `grep -rn "byType(Row)\\|byType(Column)\\|byType(Container)\\|byType(Padding)" test/` | Minor |
+| Tap by widget type, not Key | `grep -rn "tester\\.tap(find\\.byType" test/` | Major |
 
 ### Common Violations
 
 | ❌ Violation | ✅ Fix | Severity |
 |-------------|--------|----------|
-| `expect(find.byType(Icon), findsNWidgets(3))` | Use `find.byKey(Key('icon_name'))` for each icon | Critical |
-| `find.byType(CoreButton).first` | Add Key to button, use `find.byKey(Key('button_name'))` | Major |
-| `expect(find.byType(Row), findsOneWidget)` | Test user-visible content, not layout widgets | Minor |
-| `find.text('Submit').first` | Use `find.byKey` if multiple submit buttons exist | Major |
-| No Keys in production code | Add Keys to interactive elements | Major |
+| `expect(find.byType(Icon), findsNWidgets(3))` | Find each icon by its own Key | Critical |
+| `find.byType(CoreButton).first` | Add a Key; use `find.byKey(...)` | Major |
+| `expect(find.byType(Row), findsOneWidget)` | Assert on user-visible content, not layout | Minor |
+| `find.text('Submit').first` | Use `find.byKey` when multiple match | Major |
+| Interactive widget without a Key in production code | Add a semantic Key | Major |
 
 ### Review Questions
 
-1. **Does this test break if we refactor widget structure?**
-   - If YES → Test is too fragile
-
-2. **Is this test counting internal implementation widgets?**
-   - If YES → Violation
-
-3. **Does this test use positional access without semantic meaning?**
-   - If YES → Should use Keys instead
-
-4. **Would a user notice if this test's assertion fails?**
-   - If NO → Test is testing implementation, not behavior
+1. Does this test break if widget structure is refactored without behavior change? → too fragile.
+2. Is the test counting internal implementation widgets? → violation.
+3. Does the test rely on `.first` / `.last` / `.at(...)` without semantic meaning? → use a Key.
+4. Would a user notice if this assertion failed? → if no, it's testing implementation.
 
 ---
 
 ## Summary: Suggested Fixes
 
-1. **Replace type-based counting:** Use Keys for each distinct widget instance
-2. **Add Keys to production code:** Tag interactive elements with semantic Keys
-3. **Remove positional access:** Use `find.byKey` instead of `.first`, `.last`
-4. **Test user-visible content:** Focus on text, semantics, and behavior
-5. **Make tests refactor-safe:** Tests should survive internal widget restructuring
+1. **Replace type-based counting** with per-instance Keys.
+2. **Add Keys** to interactive elements in production code, at construction time — not as an afterthought.
+3. **Remove positional access** (`.first`, `.last`, `.at`) — use `find.byKey`.
+4. **Assert on user-visible content** (text via `l10n`, semantics labels).
+5. **Tests must survive refactor** — if internal restructuring breaks tests, the test is wrong.
 
 ## References
 
 - [Flutter Widget Testing Guide](https://flutter.dev/docs/cookbook/testing/widget/introduction)
-- [Effective Dart: Testing](https://dart.dev/guides/language/effective-dart/testing)
 - Review Script Lines: 360-386 in `scripts/review_pr.sh`
-- Related: RULE_9 (Unit Test Behavior) - same principle for unit tests
+- Related: RULE_9 (same principle for unit tests), RULE_10 (localized strings in assertions)
 
 ## Notes
 
-**Key Principle:** If you can refactor a widget without changing user-visible behavior, tests should still pass. Tests that rely on internal structure are brittle and provide false confidence.
-
-**Best Practice:** Add Keys during development, not as an afterthought. Include Keys in your widget's initial implementation for testability.
+**Best Practice:** Add Keys during initial widget development, not retrofitted. Include them in the constructor signature when testability matters.

--- a/skills/rules/09-unit-test-behavior.md
+++ b/skills/rules/09-unit-test-behavior.md
@@ -14,13 +14,13 @@ Testing - Unit Tests
 
 ## Description
 
-Unit tests (BLoC, Service, Repository, UseCase) should assert observable behavior and outputs, not internal structure or implementation details. Tests should verify *what* the code does, not *how* it does it.
+Unit tests (BLoC, Service, Repository, UseCase) assert observable behavior and outputs, not internal structure. Test *what* the code does, not *how*.
 
 **Core Principle:** If you can refactor code while preserving behavior, tests should still pass.
 
 ## Applicability
 
-Applies to all unit tests in `test/features/**/` for BLoCs, Services, Repositories, UseCases, and other business logic components.
+All unit tests in `test/features/**/` for BLoCs, Services, Repositories, UseCases, and other business logic.
 
 ---
 
@@ -35,388 +35,63 @@ Applies to all unit tests in `test/features/**/` for BLoCs, Services, Repositori
 ```
 What aspect of this class am I testing?
 
-├─ Public method return value?
-│  └─ Test: Call method, assert on returned value ✅
-│
-├─ Stream/BLoC state emissions?
-│  └─ Test: Dispatch event, assert on emitted states ✅
-│
-├─ Side effects (DB writes, API calls)?
-│  └─ Test: Verify data written to fake boundary ✅
-│
-├─ Error handling?
-│  └─ Test: Trigger error condition, assert on error output ✅
-│
-├─ Private method called?
-│  └─ DON'T TEST: Internal implementation detail ❌
-│
-└─ Method call count?
-   └─ DON'T TEST: Use test doubles (RULE_3), not mocks ❌
+├─ Public method return value?       → Call method, assert on returned value ✅
+├─ Stream/BLoC state emissions?      → Dispatch event, assert on emitted states ✅
+├─ Side effects (DB/API writes)?     → Verify data written to fake boundary ✅
+├─ Error handling?                   → Trigger error, assert on error output ✅
+├─ Private method called?            → DON'T TEST — implementation detail ❌
+└─ Method call count?                → DON'T TEST — use fakes (RULE_3), not mocks ❌
 ```
 
-### What to Test (Observable Behavior)
+### Canonical Examples
 
-#### ✅ Public API Return Values
-
-```dart
-// Good: Test observable output
-test('should return estimation when repository succeeds', () async {
-  // Arrange
-  fakeDataSource.mockEstimation(
-    EstimationDto(id: '123', amount: 1000),
-  );
-
-  // Act
-  final useCase = GetEstimationUseCase(repository: repository);
-  final result = await useCase.execute('123');
-
-  // Assert on observable output
-  expect(result.isRight(), true);
-  final estimation = result.getOrElse(() => throw Exception());
-  expect(estimation.id, '123');
-  expect(estimation.amount, 1000);
-});
-```
-
-#### ✅ State Emissions (BLoC)
+**BLoC state emissions** — dispatch event, assert on emitted states:
 
 ```dart
-// Good: Test state transitions
 blocTest<AuthBloc, AuthState>(
   'should emit [Loading, Authenticated] when login succeeds',
   build: () => AuthBloc(authService: authService),
-  act: (bloc) => bloc.add(LoginRequested(
-    email: 'test@example.com',
-    password: 'password',
-  )),
+  act: (bloc) => bloc.add(LoginRequested(email: 'test@example.com', password: 'password')),
   expect: () => [
-    AuthLoading(),  // ✅ Observable state
-    AuthAuthenticated(userId: '123'),  // ✅ Observable state
+    AuthLoading(),
+    AuthAuthenticated(userId: '123'),
   ],
 );
 ```
 
-#### ✅ Side Effects at Boundaries
+**Boundary side effects** — assert on the fake's state, not on method calls:
 
 ```dart
-// Good: Verify data written to boundary
 test('should save estimation to data source', () async {
-  // Arrange
-  final estimation = Estimation(id: '123', amount: 1000);
   final fakeDataSource = FakeEstimationDataSource();
+  final repository = EstimationRepositoryImpl(dataSource: fakeDataSource);
+  final estimation = Estimation(id: '123', amount: 1000);
 
-  // Act
-  final repository = EstimationRepositoryImpl(
-    dataSource: fakeDataSource,
-  );
   await repository.save(estimation);
 
-  // Assert on boundary side effect
-  expect(fakeDataSource.savedEstimations, contains(estimation));  // ✅
-});
-```
-
-#### ✅ Error Handling
-
-```dart
-// Good: Test error propagation
-test('should return Failure when network error occurs', () async {
-  // Arrange
-  fakeDataSource.mockNetworkError();
-
-  // Act
-  final result = await useCase.execute('123');
-
-  // Assert on error output
-  expect(result.isLeft(), true);
-  final failure = result.fold((f) => f, (_) => throw Exception());
-  expect(failure, isA<NetworkFailure>());  // ✅ Observable error type
-});
-```
-
-### What NOT to Test (Implementation Details)
-
-#### ❌ Private Methods
-
-```dart
-// Bad: Testing private implementation
-class EstimationCalculator {
-  double calculateTotal(List<Item> items) {
-    return items.fold(0.0, (sum, item) => sum + _itemCost(item));
-  }
-
-  double _itemCost(Item item) {  // Private helper
-    return item.price * item.quantity;
-  }
-}
-
-// ❌ DON'T DO THIS:
-test('_itemCost should multiply price by quantity', () {
-  final calculator = EstimationCalculator();
-  final item = Item(price: 10.0, quantity: 3);
-
-  // ❌ Trying to test private method
-  final cost = calculator._itemCost(item);  // Shouldn't access private!
-
-  expect(cost, 30.0);
-});
-
-// ✅ DO THIS INSTEAD:
-test('calculateTotal should sum all item costs', () {
-  final calculator = EstimationCalculator();
-  final items = [
-    Item(price: 10.0, quantity: 3),  // 30
-    Item(price: 5.0, quantity: 2),   // 10
-  ];
-
-  // ✅ Test public API
-  final total = calculator.calculateTotal(items);
-
-  expect(total, 40.0);  // Tests _itemCost indirectly
-});
-```
-
-#### ❌ Method Call Verification (Mocks)
-
-```dart
-// ❌ BAD: Using mocks to verify calls
-test('should call repository.save()', () async {
-  final mockRepository = MockEstimationRepository();  // ❌ Mock
-
-  when(mockRepository.save(any))
-      .thenAnswer((_) async => Right(unit));
-
-  final useCase = SaveEstimationUseCase(repository: mockRepository);
-  await useCase.execute(estimation);
-
-  // ❌ Verifying implementation detail
-  verify(mockRepository.save(estimation)).called(1);
-});
-
-// ✅ GOOD: Use test doubles, assert on boundary
-test('should save estimation', () async {
-  final fakeDataSource = FakeEstimationDataSource();  // ✅ Fake
-  final repository = EstimationRepositoryImpl(
-    dataSource: fakeDataSource,
-  );
-
-  final useCase = SaveEstimationUseCase(repository: repository);
-  await useCase.execute(estimation);
-
-  // ✅ Assert on observable effect
   expect(fakeDataSource.savedEstimations, contains(estimation));
 });
 ```
 
-#### ❌ Internal State
+**Async streams** — subscribe with `expectLater` *before* triggering emissions:
 
 ```dart
-// Bad: Testing private state
-class EstimationBloc {
-  final List<Estimation> _cache = [];  // Private state
+test('should emit sync statuses in order', () async {
+  final service = SyncService(dataSource: FakeEstimationDataSource());
 
-  void loadEstimations() {
-    // Populates _cache internally
-  }
-}
-
-// ❌ DON'T DO THIS:
-test('_cache should contain estimations after load', () {
-  final bloc = EstimationBloc();
-  bloc.loadEstimations();
-
-  // ❌ Accessing private state
-  expect(bloc._cache.length, 5);  // Shouldn't access private!
-});
-
-// ✅ DO THIS INSTEAD:
-blocTest<EstimationBloc, EstimationState>(
-  'should emit EstimationsLoaded after load',
-  build: () => EstimationBloc(repository: repository),
-  act: (bloc) => bloc.add(LoadEstimations()),
-  expect: () => [
-    EstimationLoading(),
-    EstimationsLoaded(estimations: [...]),  // ✅ Observable state
-  ],
-);
-```
-
-### Testing Strategies
-
-#### Strategy 1: Test Public Interface
-
-```dart
-// Example: Service with complex internal logic
-class ValidationService {
-  bool isValidEmail(String email) {
-    return _hasAtSymbol(email) &&
-           _hasValidDomain(email) &&
-           _hasValidLocalPart(email);
-  }
-
-  // Private helpers (implementation details)
-  bool _hasAtSymbol(String email) => email.contains('@');
-  bool _hasValidDomain(String email) { /* ... */ }
-  bool _hasValidLocalPart(String email) { /* ... */ }
-}
-
-// ✅ Test only public method
-test('isValidEmail should return true for valid email', () {
-  final service = ValidationService();
-
-  expect(service.isValidEmail('test@example.com'), true);  // ✅
-  expect(service.isValidEmail('invalid.email'), false);  // ✅
-  expect(service.isValidEmail('no-domain@'), false);  // ✅
-});
-
-// Don't test _hasAtSymbol, _hasValidDomain, etc. directly ❌
-// They're tested indirectly through the public API ✅
-```
-
-#### Strategy 2: Test State Transitions
-
-```dart
-// BLoC: Test observable state changes
-blocTest<EstimationBloc, EstimationState>(
-  'should transition from Empty to Loaded to Updated',
-  build: () => EstimationBloc(repository: repository),
-  act: (bloc) {
-    bloc.add(LoadEstimations('project-1'));
-    // Wait for load to complete in real test
-    bloc.add(UpdateEstimation(estimation));
-  },
-  expect: () => [
-    EstimationLoading(),
-    EstimationsLoaded(estimations: initialList),
-    EstimationsLoaded(estimations: updatedList),  // ✅ Updated state
-  ],
-);
-```
-
-#### Strategy 3: Test Boundary Interactions
-
-```dart
-// Repository: Test data written to/read from data source
-test('should fetch from data source and map to domain', () async {
-  // Arrange
-  fakeDataSource.mockDtos([
-    EstimationDto(id: '1', amountCents: 100000),
-  ]);
-
-  final repository = EstimationRepositoryImpl(
-    dataSource: fakeDataSource,
+  final expectation = expectLater(
+    service.syncStatus,
+    emitsInOrder([SyncStatus.syncing, SyncStatus.completed]),
   );
 
-  // Act
-  final result = await repository.getEstimations('project-1');
-
-  // Assert on domain model (observable output)
-  expect(result.isRight(), true);
-  final estimations = result.getOrElse(() => []);
-  expect(estimations.length, 1);
-  expect(estimations.first.amount, 1000.0);  // ✅ DTO → Domain mapping tested
+  await service.startSync();
+  await expectation;
 });
 ```
 
-### Common Patterns
+Broadcast streams don't buffer — a listener attached after emission misses events. Single-subscription streams do buffer, but subscribing first works for both, so always set up `expectLater` before the act step.
 
-#### ✅ Testing Error Paths
-
-```dart
-test('should return Failure when validation fails', () async {
-  // Arrange: Create invalid input
-  final invalidEmail = 'not-an-email';
-
-  // Act
-  final result = await useCase.execute(invalidEmail);
-
-  // Assert on error result
-  expect(result.isLeft(), true);
-  result.fold(
-    (failure) {
-      expect(failure, isA<ValidationFailure>());  // ✅
-      expect(failure.message, contains('Invalid email'));  // ✅
-    },
-    (_) => fail('Should have returned Failure'),
-  );
-});
-```
-
-#### ✅ Testing Async Streams
-
-```dart
-test('should emit multiple values over time', () async {
-  // Arrange
-  final repository = EstimationRepositoryImpl(
-    dataSource: fakeDataSource,
-  );
-
-  fakeDataSource.setupStreamWithDelays([
-    EstimationDto(id: '1', amount: 100),
-    EstimationDto(id: '2', amount: 200),
-  ]);
-
-  // Act: Subscribe to stream
-  final stream = repository.watchEstimations('project-1');
-
-  // Assert on emitted values
-  await expectLater(
-    stream,
-    emitsInOrder([
-      [Estimation(id: '1', amount: 100)],  // ✅ First emission
-      [Estimation(id: '1', amount: 100), Estimation(id: '2', amount: 200)],  // ✅ Second
-    ]),
-  );
-});
-```
-
-### Refactor-Safe Tests
-
-**Good tests survive refactoring:**
-
-```dart
-// Original implementation
-class Calculator {
-  double calculate(int a, int b) {
-    return (a + b).toDouble();
-  }
-}
-
-// Test (focuses on behavior)
-test('calculate should return sum', () {
-  final calculator = Calculator();
-  expect(calculator.calculate(2, 3), 5.0);  // ✅
-});
-
-// Refactored implementation (different approach, same behavior)
-class Calculator {
-  double calculate(int a, int b) {
-    return _add(a, b);
-  }
-
-  double _add(int x, int y) => (x + y).toDouble();
-}
-
-// ✅ Test still passes! No changes needed.
-// This is a good test - it tests behavior, not implementation.
-```
-
-**Bad tests break on refactoring:**
-
-```dart
-// Bad test (coupled to implementation)
-test('calculate should call _add', () {
-  final calculator = Calculator();
-  final spy = SpyCalculator();  // ❌ Spying on internals
-
-  calculator.calculate(2, 3);
-
-  expect(spy.addWasCalled, true);  // ❌ Implementation detail
-});
-
-// This test breaks if we refactor to not use _add
-// even though behavior is the same!
-```
+Apply the same shape for error paths (trigger via fake, assert on returned `Left(Failure)`) and public-API tests (call the method, assert on return).
 
 ---
 
@@ -424,87 +99,47 @@ test('calculate should call _add', () {
 
 ### Detection Patterns
 
-**Pattern 1: Mock/Verify Usage (Forbidden)**
-
-```bash
-# Find mock usage
-grep -rn "Mock<" test/
-grep -rn "verify(" test/
-grep -rn "when(" test/
-```
-
-**Severity:** Critical
-
-**Pattern 2: Testing Private Methods**
-
-```bash
-# Find underscore-prefixed method calls in tests
-grep -rn "\._[a-zA-Z]" test/
-```
-
-**Severity:** Critical
-
-**Pattern 3: Accessing Private State**
-
-```bash
-# Look for accessing private fields
-grep -rn "\._(cache|state|controller|[a-z][a-zA-Z]*)\b" test/
-```
-
-**Severity:** Major
-
-**Pattern 4: Tests Without Assertions**
-
-```bash
-# Tests that might only verify calls, not outputs
-grep -A 10 "test(" test/ | grep -v "expect("
-```
-
-**Severity:** Major
+| Pattern | Grep | Severity |
+|---|---|---|
+| Mocks | `grep -rn "Mock<\\|verify(\\|when(" test/` | Critical |
+| Private method calls | `grep -rn "\\._[a-zA-Z]" test/` | Critical |
+| Private state access | `grep -rn "\\._\\(cache\\|state\\|controller\\)\\b" test/` | Major |
+| Tests with no assertion | `grep -A 10 "test(" test/ \| grep -v "expect("` | Major |
 
 ### Common Violations
 
 | ❌ Violation | ✅ Fix | Severity |
 |-------------|--------|----------|
 | `verify(mockRepo.save(any))` | Assert on fake boundary state instead | Critical |
-| `calculator._privateMethod()` | Test public API that uses private method | Critical |
+| `calculator._privateMethod()` | Test public API that uses it | Critical |
 | `expect(bloc._cache.length, 5)` | Assert on emitted state instead | Major |
-| `when(mock.method()).thenReturn(...)` | Use test doubles (RULE_3) | Critical |
+| `when(mock.method()).thenReturn(...)` | Use fakes (RULE_3) | Critical |
 | No `expect()` in test body | Add assertions on observable outputs | Major |
+| Test breaks on behavior-preserving refactor | Test is coupled to implementation; rewrite against public API | Major |
 
 ### Review Questions
 
-1. **Does this test use `verify()` or `when()`?**
-   - If YES → Violation (should use test doubles per RULE_3)
-
-2. **Does this test access private methods/fields?**
-   - If YES → Violation (test public API instead)
-
-3. **Would this test break if we refactored without changing behavior?**
-   - If YES → Test is too coupled to implementation
-
-4. **Does this test assert on something a user/caller would observe?**
-   - If NO → Test is probably testing implementation
+1. Does this test use `verify()` or `when()`? → Violation (use fakes per RULE_3).
+2. Does this test access private methods/fields (`._name`)? → Violation.
+3. Would this test break if we refactored without changing behavior? → Coupled to implementation.
+4. Does this test assert on something a caller would observe? → If no, it's testing implementation.
 
 ---
 
 ## Summary: Suggested Fixes
 
-1. **Remove mocks:** Replace with test doubles (fake implementations per RULE_3)
-2. **Test public APIs only:** Remove tests of private methods/state
-3. **Assert on outputs:** Test return values, emitted states, boundary effects
-4. **Make tests refactor-safe:** Tests should pass after internal refactoring
-5. **Focus on behavior:** Test *what* code does, not *how* it does it
+1. **Remove mocks** — replace with fakes (RULE_3).
+2. **Test public APIs only** — drop tests of private methods/state.
+3. **Assert on outputs** — return values, emitted states, boundary effects.
+4. **Make tests refactor-safe** — pass after internal refactoring.
 
 ## References
 
-- [Test-Driven Development by Kent Beck](https://www.amazon.com/Test-Driven-Development-Kent-Beck/dp/0321146530)
-- [Growing Object-Oriented Software, Guided by Tests](https://www.amazon.com/Growing-Object-Oriented-Software-Guided-Tests/dp/0321503627)
 - Review Script Lines: 391-403 in `scripts/review_pr.sh`
 - Related: RULE_3 (Test Double Pattern), RULE_8 (Widget Test Finders)
 
 ## Notes
 
-**Key Insight:** Good tests provide a specification of behavior without constraining implementation. They give you freedom to refactor while ensuring correctness.
+**Key Insight:** Good tests specify behavior without constraining implementation. They give freedom to refactor while ensuring correctness.
 
 **Red Flag:** If refactoring working code breaks tests without changing behavior, your tests are coupled to implementation details.

--- a/skills/rules/10-localization.md
+++ b/skills/rules/10-localization.md
@@ -7,18 +7,18 @@ RULE_10
 Localization
 
 ## Severity Levels
-- Critical: User-facing strings are hardcoded in presentation code.
-- Major: New UI text is added without a localization key.
-- Minor: Localized lookups are present but inconsistent.
-- Suggestion: Prefer localization for all user-visible text.
+- **Critical:** User-facing strings hardcoded in presentation code
+- **Major:** New UI text added without a localization key
+- **Minor:** Localized lookups present but inconsistent
+- **Suggestion:** Prefer localization for all user-visible text
 
 ## Description
 
-All user-facing strings should use `AppLocalizations` or the project localization mixins.
+All user-facing strings use `AppLocalizations` via the `context.l10n` extension. Hardcoded strings are not localized and break i18n.
 
 ## Applicability
 
-This rule applies to all presentation code in `lib/features/**/presentation/` and `lib/app/` that renders user-visible text.
+All presentation code in `lib/features/**/presentation/` and `lib/app/` that renders user-visible text.
 
 ---
 
@@ -26,229 +26,46 @@ This rule applies to all presentation code in `lib/features/**/presentation/` an
 
 ### Core Principle
 
-**Never hardcode user-facing strings.** All text visible to users must be localized using `AppLocalizations` to support internationalization.
+**Never hardcode user-facing strings.** Anything the user reads in the UI comes from `context.l10n.<key>`.
 
-### Decision Tree: Should This String Be Localized?
+### Decision Tree
 
 ```
 Is this string visible to the user in the UI?
-  ├─ YES → Must be localized
-  │        Examples: Button labels, titles, error messages, descriptions
-  │
-  └─ NO → Can be hardcoded (but consider logging)
-           Examples: Log messages, debug strings, internal identifiers
+  ├─ YES → Must be localized (Text/labels/hints/tooltips/snackbars/dialogs/errors)
+  └─ NO  → May be hardcoded (log messages, route names, internal identifiers, test strings)
 ```
 
-### When Writing UI Code
+### Adding a New Localized String
 
-**Before adding ANY user-visible text:**
+1. **Check `lib/l10n/app_en.arb`** for an existing key. If present, reuse it.
+2. **Add a new key** to `app_en.arb` with a `@key` description (and `placeholders` if interpolated).
+3. **Run** `flutter gen-l10n` to regenerate `AppLocalizations`.
+4. **Use** `context.l10n.<key>` in the widget. The `context.l10n` extension lives in `lib/libraries/extensions/build_context_extensions.dart`. Never use raw `AppLocalizations.of(context)?.key ?? ''` — the extension is the project standard. The former `LocalizationMixin` is retired; do not reintroduce it.
 
-1. **Check if localization key exists** in `lib/l10n/app_en.arb`
-   - If YES → Use existing key
-   - If NO → Create new key (see steps below)
+For interpolated strings, declare placeholders in the ARB (`{name}`, `{count, plural, …}`) and call as `context.l10n.welcomeBackUser(userName)` / `context.l10n.estimationCount(items.length)`.
 
-2. **Use localization consistently**
-   - ✅ Use extension: `context.l10n.key` (throws StateError if not configured)
-   - ❌ Never: Hardcoded strings
-   - ❌ Never: Direct `AppLocalizations.of(context)?.key ?? ''` (use extension instead)
+### Key Naming Convention
 
-### How to Add New Localized Strings
+Pattern: `{context}{ElementType}{Description}` — e.g. `buttonSubmit`, `errorInvalidEmail`, `screenTitleSettings`.
 
-**Step 1: Create Localization Key**
-
-```dart
-// Bad: Hardcoded string
-Text('Welcome back')  // ❌
-
-// Good: Use localization key via extension
-Text(context.l10n.welcomeBack)  // ✅
-```
-
-**Step 2: Add Entry to ARB File**
-
-Add to `lib/l10n/app_en.arb`:
-
-```json
-{
-  "welcomeBack": "Welcome back",
-  "@welcomeBack": {
-    "description": "Greeting shown to returning users on login screen"
-  }
-}
-```
-
-**Step 3: Run Code Generation**
-
-```bash
-flutter gen-l10n
-```
-
-This generates the `AppLocalizations` class with your new key.
-
-### Naming Conventions for Localization Keys
-
-Use descriptive, context-aware key names:
-
-| Context | ❌ Bad Key | ✅ Good Key |
-|---------|-----------|------------|
-| Button to submit form | `submit` | `buttonSubmit` or `formSubmitButton` |
+| Context | ❌ Bad | ✅ Good |
+|---|---|---|
+| Form submit button | `submit` | `buttonSubmit` / `formSubmitButton` |
 | Error message | `error` | `errorInvalidEmail` |
-| Screen title | `title` | `screenTitleSettings` or `settingsTitle` |
-| Empty state message | `empty` | `emptyStateNoEstimations` |
+| Screen title | `title` | `settingsTitle` / `screenTitleSettings` |
+| Empty state | `empty` | `emptyStateNoEstimations` |
 | Loading indicator | `loading` | `loadingEstimations` |
-
-**Pattern:** `{context}{ElementType}{Description}`
-- `context`: Where it appears (button, screen, error, etc.)
-- `ElementType`: What it is (Title, Label, Message, etc.)
-- `Description`: What it says/does
-
-### Common Patterns
-
-#### ✅ Using LocalizationMixin (Preferred)
-
-```dart
-class LoginScreen extends StatelessWidget with LocalizationMixin {
-  @override
-  Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        title: Text(l10n?.screenTitleLogin ?? ''),  // ✅
-      ),
-      body: Column(
-        children: [
-          Text(l10n?.loginWelcomeMessage ?? ''),  // ✅
-          CoreButton(
-            label: l10n?.buttonLogin ?? '',  // ✅
-            onPressed: () => _handleLogin(),
-          ),
-          if (state.hasError)
-            Text(
-              l10n?.errorInvalidCredentials ?? '',  // ✅
-              style: CoreTypography.bodySmallRegular().copyWith(
-                color: CoreTextColors.error,
-              ),
-            ),
-        ],
-      ),
-    );
-  }
-}
-```
-
-#### ✅ Using Localization Extension
-
-```dart
-class SettingsScreen extends StatelessWidget {
-  @override
-  Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        title: Text(context.l10n.screenTitleSettings),  // ✅ Extension
-      ),
-      body: ListView(
-        children: [
-          ListTile(
-            title: Text(context.l10n.settingsLanguage),  // ✅ Extension
-            subtitle: Text(context.l10n.settingsLanguageDescription),  // ✅ Extension
-          ),
-        ],
-      ),
-    );
-  }
-}
-```
-
-#### ❌ Wrong: Hardcoded Strings
-
-```dart
-// Bad: All hardcoded
-class LoginScreen extends StatelessWidget {
-  @override
-  Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        title: Text('Login'),  // ❌ Hardcoded
-      ),
-      body: Column(
-        children: [
-          Text('Welcome back'),  // ❌ Hardcoded
-          CoreButton(
-            label: 'Login',  // ❌ Hardcoded
-            onPressed: () => _handleLogin(),
-          ),
-          if (state.hasError)
-            Text('Invalid credentials'),  // ❌ Hardcoded
-        ],
-      ),
-    );
-  }
-}
-```
 
 ### What CAN Be Hardcoded
 
-✅ **Allowed (Technical/Debug Strings):**
+Non-user-facing strings only:
+
 ```dart
-// Log messages
-AppLogger.debug('User login attempt');  // ✅ Not user-facing
-
-// Internal identifiers
-const String loginRoute = '/login';  // ✅ Technical
-
-// Test strings
-expect(find.text('test@example.com'), findsOneWidget);  // ✅ Test code
-
-// Empty strings
-Text('')  // ✅ Placeholder
-```
-
-### Interpolation and Dynamic Values
-
-**For strings with dynamic values:**
-
-ARB file:
-```json
-{
-  "welcomeBackUser": "Welcome back, {name}!",
-  "@welcomeBackUser": {
-    "description": "Personalized greeting",
-    "placeholders": {
-      "name": {
-        "type": "String",
-        "example": "John"
-      }
-    }
-  }
-}
-```
-
-Usage:
-```dart
-Text(l10n?.welcomeBackUser(userName) ?? '')  // ✅
-```
-
-### Pluralization
-
-**For strings that need plural forms:**
-
-ARB file:
-```json
-{
-  "estimationCount": "{count, plural, =0{No estimations} =1{1 estimation} other{{count} estimations}}",
-  "@estimationCount": {
-    "description": "Count of estimations",
-    "placeholders": {
-      "count": {
-        "type": "int"
-      }
-    }
-  }
-}
-```
-
-Usage:
-```dart
-Text(l10n?.estimationCount(estimations.length) ?? '')  // ✅
+AppLogger.debug('User login attempt');       // ✅ log message
+const String loginRoute = '/login';          // ✅ internal identifier
+expect(find.text('test@example.com'), ...);  // ✅ test code
+Text('')                                     // ✅ empty placeholder
 ```
 
 ---
@@ -257,132 +74,53 @@ Text(l10n?.estimationCount(estimations.length) ?? '')  // ✅
 
 ### Detection Patterns
 
-Search for violations in presentation code using these patterns:
+| # | Indicator | Regex / Grep | Severity | Fix |
+|---|---|---|---|---|
+| 1 | `Text(...)` with hardcoded string | `Text\s*\(\s*['"]([a-zA-Z][^'"]*)['"]` | Critical | `Text(context.l10n.<key>)` |
+| 2 | Hardcoded button / hint / tooltip / title | `(label\|hint\|tooltip\|title\|placeholder\|child:\s*Text)\s*:\s*['"]([a-zA-Z][^'"]*)['"]` | Critical | `label: context.l10n.<key>` |
+| 3 | Hardcoded snackbar / dialog / error message | `(showSnackBar\|showDialog\|showToast\|showAlert)\s*\([^)]*['"]([a-zA-Z][^'"]*)['"]` | Critical | Extract key, use `context.l10n.<key>` |
+| 4 | File imports `AppLocalizations` but still hardcodes UI strings | — | Major | Apply localization consistently |
+| 5 | Mixes `context.l10n.key` with `AppLocalizations.of(context)?.key` | — | Minor | Standardize on `context.l10n.<key>` |
+| 6 | Uses retired `LocalizationMixin` | `with\s+LocalizationMixin` | Minor | Remove mixin; use `context.l10n.<key>` |
 
-### Pattern 1: Hardcoded Text Strings
+**Exceptions for Pattern 1:** technical/debug strings, hardcoded IDs (`key:`, `id_…`, URLs), empty strings, single characters.
 
-**Indicator:** `Text()` widget with a hardcoded string literal (not from localization)
-
-**Examples to catch:**
-- `Text('Welcome back')`
-- `Text('Click here')`
-- `Text('Loading...')`
-- `Text('Error occurred')`
-
-**Regex:** `Text\s*\(\s*['\"]([a-zA-Z][^'\"]*)['\"]`
-
-**Severity:** Critical
-
-**Exceptions:**
-- Technical/debug strings (allowed but not recommended)
-- Hardcoded IDs or identifiers (technical strings)
-- Empty strings or single characters
-- Strings matching known technical patterns (e.g., `key:`, `id_`, URLs)
-
-**Fix:** Replace with `Text(context.l10n.yourStringKey)` using the BuildContext extension
-
----
-
-### Pattern 2: Hardcoded Button/Label Text
-
-**Indicator:** Button labels, field labels, or tooltip text without localization
-
-**Examples to catch:**
-- `label: 'Logout'`
-- `hint: 'Enter email'`
-- `tooltip: 'Save changes'`
-- `title: 'Settings'`
-- `ElevatedButton(onPressed: ..., child: Text('Submit'))`
-
-**Regex:** `(label|hint|tooltip|title|placeholder|child:\s*Text)\s*:\s*['\"]([a-zA-Z][^'\"]*)['\"]`
-
-**Severity:** Critical
-
-**Fix:** Create localization key and use: `label: context.l10n.buttonSubmit`
-
----
-
-### Pattern 3: Hardcoded Error Messages
-
-**Indicator:** Error or validation messages shown to users without localization
-
-**Examples to catch:**
-- `showSnackBar('Invalid email')`
-- `ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text('Error')))`
-- `throw Exception('User not found')`
-- `showDialog(title: 'Alert', content: Text('Something went wrong'))`
-
-**Regex:** `(showSnackBar|showDialog|showToast|showAlert)\s*\([^)]*['\"]([a-zA-Z][^'\"]*)['\"]`
-
-**Severity:** Critical
-
-**Fix:** Extract to localization and reference via `context.l10n.errorMessageKey`
-
----
-
-### Pattern 4: Missing AppLocalizations Usage
-
-**Indicator:** Localization functions/mixins available but not used in new code
-
-**Detection approach:**
-- File imports `AppLocalizations` or `LocalizationMixin`
-- But contains Pattern 1, 2, or 3 violations
-- Indicates inconsistent adoption
-
-**Severity:** Major
-
-**Fix:** Use imported localization consistently throughout file
-
----
-
-### Pattern 5: Inconsistent Localization Access
-
-**Indicator:** Widget mixes different localization patterns in same file
-
-**Examples:**
-- Some text uses `context.l10n.key`
-- Other text uses hardcoded strings
-- Mixed patterns (old `AppLocalizations.of(context)?.key` with new extension)
-
-**Severity:** Minor (code smell, not breaking)
-
-**Fix:** Standardize on extension pattern: use `context.l10n.key` for all localized strings.
-
----
-
-**Agent Workflow:**
+### Agent Workflow
 
 ```
-For each applicable file:
-  1. Check if file uses BuildContext (needed for context.l10n extension)
-  2. Search file for all Text() and widget label definitions
-  3. For each match:
-     a. Determine if string is user-facing (not technical/debug)
-     b. Check if already using localization (context.l10n.key)
-     c. If not localized: flag as violation
-     d. Extract context and line number
-  4. Check for mixed patterns (old AppLocalizations vs extension)
-  5. Create issue objects with severity
-  6. Return all issues with suggested fix (which localization key to use)
+For each presentation file changed:
+  1. Find all Text(...), label:/hint:/tooltip:/title:/placeholder:, snackbar/dialog calls.
+  2. For each match:
+     a. Is the string user-facing? (skip technical/debug)
+     b. Is it `context.l10n.<key>`? Pass.
+     c. Otherwise flag with Pattern # and severity.
+  3. Flag mixed access patterns (Pattern 5) and retired `LocalizationMixin` usage (Pattern 6) as Minor.
+  4. Suggest a key name following the {context}{ElementType}{Description} convention.
 ```
+
+### Common Violations
+
+| ❌ Violation | ✅ Fix | Severity |
+|---|---|---|
+| `Text('Welcome back')` | `Text(context.l10n.welcomeBack)` | Critical |
+| `label: 'Login'` | `label: context.l10n.buttonLogin` | Critical |
+| `showSnackBar(SnackBar(content: Text('Error')))` | localize error message via `context.l10n.<key>` | Critical |
+| `AppLocalizations.of(context)?.key ?? ''` | `context.l10n.key` | Minor |
+| `class MyWidget with LocalizationMixin` | Drop the mixin; use `context.l10n.<key>` | Minor |
+
+---
 
 ## Summary: Suggested Fixes
 
-Replace hardcoded strings with localized keys and add the missing entry to the ARB files.
-
-**Steps to fix:**
-1. Identify all hardcoded user-facing strings in the changed file
-2. For each string, create a unique localization key following the naming pattern: `{context}{ElementType}{Description}`
-   - Examples: `buttonSubmit`, `errorInvalidEmail`, `screenTitleSettings`
-3. Add entry to `lib/l10n/app_en.arb` with the English text and description
-4. Run `flutter gen-l10n` to regenerate AppLocalizations class
-5. Replace hardcoded string with:
-   - Using extension: `Text(context.l10n.buttonSubmit)` ✅ Preferred
-   - See: `lib/libraries/extensions/build_context_extensions.dart` for extension implementation
+1. Identify all hardcoded user-facing strings in the diff.
+2. For each: create a key following `{context}{ElementType}{Description}`.
+3. Add entry to `lib/l10n/app_en.arb` (with `@key` description and `placeholders` if needed).
+4. Run `flutter gen-l10n`.
+5. Replace with `Text(context.l10n.<key>)` (or `label: context.l10n.<key>` etc.).
 
 ## References
 
 - [Flutter Localization Guide](https://flutter.dev/docs/development/accessibility-and-localization/internationalization)
-- ARB files location: `lib/l10n/app_en.arb`
-- AppLocalizations class: Generated from ARB files in `lib/l10n/`
+- ARB file: `lib/l10n/app_en.arb`
+- Extension: `lib/libraries/extensions/build_context_extensions.dart`
 - Review Script Lines: 408-432 in `scripts/review_pr.sh`

--- a/skills/rules/13-mutation-testing.md
+++ b/skills/rules/13-mutation-testing.md
@@ -14,262 +14,77 @@ Testing - Quality Assurance
 
 ## Description
 
-PRs that introduce or modify complex business logic, mathematical calculations, or data transformations must be validated with mutation testing. This ensures unit tests actually verify correctness, not just code coverage.
+PRs that introduce or modify complex business logic, mathematical calculations, or data transformations are validated with mutation testing — introducing bugs (mutants) and checking whether tests catch them. This validates that tests verify *correctness*, not just line coverage.
 
-**Core Principle:** Mutation testing finds gaps in your test suite by introducing bugs (mutants) and checking if tests catch them.
+**Core Principle:** mutation testing finds gaps in your tests that code coverage cannot detect.
 
 ## Applicability
 
-**This is a GATED practice.** Only apply to:
-- Files with complex business logic (3+ conditional branches)
-- Mathematical calculations or algorithms
+**GATED.** Apply only to:
+- Files with 3+ conditional branches
+- Mathematical calculations / algorithms
 - Data transformation logic (pagination, filtering, sorting)
-- Critical decision paths (authentication, authorization, payment)
+- Critical decision paths (auth, authorization, payment)
 
-**DO NOT apply to:**
-- Simple CRUD operations
-- UI/presentation code (use widget tests instead)
-- Generated code
+**Do NOT apply to:** simple CRUD, UI/presentation, generated code.
 
-**Typical targets:**
-- `lib/features/**/domain/usecases/*.dart`
-- `lib/features/**/domain/services/*.dart`
-- `lib/features/**/data/repositories/*_impl.dart`
-- `lib/features/**/data/data_source/*.dart` (if contains logic)
+**Typical targets:** `lib/features/**/domain/usecases/*.dart`, `lib/features/**/domain/services/*.dart`, `lib/features/**/data/repositories/*_impl.dart`, `lib/features/**/data/data_source/*.dart` (if it contains logic).
 
 ---
 
 ## For Coding Agents (Prescriptive)
 
-### Decision Gate: Should I Run Mutation Testing?
+### Decision Gate
 
 ```
-Does the class contain logic-heavy code?
+Does the file contain logic-heavy code?
 
-├─ Complex conditionals (3+ branches)?
-│  └─ YES → Run mutation testing
-│
-├─ Mathematical calculations?
-│  └─ YES → Run mutation testing
-│
-├─ Data transformation logic?
-│  └─ YES → Run mutation testing
-│
-├─ Critical decision paths?
-│  └─ YES → Run mutation testing
-│
-└─ Simple CRUD or UI code?
-   └─ NO → Skip mutation testing
+├─ Complex conditionals (3+ branches)?  → Run mutation testing
+├─ Mathematical calculations?           → Run mutation testing
+├─ Data transformation logic?           → Run mutation testing
+├─ Critical decision paths?             → Run mutation testing
+└─ Simple CRUD / UI code?               → Skip
 ```
 
-### What is Mutation Testing?
+### What Mutation Testing Does
 
-**Concept:** Mutation testing modifies your code (introduces "mutants") and checks if your tests catch the bugs.
+The tool changes one operator/branch/return at a time (a "mutant") and re-runs tests. If tests still pass, the mutant **survived** → there's a gap. If tests fail, the mutant was **killed** → tests cover that behavior. Equivalent mutants (no behavior change, e.g. `&&` → `&` with no short-circuit difference) cannot be killed and are excluded.
 
-**Example:**
+### Score Thresholds
 
-```dart
-// Original code
-if (amount > 0) {
-  processPayment(amount);
-}
+- **Critical paths** (auth, authorization, payment, financial calculations, security-relevant validation): **≥ 85%**.
+- **Non-critical logic** (display formatting, UI-side sorting/filtering, secondary features): **≥ 70%** acceptable.
+- **< 60% on any logic-heavy file:** insufficient — add tests for surviving mutants and re-run.
 
-// Mutant 1: Changed > to >=
-if (amount >= 0) {  // 🧬 Mutant
-  processPayment(amount);
-}
+### Mutation Categories to Hand-Author
 
-// Mutant 2: Changed > to <
-if (amount < 0) {  // 🧬 Mutant
-  processPayment(amount);
-}
+The repo runs `mutation_test` with `--no-builtin`, so all mutations are explicit `<regex pattern="…" id="…"><mutation text="…"/></regex>` rules in the XML config — not auto-generated. Cover at least these categories per file:
 
-// Mutant 3: Removed condition
-processPayment(amount);  // 🧬 Mutant
-
-// If your tests pass with any of these mutants,
-// it means you have a gap in your test coverage!
-```
-
-### When to Use
-
-**✅ Run mutation testing for:**
-
-- **Complex conditionals:**
-  ```dart
-  if (user.isAdmin && project.isActive || user.isOwner) {
-    // Logic with multiple conditions
-  }
-  ```
-
-- **Mathematical operations:**
-  ```dart
-  double calculateDiscount(double price, int loyaltyPoints) {
-    final baseDiscount = price * 0.1;
-    final bonusDiscount = loyaltyPoints > 1000 ? price * 0.05 : 0;
-    return baseDiscount + bonusDiscount;
-  }
-  ```
-
-- **Data transformations:**
-  ```dart
-  List<Estimation> paginateEstimations(List<Estimation> all, int page, int pageSize) {
-    final start = page * pageSize;
-    final end = min(start + pageSize, all.length);
-    return all.sublist(start, end);
-  }
-  ```
-
-**❌ Skip mutation testing for:**
-
-- Simple getters/setters
-- UI widgets
-- Data models (freezed classes)
-- Simple CRUD without logic
-
-### How to Run Mutation Testing
-
-**Step 1: Install mutant (mutation testing tool)**
-
-```yaml
-# pubspec.yaml
-dev_dependencies:
-  mutant: ^latest_version
-  # See: https://pub.dev/packages/mutant
-```
-
-**Step 2: Run mutation tests on specific file**
-
-```bash
-# Target specific logic-heavy file
-dart run mutant \
-  --file lib/features/estimation/domain/usecases/calculate_total_usecase.dart \
-  --test-file test/features/estimation/domain/usecases/calculate_total_usecase_test.dart
-```
-
-**Step 3: Analyze results**
-
-```
-Mutation Score: 85% (17/20 mutants killed)
-
-Surviving Mutants:
-- Line 42: Changed > to >= (SURVIVED)
-- Line 58: Removed null check (SURVIVED)
-- Line 71: Changed + to - (SURVIVED)
-```
-
-**Step 4: Add tests for surviving mutants**
-
-```dart
-// Surviving mutant: Changed > to >=
-// This means we're missing a boundary test!
-
-// Add test
-test('should not process payment when amount is exactly zero', () async {
-  final result = await useCase.execute(amount: 0.0);
-
-  expect(result.isLeft(), true);  // Should fail, not process
-  // ✅ Now mutant is killed
-});
-```
-
-### Target: 80% Mutation Score
-
-**Acceptable mutation score: ≥80%**
-
-- 80-100%: Excellent coverage ✅
-- 60-79%: Acceptable for non-critical logic ⚠️
-- <60%: Insufficient, add more tests ❌
-
-**Note:** 100% is ideal but not always necessary. Some mutants are equivalent (don't change behavior).
-
-### Common Mutation Types
-
-| Mutation Type | Example | What it Tests |
-|---------------|---------|---------------|
-| **Conditional Boundary** | `>` → `>=` | Boundary conditions |
-| **Negation** | `if (x)` → `if (!x)` | Boolean logic |
+| Category | Example rule (regex → mutation) | What it Tests |
+|---|---|---|
+| **Conditional boundary** | `>` → `>=` | Boundary conditions |
+| **Negation** | `if (x)` → `if (!x)`, `isEmpty` → `isNotEmpty` | Boolean logic |
 | **Arithmetic** | `+` → `-`, `*` → `/` | Calculations |
-| **Return Value** | `return x` → `return null` | Null handling |
-| **Constant** | `0.1` → `0.0` | Magic numbers |
-| **Statement Deletion** | Remove line | Statement necessity |
+| **Return value** | `return Right(x)` → `return Left(UnexpectedFailure())` | Failure / success paths |
+| **Constant** | `0.0` → `10.0`, `MarkupType.overall` → `MarkupType.perAssembly` | Magic values / enum cases |
+| **Skip statement / null-replace** | `value = compute();` → `value = null;` | Statement necessity |
 
-### Writing Tests to Kill Mutants
+See `test/features/estimations/mutations/add_cost_estimation_usecase.xml` for a worked example (23 rules covering all six categories).
 
-**Strategy 1: Test Boundary Conditions**
+### Canonical Test Pattern — Boundary Mutants
 
-```dart
-// Code with boundary
-if (age >= 18) {
-  grantAccess();
-}
-
-// Tests to kill boundary mutants
-test('should grant access when age is exactly 18', () { });  // Boundary
-test('should deny access when age is 17', () { });  // Just below
-test('should grant access when age is 19', () { });  // Just above
-```
-
-**Strategy 2: Test All Branches**
+When the survived mutant is a boundary change (`>` → `>=`), add a boundary-equality test:
 
 ```dart
-// Code with multiple branches
-if (status == 'active') {
-  return ActiveState();
-} else if (status == 'pending') {
-  return PendingState();
-} else {
-  return InactiveState();
-}
+// Source
+if (age >= 18) grantAccess();
 
-// Tests to kill branch mutants
-test('should return ActiveState when status is active', () { });
-test('should return PendingState when status is pending', () { });
-test('should return InactiveState when status is neither', () { });
+// Tests that kill the boundary mutant
+test('grants access at the boundary (age == 18)', () { /* … */ });
+test('denies access just below the boundary (age == 17)', () { /* … */ });
 ```
 
-**Strategy 3: Test Calculations**
-
-```dart
-// Code with calculation
-double calculateTax(double price) {
-  return price * 0.08;
-}
-
-// Tests to kill arithmetic mutants
-test('should calculate 8% tax correctly', () {
-  expect(calculateTax(100.0), 8.0);  // Kills * → /, * → +, etc.
-});
-test('should return 0 for 0 price', () {
-  expect(calculateTax(0.0), 0.0);  // Kills constant mutations
-});
-```
-
-### Interpreting Results
-
-**Mutant Killed ✅:**
-```
-✓ Mutant: Changed > to >= on line 42
-  Test: should not process zero amount
-  Status: KILLED
-```
-→ Good! Your test caught the bug.
-
-**Mutant Survived ❌:**
-```
-✗ Mutant: Changed > to >= on line 42
-  Test: (no test failed)
-  Status: SURVIVED
-```
-→ Gap in tests! Add test for boundary condition.
-
-**Equivalent Mutant ⚠️:**
-```
-~ Mutant: Changed && to &
-  Note: Logically equivalent (no short-circuit difference)
-  Status: EQUIVALENT
-```
-→ Can't be killed (doesn't change behavior). Mark as equivalent.
+The same shape applies to arithmetic mutants (assert exact result for non-zero and zero inputs) and branch mutants (one test per branch).
 
 ---
 
@@ -277,99 +92,47 @@ test('should return 0 for 0 price', () {
 
 ### Detection Patterns
 
-**Pattern 1: Logic-Heavy Files Without Mutation Testing**
-
-Identify files with complex logic:
-
-```bash
-# Find files with multiple conditionals
-grep -rn "if.*&&\|if.*||" lib/features/**/domain/ | wc -l
-
-# Find files with calculations
-grep -rn "[+\-*/]" lib/features/**/domain/usecases/ lib/features/**/data/repositories/
-```
-
-**If file has 3+ conditional branches** → Should have mutation test results
-
-**Pattern 2: Low Mutation Score in PR**
-
-Check if mutation score is mentioned:
-- Look for mutation test output in PR description or comments
-- Check for `mutation_score:` annotation
-
-**If mutation score <80%** → Major violation
-
-**Pattern 3: Surviving Mutants in Critical Paths**
-
-Critical paths:
-- Authentication/authorization logic
-- Payment/financial calculations
-- Data validation logic
-- Access control checks
-
-**If critical path has surviving mutants** → Critical violation
+| Pattern | Grep / Indicator | Severity |
+|---|---|---|
+| Logic-heavy file with no mutation run | `grep -rn "if.*&&\\|if.*\\|\\|" lib/features/**/domain/ \| wc -l` (3+ in one file) and no mutation report | Major |
+| Mutation score below threshold (85% critical / 70% non-critical) | mutation-test-report or PR description | Critical (<60%) / Major (60% – threshold) |
+| Surviving mutant in auth / payment / authorization | identify file + line in mutation report | Critical |
 
 ### Review Questions
 
-1. **Does this PR modify logic-heavy code?**
-   - If YES → Check for mutation test results
-
-2. **What is the mutation score?**
-   - <60%: Critical
-   - 60-79%: Major
-   - ≥80%: Good ✅
-
-3. **Are there surviving mutants?**
-   - Check which mutants survived
-   - Are they in critical code paths?
-
-4. **Were new tests added to kill mutants?**
-   - Look for test additions addressing gaps
+1. Does this PR modify logic-heavy code? → if yes, expect mutation results.
+2. What's the mutation score? → <60% Critical, 60% – threshold Major, ≥ threshold pass (threshold is 85% for critical paths, 70% otherwise).
+3. Are surviving mutants in critical paths? → Critical.
+4. Were new tests added to kill the surviving mutants? → expect tests for each.
 
 ### Common Violations
 
 | ❌ Violation | ✅ Fix | Severity |
-|-------------|--------|----------|
+|---|---|---|
 | Complex logic added, no mutation testing | Run mutation tests, report score | Major |
-| Mutation score <80% | Add tests for surviving mutants | Critical |
-| Surviving mutant in auth logic | Add test for that specific condition | Critical |
-| No mutation testing in PR with calculations | Run mutation tests on calculation logic | Major |
+| Mutation score below threshold (85% critical / 70% non-critical) | Add tests for surviving mutants | Critical |
+| Surviving mutant in auth / payment logic | Add test for that specific condition | Critical |
+| No mutation testing in PR with calculations | Run mutation tests on the calculation logic | Major |
 
 ---
 
-## Summary: How to Apply
+## Summary
 
-**For Developers:**
+**Dev workflow:** identify logic-heavy files → run mutation tests on them → kill surviving mutants → include score in PR description.
 
-1. **Before PR:** Identify logic-heavy files you changed
-2. **Run mutation tests:** Target those specific files
-3. **Analyze results:** Note mutation score and surviving mutants
-4. **Add tests:** Write tests to kill surviving mutants
-5. **Document in PR:** Include mutation score in PR description
-
-**For Reviewers:**
-
-1. **Identify logic changes:** Look for complex conditionals, calculations
-2. **Request mutation testing:** If logic-heavy and not tested
-3. **Check score:** Ensure ≥80% mutation score
-4. **Review surviving mutants:** Ensure none in critical paths
+**Reviewer workflow:** spot logic changes → require mutation score → enforce thresholds (85% critical paths, 70% non-critical) → no surviving mutants in critical paths.
 
 ## References
 
-- [Mutation Testing Introduction](https://en.wikipedia.org/wiki/Mutation_testing)
-- [Stryker Mutator](https://stryker-mutator.io/) - Popular mutation testing framework
-- [Dart Mutant Package](https://pub.dev/packages/mutant)
+- [Mutation Testing (Wikipedia)](https://en.wikipedia.org/wiki/Mutation_testing)
+- [Dart `mutation_test` package](https://pub.dev/packages/mutation_test) — declared as `dev_dependency` in `pubspec.yaml`
+- CI runner: `scripts/run_check.sh` (`run_mutation_tests`, line 202) and `docs/Testing/CI-Scripts.md`
 - Review Script Lines: 484-496 in `scripts/review_pr.sh`
+
+**Related:** if you also need to *run* the tool (commands, config XML, output interpretation), the `write-tests-mutation` skill is the operational runbook.
 
 ## Notes
 
-**Mutation Testing vs Code Coverage:**
+**Mutation testing vs code coverage:** coverage asks "did this line run?"; mutation asks "do tests verify this line is correct?". 100% coverage with weak assertions still passes survived mutants.
 
-- **Code Coverage:** Did tests execute this line? (quantity)
-- **Mutation Testing:** Do tests verify this line is correct? (quality)
-
-You can have 100% code coverage but still have bugs that tests don't catch. Mutation testing finds those gaps.
-
-**Best Practice:** Run mutation testing during PR review for logic-heavy changes, not on every commit (it's slow).
-
-**Time Consideration:** Mutation testing is computationally expensive. Run it only on changed files, not entire codebase.
+**Cost:** mutation testing is slow — run on changed files only, in PR review (not every commit).

--- a/skills/rules/14-accessibility-testing.md
+++ b/skills/rules/14-accessibility-testing.md
@@ -7,7 +7,7 @@ RULE_14
 Testing - Accessibility
 
 ## Severity Levels
-- **Critical:** Interactive elements without semantic labels or removing semantics without justification
+- **Critical:** Interactive elements without semantic labels, or removing semantics without justification
 - **Major:** UI changes to key screens without updating a11y tests
 - **Minor:** Missing accessibility checks in widget tests for new interactive elements
 - **Suggestion:** Consider adding semantic labels for screen reader support
@@ -16,7 +16,7 @@ Testing - Accessibility
 
 User-facing flows must remain perceivable, operable, and understandable for assistive technology users. Accessibility-focused widget tests must be added or updated when UI structure, semantics, or interaction patterns change.
 
-**This is a GATED practice:** Only applies when modifying user-facing UI screens.
+**GATED:** only applies when modifying user-facing UI.
 
 ## Applicability
 
@@ -37,382 +37,41 @@ User-facing flows must remain perceivable, operable, and understandable for assi
 ```
 Is this change user-facing UI?
 
-├─ New screen or major UI change?
-│  └─ YES → Create new a11y test file
-│
-├─ Modification to existing interactive screen?
-│  └─ YES → Update existing a11y test
-│
-├─ New interactive element (button, input)?
-│  └─ YES → Add semantic labels + a11y assertions
-│
-└─ Backend/domain logic only?
-   └─ NO → Skip a11y tests
+├─ New screen or major UI change?              → Create new a11y test file
+├─ Modification to existing interactive screen?→ Update existing a11y test
+├─ New interactive element (button, input)?    → Add semantic labels + a11y test
+└─ Backend/domain logic only?                  → Skip a11y tests
 ```
-
-### Core Principles
-
-1. **Perceivable:** All information must be available to screen readers
-2. **Operable:** All interactions must work with assistive technology
-3. **Understandable:** Navigation and feedback must be clear
-4. **Robust:** Works across different assistive technologies
 
 ### Making Widgets Accessible
 
-#### ✅ Add Semantic Labels
+- **Semantic labels:** every interactive element needs a label — prefer `IconButton(tooltip: ...)`, or wrap in `Semantics(label:, button: true, ...)`. Decorative widgets may set `excludeSemantics: true` — **never** on interactive elements.
+- **Tap targets ≥48×48 dp:** prefer `IconButton` (enforces it) or add `Padding` around custom `GestureDetector`s.
+- **Contrast:** use `CoreTextColors.*` / CoreUI tokens (pre-validated). Don't hand-pick low-contrast hex colors.
+- **Focus order:** rely on widget tree order; only override with `Focus`/`FocusTraversalGroup` when needed.
 
-**Interactive elements MUST have meaningful labels:**
+### Writing A11y Tests — Use the Shared Helpers
 
-```dart
-// ❌ Bad: Icon without label
-IconButton(
-  icon: Icon(Icons.close),
-  onPressed: () => Navigator.pop(context),
-)
+All a11y tests use helpers from **`test/utils/a11y/a11y_guidelines.dart`**:
 
-// ✅ Good: Icon with semantic label
-IconButton(
-  icon: Icon(Icons.close),
-  onPressed: () => Navigator.pop(context),
-  tooltip: 'Close dialog',  // ✅ Screen reader announces this
-)
+- `setupA11yTest(tester)` — sets the standard a11y surface size, restores it in tear-down.
+- `expectMeetsTapTargetAndLabelGuidelines(tester, finder)` — asserts Android + iOS tap target, labeled tap target, text contrast.
+- `expectMeetsTapTargetAndLabelGuidelinesForEachTheme(tester, buildWidget, finder)` — runs the same assertions in both light and dark themes; use this for screen-level tests.
 
-// ✅ Better: Explicit semantics
-Semantics(
-  label: 'Close dialog',
-  button: true,
-  child: IconButton(
-    icon: Icon(Icons.close),
-    onPressed: () => Navigator.pop(context),
-  ),
-)
-```
-
-**Decorative elements can exclude semantics:**
+Canonical pattern:
 
 ```dart
-// ✅ Good: Decorative icon (not interactive)
-Semantics(
-  excludeSemantics: true,  // ✅ Justified: decorative only
-  child: Icon(Icons.star, color: Colors.gold),
-)
-
-// But adjacent text should have label:
-Text('Premium Feature')  // Screen reader reads this instead
-```
-
-#### ✅ Ensure Tap Target Size
-
-**Minimum tap target: 48x48 dp**
-
-```dart
-// ❌ Bad: Small tap target
-GestureDetector(
-  onTap: () => handleTap(),
-  child: Container(
-    width: 24,  // ❌ Too small
-    height: 24,
-    child: Icon(Icons.delete),
-  ),
-)
-
-// ✅ Good: Adequate tap target
-IconButton(  // IconButton enforces 48x48 minimum
-  icon: Icon(Icons.delete),
-  onPressed: () => handleTap(),
-  tooltip: 'Delete item',
-)
-
-// ✅ Good: Custom with padding
-GestureDetector(
-  onTap: () => handleTap(),
-  child: Padding(
-    padding: EdgeInsets.all(12),  // ✅ Increases tap area
-    child: Icon(Icons.delete, size: 24),
-  ),
-)
-```
-
-#### ✅ Provide Text Contrast
-
-**Minimum contrast ratios:**
-- Normal text: 4.5:1
-- Large text (18pt+): 3:1
-- Interactive elements: 3:1
-
-```dart
-// ✅ Use CoreUI colors (pre-validated for contrast)
-Text(
-  'Important message',
-  style: CoreTypography.bodyMediumRegular().copyWith(
-    color: CoreTextColors.primary,  // ✅ Meets contrast requirements
-  ),
-)
-
-// ❌ Avoid custom low-contrast colors
-Text(
-  'Hard to read',
-  style: TextStyle(
-    color: Color(0xFFCCCCCC),  // ❌ Likely fails contrast check
-  ),
-)
-```
-
-#### ✅ Support Focus Navigation
-
-```dart
-// ✅ Good: Focusable interactive element
-FocusableActionDetector(
-  child: CoreButton(
-    label: 'Submit',
-    onPressed: () => handleSubmit(),
-  ),
-)
-
-// ✅ Good: Custom focus order
-Focus(
-  skipTraversal: false,  // ✅ Included in tab order
-  child: CustomInteractiveWidget(...),
-)
-```
-
-### Writing A11y Tests
-
-#### Test Structure
-
-```dart
-// test/features/auth/widgets/accessibility/login_screen_a11y_test.dart
-
-import 'package:flutter_test/flutter_test.dart';
-import 'package:your_app/test_helpers/a11y_test_helpers.dart';
-
-void main() {
-  group('LoginScreen Accessibility', () {
-    testWidgets('should meet tap target guidelines', (tester) async {
-      // Arrange: Set up a11y test environment
-      await setupA11yTest(tester);  // Helper: disables overflow checks
-
-      await tester.pumpWidget(
-        MaterialApp(home: LoginScreen()),
-      );
-
-      // Act & Assert: Check tap targets and labels
-      await expectMeetsTapTargetAndLabelGuidelines(
-        tester,
-        excludedPaths: ['decorative_icon'],  // Can exclude decorative elements
-      );
-    });
-
-    testWidgets('should support both light and dark themes', (tester) async {
-      await setupA11yTest(tester);
-
-      // Test light theme
-      await tester.pumpWidget(
-        MaterialApp(
-          theme: CoreTheme.lightTheme,
-          home: LoginScreen(),
-        ),
-      );
-      await expectMeetsTapTargetAndLabelGuidelines(tester);
-
-      // Test dark theme
-      await tester.pumpWidget(
-        MaterialApp(
-          theme: CoreTheme.darkTheme,
-          home: LoginScreen(),
-        ),
-      );
-      await expectMeetsTapTargetAndLabelGuidelines(tester);
-    });
-
-    testWidgets('should have semantic labels for all interactive elements', (tester) async {
-      await setupA11yTest(tester);
-      await tester.pumpWidget(MaterialApp(home: LoginScreen()));
-
-      // Assert: All buttons have labels
-      final semantics = tester.getSemantics(find.byType(IconButton).first);
-      expect(semantics.label, isNotEmpty);  // ✅ Has label
-      expect(semantics.isButton, true);  // ✅ Marked as button
-    });
-
-    testWidgets('should have proper focus order', (tester) async {
-      await setupA11yTest(tester);
-      await tester.pumpWidget(MaterialApp(home: LoginScreen()));
-
-      // Verify focus order: email → password → submit
-      final emailField = find.byKey(Key('email_input'));
-      final passwordField = find.byKey(Key('password_input'));
-      final submitButton = find.byKey(Key('submit_button'));
-
-      // Test tab navigation
-      await tester.sendKeyEvent(LogicalKeyboardKey.tab);
-      expect(tester.binding.focusManager.primaryFocus?.debugLabel,
-             contains('email'));  // ✅ First field focused
-
-      await tester.sendKeyEvent(LogicalKeyboardKey.tab);
-      expect(tester.binding.focusManager.primaryFocus?.debugLabel,
-             contains('password'));  // ✅ Second field focused
-
-      await tester.sendKeyEvent(LogicalKeyboardKey.tab);
-      expect(tester.binding.focusManager.primaryFocus?.debugLabel,
-             contains('submit'));  // ✅ Button focused
-    });
-  });
-}
-```
-
-#### Helper: setupA11yTest
-
-```dart
-// test_helpers/a11y_test_helpers.dart
-
-Future<void> setupA11yTest(WidgetTester tester) async {
-  // Disable overflow checks (common in constrained a11y tests)
-  tester.binding.setSurfaceSize(Size(1080, 1920));  // Standard phone size
-  addTearDown(() => tester.binding.setSurfaceSize(null));
-}
-
-Future<void> expectMeetsTapTargetAndLabelGuidelines(
-  WidgetTester tester, {
-  List<String> excludedPaths = const [],
-}) async {
-  // Find all interactive elements
-  final interactiveWidgets = [
-    ...tester.widgetList(find.byType(IconButton)),
-    ...tester.widgetList(find.byType(CoreButton)),
-    ...tester.widgetList(find.byType(GestureDetector)),
-  ];
-
-  for (final widget in interactiveWidgets) {
-    final renderObject = tester.renderObject(find.byWidget(widget));
-    final size = renderObject.paintBounds.size;
-
-    // Assert: Tap target at least 48x48
-    expect(
-      size.width >= 48 && size.height >= 48,
-      true,
-      reason: 'Widget $widget has tap target ${size.width}x${size.height}, minimum is 48x48',
-    );
-
-    // Assert: Has semantic label
-    final semantics = tester.getSemantics(find.byWidget(widget));
-    if (!excludedPaths.contains(widget.key?.toString())) {
-      expect(
-        semantics.label?.isNotEmpty ?? false,
-        true,
-        reason: 'Interactive widget $widget missing semantic label',
-      );
-    }
-  }
-}
-```
-
-### Common Patterns
-
-#### Pattern 1: Test Screen Reader Announcements
-
-```dart
-testWidgets('should announce error messages', (tester) async {
+testWidgets('login screen meets a11y guidelines', (tester) async {
   await setupA11yTest(tester);
-  await tester.pumpWidget(MaterialApp(home: LoginScreen()));
-
-  // Trigger error
-  await tester.tap(find.byKey(Key('submit_button')));
-  await tester.pumpAndSettle();
-
-  // Assert: Error message is semantically announced
-  final errorSemantics = tester.getSemantics(
-    find.text('Invalid email format'),
-  );
-  expect(errorSemantics.label, contains('Invalid email'));
-  expect(errorSemantics.isLiveRegion, true);  // ✅ Announced immediately
-});
-```
-
-#### Pattern 2: Test List Navigation
-
-```dart
-testWidgets('should support semantic list navigation', (tester) async {
-  await setupA11yTest(tester);
-  await tester.pumpWidget(MaterialApp(home: EstimationListScreen()));
-
-  // Assert: List items have semantic index
-  final listItems = tester.widgetList(find.byType(EstimationCard));
-
-  for (var i = 0; i < listItems.length; i++) {
-    final semantics = tester.getSemantics(find.byWidget(listItems.elementAt(i)));
-    expect(semantics.indexInParent, i);  // ✅ Correct order
-    expect(semantics.scrollChildCount, listItems.length);  // ✅ Total count
-  }
-});
-```
-
-#### Pattern 3: Test Dynamic Content
-
-```dart
-testWidgets('should announce loading state changes', (tester) async {
-  await setupA11yTest(tester);
-  await tester.pumpWidget(MaterialApp(home: DataScreen()));
-
-  // Assert: Loading state announced
-  expect(
-    tester.getSemantics(find.byType(LoadingIndicator)).label,
-    'Loading data',  // ✅ Screen reader announces
-  );
-
-  // Simulate data load
-  await tester.pumpAndSettle();
-
-  // Assert: Content state announced
-  expect(
-    find.bySemanticsLabel('Data loaded successfully'),
-    findsOneWidget,
+  await expectMeetsTapTargetAndLabelGuidelinesForEachTheme(
+    tester,
+    (theme) => makeTestableWidget(theme: theme, child: LoginWithEmailPage()),
+    find.text(l10n().continueButton),
   );
 });
 ```
 
-### When to Exclude Semantics
-
-**Valid reasons to use `excludeSemantics: true`:**
-
-✅ **Decorative elements:**
-```dart
-Semantics(
-  excludeSemantics: true,  // ✅ Decorative background
-  child: Image.asset('background.png'),
-)
-```
-
-✅ **Redundant nested widgets:**
-```dart
-// Parent has label, child doesn't need separate announcement
-Semantics(
-  label: 'Product: Blue Shirt, \$29.99',  // ✅ Complete info
-  child: Row(
-    children: [
-      Semantics(
-        excludeSemantics: true,  // ✅ Avoid duplicate reading
-        child: Text('Blue Shirt'),
-      ),
-      Semantics(
-        excludeSemantics: true,  // ✅ Avoid duplicate reading
-        child: Text('\$29.99'),
-      ),
-    ],
-  ),
-)
-```
-
-❌ **NEVER exclude interactive elements:**
-```dart
-Semantics(
-  excludeSemantics: true,  // ❌ FORBIDDEN: button must be announced
-  child: IconButton(
-    icon: Icon(Icons.delete),
-    onPressed: () => deleteItem(),
-  ),
-)
-```
+Existing examples: `test/features/auth/widgets/accessibility/*`, `test/features/estimations/widgets/accessibility/*`.
 
 ---
 
@@ -420,92 +79,49 @@ Semantics(
 
 ### Detection Patterns
 
-**Pattern 1: Interactive Elements Without Labels**
-
-```bash
-# Find IconButtons without tooltip or Semantics
-grep -rn "IconButton(" lib/features/**/presentation/ | grep -v "tooltip:"
-```
-
-**Severity:** Critical
-
-**Pattern 2: Removed/Bypassed Semantics**
-
-```bash
-# Find excludeSemantics on interactive widgets
-grep -rn "excludeSemantics: true" lib/ | grep -E "(Button|GestureDetector|InkWell)"
-```
-
-**Severity:** Critical (if not justified)
-
-**Pattern 3: Modified Screens Without A11y Tests**
-
-Check if:
-- File `lib/features/**/presentation/screens/foo_screen.dart` was modified
-- But `test/features/**/widgets/accessibility/foo_screen_a11y_test.dart` was NOT updated
-
-**Severity:** Major
-
-**Pattern 4: Small Tap Targets**
-
-```bash
-# Find small custom tap areas
-grep -rn "GestureDetector\|InkWell" lib/ | grep -E "width:\s*[1-3][0-9]|height:\s*[1-3][0-9]"
-```
-
-**Severity:** Major
+| Pattern | Grep | Severity |
+|---|---|---|
+| IconButton without tooltip | `grep -rn "IconButton(" lib/features/**/presentation/ \| grep -v "tooltip:"` | Critical |
+| `excludeSemantics` on interactive widgets | `grep -rn "excludeSemantics: true" lib/ \| grep -E "(Button\|GestureDetector\|InkWell)"` | Critical |
+| Small custom tap targets | `grep -rn "GestureDetector\|InkWell" lib/ \| grep -E "width:\s*[1-3][0-9]\|height:\s*[1-3][0-9]"` | Major |
+| Modified screen, a11y test not touched | Diff check: `lib/.../foo_page.dart` changed but `test/.../foo_page_a11y_test.dart` not changed | Major |
 
 ### Common Violations
 
 | ❌ Violation | ✅ Fix | Severity |
 |-------------|--------|----------|
 | `IconButton` without `tooltip` | Add `tooltip: 'Description'` | Critical |
-| `excludeSemantics: true` on button | Remove or justify with comment | Critical |
-| Modified screen, no a11y test update | Update `*_a11y_test.dart` file | Major |
-| Custom `GestureDetector` with 24x24 size | Increase to ≥48x48 or use `IconButton` | Major |
-| Text with low contrast color | Use `CoreTextColors.*` | Major |
+| `excludeSemantics: true` on a button/tap target | Remove or justify with comment (decorative/redundant only) | Critical |
+| Custom `GestureDetector` with 24×24 size | Increase to ≥48×48 or use `IconButton` | Major |
+| Text with low-contrast color | Use `CoreTextColors.*` | Major |
+| Modified screen, no a11y test update | Update `*_a11y_test.dart` | Major |
+| A11y test does not run in both themes | Use `expectMeetsTapTargetAndLabelGuidelinesForEachTheme` | Minor |
 
 ### Review Questions
 
-1. **Are there new interactive elements?**
-   - Check for semantic labels
-
-2. **Was an existing screen modified?**
-   - Check if a11y tests were updated
-
-3. **Are there small tap targets?**
-   - Verify ≥48x48 dp
-
-4. **Is `excludeSemantics` used?**
-   - Verify justification (must be decorative or redundant)
+1. Are there new interactive elements? → check for semantic labels.
+2. Was an existing screen modified? → check whether a11y tests were updated.
+3. Are there small tap targets (<48×48)? → flag.
+4. Is `excludeSemantics: true` used? → must be justified (decorative or duplicate-info only).
 
 ---
 
 ## Summary: Suggested Fixes
 
-1. **Add semantic labels:** Every interactive element needs `tooltip` or `Semantics` label
-2. **Update a11y tests:** When modifying screens, update corresponding `*_a11y_test.dart`
-3. **Ensure tap targets ≥48x48:** Use `IconButton` or add padding
-4. **Test both themes:** Verify light and dark mode accessibility
-5. **Remove unjustified `excludeSemantics`:** Only use for decorative elements
+1. **Semantic labels:** every interactive element gets `tooltip:` or a `Semantics` wrapper.
+2. **A11y tests:** when modifying screens, update the corresponding `*_a11y_test.dart`.
+3. **Tap targets ≥48×48:** use `IconButton` or pad `GestureDetector`.
+4. **Both themes:** use the `…ForEachTheme` helper for screen-level checks.
+5. **Justify `excludeSemantics`:** only for decorative or redundant elements.
 
 ## References
 
+- Shared helpers: **`test/utils/a11y/a11y_guidelines.dart`**
+- Examples: `test/features/auth/widgets/accessibility/`, `test/features/estimations/widgets/accessibility/`
 - [Flutter Accessibility Guide](https://flutter.dev/docs/development/accessibility-and-localization/accessibility)
-- [WCAG 2.1 Guidelines](https://www.w3.org/WAI/WCAG21/quickref/)
-- [Material Design Accessibility](https://material.io/design/usability/accessibility.html)
+- [WCAG 2.1 Quickref](https://www.w3.org/WAI/WCAG21/quickref/)
 - Review Script Lines: 501-514 in `scripts/review_pr.sh`
 
 ## Notes
 
-**WCAG Levels:**
-- **Level A:** Minimum (must meet)
-- **Level AA:** Standard (target for most apps)
-- **Level AAA:** Enhanced (ideal but not always achievable)
-
-**Testing Tools:**
-- Flutter's built-in semantic debugger
-- Screen reader testing (TalkBack on Android, VoiceOver on iOS)
-- Contrast checker tools
-
-**Best Practice:** Enable TalkBack/VoiceOver and manually test critical flows to ensure good UX for assistive technology users.
+WCAG target: **Level AA**. Manual testing with TalkBack (Android) / VoiceOver (iOS) on critical flows remains the gold standard — automated helpers cover the basics, not the full UX.

--- a/skills/rules/15-sentry-logging.md
+++ b/skills/rules/15-sentry-logging.md
@@ -14,13 +14,13 @@ Error Handling & Monitoring
 
 ## Description
 
-`AppLogger.error()` and `AppLogger.omg()` send events to Sentry and consume quota. Reserve them for genuinely unexpected failures only. Expected errors, validation failures, and normal business flow errors should use lower severity levels.
+`AppLogger.error()` and `AppLogger.omg()` send events to Sentry and consume quota. Reserve them for genuinely unexpected failures. Expected errors, validation failures, and normal business-flow errors use lower severity levels.
 
-**Core Principle:** Sentry is for bugs and unexpected system failures, not expected business logic errors.
+**Core Principle:** Sentry is for bugs and unexpected system failures, not expected business-logic errors.
 
 ## Applicability
 
-Applies to all code that uses `AppLogger` in `lib/` directory, particularly in:
+Applies to all code that uses `AppLogger` in `lib/`, particularly:
 - Data layer: `lib/features/**/data/`
 - Repository implementations
 - DataSources
@@ -32,35 +32,23 @@ Applies to all code that uses `AppLogger` in `lib/` directory, particularly in:
 
 ### Core Principle
 
-**Log errors at ONE layer only.** Typically at the Repository or DataSource where the error originates. Upper layers (BLoC, UseCase) handle `Either<Failure, T>` without logging.
+**Log errors at ONE layer only** — typically the DataSource (or Wrapper) at the system boundary. Upper layers (Repository, UseCase, BLoC) consume `Either<Failure, T>` without re-logging.
 
 ### Decision Tree: Which Log Level?
 
 ```
 Is this error expected in normal operation?
 
-├─ YES (Expected Business Error)
-│  ├─ User input validation failed?
-│  │  └─ Use: debug() or warning()  // ✅ Not Sentry
-│  │
-│  ├─ Expected API error (404, 409 conflict)?
-│  │  └─ Use: warning() or info()  // ✅ Breadcrumb only
-│  │
-│  └─ Duplicate entry (unique constraint)?
-│     └─ Use: warning()  // ✅ Breadcrumb only
+├─ YES (expected business/system error)
+│  ├─ User input validation failed?     → debug() or warning()  (no Sentry)
+│  ├─ Expected API error (404, 409)?    → warning() or info()   (breadcrumb)
+│  └─ Duplicate entry (unique constraint)? → warning()           (breadcrumb)
 │
-└─ NO (Unexpected System Failure)
-   ├─ Parsing failed unexpectedly?
-   │  └─ Use: error()  // ✅ Sentry event
-   │
-   ├─ Auth token invalid/expired?
-   │  └─ Use: error()  // ✅ Sentry event
-   │
-   ├─ Critical storage failure?
-   │  └─ Use: omg()  // ✅ Critical Sentry event
-   │
-   └─ Invariant violation?
-      └─ Use: omg()  // ✅ Critical Sentry event
+└─ NO (unexpected system failure)
+   ├─ Parsing failed unexpectedly?     → error()  (Sentry event)
+   ├─ Auth token invalid/expired?      → error()  (Sentry event)
+   ├─ Critical storage failure?        → omg()    (critical Sentry event)
+   └─ Invariant violation?             → omg()    (critical Sentry event)
 ```
 
 ### AppLogger Levels
@@ -70,309 +58,49 @@ Is this error expected in normal operation?
 | `debug()` | None | Development debugging | `AppLogger.debug('Fetching user data')` |
 | `info()` | Breadcrumb only | Normal operations | `AppLogger.info('User logged in successfully')` |
 | `warning()` | Breadcrumb only | Expected errors | `AppLogger.warning('Invalid email format')` |
-| `error()` | **Sentry event** ⚠️ | Unexpected failures | `AppLogger.error('Failed to parse response', error)` |
-| `omg()` | **Critical Sentry event** 🚨 | Critical failures | `AppLogger.omg('Database corruption detected', error)` |
+| `error()` | **Sentry event** ⚠️ | Unexpected failures | `AppLogger.error('Failed to parse response', error, stack)` |
+| `omg()` | **Critical Sentry event** 🚨 | Critical failures | `AppLogger.omg('Database corruption detected', error, stack)` |
 
-### When to Use error() / omg()
+### Log Once — at the Boundary
 
-#### ✅ Genuinely Unexpected Failures
-
-```dart
-// ✅ Good: Unexpected parsing failure
-Future<Either<Failure, User>> getUser(String id) async {
-  try {
-    final json = await _api.fetchUser(id);
-    return Right(User.fromJson(json));
-  } on FormatException catch (e, stack) {
-    // ✅ Unexpected: API should return valid JSON
-    AppLogger.error('Failed to parse user JSON', e, stack);
-    return Left(ParsingFailure(message: 'Invalid user data'));
-  }
-}
-```
+Canonical pair (DataSource logs, Repository transforms):
 
 ```dart
-// ✅ Good: Critical storage failure
-Future<void> saveAuthToken(String token) async {
-  try {
-    await _secureStorage.write(key: 'auth_token', value: token);
-  } catch (e, stack) {
-    // ✅ Critical: Can't save auth token = can't use app
-    AppLogger.omg('Failed to save auth token to secure storage', e, stack);
-    rethrow;
-  }
-}
-```
-
-```dart
-// ✅ Good: Invariant violation
-if (userId == null && isAuthenticated) {
-  // ✅ Should never happen: authenticated but no userId
-  AppLogger.omg('Invariant violated: authenticated with null userId');
-  throw StateError('Invalid authentication state');
-}
-```
-
-#### ❌ Expected Business Errors
-
-```dart
-// ❌ Bad: Expected validation error
-Future<Either<Failure, void>> createAccount(String email) async {
-  if (!_isValidEmail(email)) {
-    // ❌ Don't send to Sentry: expected validation failure
-    AppLogger.error('Invalid email format: $email');  // ❌
-    return Left(ValidationFailure(message: 'Invalid email'));
-  }
-}
-
-// ✅ Good: Use warning for expected errors
-Future<Either<Failure, void>> createAccount(String email) async {
-  if (!_isValidEmail(email)) {
-    // ✅ Breadcrumb only, no Sentry event
-    AppLogger.warning('Validation failed: invalid email format');
-    return Left(ValidationFailure(message: 'Invalid email'));
-  }
-}
-```
-
-```dart
-// ❌ Bad: Expected Supabase error
-Future<Either<Failure, User>> login(String email, String password) async {
-  try {
-    final response = await _supabase.auth.signInWithPassword(
-      email: email,
-      password: password,
-    );
-    return Right(User.from(response.user));
-  } on AuthException catch (e, stack) {
-    if (e.message.contains('Invalid login credentials')) {
-      // ❌ Expected: wrong password
-      AppLogger.error('Login failed: invalid credentials', e, stack);  // ❌
-      return Left(AuthFailure(message: 'Invalid credentials'));
-    }
-  }
-}
-
-// ✅ Good: Distinguish expected from unexpected
-Future<Either<Failure, User>> login(String email, String password) async {
-  try {
-    final response = await _supabase.auth.signInWithPassword(
-      email: email,
-      password: password,
-    );
-    return Right(User.from(response.user));
-  } on AuthException catch (e, stack) {
-    if (e.message.contains('Invalid login credentials')) {
-      // ✅ Expected error: just a breadcrumb
-      AppLogger.warning('Login attempt with invalid credentials');
-      return Left(AuthFailure(message: 'Invalid credentials'));
-    } else {
-      // ✅ Unexpected auth error: send to Sentry
-      AppLogger.error('Unexpected auth error during login', e, stack);
-      return Left(AuthFailure(message: 'Login failed'));
-    }
-  }
-}
-```
-
-### No Duplicate Logging
-
-**Log once, at the boundary where the error occurs:**
-
-```dart
-// ❌ Bad: Logging at multiple layers
+// DataSource: log at boundary, then rethrow
 class RemoteUserDataSource {
   Future<UserDto> fetchUser(String id) async {
     try {
       return await _api.get('/users/$id');
     } catch (e, stack) {
-      AppLogger.error('DataSource: Failed to fetch user', e, stack);  // ❌ Log #1
+      AppLogger.error('Failed to fetch user from API', e, stack); // ✅ log once
       rethrow;
     }
   }
 }
 
+// Repository: no re-log, just translate to Failure
 class UserRepositoryImpl {
   Future<Either<Failure, User>> getUser(String id) async {
     try {
       final dto = await _dataSource.fetchUser(id);
       return Right(User.fromDto(dto));
-    } catch (e, stack) {
-      AppLogger.error('Repository: Failed to get user', e, stack);  // ❌ Log #2 (duplicate!)
-      return Left(NetworkFailure(message: 'Failed to fetch user'));
-    }
-  }
-}
-
-// ✅ Good: Log once at the boundary
-class RemoteUserDataSource {
-  Future<UserDto> fetchUser(String id) async {
-    try {
-      return await _api.get('/users/$id);
-    } catch (e, stack) {
-      // ✅ Log once, at the source
-      AppLogger.error('Failed to fetch user from API', e, stack);
-      rethrow;
-    }
-  }
-}
-
-class UserRepositoryImpl {
-  Future<Either<Failure, User>> getUser(String id) async {
-    try {
-      final dto = await _dataSource.fetchUser(id);
-      return Right(User.fromDto(dto));
-    } catch (e, stack) {
-      // ✅ No logging: error already logged in DataSource
-      return Left(NetworkFailure(message: 'Failed to fetch user'));
-    }
-  }
-}
-```
-
-### Where to Log
-
-**Recommended logging location:**
-
-```
-DataSource (boundary)
-  └─ ✅ Log unexpected errors here
-       └─ Throw/return error
-
-Repository (transforms errors)
-  └─ ❌ Don't log again
-       └─ Return Either<Failure, T>
-
-UseCase (business logic)
-  └─ ❌ Don't log
-       └─ Handle Either<Failure, T>
-
-BLoC (state management)
-  └─ ❌ Don't log
-       └─ Emit error state
-```
-
-**Example:**
-
-```dart
-// DataSource: Log at boundary
-class RemoteEstimationDataSource {
-  Future<List<EstimationDto>> fetch(String projectId) async {
-    try {
-      final response = await _supabase
-          .from('estimations')
-          .select()
-          .eq('project_id', projectId);
-
-      return response.map((json) => EstimationDto.fromJson(json)).toList();
-    } on PostgrestException catch (e, stack) {
-      // ✅ Log unexpected database error
-      AppLogger.error('Supabase query failed for project $projectId', e, stack);
-      rethrow;
-    }
-  }
-}
-
-// Repository: Don't log, transform error
-class EstimationRepositoryImpl {
-  Future<Either<Failure, List<Estimation>>> getEstimations(String projectId) async {
-    try {
-      final dtos = await _dataSource.fetch(projectId);
-      return Right(dtos.map((dto) => Estimation.fromDto(dto)).toList());
     } catch (e) {
-      // ✅ Don't log again, just transform to domain Failure
-      return Left(DatabaseFailure(message: 'Failed to load estimations'));
+      return Left(NetworkFailure(message: 'Failed to fetch user')); // ✅ no log
     }
   }
 }
-
-// UseCase: Don't log, pass through
-class GetEstimationsUseCase {
-  Future<Either<Failure, List<Estimation>>> execute(String projectId) {
-    // ✅ Don't log, just delegate
-    return repository.getEstimations(projectId);
-  }
-}
-
-// BLoC: Don't log, emit state
-class EstimationBloc {
-  Future<void> _onLoad(LoadEstimations event, Emitter emit) async {
-    final result = await useCase.execute(event.projectId);
-
-    result.fold(
-      (failure) {
-        // ✅ Don't log, emit error state
-        emit(EstimationError(message: failure.message));
-      },
-      (estimations) => emit(EstimationsLoaded(estimations)),
-    );
-  }
-}
 ```
 
-### Common Scenarios
+**UseCase and BLoC do not log** — UseCase passes through `Either`, BLoC emits an error state.
 
-#### Scenario 1: Supabase Errors
+### Distinguishing Expected from Unexpected
 
-```dart
-// Distinguish expected from unexpected
-try {
-  await _supabase.from('users').insert(userData);
-} on PostgrestException catch (e, stack) {
-  if (e.code == '23505') {  // Unique constraint violation
-    // ✅ Expected: duplicate entry
-    AppLogger.warning('Duplicate user entry attempt: ${userData.email}');
-    return Left(DuplicateFailure(message: 'User already exists'));
-  } else {
-    // ✅ Unexpected: other database error
-    AppLogger.error('Unexpected database error', e, stack);
-    return Left(DatabaseFailure(message: 'Failed to create user'));
-  }
-}
-```
+Inside a `catch` block, branch on the error code/type before choosing a log level:
 
-#### Scenario 2: Network Errors
-
-```dart
-try {
-  final response = await _http.get(url);
-  return response.data;
-} on DioError catch (e, stack) {
-  if (e.response?.statusCode == 404) {
-    // ✅ Expected: resource not found
-    AppLogger.info('Resource not found: $url');
-    return Left(NotFoundFailure());
-  } else if (e.response?.statusCode == 401) {
-    // ✅ Important: auth token expired
-    AppLogger.error('Auth token expired or invalid', e, stack);
-    return Left(AuthFailure(message: 'Unauthorized'));
-  } else {
-    // ✅ Unexpected: other network error
-    AppLogger.error('Network request failed: $url', e, stack);
-    return Left(NetworkFailure());
-  }
-}
-```
-
-#### Scenario 3: Validation
-
-```dart
-// ❌ Bad: Logging validation errors
-Future<Either<Failure, void>> updateEmail(String email) async {
-  if (!_isValidEmail(email)) {
-    AppLogger.error('Invalid email: $email');  // ❌ Wastes Sentry quota
-    return Left(ValidationFailure());
-  }
-}
-
-// ✅ Good: Validation errors are debug-level
-Future<Either<Failure, void>> updateEmail(String email) async {
-  if (!_isValidEmail(email)) {
-    AppLogger.debug('Email validation failed: $email');  // ✅ Debug only
-    return Left(ValidationFailure());
-  }
-}
-```
+- **Supabase / Postgrest:** `PGRST116` (not found), `23505` (duplicate), `23503` (FK) → `warning()`. Unknown PG codes, server errors → `error()`.
+- **HTTP / Dio:** `404` → `info()`; `401` (token expired) → `error()`; other 5xx / network → `error()`.
+- **Validation:** invalid input from the user is always `debug()` or `warning()`, **never** `error()`.
+- **Auth:** wrong credentials → `warning()`; unexpected auth exception → `error()`.
 
 ---
 
@@ -380,40 +108,11 @@ Future<Either<Failure, void>> updateEmail(String email) async {
 
 ### Detection Patterns
 
-**Pattern 1: Expected Errors Logged with error()**
-
-Look for validation, 404, duplicate errors logged with `error()`:
-
-```bash
-grep -rn "AppLogger.error\|AppLogger.omg" lib/
-```
-
-Check context:
-- Is it validation? → Should be `warning()` or `debug()`
-- Is it 404/409? → Should be `info()` or `warning()`
-- Is it duplicate entry? → Should be `warning()`
-
-**Pattern 2: Duplicate Logging**
-
-Same error logged at DataSource AND Repository:
-
-```bash
-# Find files with both error logs and rethrow/return Left
-grep -A 5 "AppLogger.error" lib/ | grep -E "(rethrow|return Left)"
-```
-
-**Severity:** Major
-
-**Pattern 3: Logging in Upper Layers**
-
-`AppLogger.error()` in BLoC or UseCase (should only be in DataSource/Repository):
-
-```bash
-grep -rn "AppLogger.error" lib/features/**/domain/
-grep -rn "AppLogger.error" lib/features/**/presentation/
-```
-
-**Severity:** Major
+| Pattern | Grep | Severity |
+|---|---|---|
+| `error()` / `omg()` use | `grep -rn "AppLogger.error\\|AppLogger.omg" lib/` — review each for "expected" context | Critical (if expected) |
+| Duplicate logging at DataSource + Repository | `grep -A 5 "AppLogger.error" lib/ \| grep -E "(rethrow\\|return Left)"` | Major |
+| Logging in upper layers | `grep -rn "AppLogger.error" lib/features/**/domain/ lib/features/**/presentation/` | Major |
 
 ### Common Violations
 
@@ -421,45 +120,35 @@ grep -rn "AppLogger.error" lib/features/**/presentation/
 |-------------|--------|----------|
 | `error('Invalid email')` | Use `debug()` or `warning()` | Critical |
 | `error('404 not found')` | Use `info()` or `warning()` | Critical |
-| `error('Duplicate entry')` | Use `warning()` | Critical |
-| Error logged in DataSource AND Repository | Remove duplicate, log once | Major |
-| `error()` in BLoC/UseCase | Move to DataSource/Repository | Major |
-| `error()` without checking if expected | Add conditional logic | Major |
+| `error('Duplicate entry')` (PG `23505`) | Use `warning()` | Critical |
+| `error('Invalid credentials')` | Use `warning()` | Critical |
+| Same error logged in DataSource AND Repository | Remove duplicate; log once at boundary | Major |
+| `error()` in BLoC / UseCase | Move to DataSource / Repository / Wrapper | Major |
+| `error()` without branching on error code | Add conditional: expected → `warning()`, unexpected → `error()` | Major |
 
 ### Review Questions
 
-1. **Is this error expected in normal operation?**
-   - If YES → Should not use `error()` or `omg()`
-
-2. **Is the error logged at multiple layers?**
-   - If YES → Remove duplicate logging
-
-3. **Is this a validation or user input error?**
-   - If YES → Should use `debug()` or `warning()`
-
-4. **Does the error come from a known Supabase/API error code?**
-   - Check if it's documented/expected → Use `warning()`
+1. Is this error expected in normal operation? → if yes, must not be `error()` / `omg()`.
+2. Is the error logged at multiple layers? → if yes, remove duplicate.
+3. Is this a validation / user-input error? → must be `debug()` or `warning()`.
+4. Does the catch branch on the SDK error code? → if not, it's likely over-logging.
 
 ---
 
 ## Summary: Suggested Fixes
 
-1. **Reserve `error()` for unexpected failures:** Parsing errors, system failures, invariant violations
-2. **Use `warning()` for expected errors:** Validation failures, 404s, duplicate entries, invalid credentials
-3. **Log once at the boundary:** Typically DataSource, not Repository/UseCase/BLoC
-4. **Distinguish expected from unexpected:** Check error codes/types before logging
-5. **Use breadcrumbs for context:** `info()` and `warning()` create breadcrumbs without consuming quota
+1. **Reserve `error()` for unexpected failures** — parsing errors, system failures, invariant violations.
+2. **Use `warning()` for expected errors** — validation, 404s, duplicates, invalid credentials.
+3. **Log once at the boundary** — typically DataSource / Wrapper; never in UseCase / BLoC.
+4. **Branch on error code** before picking a log level.
+5. **Use breadcrumbs liberally** — `info()` / `warning()` are free context attached to real events.
 
 ## References
 
 - [Sentry Best Practices](https://docs.sentry.io/platforms/flutter/best-practices/)
-- [Sentry Pricing](https://sentry.io/pricing/) - Understand quota costs
 - Review Script Lines: 519-539 in `scripts/review_pr.sh`
+- Related: RULE_5 (UI/Business separation), `code-data` skill (error mapping table)
 
 ## Notes
 
-**Quota Awareness:** Each `error()` or `omg()` call creates a Sentry event. On a free/low-tier plan, excessive error logging can exhaust quota quickly.
-
-**Breadcrumbs:** `debug()`, `info()`, and `warning()` create breadcrumbs that are attached to error events but don't consume quota on their own. They provide context when real errors occur.
-
-**Best Practice:** Use `warning()` liberally for expected errors (free breadcrumbs), but be very selective with `error()` and `omg()` (quota cost).
+**Quota awareness:** every `error()` / `omg()` is a billable Sentry event. `debug()` / `info()` / `warning()` are free and produce breadcrumbs attached to the next real event.


### PR DESCRIPTION
Compresses ten architectural rule documents (RULE_2, 3, 4, 7, 8, 9, 10, 13, 14, 15) to reduce the context size loaded by AI agents, while preserving 
  all enforcement-critical detection patterns, severity tables, and violation-to-fix mappings.

  ### Compression (all ten rules)
  - Rewrote severity levels, descriptions, and applicability sections for brevity and direct language.
  - Simplified decision trees, checklists, and violation tables; removed redundant prose and duplicate examples.

  ### Substantive changes beyond compression
  - **RULE_4 (CoreUI components):** full token tables (spacing, typography, colors) moved to `skills/references/coreui-api.md`; the rule now points there
   instead of duplicating them.
  - **RULE_13 (mutation testing):** mutation score thresholds differentiated — ≥85% for critical paths, ≥70% for non-critical (was a flat ≥80%); tool
  reference corrected from `mutant` to `mutation_test`.
  - **RULE_14 (accessibility testing):** now references the real project helper `expectMeetsTapTargetAndLabelGuidelinesForEachTheme` from
  `test/utils/a11y/a11y_guidelines.dart`.
  - **RULE_15 (Sentry logging):** adds specific Supabase/HTTP error codes for log-level decisions.

  ### Review follow-ups addressed
  - **RULE_9:** restored the worked async stream test example (`expectLater` + `emitsInOrder`) with a note on broadcast vs single-subscription delivery.
  - **RULE_10:** `LocalizationMixin` is explicitly retired; detection Pattern 6 now flags any reintroduction as a Minor violation.

  Summary of local file changes (uncommitted, on your branch):
  - skills/rules/09-unit-test-behavior.md — restored the async stream worked example with subscribe-before-act guidance (addresses the broadcast/sync
  nuance the reviewer flagged).
  - skills/rules/10-localization.md — added explicit LocalizationMixin retirement note, detection Pattern 6 (with\s+LocalizationMixin, Minor), anda
  violations-table row.
  - RULE_4's coreui-api.md pointer checked — the reference file is complete (11 spacing tokens, 11 typography variants, full color/icon/component
  tables), so no change needed there.