### PR TITLE
Ca 118 feat/search button

### DIFF
--- a/lib/app/shell/app_shell_page.dart
+++ b/lib/app/shell/app_shell_page.dart
@@ -10,6 +10,7 @@ import 'package:construculator/features/estimation/estimation_module.dart';
 import 'package:construculator/features/global_search/presentation/pages/global_search_page.dart';
 import 'package:construculator/features/members/presentation/pages/members_page.dart';
 import 'package:construculator/libraries/extensions/extensions.dart';
+import 'package:construculator/libraries/logging/app_logger.dart';
 import 'package:construculator/libraries/project/interfaces/current_project_notifier.dart';
 import 'package:construculator/libraries/project/presentation/project_ui_provider.dart';
 import 'package:flutter/material.dart';
@@ -35,6 +36,7 @@ class AppShellPage extends StatefulWidget {
 }
 
 class _AppShellPageState extends State<AppShellPage> {
+  static final _logger = AppLogger().tag('AppShellPage');
   final AppShellBloc _bloc = Modular.get<AppShellBloc>();
   late final CurrentProjectNotifier _currentProjectNotifier;
   StreamSubscription<String?>? _projectSubscription;
@@ -105,6 +107,27 @@ class _AppShellPageState extends State<AppShellPage> {
     }
   }
 
+  void _navigateToSearch(BuildContext context) {
+    if (!mounted) return;
+    try {
+      Navigator.of(context).push(
+        MaterialPageRoute<void>(builder: (_) => const GlobalSearchPage()),
+      );
+    } catch (error, stackTrace) {
+      _logger.error(
+        'Failed to navigate to GlobalSearchPage: $error',
+        stackTrace.toString(),
+      );
+      if (mounted) {
+        CoreToast.showError(
+          context,
+          context.l10n.searchNavigationError,
+          context.l10n.closeButton,
+        );
+      }
+    }
+  }
+
   PreferredSizeWidget _buildAppBar(BuildContext context) {
     final projectId = _currentProjectId ?? '';
     if (projectId.isEmpty) {
@@ -146,8 +169,7 @@ class _AppShellPageState extends State<AppShellPage> {
     return Modular.get<ProjectUIProvider>().buildProjectHeaderAppbar(
       projectId: projectId,
       onProjectTap: () => ProjectsBottomSheet.show(context),
-      onSearchTap: () => Navigator.of(context).push(
-        MaterialPageRoute<void>(builder: (_) => const GlobalSearchPage()),
+      onSearchTap: () => _navigateToSearch(context),
       ),
     );
   }

--- a/test/app/shell/app_shell_page_test.dart
+++ b/test/app/shell/app_shell_page_test.dart
@@ -3,6 +3,7 @@ import 'package:construculator/app/shell/shell_module.dart';
 import 'package:construculator/features/calculations/presentation/pages/calculations_page.dart';
 import 'package:construculator/features/dashboard/presentation/pages/dashboard_page.dart';
 import 'package:construculator/features/estimation/presentation/pages/cost_estimation_landing_page.dart';
+import 'package:construculator/features/global_search/presentation/pages/global_search_page.dart';
 import 'package:construculator/features/members/presentation/pages/members_page.dart';
 import 'package:construculator/l10n/generated/app_localizations.dart';
 import 'package:construculator/libraries/auth/data/models/auth_user.dart';
@@ -300,11 +301,29 @@ void main() {
         );
       },
     );
+
+    testWidgets('tapping search opens GlobalSearchPage', (tester) async {
+      fakeProjectNotifier.setCurrentProjectId(
+        '950e8400-e29b-41d4-a716-446655440001',
+      );
+      final fakeProvider = _FakeProjectUIProvider();
+      Modular.replaceInstance<ProjectUIProvider>(fakeProvider);
+
+      await tester.pumpWidget(makeApp());
+      await tester.pump();
+
+      fakeProvider.capturedOnSearchTap?.call();
+      await tester.pumpAndSettle();
+
+      expect(find.byType(GlobalSearchPage), findsOneWidget);
+    });
   });
 }
 
 // TODO: [CA-724] Migrate to lib/libraries/project/testing/fake_project_ui_provider.dart
 class _FakeProjectUIProvider extends ProjectUIProvider {
+  VoidCallback? capturedOnSearchTap;
+
   @override
   PreferredSizeWidget buildProjectHeaderAppbar({
     required String projectId,
@@ -312,6 +331,7 @@ class _FakeProjectUIProvider extends ProjectUIProvider {
     VoidCallback? onSearchTap,
     VoidCallback? onNotificationTap,
   }) {
+    capturedOnSearchTap = onSearchTap;
     return PreferredSize(
       preferredSize: const Size.fromHeight(kToolbarHeight),
       child: AppBar(key: Key('project_app_bar_$projectId')),


### PR DESCRIPTION
## Summary

This PR completes CA-118 by adding error-safe navigation from the app bar search button to `GlobalSearchPage`. The visual work — search icon, `Semantics` wrapper, `onSearchTap` callback, and `dashboardSearchSemanticLabel` — was delivered in CA-119c. This PR extracts the inline `Navigator.push` lambda into a dedicated `_navigateToSearch` private method that wraps the push in a try/catch: unexpected failures are logged via `AppLogger.error` (tagged `'AppShellPage'`) and surfaced to the user as a `CoreToast.showError` with the new localized `searchNavigationError` key, guarded by `mounted` to prevent post-disposal calls. Navigation is fully in-memory and works offline; the `GlobalSearchBloc` handles its own downstream failure states. `ProjectDropdownBloc` state is preserved on return because it is a DI-owned singleton. A new widget test captures `onSearchTap` via `_FakeProjectUIProvider` and asserts that invoking the callback pushes `GlobalSearchPage` onto the navigator.

---

## Changes Overview

### Impact Stats

| Category                     | Value                         |
|------------------------------|-------------------------------|
| **Production files changed** | 4 (`app_shell_page.dart`, `app_en.arb` + 2 generated) |
| **Production lines added**   | +27                           |
| **Production lines removed** | −3                            |
| **Net production change**    | +24 lines                     |
| **PR Size Classification**   | **XS** (<50 production lines) |
| **Test files changed**       | 1                             |
| **Net test lines changed**   | +19                           |

### Rule-Based Review

| Rule | Status | Notes |
|------|--------|-------|
| **Rule 1 – Digestible PR** | ✅ Pass | XS at +24 net production lines. Single, focused purpose: error-safe search navigation. The PR is independently testable. |
| **Rule 2 – Class Naming** | ✅ Pass | No new classes. `_navigateToSearch` is an appropriately named private method — lowercase verb-noun, scoped to the widget. `_logger` follows the static final logger field convention. |
| **Rule 3 – Test Double Pattern** | ✅ Pass | `_FakeProjectUIProvider.capturedOnSearchTap` captures the callback at the rendering boundary. The test invokes the callback and asserts `GlobalSearchPage` is rendered — real `AppShellBloc` and real navigator are exercised. No mocks or stubs. |
| **Rule 5 – UI/Business Logic Separation** | ✅ Pass | Navigation is a UI concern. The try/catch contains only presentation-layer error recovery: logging and a toast. No domain validation, data transformation, or routing decisions based on business state. |
| **Rule 6 – Stream Lifecycle** | ✅ Pass | No new streams, controllers, or subscriptions introduced. `mounted` guard on the toast call prevents `setState`/UI interaction after disposal. |
