### PR TITLE
fix: remove duplicate app header on dashboard page

### DIFF
--- a/lib/app/shell/app_shell_page.dart
+++ b/lib/app/shell/app_shell_page.dart
@@ -4,6 +4,7 @@ import 'package:construculator/app/shell/widgets/tab_navigator.dart';
 import 'package:construculator/features/calculations/presentation/pages/calculations_page.dart';
 import 'package:construculator/features/dashboard/presentation/pages/dashboard_page.dart';
 import 'package:construculator/features/estimation/estimation_module.dart';
+import 'package:construculator/features/global_search/presentation/pages/global_search_page.dart';
 import 'package:construculator/features/members/presentation/pages/members_page.dart';
 import 'package:construculator/libraries/extensions/extensions.dart';
 import 'package:construculator/libraries/project/presentation/project_ui_provider.dart';
@@ -99,6 +100,18 @@ class _AppShellPageState extends State<AppShellPage> {
             centerTitle: true,
             titleSpacing: 0,
             title: Text(context.l10n.appTitle),
+            actions: [
+              CoreIconWidget(
+                icon: CoreIcons.search,
+                semanticLabel: context.l10n.dashboardSearchSemanticLabel,
+                onTap: () => Navigator.of(context).push(
+                  MaterialPageRoute<void>(
+                    builder: (_) => const GlobalSearchPage(),
+                  ),
+                ),
+              ),
+              const SizedBox(width: CoreSpacing.space4),
+            ],
           ),
         ),
       );

--- a/lib/features/dashboard/presentation/pages/dashboard_page.dart
+++ b/lib/features/dashboard/presentation/pages/dashboard_page.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:construculator/features/dashboard/presentation/widgets/recent_estimations_section.dart';
 import 'package:construculator/libraries/auth/interfaces/auth_manager.dart';
 import 'package:construculator/libraries/auth/interfaces/auth_notifier.dart';
@@ -20,14 +22,17 @@ class _DashboardPageState extends State<DashboardPage> {
   final authManager = Modular.get<AuthManager>();
   String userInfo = '...';
   final AppRouter _router = Modular.get<AppRouter>();
+  StreamSubscription<dynamic>? _profileSubscription;
+
   @override
   void dispose() {
+    _profileSubscription?.cancel();
     super.dispose();
   }
 
   @override
   void initState() {
-    notifier.onUserProfileChanged.listen((event) {
+    _profileSubscription = notifier.onUserProfileChanged.listen((event) {
       if (event == null) {
         final cred = authManager.getCurrentCredentials();
         _router.navigate(fullCreateAccountRoute, arguments: cred.data?.email);
@@ -58,6 +63,7 @@ class _DashboardPageState extends State<DashboardPage> {
   @override
   Widget build(BuildContext context) {
     final typography = context.textTheme;
+    final l10n = context.l10n;
     return SingleChildScrollView(
       padding: const EdgeInsets.all(CoreSpacing.space6),
       child: Column(
@@ -73,13 +79,13 @@ class _DashboardPageState extends State<DashboardPage> {
                 ),
                 const SizedBox(height: CoreSpacing.space6),
                 Text(
-                  'Welcome back, $userInfo',
+                  l10n.dashboardWelcomeMessage(userInfo),
                   textAlign: TextAlign.center,
                   style: typography.headlineMediumSemiBold,
                 ),
                 const SizedBox(height: CoreSpacing.space2),
                 Text(
-                  'You are now logged in to your account',
+                  l10n.dashboardLoggedInSubtitle,
                   textAlign: TextAlign.center,
                   style: typography.bodyLargeRegular,
                 ),
@@ -93,7 +99,6 @@ class _DashboardPageState extends State<DashboardPage> {
           Center(
             child: CoreButton(
               onPressed: () {
-                final authManager = Modular.get<AuthManager>();
                 authManager.logout();
                 _router.navigate(fullLoginRoute);
               },

--- a/lib/features/dashboard/presentation/pages/dashboard_page.dart
+++ b/lib/features/dashboard/presentation/pages/dashboard_page.dart
@@ -1,5 +1,4 @@
 import 'package:construculator/features/dashboard/presentation/widgets/recent_estimations_section.dart';
-import 'package:construculator/features/global_search/presentation/pages/global_search_page.dart';
 import 'package:construculator/libraries/auth/interfaces/auth_manager.dart';
 import 'package:construculator/libraries/auth/interfaces/auth_notifier.dart';
 import 'package:construculator/libraries/extensions/extensions.dart';
@@ -59,71 +58,50 @@ class _DashboardPageState extends State<DashboardPage> {
   @override
   Widget build(BuildContext context) {
     final typography = context.textTheme;
-    final colors = context.colorTheme;
-    final l10n = context.l10n;
-    return Scaffold(
-      appBar: AppBar(
-        title: Text(l10n.dashboardTitle),
-        centerTitle: true,
-        backgroundColor: colors.pageBackground,
-        actions: [
-          CoreIconWidget(
-            icon: CoreIcons.search,
-            semanticLabel: l10n.dashboardSearchSemanticLabel,
-            onTap: () => Navigator.of(context).push(
-              MaterialPageRoute<void>(
-                builder: (_) => const GlobalSearchPage(),
-              ),
+    return SingleChildScrollView(
+      padding: const EdgeInsets.all(CoreSpacing.space6),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Center(
+            child: Column(
+              children: [
+                Icon(
+                  Icons.dashboard,
+                  size: CoreSpacing.space16,
+                  color: Theme.of(context).primaryColor,
+                ),
+                const SizedBox(height: CoreSpacing.space6),
+                Text(
+                  'Welcome back, $userInfo',
+                  textAlign: TextAlign.center,
+                  style: typography.headlineMediumSemiBold,
+                ),
+                const SizedBox(height: CoreSpacing.space2),
+                Text(
+                  'You are now logged in to your account',
+                  textAlign: TextAlign.center,
+                  style: typography.bodyLargeRegular,
+                ),
+                const SizedBox(height: CoreSpacing.space8),
+              ],
             ),
           ),
-          const SizedBox(width: CoreSpacing.space4),
+          const SizedBox(height: CoreSpacing.space8),
+          const RecentEstimationsSection(),
+          const SizedBox(height: CoreSpacing.space8),
+          Center(
+            child: CoreButton(
+              onPressed: () {
+                final authManager = Modular.get<AuthManager>();
+                authManager.logout();
+                _router.navigate(fullLoginRoute);
+              },
+              label: 'Logout',
+              centerAlign: true,
+            ),
+          ),
         ],
-      ),
-      body: SingleChildScrollView(
-        padding: const EdgeInsets.all(CoreSpacing.space6),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Center(
-              child: Column(
-                children: [
-                  Icon(
-                    Icons.dashboard,
-                    size: CoreSpacing.space16,
-                    color: Theme.of(context).primaryColor,
-                  ),
-                  const SizedBox(height: CoreSpacing.space6),
-                  Text(
-                    'Welcome back, $userInfo',
-                    textAlign: TextAlign.center,
-                    style: typography.headlineMediumSemiBold,
-                  ),
-                  const SizedBox(height: CoreSpacing.space2),
-                  Text(
-                    'You are now logged in to your account',
-                    textAlign: TextAlign.center,
-                    style: typography.bodyLargeRegular,
-                  ),
-                  const SizedBox(height: CoreSpacing.space8),
-                ],
-              ),
-            ),
-            const SizedBox(height: CoreSpacing.space8),
-            const RecentEstimationsSection(),
-            const SizedBox(height: CoreSpacing.space8),
-            Center(
-              child: CoreButton(
-                onPressed: () {
-                  final authManager = Modular.get<AuthManager>();
-                  authManager.logout();
-                  _router.navigate(fullLoginRoute);
-                },
-                label: 'Logout',
-                centerAlign: true,
-              ),
-            ),
-          ],
-        ),
       ),
     );
   }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1196,5 +1196,21 @@
   "@globalSearchSuggestionsErrorMessage": {
     "description": "Warning toast shown when loading search suggestions fails",
     "context": "N/A"
+  },
+  "dashboardWelcomeMessage": "Welcome back, {name}",
+  "@dashboardWelcomeMessage": {
+    "description": "Greeting shown at the top of the dashboard with the user's full name",
+    "context": "N/A",
+    "placeholders": {
+      "name": {
+        "type": "String",
+        "example": "John Doe!"
+      }
+    }
+  },
+  "dashboardLoggedInSubtitle": "You are now logged in to your account",
+  "@dashboardLoggedInSubtitle": {
+    "description": "Subtitle shown below the welcome greeting on the dashboard",
+    "context": "N/A"
   }
 }

--- a/lib/l10n/generated/app_localizations.dart
+++ b/lib/l10n/generated/app_localizations.dart
@@ -1443,6 +1443,18 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Could not load suggestions.'**
   String get globalSearchSuggestionsErrorMessage;
+
+  /// Greeting shown at the top of the dashboard with the user's full name
+  ///
+  /// In en, this message translates to:
+  /// **'Welcome back, {name}'**
+  String dashboardWelcomeMessage(String name);
+
+  /// Subtitle shown below the welcome greeting on the dashboard
+  ///
+  /// In en, this message translates to:
+  /// **'You are now logged in to your account'**
+  String get dashboardLoggedInSubtitle;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/generated/app_localizations_en.dart
+++ b/lib/l10n/generated/app_localizations_en.dart
@@ -757,4 +757,13 @@ class AppLocalizationsEn extends AppLocalizations {
   @override
   String get globalSearchSuggestionsErrorMessage =>
       'Could not load suggestions.';
+
+  @override
+  String dashboardWelcomeMessage(String name) {
+    return 'Welcome back, $name';
+  }
+
+  @override
+  String get dashboardLoggedInSubtitle =>
+      'You are now logged in to your account';
 }


### PR DESCRIPTION
## Summary

  - `DashboardPage` was wrapping its content in a `Scaffold` with its own `AppBar`, causing two headers to stack since `AppShellPage` already provides one
  - Removed the inner `Scaffold` and `AppBar` from `DashboardPage` — it now returns the body content directly
  - Removed unused imports (`GlobalSearchPage`, `colorTheme`)

  > **Note:** The search icon that lived in the dashboard's `AppBar` was removed as part of this fix. It should be moved into the shell's `AppBar` for the dashboard tab as a follow-up.