### PR TITLE
CA-250: repository fake and module

### DIFF
--- a/lib/libraries/project/testing/fake_project_setting_repository.dart
+++ b/lib/libraries/project/testing/fake_project_setting_repository.dart
@@ -36,11 +36,15 @@ class FakeProjectSettingRepository implements ProjectSettingRepository {
     errorType: ProjectErrorType.unexpectedError,
   );
 
-  late final StreamController<Either<Failure, Project>> _watchController;
+  late StreamController<Either<Failure, Project>> _watchController;
 
   /// Creates a [FakeProjectSettingRepository].
   FakeProjectSettingRepository() {
-    _watchController = StreamController<Either<Failure, Project>>.broadcast(
+    _watchController = _createWatchController();
+  }
+
+  StreamController<Either<Failure, Project>> _createWatchController() {
+    return StreamController<Either<Failure, Project>>.broadcast(
       onListen: () {
         _activeWatchListeners++;
       },
@@ -78,7 +82,8 @@ class FakeProjectSettingRepository implements ProjectSettingRepository {
       return Left(failureToReturn);
     }
 
-    return Right(projectToReturn ?? project);
+    projectToReturn = project;
+    return Right(project);
   }
 
   @override
@@ -89,6 +94,7 @@ class FakeProjectSettingRepository implements ProjectSettingRepository {
       return Left(failureToReturn);
     }
 
+    projectToReturn = null;
     return const Right(null);
   }
 
@@ -165,6 +171,9 @@ class FakeProjectSettingRepository implements ProjectSettingRepository {
   }
 
   /// Resets all flags, data, and recorded calls.
+  ///
+  /// Recreates the watch controller if it was closed by a prior [dispose] call,
+  /// so the fake can model a full repository lifecycle across test scenarios.
   void reset() {
     shouldFailOnGet = false;
     shouldFailOnUpdate = false;
@@ -176,5 +185,9 @@ class FakeProjectSettingRepository implements ProjectSettingRepository {
     projectToReturn = null;
     _methodCalls.clear();
     _isDisposed = false;
+    _activeWatchListeners = 0;
+    if (_watchController.isClosed) {
+      _watchController = _createWatchController();
+    }
   }
 }

--- a/lib/libraries/project/testing/fake_project_setting_repository.dart
+++ b/lib/libraries/project/testing/fake_project_setting_repository.dart
@@ -8,13 +8,14 @@ import 'package:construculator/libraries/project/domain/repositories/project_set
 
 /// Fake implementation of [ProjectSettingRepository] for testing.
 class FakeProjectSettingRepository implements ProjectSettingRepository {
-  /// Tracks method calls for boundary assertions.
+  // Tracks method calls for boundary assertions.
   final List<Map<String, dynamic>> _methodCalls = [];
 
   int _activeWatchListeners = 0;
   bool _isDisposed = false;
 
-  /// The [Project] returned by [getProjectSetting] and [updateProject].
+  /// The persisted project state. Read by [getProjectSetting], mutated by
+  /// [updateProject], and cleared by [deleteProject].
   Project? projectToReturn;
 
   /// When true, [getProjectSetting] returns a [Left] failure.

--- a/lib/libraries/project/testing/fake_project_setting_repository.dart
+++ b/lib/libraries/project/testing/fake_project_setting_repository.dart
@@ -1,0 +1,138 @@
+import 'dart:async';
+
+import 'package:construculator/libraries/either/either.dart';
+import 'package:construculator/libraries/errors/failures.dart';
+import 'package:construculator/libraries/project/domain/entities/project_entity.dart';
+import 'package:construculator/libraries/project/domain/project_error_type.dart';
+import 'package:construculator/libraries/project/domain/repositories/project_setting_repository.dart';
+
+/// Fake implementation of [ProjectSettingRepository] for testing.
+class FakeProjectSettingRepository implements ProjectSettingRepository {
+  /// Tracks method calls for boundary assertions.
+  final List<Map<String, dynamic>> _methodCalls = [];
+
+  /// The [Project] returned by [getProjectSetting] and [updateProject].
+  Project? projectToReturn;
+
+  /// When true, [getProjectSetting] returns a [Left] failure.
+  bool shouldFailOnGet = false;
+
+  /// When true, [updateProject] returns a [Left] failure.
+  bool shouldFailOnUpdate = false;
+
+  /// When true, [deleteProject] returns a [Left] failure.
+  bool shouldFailOnDelete = false;
+
+  /// When true, [watchProjectSetting] returns a [Left] failure via the stream.
+  bool shouldFailOnWatch = false;
+
+  /// The [Failure] returned when a [shouldFailOn*] flag is true.
+  ///
+  /// Defaults to [ProjectFailure] with [ProjectErrorType.unexpectedError].
+  Failure failureToReturn = const ProjectFailure(
+    errorType: ProjectErrorType.unexpectedError,
+  );
+
+  final StreamController<Either<Failure, Project>> _watchController =
+      StreamController<Either<Failure, Project>>.broadcast();
+
+  /// Creates a [FakeProjectSettingRepository].
+  FakeProjectSettingRepository();
+
+  @override
+  Future<Either<Failure, Project>> getProjectSetting(String projectId) async {
+    _methodCalls.add({'method': 'getProjectSetting', 'projectId': projectId});
+
+    if (shouldFailOnGet) {
+      return Left(failureToReturn);
+    }
+
+    final project = projectToReturn;
+    if (project == null) {
+      return const Left(
+        ProjectFailure(errorType: ProjectErrorType.notFoundError),
+      );
+    }
+
+    return Right(project);
+  }
+
+  @override
+  Future<Either<Failure, Project>> updateProject(Project project) async {
+    _methodCalls.add({'method': 'updateProject', 'project': project});
+
+    if (shouldFailOnUpdate) {
+      return Left(failureToReturn);
+    }
+
+    return Right(projectToReturn ?? project);
+  }
+
+  @override
+  Future<Either<Failure, void>> deleteProject(String projectId) async {
+    _methodCalls.add({'method': 'deleteProject', 'projectId': projectId});
+
+    if (shouldFailOnDelete) {
+      return Left(failureToReturn);
+    }
+
+    return const Right(null);
+  }
+
+  @override
+  Stream<Either<Failure, Project>> watchProjectSetting(String projectId) {
+    _methodCalls.add({
+      'method': 'watchProjectSetting',
+      'projectId': projectId,
+    });
+
+    if (shouldFailOnWatch) {
+      return Stream.value(Left(failureToReturn));
+    }
+
+    return _watchController.stream;
+  }
+
+  @override
+  void dispose() {
+    _watchController.close();
+  }
+
+  /// Emits a [Right] with [project] to active [watchProjectSetting] subscribers.
+  void emitProject(Project project) {
+    _watchController.add(Right(project));
+  }
+
+  /// Emits a [Left] with [failure] to active [watchProjectSetting] subscribers.
+  void emitFailure(Failure failure) {
+    _watchController.add(Left(failure));
+  }
+
+  /// Emits an error event to active [watchProjectSetting] subscribers.
+  void emitStreamError(Object error, [StackTrace? stackTrace]) {
+    _watchController.addError(error, stackTrace);
+  }
+
+  /// Returns a copy of all recorded method calls.
+  List<Map<String, dynamic>> getMethodCalls() => List.from(_methodCalls);
+
+  /// Returns all calls for the given [methodName].
+  List<Map<String, dynamic>> getMethodCallsFor(String methodName) {
+    return _methodCalls
+        .where((call) => call['method'] == methodName)
+        .toList();
+  }
+
+  /// Resets all flags, data, and recorded calls.
+  void reset() {
+    shouldFailOnGet = false;
+    shouldFailOnUpdate = false;
+    shouldFailOnDelete = false;
+    shouldFailOnWatch = false;
+    failureToReturn = const ProjectFailure(
+      errorType: ProjectErrorType.unexpectedError,
+    );
+    projectToReturn = null;
+    _methodCalls.clear();
+  }
+}

--- a/lib/libraries/project/testing/fake_project_setting_repository.dart
+++ b/lib/libraries/project/testing/fake_project_setting_repository.dart
@@ -113,7 +113,7 @@ class FakeProjectSettingRepository implements ProjectSettingRepository {
     try {
       _watchController.add(result);
     } on StateError {
-      // The controller may have been closed between the guard and the add.
+      // Guards against concurrent dispose() closing the controller.
     }
   }
 
@@ -127,7 +127,7 @@ class FakeProjectSettingRepository implements ProjectSettingRepository {
     try {
       _watchController.addError(error, stackTrace);
     } on StateError {
-      // The controller may have been closed between the guard and the add.
+      // Guards against concurrent dispose() closing the controller.
     }
   }
 

--- a/lib/libraries/project/testing/fake_project_setting_repository.dart
+++ b/lib/libraries/project/testing/fake_project_setting_repository.dart
@@ -11,6 +11,9 @@ class FakeProjectSettingRepository implements ProjectSettingRepository {
   /// Tracks method calls for boundary assertions.
   final List<Map<String, dynamic>> _methodCalls = [];
 
+  int _activeWatchListeners = 0;
+  bool _isDisposed = false;
+
   /// The [Project] returned by [getProjectSetting] and [updateProject].
   Project? projectToReturn;
 
@@ -33,11 +36,21 @@ class FakeProjectSettingRepository implements ProjectSettingRepository {
     errorType: ProjectErrorType.unexpectedError,
   );
 
-  final StreamController<Either<Failure, Project>> _watchController =
-      StreamController<Either<Failure, Project>>.broadcast();
+  late final StreamController<Either<Failure, Project>> _watchController;
 
   /// Creates a [FakeProjectSettingRepository].
-  FakeProjectSettingRepository();
+  FakeProjectSettingRepository() {
+    _watchController = StreamController<Either<Failure, Project>>.broadcast(
+      onListen: () {
+        _activeWatchListeners++;
+      },
+      onCancel: () {
+        if (_activeWatchListeners > 0) {
+          _activeWatchListeners--;
+        }
+      },
+    );
+  }
 
   @override
   Future<Either<Failure, Project>> getProjectSetting(String projectId) async {
@@ -81,10 +94,7 @@ class FakeProjectSettingRepository implements ProjectSettingRepository {
 
   @override
   Stream<Either<Failure, Project>> watchProjectSetting(String projectId) {
-    _methodCalls.add({
-      'method': 'watchProjectSetting',
-      'projectId': projectId,
-    });
+    _methodCalls.add({'method': 'watchProjectSetting', 'projectId': projectId});
 
     if (shouldFailOnWatch) {
       return Stream.value(Left(failureToReturn));
@@ -93,24 +103,57 @@ class FakeProjectSettingRepository implements ProjectSettingRepository {
     return _watchController.stream;
   }
 
+  void _emitToWatchController(Either<Failure, Project> result) {
+    if (_isDisposed ||
+        _watchController.isClosed ||
+        _activeWatchListeners == 0) {
+      return;
+    }
+
+    try {
+      _watchController.add(result);
+    } on StateError {
+      // The controller may have been closed between the guard and the add.
+    }
+  }
+
+  void _emitWatchControllerError(Object error, [StackTrace? stackTrace]) {
+    if (_isDisposed ||
+        _watchController.isClosed ||
+        _activeWatchListeners == 0) {
+      return;
+    }
+
+    try {
+      _watchController.addError(error, stackTrace);
+    } on StateError {
+      // The controller may have been closed between the guard and the add.
+    }
+  }
+
   @override
   void dispose() {
+    if (_isDisposed || _watchController.isClosed) {
+      return;
+    }
+
+    _isDisposed = true;
     _watchController.close();
   }
 
   /// Emits a [Right] with [project] to active [watchProjectSetting] subscribers.
   void emitProject(Project project) {
-    _watchController.add(Right(project));
+    _emitToWatchController(Right(project));
   }
 
   /// Emits a [Left] with [failure] to active [watchProjectSetting] subscribers.
   void emitFailure(Failure failure) {
-    _watchController.add(Left(failure));
+    _emitToWatchController(Left(failure));
   }
 
   /// Emits an error event to active [watchProjectSetting] subscribers.
   void emitStreamError(Object error, [StackTrace? stackTrace]) {
-    _watchController.addError(error, stackTrace);
+    _emitWatchControllerError(error, stackTrace);
   }
 
   /// Returns a copy of all recorded method calls.
@@ -118,9 +161,7 @@ class FakeProjectSettingRepository implements ProjectSettingRepository {
 
   /// Returns all calls for the given [methodName].
   List<Map<String, dynamic>> getMethodCallsFor(String methodName) {
-    return _methodCalls
-        .where((call) => call['method'] == methodName)
-        .toList();
+    return _methodCalls.where((call) => call['method'] == methodName).toList();
   }
 
   /// Resets all flags, data, and recorded calls.
@@ -134,5 +175,6 @@ class FakeProjectSettingRepository implements ProjectSettingRepository {
     );
     projectToReturn = null;
     _methodCalls.clear();
+    _isDisposed = false;
   }
 }

--- a/lib/libraries/project/testing/fake_project_setting_repository.dart
+++ b/lib/libraries/project/testing/fake_project_setting_repository.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:construculator/libraries/either/either.dart';
 import 'package:construculator/libraries/errors/failures.dart';
 import 'package:construculator/libraries/project/domain/entities/project_entity.dart';
@@ -11,12 +9,12 @@ class FakeProjectSettingRepository implements ProjectSettingRepository {
   // Tracks method calls for boundary assertions.
   final List<Map<String, dynamic>> _methodCalls = [];
 
-  int _activeWatchListeners = 0;
-  bool _isDisposed = false;
-
   /// The persisted project state. Read by [getProjectSetting], mutated by
   /// [updateProject], and cleared by [deleteProject].
   Project? projectToReturn;
+
+  /// When true, [createProject] returns a [Left] failure.
+  bool shouldFailOnCreate = false;
 
   /// When true, [getProjectSetting] returns a [Left] failure.
   bool shouldFailOnGet = false;
@@ -27,9 +25,6 @@ class FakeProjectSettingRepository implements ProjectSettingRepository {
   /// When true, [deleteProject] returns a [Left] failure.
   bool shouldFailOnDelete = false;
 
-  /// When true, [watchProjectSetting] returns a [Left] failure via the stream.
-  bool shouldFailOnWatch = false;
-
   /// The [Failure] returned when a [shouldFailOn*] flag is true.
   ///
   /// Defaults to [ProjectFailure] with [ProjectErrorType.unexpectedError].
@@ -37,24 +32,15 @@ class FakeProjectSettingRepository implements ProjectSettingRepository {
     errorType: ProjectErrorType.unexpectedError,
   );
 
-  late StreamController<Either<Failure, Project>> _watchController;
+  @override
+  Future<Either<Failure, Project>> createProject(Project project) async {
+    _methodCalls.add({'method': 'createProject', 'project': project});
 
-  /// Creates a [FakeProjectSettingRepository].
-  FakeProjectSettingRepository() {
-    _watchController = _createWatchController();
-  }
+    if (shouldFailOnCreate) {
+      return Left(failureToReturn);
+    }
 
-  StreamController<Either<Failure, Project>> _createWatchController() {
-    return StreamController<Either<Failure, Project>>.broadcast(
-      onListen: () {
-        _activeWatchListeners++;
-      },
-      onCancel: () {
-        if (_activeWatchListeners > 0) {
-          _activeWatchListeners--;
-        }
-      },
-    );
+    return Right(project);
   }
 
   @override
@@ -99,70 +85,6 @@ class FakeProjectSettingRepository implements ProjectSettingRepository {
     return const Right(null);
   }
 
-  @override
-  Stream<Either<Failure, Project>> watchProjectSetting(String projectId) {
-    _methodCalls.add({'method': 'watchProjectSetting', 'projectId': projectId});
-
-    if (shouldFailOnWatch) {
-      return Stream.value(Left(failureToReturn));
-    }
-
-    return _watchController.stream;
-  }
-
-  void _emitToWatchController(Either<Failure, Project> result) {
-    if (_isDisposed ||
-        _watchController.isClosed ||
-        _activeWatchListeners == 0) {
-      return;
-    }
-
-    try {
-      _watchController.add(result);
-    } on StateError {
-      // Guards against concurrent dispose() closing the controller.
-    }
-  }
-
-  void _emitWatchControllerError(Object error, [StackTrace? stackTrace]) {
-    if (_isDisposed ||
-        _watchController.isClosed ||
-        _activeWatchListeners == 0) {
-      return;
-    }
-
-    try {
-      _watchController.addError(error, stackTrace);
-    } on StateError {
-      // Guards against concurrent dispose() closing the controller.
-    }
-  }
-
-  @override
-  void dispose() {
-    if (_isDisposed || _watchController.isClosed) {
-      return;
-    }
-
-    _isDisposed = true;
-    _watchController.close();
-  }
-
-  /// Emits a [Right] with [project] to active [watchProjectSetting] subscribers.
-  void emitProject(Project project) {
-    _emitToWatchController(Right(project));
-  }
-
-  /// Emits a [Left] with [failure] to active [watchProjectSetting] subscribers.
-  void emitFailure(Failure failure) {
-    _emitToWatchController(Left(failure));
-  }
-
-  /// Emits an error event to active [watchProjectSetting] subscribers.
-  void emitStreamError(Object error, [StackTrace? stackTrace]) {
-    _emitWatchControllerError(error, stackTrace);
-  }
-
   /// Returns a copy of all recorded method calls.
   List<Map<String, dynamic>> getMethodCalls() => List.from(_methodCalls);
 
@@ -172,23 +94,18 @@ class FakeProjectSettingRepository implements ProjectSettingRepository {
   }
 
   /// Resets all flags, data, and recorded calls.
-  ///
-  /// Recreates the watch controller if it was closed by a prior [dispose] call,
-  /// so the fake can model a full repository lifecycle across test scenarios.
   void reset() {
+    shouldFailOnCreate = false;
     shouldFailOnGet = false;
     shouldFailOnUpdate = false;
     shouldFailOnDelete = false;
-    shouldFailOnWatch = false;
     failureToReturn = const ProjectFailure(
       errorType: ProjectErrorType.unexpectedError,
     );
     projectToReturn = null;
     _methodCalls.clear();
-    _isDisposed = false;
-    _activeWatchListeners = 0;
-    if (_watchController.isClosed) {
-      _watchController = _createWatchController();
-    }
   }
+
+  @override
+  void dispose() {}
 }

--- a/lib/libraries/project/testing/project_library_test_module.dart
+++ b/lib/libraries/project/testing/project_library_test_module.dart
@@ -1,5 +1,7 @@
 import 'package:construculator/libraries/project/domain/repositories/project_repository.dart';
+import 'package:construculator/libraries/project/domain/repositories/project_setting_repository.dart';
 import 'package:construculator/libraries/project/testing/fake_project_repository.dart';
+import 'package:construculator/libraries/project/testing/fake_project_setting_repository.dart';
 import 'package:construculator/libraries/time/testing/clock_test_module.dart';
 import 'package:flutter_modular/flutter_modular.dart';
 
@@ -12,6 +14,11 @@ class ProjectTestModule extends Module {
     i.addLazySingleton<ProjectRepository>(
       () => FakeProjectRepository(),
       key: 'fakeProjectRepository',
+    );
+
+    i.addLazySingleton<ProjectSettingRepository>(
+      () => FakeProjectSettingRepository(),
+      key: 'fakeProjectSettingRepository',
     );
   }
 }

--- a/lib/libraries/project/testing/project_library_test_module.dart
+++ b/lib/libraries/project/testing/project_library_test_module.dart
@@ -5,6 +5,7 @@ import 'package:construculator/libraries/project/testing/fake_project_setting_re
 import 'package:construculator/libraries/time/testing/clock_test_module.dart';
 import 'package:flutter_modular/flutter_modular.dart';
 
+/// Modular test module that binds project-library fakes for unit tests.
 class ProjectTestModule extends Module {
   @override
   List<Module> get imports => [ClockTestModule()];

--- a/test/libraries/project/units/data/repositories/project_setting_repository_impl_test.dart
+++ b/test/libraries/project/units/data/repositories/project_setting_repository_impl_test.dart
@@ -49,6 +49,17 @@ void main() {
       Modular.destroy();
     });
 
+    test('exports the real repository and data source bindings', () {
+      expect(
+        Modular.get<ProjectSettingRepository>(),
+        isA<ProjectSettingRepositoryImpl>(),
+      );
+      expect(
+        Modular.get<ProjectSettingDataSource>(),
+        isA<RemoteProjectSettingDataSource>(),
+      );
+    });
+
     group('getProjectSetting', () {
       test('returns Right(project) when data source succeeds', () async {
         fakeSupabaseWrapper.addTableData(DatabaseConstants.projectsTable, [

--- a/test/libraries/project/units/fakes/fake_project_setting_repository_test.dart
+++ b/test/libraries/project/units/fakes/fake_project_setting_repository_test.dart
@@ -134,7 +134,7 @@ void main() {
           (_) => fail('Expected Right'),
           (project) => expect(project.projectName, equals('New')),
         );
-        expect(fake.projectToReturn?.projectName, equals('New'));
+        expect(fake.projectToReturn!.projectName, equals('New'));
       });
 
       test(

--- a/test/libraries/project/units/fakes/fake_project_setting_repository_test.dart
+++ b/test/libraries/project/units/fakes/fake_project_setting_repository_test.dart
@@ -191,6 +191,9 @@ void main() {
         fake.shouldFailOnUpdate = true;
         fake.shouldFailOnDelete = true;
         fake.projectToReturn = _fakeProject(id: 'p-1');
+        fake.failureToReturn = const ProjectFailure(
+          errorType: ProjectErrorType.connectionError,
+        );
         await fake.deleteProject('p-1');
 
         fake.reset();
@@ -201,6 +204,12 @@ void main() {
         expect(fake.shouldFailOnDelete, isFalse);
         expect(fake.projectToReturn, isNull);
         expect(fake.getMethodCalls(), isEmpty);
+        expect(
+          fake.failureToReturn,
+          equals(
+            const ProjectFailure(errorType: ProjectErrorType.unexpectedError),
+          ),
+        );
       });
     });
   });

--- a/test/libraries/project/units/fakes/fake_project_setting_repository_test.dart
+++ b/test/libraries/project/units/fakes/fake_project_setting_repository_test.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:construculator/libraries/either/either.dart';
 import 'package:construculator/libraries/errors/failures.dart';
 import 'package:construculator/libraries/project/domain/entities/enums.dart';
@@ -19,6 +17,38 @@ void main() {
     tearDown(() {
       fake.reset();
       fake.dispose();
+    });
+
+    group('createProject', () {
+      test('returns Right(project) by default', () async {
+        final project = _fakeProject(id: 'p-1', projectName: 'New Project');
+
+        final result = await fake.createProject(project);
+
+        expect(result.isRight(), isTrue);
+        result.fold(
+          (_) => fail('Expected Right'),
+          (p) => expect(p.projectName, equals('New Project')),
+        );
+      });
+
+      test('records method call with project', () async {
+        final project = _fakeProject(id: 'p-1');
+
+        await fake.createProject(project);
+
+        final calls = fake.getMethodCallsFor('createProject');
+        expect(calls, hasLength(1));
+        expect(calls.first['project'], equals(project));
+      });
+
+      test('returns Left when shouldFailOnCreate is true', () async {
+        fake.shouldFailOnCreate = true;
+
+        final result = await fake.createProject(_fakeProject(id: 'p-1'));
+
+        expect(result.isLeft(), isTrue);
+      });
     });
 
     group('getProjectSetting', () {
@@ -154,116 +184,21 @@ void main() {
       });
     });
 
-    group('watchProjectSetting', () {
-      test('records method call with projectId', () {
-        fake.watchProjectSetting('p-1').listen((_) {});
-
-        final calls = fake.getMethodCallsFor('watchProjectSetting');
-        expect(calls, hasLength(1));
-        expect(calls.first['projectId'], equals('p-1'));
-      });
-
-      test('emits Right(project) after emitProject', () async {
-        final emittedCompleter = Completer<Project>();
-        final subscription = fake.watchProjectSetting('p-1').listen((result) {
-          result.fold((_) {}, (project) {
-            if (!emittedCompleter.isCompleted) {
-              emittedCompleter.complete(project);
-            }
-          });
-        });
-
-        final project = _fakeProject(id: 'p-1', projectName: 'Emitted');
-        fake.emitProject(project);
-
-        final received = await emittedCompleter.future;
-        expect(received.projectName, equals('Emitted'));
-        await subscription.cancel();
-      });
-
-      test('emits Left after emitFailure', () async {
-        final failureCompleter = Completer<Failure>();
-        final subscription = fake.watchProjectSetting('p-1').listen((result) {
-          result.fold((failure) {
-            if (!failureCompleter.isCompleted)
-              failureCompleter.complete(failure);
-          }, (_) {});
-        });
-
-        fake.emitFailure(
-          const ProjectFailure(errorType: ProjectErrorType.notFoundError),
-        );
-
-        final received = await failureCompleter.future;
-        expect(received, isA<ProjectFailure>());
-        await subscription.cancel();
-      });
-
-      test('forwards error on emitStreamError', () async {
-        final errorCompleter = Completer<Object>();
-        final subscription = fake
-            .watchProjectSetting('p-1')
-            .listen(
-              (_) {},
-              onError: (Object error, StackTrace _) {
-                if (!errorCompleter.isCompleted) errorCompleter.complete(error);
-              },
-            );
-
-        fake.emitStreamError(Exception('test error'));
-
-        final received = await errorCompleter.future;
-        expect(received, isA<Exception>());
-        await subscription.cancel();
-      });
-
-      test(
-        'returns stream with single Left when shouldFailOnWatch is true',
-        () async {
-          fake.shouldFailOnWatch = true;
-
-          final result = await fake.watchProjectSetting('p-1').first;
-
-          expect(result.isLeft(), isTrue);
-        },
-      );
-
-      test('ignores emits after dispose', () {
-        fake.watchProjectSetting('p-1').listen((_) {});
-        fake.dispose();
-
-        expect(
-          () => fake.emitProject(_fakeProject(id: 'p-1')),
-          returnsNormally,
-        );
-        expect(
-          () => fake.emitFailure(
-            const ProjectFailure(errorType: ProjectErrorType.connectionError),
-          ),
-          returnsNormally,
-        );
-        expect(
-          () => fake.emitStreamError(Exception('disposed stream')),
-          returnsNormally,
-        );
-      });
-    });
-
     group('reset', () {
       test('clears all flags, data, and method calls', () async {
+        fake.shouldFailOnCreate = true;
         fake.shouldFailOnGet = true;
         fake.shouldFailOnUpdate = true;
         fake.shouldFailOnDelete = true;
-        fake.shouldFailOnWatch = true;
         fake.projectToReturn = _fakeProject(id: 'p-1');
         await fake.deleteProject('p-1');
 
         fake.reset();
 
+        expect(fake.shouldFailOnCreate, isFalse);
         expect(fake.shouldFailOnGet, isFalse);
         expect(fake.shouldFailOnUpdate, isFalse);
         expect(fake.shouldFailOnDelete, isFalse);
-        expect(fake.shouldFailOnWatch, isFalse);
         expect(fake.projectToReturn, isNull);
         expect(fake.getMethodCalls(), isEmpty);
       });

--- a/test/libraries/project/units/fakes/fake_project_setting_repository_test.dart
+++ b/test/libraries/project/units/fakes/fake_project_setting_repository_test.dart
@@ -94,16 +94,17 @@ void main() {
         expect(calls.first['project'], equals(project));
       });
 
-      test('returns Right(projectToReturn) when set', () async {
-        final returned = _fakeProject(id: 'p-1', projectName: 'Returned');
-        fake.projectToReturn = returned;
+      test('returns Right(passed project) and mutates projectToReturn', () async {
+        fake.projectToReturn = _fakeProject(id: 'p-1', projectName: 'Old');
+        final updated = _fakeProject(id: 'p-1', projectName: 'New');
 
-        final result = await fake.updateProject(_fakeProject(id: 'p-1'));
+        final result = await fake.updateProject(updated);
 
         result.fold(
           (_) => fail('Expected Right'),
-          (project) => expect(project.projectName, equals('Returned')),
+          (project) => expect(project.projectName, equals('New')),
         );
+        expect(fake.projectToReturn?.projectName, equals('New'));
       });
 
       test(

--- a/test/libraries/project/units/fakes/fake_project_setting_repository_test.dart
+++ b/test/libraries/project/units/fakes/fake_project_setting_repository_test.dart
@@ -33,7 +33,10 @@ void main() {
       });
 
       test('returns Right(project) when projectToReturn is set', () async {
-        fake.projectToReturn = _fakeProject(id: 'p-1', projectName: 'My Project');
+        fake.projectToReturn = _fakeProject(
+          id: 'p-1',
+          projectName: 'My Project',
+        );
 
         final result = await fake.getProjectSetting('p-1');
 
@@ -44,36 +47,39 @@ void main() {
         );
       });
 
-      test('returns Left(notFoundError) when projectToReturn is null', () async {
-        final result = await fake.getProjectSetting('p-1');
+      test(
+        'returns Left(notFoundError) when projectToReturn is null',
+        () async {
+          final result = await fake.getProjectSetting('p-1');
 
-        expect(result.isLeft(), isTrue);
-        result.fold(
-          (failure) {
+          expect(result.isLeft(), isTrue);
+          result.fold((failure) {
             expect(failure, isA<ProjectFailure>());
             expect(
               (failure as ProjectFailure).errorType,
               equals(ProjectErrorType.notFoundError),
             );
-          },
-          (_) => fail('Expected Left'),
-        );
-      });
+          }, (_) => fail('Expected Left'));
+        },
+      );
 
-      test('returns Left(failureToReturn) when shouldFailOnGet is true', () async {
-        fake.shouldFailOnGet = true;
-        fake.failureToReturn = const ProjectFailure(
-          errorType: ProjectErrorType.connectionError,
-        );
+      test(
+        'returns Left(failureToReturn) when shouldFailOnGet is true',
+        () async {
+          fake.shouldFailOnGet = true;
+          fake.failureToReturn = const ProjectFailure(
+            errorType: ProjectErrorType.connectionError,
+          );
 
-        final result = await fake.getProjectSetting('p-1');
+          final result = await fake.getProjectSetting('p-1');
 
-        expect(result.isLeft(), isTrue);
-        expect(
-          ((result as Left).value as ProjectFailure).errorType,
-          equals(ProjectErrorType.connectionError),
-        );
-      });
+          expect(result.isLeft(), isTrue);
+          expect(
+            ((result as Left).value as ProjectFailure).errorType,
+            equals(ProjectErrorType.connectionError),
+          );
+        },
+      );
     });
 
     group('updateProject', () {
@@ -100,16 +106,19 @@ void main() {
         );
       });
 
-      test('returns Right(passed project) when projectToReturn is null', () async {
-        final project = _fakeProject(id: 'p-1', projectName: 'Fallback');
+      test(
+        'returns Right(passed project) when projectToReturn is null',
+        () async {
+          final project = _fakeProject(id: 'p-1', projectName: 'Fallback');
 
-        final result = await fake.updateProject(project);
+          final result = await fake.updateProject(project);
 
-        result.fold(
-          (_) => fail('Expected Right'),
-          (p) => expect(p.projectName, equals('Fallback')),
-        );
-      });
+          result.fold(
+            (_) => fail('Expected Right'),
+            (p) => expect(p.projectName, equals('Fallback')),
+          );
+        },
+      );
 
       test('returns Left when shouldFailOnUpdate is true', () async {
         fake.shouldFailOnUpdate = true;
@@ -156,14 +165,11 @@ void main() {
       test('emits Right(project) after emitProject', () async {
         final emittedCompleter = Completer<Project>();
         final subscription = fake.watchProjectSetting('p-1').listen((result) {
-          result.fold(
-            (_) {},
-            (project) {
-              if (!emittedCompleter.isCompleted) {
-                emittedCompleter.complete(project);
-              }
-            },
-          );
+          result.fold((_) {}, (project) {
+            if (!emittedCompleter.isCompleted) {
+              emittedCompleter.complete(project);
+            }
+          });
         });
 
         final project = _fakeProject(id: 'p-1', projectName: 'Emitted');
@@ -178,7 +184,8 @@ void main() {
         final failureCompleter = Completer<Failure>();
         final subscription = fake.watchProjectSetting('p-1').listen((result) {
           result.fold((failure) {
-            if (!failureCompleter.isCompleted) failureCompleter.complete(failure);
+            if (!failureCompleter.isCompleted)
+              failureCompleter.complete(failure);
           }, (_) {});
         });
 
@@ -193,12 +200,14 @@ void main() {
 
       test('forwards error on emitStreamError', () async {
         final errorCompleter = Completer<Object>();
-        final subscription = fake.watchProjectSetting('p-1').listen(
-          (_) {},
-          onError: (Object error, StackTrace _) {
-            if (!errorCompleter.isCompleted) errorCompleter.complete(error);
-          },
-        );
+        final subscription = fake
+            .watchProjectSetting('p-1')
+            .listen(
+              (_) {},
+              onError: (Object error, StackTrace _) {
+                if (!errorCompleter.isCompleted) errorCompleter.complete(error);
+              },
+            );
 
         fake.emitStreamError(Exception('test error'));
 
@@ -207,12 +216,35 @@ void main() {
         await subscription.cancel();
       });
 
-      test('returns stream with single Left when shouldFailOnWatch is true', () async {
-        fake.shouldFailOnWatch = true;
+      test(
+        'returns stream with single Left when shouldFailOnWatch is true',
+        () async {
+          fake.shouldFailOnWatch = true;
 
-        final result = await fake.watchProjectSetting('p-1').first;
+          final result = await fake.watchProjectSetting('p-1').first;
 
-        expect(result.isLeft(), isTrue);
+          expect(result.isLeft(), isTrue);
+        },
+      );
+
+      test('ignores emits after dispose', () {
+        fake.watchProjectSetting('p-1').listen((_) {});
+        fake.dispose();
+
+        expect(
+          () => fake.emitProject(_fakeProject(id: 'p-1')),
+          returnsNormally,
+        );
+        expect(
+          () => fake.emitFailure(
+            const ProjectFailure(errorType: ProjectErrorType.connectionError),
+          ),
+          returnsNormally,
+        );
+        expect(
+          () => fake.emitStreamError(Exception('disposed stream')),
+          returnsNormally,
+        );
       });
     });
 

--- a/test/libraries/project/units/fakes/fake_project_setting_repository_test.dart
+++ b/test/libraries/project/units/fakes/fake_project_setting_repository_test.dart
@@ -1,0 +1,250 @@
+import 'dart:async';
+
+import 'package:construculator/libraries/either/either.dart';
+import 'package:construculator/libraries/errors/failures.dart';
+import 'package:construculator/libraries/project/domain/entities/enums.dart';
+import 'package:construculator/libraries/project/domain/entities/project_entity.dart';
+import 'package:construculator/libraries/project/domain/project_error_type.dart';
+import 'package:construculator/libraries/project/testing/fake_project_setting_repository.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('FakeProjectSettingRepository', () {
+    late FakeProjectSettingRepository fake;
+
+    setUp(() {
+      fake = FakeProjectSettingRepository();
+    });
+
+    tearDown(() {
+      fake.reset();
+      fake.dispose();
+    });
+
+    group('getProjectSetting', () {
+      test('records method call with projectId', () async {
+        fake.projectToReturn = _fakeProject(id: 'p-1');
+
+        await fake.getProjectSetting('p-1');
+
+        final calls = fake.getMethodCallsFor('getProjectSetting');
+        expect(calls, hasLength(1));
+        expect(calls.first['projectId'], equals('p-1'));
+      });
+
+      test('returns Right(project) when projectToReturn is set', () async {
+        fake.projectToReturn = _fakeProject(id: 'p-1', projectName: 'My Project');
+
+        final result = await fake.getProjectSetting('p-1');
+
+        expect(result.isRight(), isTrue);
+        result.fold(
+          (_) => fail('Expected Right'),
+          (project) => expect(project.projectName, equals('My Project')),
+        );
+      });
+
+      test('returns Left(notFoundError) when projectToReturn is null', () async {
+        final result = await fake.getProjectSetting('p-1');
+
+        expect(result.isLeft(), isTrue);
+        result.fold(
+          (failure) {
+            expect(failure, isA<ProjectFailure>());
+            expect(
+              (failure as ProjectFailure).errorType,
+              equals(ProjectErrorType.notFoundError),
+            );
+          },
+          (_) => fail('Expected Left'),
+        );
+      });
+
+      test('returns Left(failureToReturn) when shouldFailOnGet is true', () async {
+        fake.shouldFailOnGet = true;
+        fake.failureToReturn = const ProjectFailure(
+          errorType: ProjectErrorType.connectionError,
+        );
+
+        final result = await fake.getProjectSetting('p-1');
+
+        expect(result.isLeft(), isTrue);
+        expect(
+          ((result as Left).value as ProjectFailure).errorType,
+          equals(ProjectErrorType.connectionError),
+        );
+      });
+    });
+
+    group('updateProject', () {
+      test('records method call with project', () async {
+        final project = _fakeProject(id: 'p-1');
+        fake.projectToReturn = project;
+
+        await fake.updateProject(project);
+
+        final calls = fake.getMethodCallsFor('updateProject');
+        expect(calls, hasLength(1));
+        expect(calls.first['project'], equals(project));
+      });
+
+      test('returns Right(projectToReturn) when set', () async {
+        final returned = _fakeProject(id: 'p-1', projectName: 'Returned');
+        fake.projectToReturn = returned;
+
+        final result = await fake.updateProject(_fakeProject(id: 'p-1'));
+
+        result.fold(
+          (_) => fail('Expected Right'),
+          (project) => expect(project.projectName, equals('Returned')),
+        );
+      });
+
+      test('returns Right(passed project) when projectToReturn is null', () async {
+        final project = _fakeProject(id: 'p-1', projectName: 'Fallback');
+
+        final result = await fake.updateProject(project);
+
+        result.fold(
+          (_) => fail('Expected Right'),
+          (p) => expect(p.projectName, equals('Fallback')),
+        );
+      });
+
+      test('returns Left when shouldFailOnUpdate is true', () async {
+        fake.shouldFailOnUpdate = true;
+
+        final result = await fake.updateProject(_fakeProject(id: 'p-1'));
+
+        expect(result.isLeft(), isTrue);
+      });
+    });
+
+    group('deleteProject', () {
+      test('records method call with projectId', () async {
+        await fake.deleteProject('p-1');
+
+        final calls = fake.getMethodCallsFor('deleteProject');
+        expect(calls, hasLength(1));
+        expect(calls.first['projectId'], equals('p-1'));
+      });
+
+      test('returns Right(null) by default', () async {
+        final result = await fake.deleteProject('p-1');
+
+        expect(result.isRight(), isTrue);
+      });
+
+      test('returns Left when shouldFailOnDelete is true', () async {
+        fake.shouldFailOnDelete = true;
+
+        final result = await fake.deleteProject('p-1');
+
+        expect(result.isLeft(), isTrue);
+      });
+    });
+
+    group('watchProjectSetting', () {
+      test('records method call with projectId', () {
+        fake.watchProjectSetting('p-1').listen((_) {});
+
+        final calls = fake.getMethodCallsFor('watchProjectSetting');
+        expect(calls, hasLength(1));
+        expect(calls.first['projectId'], equals('p-1'));
+      });
+
+      test('emits Right(project) after emitProject', () async {
+        final emittedCompleter = Completer<Project>();
+        final subscription = fake.watchProjectSetting('p-1').listen((result) {
+          result.fold(
+            (_) {},
+            (project) {
+              if (!emittedCompleter.isCompleted) {
+                emittedCompleter.complete(project);
+              }
+            },
+          );
+        });
+
+        final project = _fakeProject(id: 'p-1', projectName: 'Emitted');
+        fake.emitProject(project);
+
+        final received = await emittedCompleter.future;
+        expect(received.projectName, equals('Emitted'));
+        await subscription.cancel();
+      });
+
+      test('emits Left after emitFailure', () async {
+        final failureCompleter = Completer<Failure>();
+        final subscription = fake.watchProjectSetting('p-1').listen((result) {
+          result.fold((failure) {
+            if (!failureCompleter.isCompleted) failureCompleter.complete(failure);
+          }, (_) {});
+        });
+
+        fake.emitFailure(
+          const ProjectFailure(errorType: ProjectErrorType.notFoundError),
+        );
+
+        final received = await failureCompleter.future;
+        expect(received, isA<ProjectFailure>());
+        await subscription.cancel();
+      });
+
+      test('forwards error on emitStreamError', () async {
+        final errorCompleter = Completer<Object>();
+        final subscription = fake.watchProjectSetting('p-1').listen(
+          (_) {},
+          onError: (Object error, StackTrace _) {
+            if (!errorCompleter.isCompleted) errorCompleter.complete(error);
+          },
+        );
+
+        fake.emitStreamError(Exception('test error'));
+
+        final received = await errorCompleter.future;
+        expect(received, isA<Exception>());
+        await subscription.cancel();
+      });
+
+      test('returns stream with single Left when shouldFailOnWatch is true', () async {
+        fake.shouldFailOnWatch = true;
+
+        final result = await fake.watchProjectSetting('p-1').first;
+
+        expect(result.isLeft(), isTrue);
+      });
+    });
+
+    group('reset', () {
+      test('clears all flags, data, and method calls', () async {
+        fake.shouldFailOnGet = true;
+        fake.shouldFailOnUpdate = true;
+        fake.shouldFailOnDelete = true;
+        fake.shouldFailOnWatch = true;
+        fake.projectToReturn = _fakeProject(id: 'p-1');
+        await fake.deleteProject('p-1');
+
+        fake.reset();
+
+        expect(fake.shouldFailOnGet, isFalse);
+        expect(fake.shouldFailOnUpdate, isFalse);
+        expect(fake.shouldFailOnDelete, isFalse);
+        expect(fake.shouldFailOnWatch, isFalse);
+        expect(fake.projectToReturn, isNull);
+        expect(fake.getMethodCalls(), isEmpty);
+      });
+    });
+  });
+}
+
+Project _fakeProject({required String id, String? projectName}) {
+  return Project(
+    id: id,
+    projectName: projectName ?? 'Test Project',
+    creatorUserId: 'user-1',
+    createdAt: DateTime(2025, 1, 1),
+    updatedAt: DateTime(2025, 1, 2),
+    status: ProjectStatus.active,
+  );
+}


### PR DESCRIPTION
### 1. PR SUMMARY
This PR adds `createProject` to `FakeProjectSettingRepository`, removes the now-deleted `watchProjectSetting` stream infrastructure, wires the fake into the project test module, and adds coverage for the real repository bindings plus the updated fake's behavior.

Replaces #318 (auto-closed when `CA-250/repo-watch` was folded into `CA-250/repo-write`).

### 2. Changes
- `FakeProjectSettingRepository`: added `createProject`/`shouldFailOnCreate`, removed all watch stream infrastructure (`_watchController`, `emitProject`, `emitFailure`, `emitStreamError`, `shouldFailOnWatch`, etc.)
- `fake_project_setting_repository_test.dart`: added `createProject` group (3 tests), removed `watchProjectSetting` group