### PR TITLE
CA-251: feat(global-search): wire owner filter into GlobalSearchBloc

### DIFF
--- a/lib/features/global_search/global_search_module.dart
+++ b/lib/features/global_search/global_search_module.dart
@@ -7,6 +7,7 @@ import 'package:construculator/features/global_search/presentation/bloc/global_s
 import 'package:construculator/features/global_search/presentation/pages/global_search_page.dart';
 import 'package:construculator/libraries/estimation/data/estimation_tile_provider_impl.dart';
 import 'package:construculator/libraries/estimation/domain/estimation_tile_provider.dart';
+import 'package:construculator/libraries/owner/owner_library_module.dart';
 import 'package:construculator/libraries/router/guards/auth_guard.dart';
 import 'package:construculator/libraries/router/routes/global_search_routes.dart';
 import 'package:construculator/libraries/supabase/supabase_module.dart';
@@ -26,6 +27,7 @@ class GlobalSearchModule extends Module {
   List<Module> get imports => [
     SupabaseModule(appBootstrap),
     TagLibraryModule(appBootstrap),
+    OwnerLibraryModule(appBootstrap),
   ];
 
   @override
@@ -39,7 +41,11 @@ class GlobalSearchModule extends Module {
       () => GlobalSearchRepositoryImpl(dataSource: i()),
     );
     i.add<GlobalSearchBloc>(
-      () => GlobalSearchBloc(repository: i(), tagRepository: i()),
+      () => GlobalSearchBloc(
+        repository: i(),
+        tagRepository: i(),
+        ownerRepository: i(),
+      ),
     );
     i.addSingleton<EstimationTileProvider>(
       () => const EstimationTileProviderImpl(),

--- a/lib/features/global_search/presentation/bloc/global_search_bloc/global_search_bloc.dart
+++ b/lib/features/global_search/presentation/bloc/global_search_bloc/global_search_bloc.dart
@@ -3,8 +3,10 @@ import 'package:construculator/features/global_search/domain/entities/search_par
 import 'package:construculator/features/global_search/domain/entities/search_results.dart';
 import 'package:construculator/features/global_search/domain/entities/search_scope_entity.dart';
 import 'package:construculator/features/global_search/domain/repositories/global_search_repository.dart';
+import 'package:construculator/libraries/auth/domain/entities/user_profile_entity.dart';
 import 'package:construculator/libraries/errors/failures.dart';
 import 'package:construculator/libraries/logging/app_logger.dart';
+import 'package:construculator/libraries/owner/domain/repositories/owner_repository.dart';
 import 'package:construculator/libraries/tag/domain/repositories/tag_repository.dart';
 import 'package:equatable/equatable.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -30,6 +32,7 @@ class GlobalSearchBloc extends Bloc<GlobalSearchEvent, GlobalSearchState> {
   static final _logger = AppLogger().tag('GlobalSearchBloc');
   final GlobalSearchRepository _repository;
   final TagRepository _tagRepository;
+  final OwnerRepository _ownerRepository;
 
   List<String> _recentSearches = const [];
 
@@ -48,11 +51,24 @@ class GlobalSearchBloc extends Bloc<GlobalSearchEvent, GlobalSearchState> {
 
   String _tagSearchQuery = '';
 
+  Set<String> _selectedOwnerIds = const {};
+
+  // Full list of available owners fetched from OwnerRepository.
+  List<UserProfile> _availableOwners = const [];
+
+  // Whether _availableOwners has been fetched at least once, so subsequent
+  // sheet openings reuse the cached list instead of refetching.
+  bool _availableOwnersFetched = false;
+
+  String _ownerSearchQuery = '';
+
   GlobalSearchBloc({
     required GlobalSearchRepository repository,
     required TagRepository tagRepository,
+    required OwnerRepository ownerRepository,
   }) : _repository = repository,
        _tagRepository = tagRepository,
+       _ownerRepository = ownerRepository,
        super(const GlobalSearchInitial()) {
     on<GlobalSearchStarted>(_onStarted);
     on<GlobalSearchQueryUpdated>(
@@ -70,6 +86,12 @@ class GlobalSearchBloc extends Bloc<GlobalSearchEvent, GlobalSearchState> {
     // Intentionally not debounced: tag filtering is in-memory (no network
     // call), so instant per-keystroke feedback is cheap and preferable.
     on<GlobalSearchTagSearchQueryUpdated>(_onTagSearchQueryUpdated);
+    on<GlobalSearchOwnerFiltersApplied>(_onOwnerFiltersApplied);
+    on<GlobalSearchOwnerFilterCleared>(_onOwnerFilterCleared);
+    on<GlobalSearchAvailableOwnersRequested>(_onAvailableOwnersRequested);
+    // Intentionally not debounced: owner filtering is in-memory (no network
+    // call), so instant per-keystroke feedback is cheap and preferable.
+    on<GlobalSearchOwnerSearchQueryUpdated>(_onOwnerSearchQueryUpdated);
   }
 
   // Returns _availableTags filtered by the current tag search query.
@@ -81,10 +103,21 @@ class GlobalSearchBloc extends Bloc<GlobalSearchEvent, GlobalSearchState> {
         .toList();
   }
 
+  // Returns _availableOwners filtered by the current owner search query,
+  // matching against the owner's full name.
+  List<UserProfile> _filterAvailableOwners() {
+    if (_ownerSearchQuery.isEmpty) return _availableOwners;
+    final lower = _ownerSearchQuery.toLowerCase();
+    return _availableOwners
+        .where((owner) => owner.fullName.toLowerCase().contains(lower))
+        .toList();
+  }
+
   // Builds a GlobalSearchReady from the current internal fields.
   GlobalSearchReady _readyState({
     bool suggestionsLoading = false,
     bool availableTagsLoading = false,
+    bool availableOwnersLoading = false,
   }) {
     return GlobalSearchReady(
       recentSearches: _recentSearches,
@@ -94,6 +127,9 @@ class GlobalSearchBloc extends Bloc<GlobalSearchEvent, GlobalSearchState> {
       selectedTags: _selectedTags,
       availableTags: _filterAvailableTags(),
       availableTagsLoading: availableTagsLoading,
+      selectedOwnerIds: _selectedOwnerIds,
+      availableOwners: _filterAvailableOwners(),
+      availableOwnersLoading: availableOwnersLoading,
     );
   }
 
@@ -145,6 +181,8 @@ class GlobalSearchBloc extends Bloc<GlobalSearchEvent, GlobalSearchState> {
       _currentQuery = '';
       _selectedTags = const {};
       _tagSearchQuery = '';
+      _selectedOwnerIds = const {};
+      _ownerSearchQuery = '';
       emit(_readyState());
     });
   }
@@ -178,6 +216,11 @@ class GlobalSearchBloc extends Bloc<GlobalSearchEvent, GlobalSearchState> {
         filterByTag: _selectedTags.isEmpty
             ? null
             : (_selectedTags.toList()..sort()).first,
+        // SearchParams accepts a single owner; sort for deterministic
+        // selection until the API supports multi-owner filtering.
+        filterByOwner: _selectedOwnerIds.isEmpty
+            ? null
+            : (_selectedOwnerIds.toList()..sort()).first,
       ),
     );
 
@@ -267,6 +310,59 @@ class GlobalSearchBloc extends Bloc<GlobalSearchEvent, GlobalSearchState> {
   ) {
     _selectedTags = Set.unmodifiable(
       _selectedTags.where((t) => t != event.tag),
+    );
+    emit(_readyState());
+  }
+
+  Future<void> _onAvailableOwnersRequested(
+    GlobalSearchAvailableOwnersRequested event,
+    Emitter<GlobalSearchState> emit,
+  ) async {
+    _ownerSearchQuery = '';
+    if (_availableOwnersFetched) {
+      emit(_readyState());
+      return;
+    }
+
+    emit(_readyState(availableOwnersLoading: true));
+
+    final result = await _ownerRepository.getOwners();
+
+    result.fold(
+      (failure) {
+        emit(GlobalSearchOwnersLoadFailure(failure: failure));
+        emit(_readyState());
+      },
+      (owners) {
+        _availableOwners = List.unmodifiable(owners);
+        _availableOwnersFetched = true;
+        emit(_readyState());
+      },
+    );
+  }
+
+  void _onOwnerSearchQueryUpdated(
+    GlobalSearchOwnerSearchQueryUpdated event,
+    Emitter<GlobalSearchState> emit,
+  ) {
+    _ownerSearchQuery = event.query.trim();
+    emit(_readyState());
+  }
+
+  void _onOwnerFiltersApplied(
+    GlobalSearchOwnerFiltersApplied event,
+    Emitter<GlobalSearchState> emit,
+  ) {
+    _selectedOwnerIds = Set.unmodifiable(event.ownerIds);
+    emit(_readyState());
+  }
+
+  void _onOwnerFilterCleared(
+    GlobalSearchOwnerFilterCleared event,
+    Emitter<GlobalSearchState> emit,
+  ) {
+    _selectedOwnerIds = Set.unmodifiable(
+      _selectedOwnerIds.where((id) => id != event.ownerId),
     );
     emit(_readyState());
   }

--- a/lib/features/global_search/presentation/bloc/global_search_bloc/global_search_bloc.dart
+++ b/lib/features/global_search/presentation/bloc/global_search_bloc/global_search_bloc.dart
@@ -217,7 +217,8 @@ class GlobalSearchBloc extends Bloc<GlobalSearchEvent, GlobalSearchState> {
             ? null
             : (_selectedTags.toList()..sort()).first,
         // SearchParams accepts a single owner; sort for deterministic
-        // selection until the API supports multi-owner filtering.
+        // selection until CA-737 extends the API to support multi-owner
+        // filtering.
         filterByOwner: _selectedOwnerIds.isEmpty
             ? null
             : (_selectedOwnerIds.toList()..sort()).first,

--- a/lib/features/global_search/presentation/bloc/global_search_bloc/global_search_event.dart
+++ b/lib/features/global_search/presentation/bloc/global_search_bloc/global_search_event.dart
@@ -120,3 +120,51 @@ class GlobalSearchTagSearchQueryUpdated extends GlobalSearchEvent {
   @override
   List<Object?> get props => [query];
 }
+
+/// Applies (or replaces) the active owner filter set.
+///
+/// Dispatched when the user taps Apply in the Owner filter sheet.
+/// An empty [ownerIds] set clears the owner filter entirely.
+class GlobalSearchOwnerFiltersApplied extends GlobalSearchEvent {
+  /// The set of owner ids to apply as active filters.
+  final Set<String> ownerIds;
+
+  const GlobalSearchOwnerFiltersApplied({required this.ownerIds});
+
+  @override
+  List<Object?> get props => [ownerIds];
+}
+
+/// Clears a single owner from the active owner filter set.
+///
+/// Dispatched when the user taps the × icon on an individual active owner chip.
+class GlobalSearchOwnerFilterCleared extends GlobalSearchEvent {
+  /// The owner id to remove from the active filter set.
+  final String ownerId;
+
+  const GlobalSearchOwnerFilterCleared({required this.ownerId});
+
+  @override
+  List<Object?> get props => [ownerId];
+}
+
+/// Requests the list of available owners for the Owner filter sheet.
+///
+/// Dispatched when the user opens the Owner filter sheet. The BLoC fetches
+/// owners from [OwnerRepository] on the first request and serves the cached
+/// list on subsequent requests.
+class GlobalSearchAvailableOwnersRequested extends GlobalSearchEvent {
+  const GlobalSearchAvailableOwnersRequested();
+}
+
+/// Updates the search query used to filter the available owners list
+/// inside the Owner filter sheet.
+class GlobalSearchOwnerSearchQueryUpdated extends GlobalSearchEvent {
+  /// The current value of the owner search input field.
+  final String query;
+
+  const GlobalSearchOwnerSearchQueryUpdated({required this.query});
+
+  @override
+  List<Object?> get props => [query];
+}

--- a/lib/features/global_search/presentation/bloc/global_search_bloc/global_search_state.dart
+++ b/lib/features/global_search/presentation/bloc/global_search_bloc/global_search_state.dart
@@ -41,6 +41,17 @@ class GlobalSearchReady extends GlobalSearchState {
   /// Whether the available tags fetch is currently in flight.
   final bool availableTagsLoading;
 
+  /// Owner ids currently applied as filters. Empty means no owner filter
+  /// is active.
+  final Set<String> selectedOwnerIds;
+
+  /// Available owners to display in the Owner filter sheet, already filtered
+  /// by the current owner search query.
+  final List<UserProfile> availableOwners;
+
+  /// Whether the available owners fetch is currently in flight.
+  final bool availableOwnersLoading;
+
   const GlobalSearchReady({
     this.recentSearches = const [],
     this.query = '',
@@ -49,6 +60,9 @@ class GlobalSearchReady extends GlobalSearchState {
     this.selectedTags = const {},
     this.availableTags = const [],
     this.availableTagsLoading = false,
+    this.selectedOwnerIds = const {},
+    this.availableOwners = const [],
+    this.availableOwnersLoading = false,
   });
 
   /// Returns a copy of this state with the given fields replaced.
@@ -60,6 +74,9 @@ class GlobalSearchReady extends GlobalSearchState {
     Set<String>? selectedTags,
     List<String>? availableTags,
     bool? availableTagsLoading,
+    Set<String>? selectedOwnerIds,
+    List<UserProfile>? availableOwners,
+    bool? availableOwnersLoading,
   }) {
     return GlobalSearchReady(
       recentSearches: recentSearches ?? this.recentSearches,
@@ -69,6 +86,10 @@ class GlobalSearchReady extends GlobalSearchState {
       selectedTags: selectedTags ?? this.selectedTags,
       availableTags: availableTags ?? this.availableTags,
       availableTagsLoading: availableTagsLoading ?? this.availableTagsLoading,
+      selectedOwnerIds: selectedOwnerIds ?? this.selectedOwnerIds,
+      availableOwners: availableOwners ?? this.availableOwners,
+      availableOwnersLoading:
+          availableOwnersLoading ?? this.availableOwnersLoading,
     );
   }
 
@@ -81,6 +102,9 @@ class GlobalSearchReady extends GlobalSearchState {
     selectedTags,
     availableTags,
     availableTagsLoading,
+    selectedOwnerIds,
+    availableOwners,
+    availableOwnersLoading,
   ];
 }
 
@@ -167,6 +191,18 @@ class GlobalSearchTagsLoadFailure extends GlobalSearchState {
 
   /// Creates a [GlobalSearchTagsLoadFailure].
   const GlobalSearchTagsLoadFailure({required this.failure});
+
+  @override
+  List<Object?> get props => [failure];
+}
+
+/// Emitted when loading the available owners for the filter sheet fails.
+class GlobalSearchOwnersLoadFailure extends GlobalSearchState {
+  /// The failure describing why the owners fetch failed.
+  final Failure failure;
+
+  /// Creates a [GlobalSearchOwnersLoadFailure].
+  const GlobalSearchOwnersLoadFailure({required this.failure});
 
   @override
   List<Object?> get props => [failure];

--- a/test/features/global_search/units/blocs/global_search_bloc_test.dart
+++ b/test/features/global_search/units/blocs/global_search_bloc_test.dart
@@ -109,6 +109,26 @@ void main() {
       );
     }
 
+    // Seeds the project owners RPC with one owner per (id, firstName) pair,
+    // preserving order so tests can assert the bloc keeps RPC ordering.
+    void seedOwners(List<({String id, String firstName})> owners) {
+      fakeSupabase.setRpcResponse(
+        DatabaseConstants.projectOwnersRpcFunction,
+        owners
+            .map(
+              (owner) => <String, dynamic>{
+                DatabaseConstants.idColumn: owner.id,
+                DatabaseConstants.credentialIdColumn: null,
+                DatabaseConstants.firstNameColumn: owner.firstName,
+                DatabaseConstants.lastNameColumn: 'Doe',
+                DatabaseConstants.professionalRoleColumn: 'Engineer',
+                DatabaseConstants.profilePhotoUrlColumn: null,
+              },
+            )
+            .toList(),
+      );
+    }
+
     test(
       'initial state is GlobalSearchInitial (cold start, no history yet)',
       () {
@@ -597,6 +617,59 @@ void main() {
             rpcParams['filter_by_tag'],
             equals('Roofing'),
             reason: 'must forward the alphabetically first tag, not an arbitrary Set element',
+          );
+        },
+      );
+
+      blocTest<GlobalSearchBloc, GlobalSearchState>(
+        'forwards the alphabetically first selected owner id to the RPC when multiple owners are active',
+        setUp: () {
+          fakeSupabase.setCurrentUser(
+            FakeUser(
+              id: _testUserId,
+              email: _testUserEmail,
+              createdAt: fakeClock.now().toIso8601String(),
+            ),
+          );
+          fakeSupabase.setRpcResponse(
+            DatabaseConstants.globalSearchRpcFunction,
+            {'projects': [], 'estimations': [], 'members': []},
+          );
+        },
+        build: () => Modular.get<GlobalSearchBloc>(),
+        act: (bloc) async {
+          // Apply two owners; 'owner-1' sorts before 'owner-2'.
+          bloc.add(
+            const GlobalSearchOwnerFiltersApplied(
+              ownerIds: {'owner-2', 'owner-1'},
+            ),
+          );
+          await bloc.stream.first;
+          bloc.add(const GlobalSearchPerformed(query: 'steel'));
+        },
+        expect: () => [
+          isA<GlobalSearchReady>().having(
+            (s) => s.selectedOwnerIds,
+            'owners applied',
+            containsAll(['owner-1', 'owner-2']),
+          ),
+          const GlobalSearchLoadInProgress(query: 'steel'),
+          isA<GlobalSearchLoadEmpty>(),
+        ],
+        verify: (_) {
+          final rpcCalls = fakeSupabase.getMethodCallsFor('rpc');
+          final globalSearchCall = rpcCalls.firstWhere(
+            (call) =>
+                call['functionName'] ==
+                DatabaseConstants.globalSearchRpcFunction,
+          );
+          final rpcParams =
+              globalSearchCall['params'] as Map<String, dynamic>;
+          expect(
+            rpcParams['filter_by_owner'],
+            equals('owner-1'),
+            reason:
+                'must forward the alphabetically first owner id, not an arbitrary Set element',
           );
         },
       );
@@ -1134,6 +1207,326 @@ void main() {
             (s) => s.availableTags,
             'query reset restores full list',
             ['Roofing', 'Wall'],
+          ),
+        ],
+      );
+    });
+
+    group('GlobalSearchOwnerFiltersApplied', () {
+      blocTest<GlobalSearchBloc, GlobalSearchState>(
+        'emits GlobalSearchReady with selectedOwnerIds when owners are applied',
+        build: () => Modular.get<GlobalSearchBloc>(),
+        act: (bloc) => bloc.add(
+          const GlobalSearchOwnerFiltersApplied(
+            ownerIds: {'owner-1', 'owner-2'},
+          ),
+        ),
+        expect: () => [
+          isA<GlobalSearchReady>().having(
+            (s) => s.selectedOwnerIds,
+            'selectedOwnerIds',
+            containsAll(['owner-1', 'owner-2']),
+          ),
+        ],
+      );
+
+      blocTest<GlobalSearchBloc, GlobalSearchState>(
+        'emits GlobalSearchReady with empty selectedOwnerIds when empty set is applied',
+        build: () => Modular.get<GlobalSearchBloc>(),
+        act: (bloc) =>
+            bloc.add(const GlobalSearchOwnerFiltersApplied(ownerIds: {})),
+        expect: () => [
+          isA<GlobalSearchReady>().having(
+            (s) => s.selectedOwnerIds,
+            'selectedOwnerIds',
+            isEmpty,
+          ),
+        ],
+      );
+    });
+
+    group('GlobalSearchOwnerFilterCleared', () {
+      blocTest<GlobalSearchBloc, GlobalSearchState>(
+        'emits GlobalSearchReady with owner removed from selectedOwnerIds',
+        build: () => Modular.get<GlobalSearchBloc>(),
+        act: (bloc) async {
+          bloc.add(
+            const GlobalSearchOwnerFiltersApplied(
+              ownerIds: {'owner-1', 'owner-2'},
+            ),
+          );
+          await bloc.stream.first;
+          bloc.add(const GlobalSearchOwnerFilterCleared(ownerId: 'owner-1'));
+        },
+        expect: () => [
+          isA<GlobalSearchReady>().having(
+            (s) => s.selectedOwnerIds,
+            'two owners selected',
+            containsAll(['owner-1', 'owner-2']),
+          ),
+          isA<GlobalSearchReady>()
+              .having(
+                (s) => s.selectedOwnerIds,
+                'owner-1 removed',
+                isNot(contains('owner-1')),
+              )
+              .having(
+                (s) => s.selectedOwnerIds,
+                'owner-2 remains',
+                contains('owner-2'),
+              ),
+        ],
+      );
+
+      blocTest<GlobalSearchBloc, GlobalSearchState>(
+        'emits GlobalSearchReady with empty selectedOwnerIds when last owner is cleared',
+        build: () => Modular.get<GlobalSearchBloc>(),
+        act: (bloc) async {
+          bloc.add(
+            const GlobalSearchOwnerFiltersApplied(ownerIds: {'owner-1'}),
+          );
+          await bloc.stream.first;
+          bloc.add(const GlobalSearchOwnerFilterCleared(ownerId: 'owner-1'));
+        },
+        expect: () => [
+          isA<GlobalSearchReady>().having(
+            (s) => s.selectedOwnerIds,
+            'one owner selected',
+            contains('owner-1'),
+          ),
+          isA<GlobalSearchReady>().having(
+            (s) => s.selectedOwnerIds,
+            'selectedOwnerIds empty after last cleared',
+            isEmpty,
+          ),
+        ],
+      );
+    });
+
+    group('GlobalSearchStarted resets selectedOwnerIds', () {
+      blocTest<GlobalSearchBloc, GlobalSearchState>(
+        'clears selectedOwnerIds when GlobalSearchStarted is dispatched after owners were applied',
+        setUp: () {
+          fakeSupabase.setCurrentUser(null);
+        },
+        build: () => Modular.get<GlobalSearchBloc>(),
+        act: (bloc) async {
+          bloc.add(
+            const GlobalSearchOwnerFiltersApplied(ownerIds: {'owner-1'}),
+          );
+          await bloc.stream.first;
+          bloc.add(const GlobalSearchStarted());
+        },
+        expect: () => [
+          isA<GlobalSearchReady>().having(
+            (s) => s.selectedOwnerIds,
+            'owners applied',
+            contains('owner-1'),
+          ),
+          isA<GlobalSearchReady>().having(
+            (s) => s.selectedOwnerIds,
+            'owners reset on restart',
+            isEmpty,
+          ),
+        ],
+      );
+    });
+
+    group('GlobalSearchAvailableOwnersRequested', () {
+      blocTest<GlobalSearchBloc, GlobalSearchState>(
+        'emits loading then owners in RPC order on success',
+        setUp: () => seedOwners([
+          (id: 'owner-1', firstName: 'John'),
+          (id: 'owner-2', firstName: 'Floyd'),
+        ]),
+        build: () => Modular.get<GlobalSearchBloc>(),
+        act: (bloc) => bloc.add(const GlobalSearchAvailableOwnersRequested()),
+        expect: () => [
+          isA<GlobalSearchReady>().having(
+            (s) => s.availableOwnersLoading,
+            'availableOwnersLoading',
+            isTrue,
+          ),
+          isA<GlobalSearchReady>()
+              .having(
+                (s) => s.availableOwners.map((o) => o.id).toList(),
+                'availableOwners',
+                ['owner-1', 'owner-2'],
+              )
+              .having(
+                (s) => s.availableOwnersLoading,
+                'availableOwnersLoading',
+                isFalse,
+              ),
+        ],
+      );
+
+      blocTest<GlobalSearchBloc, GlobalSearchState>(
+        'reuses cached owners without refetching on subsequent requests',
+        setUp: () => seedOwners([(id: 'owner-1', firstName: 'John')]),
+        build: () => Modular.get<GlobalSearchBloc>(),
+        act: (bloc) async {
+          bloc.add(const GlobalSearchAvailableOwnersRequested());
+          await bloc.stream.firstWhere(
+            (state) =>
+                state is GlobalSearchReady && !state.availableOwnersLoading,
+          );
+          bloc.add(const GlobalSearchAvailableOwnersRequested());
+        },
+        verify: (_) {
+          final rpcCalls = fakeSupabase.getMethodCallsFor('rpc').where(
+                (call) =>
+                    call['functionName'] ==
+                    DatabaseConstants.projectOwnersRpcFunction,
+              );
+          expect(rpcCalls.length, 1);
+        },
+      );
+
+      blocTest<GlobalSearchBloc, GlobalSearchState>(
+        'emits GlobalSearchOwnersLoadFailure then recovers to Ready on error',
+        setUp: () {
+          fakeSupabase.shouldThrowOnRpc = true;
+          fakeSupabase.rpcExceptionType = SupabaseExceptionType.postgrest;
+        },
+        build: () => Modular.get<GlobalSearchBloc>(),
+        act: (bloc) => bloc.add(const GlobalSearchAvailableOwnersRequested()),
+        expect: () => [
+          isA<GlobalSearchReady>().having(
+            (s) => s.availableOwnersLoading,
+            'availableOwnersLoading',
+            isTrue,
+          ),
+          isA<GlobalSearchOwnersLoadFailure>().having(
+            (s) => s.failure,
+            'failure',
+            isA<SearchFailure>(),
+          ),
+          isA<GlobalSearchReady>().having(
+            (s) => s.availableOwners,
+            'availableOwners stay empty',
+            isEmpty,
+          ),
+        ],
+      );
+
+      blocTest<GlobalSearchBloc, GlobalSearchState>(
+        're-fetches owners on the next request after a failed fetch',
+        setUp: () {
+          fakeSupabase.shouldThrowOnRpc = true;
+          fakeSupabase.rpcExceptionType = SupabaseExceptionType.postgrest;
+        },
+        build: () => Modular.get<GlobalSearchBloc>(),
+        act: (bloc) async {
+          bloc.add(const GlobalSearchAvailableOwnersRequested());
+          await bloc.stream.firstWhere(
+            (state) =>
+                state is GlobalSearchReady && !state.availableOwnersLoading,
+          );
+          // Recover the backend, then request again: the failed fetch must
+          // not have cached, so this second request hits the RPC again.
+          fakeSupabase.shouldThrowOnRpc = false;
+          seedOwners([(id: 'owner-1', firstName: 'John')]);
+          bloc.add(const GlobalSearchAvailableOwnersRequested());
+          await bloc.stream.firstWhere(
+            (state) =>
+                state is GlobalSearchReady &&
+                !state.availableOwnersLoading &&
+                state.availableOwners.isNotEmpty,
+          );
+        },
+        verify: (_) {
+          final rpcCalls = fakeSupabase.getMethodCallsFor('rpc').where(
+                (call) =>
+                    call['functionName'] ==
+                    DatabaseConstants.projectOwnersRpcFunction,
+              );
+          expect(
+            rpcCalls.length,
+            2,
+            reason: 'a failed fetch must not cache; the retry refetches',
+          );
+        },
+      );
+    });
+
+    group('GlobalSearchOwnerSearchQueryUpdated', () {
+      blocTest<GlobalSearchBloc, GlobalSearchState>(
+        'filters available owners case-insensitively by full name substring',
+        setUp: () => seedOwners([
+          (id: 'owner-1', firstName: 'John'),
+          (id: 'owner-2', firstName: 'Johnny'),
+          (id: 'owner-3', firstName: 'Floyd'),
+        ]),
+        build: () => Modular.get<GlobalSearchBloc>(),
+        act: (bloc) async {
+          bloc.add(const GlobalSearchAvailableOwnersRequested());
+          await bloc.stream.firstWhere(
+            (state) =>
+                state is GlobalSearchReady && !state.availableOwnersLoading,
+          );
+          bloc.add(const GlobalSearchOwnerSearchQueryUpdated(query: 'JOHN'));
+        },
+        skip: 2,
+        expect: () => [
+          isA<GlobalSearchReady>().having(
+            (s) => s.availableOwners.map((o) => o.id).toList(),
+            'filtered owners',
+            ['owner-1', 'owner-2'],
+          ),
+        ],
+      );
+
+      blocTest<GlobalSearchBloc, GlobalSearchState>(
+        'restores the full list when the query is cleared',
+        setUp: () => seedOwners([
+          (id: 'owner-1', firstName: 'John'),
+          (id: 'owner-2', firstName: 'Floyd'),
+        ]),
+        build: () => Modular.get<GlobalSearchBloc>(),
+        act: (bloc) async {
+          bloc.add(const GlobalSearchAvailableOwnersRequested());
+          await bloc.stream.firstWhere(
+            (state) =>
+                state is GlobalSearchReady && !state.availableOwnersLoading,
+          );
+          bloc.add(const GlobalSearchOwnerSearchQueryUpdated(query: 'john'));
+          await bloc.stream.first;
+          bloc.add(const GlobalSearchOwnerSearchQueryUpdated(query: ''));
+        },
+        skip: 3,
+        expect: () => [
+          isA<GlobalSearchReady>().having(
+            (s) => s.availableOwners.map((o) => o.id).toList(),
+            'full list restored',
+            ['owner-1', 'owner-2'],
+          ),
+        ],
+      );
+
+      blocTest<GlobalSearchBloc, GlobalSearchState>(
+        'resets the owner search query when the sheet is reopened',
+        setUp: () => seedOwners([
+          (id: 'owner-1', firstName: 'John'),
+          (id: 'owner-2', firstName: 'Floyd'),
+        ]),
+        build: () => Modular.get<GlobalSearchBloc>(),
+        act: (bloc) async {
+          bloc.add(const GlobalSearchAvailableOwnersRequested());
+          await bloc.stream.firstWhere(
+            (state) =>
+                state is GlobalSearchReady && !state.availableOwnersLoading,
+          );
+          bloc.add(const GlobalSearchOwnerSearchQueryUpdated(query: 'john'));
+          await bloc.stream.first;
+          bloc.add(const GlobalSearchAvailableOwnersRequested());
+        },
+        skip: 3,
+        expect: () => [
+          isA<GlobalSearchReady>().having(
+            (s) => s.availableOwners.map((o) => o.id).toList(),
+            'query reset restores full list',
+            ['owner-1', 'owner-2'],
           ),
         ],
       );


### PR DESCRIPTION
# PR Review — CA-251: feat(global-search): wire owner filter into GlobalSearchBloc

| Field          | Detail                                                                  |
|----------------|-------------------------------------------------------------------------|
| **PR**         | [#359](https://github.com/ripplearc/construculator-app/pull/359)        |
| **Source**     | `CA-251-feat/global-search-owner-bloc`                                  |
| **Target**     | `CA-251-feat/owner-repository`                                          |
| **Date**       | 2026-06-17                                                              |
| **Reviewer**   | Senior Engineer (AI-assisted review)                                    |
| **Stack position** | PR 5 of 5 (top) — #345 → #346 → #357 → #358 → **#359**           |

---

## Summary

This PR wires `OwnerRepository` into `GlobalSearchBloc`, adding four new events (`GlobalSearchOwnerFiltersApplied`, `GlobalSearchOwnerFilterCleared`, `GlobalSearchAvailableOwnersRequested`, `GlobalSearchOwnerSearchQueryUpdated`), three new state fields (`selectedOwnerIds`, `availableOwners`, `availableOwnersLoading`), and a new terminal state `GlobalSearchOwnersLoadFailure`. The owner list is fetched lazily on first sheet open and cached via `_availableOwnersFetched`, preventing redundant network calls on subsequent openings. In-memory owner search filtering mirrors the existing tag-filter pattern. The `GlobalSearchModule` is updated to import `OwnerLibraryModule` and inject `OwnerRepository` into the BLoC.

---

## Changes Overview

### Impact Stats

| Category                    | Value                              |
|-----------------------------|------------------------------------|
| **Production files changed**| 4                                  |
| **Production lines changed**| ~188                               |
| **Test files changed**      | 1                                  |
| **Test lines changed**      | ~393                               |
| **PR Size Classification**  | **M** (100–200 production lines)   |
| **Architecture layers**     | Presentation (BLoC, State, Events) + DI module |

---

### Rule-Based Review

| Rule | Status | Notes |
|------|--------|-------|
| **Rule 1 — Digestible PR** | ✅ Pass | M-size (188 production lines). Single clear purpose: wiring one new repository into one BLoC. Independently testable on its stacked base. |
| **Rule 2 — Naming Conventions** | ✅ Pass | All four new event classes follow `GlobalSearch[Noun][Verb]` → `GlobalSearchEvent` naming pattern consistent with existing events. `GlobalSearchOwnersLoadFailure` follows the established `GlobalSearch[Noun]LoadFailure` terminal-state pattern. Field names (`selectedOwnerIds`, `availableOwners`, `availableOwnersLoading`) are descriptive and consistent with `selectedTags` / `availableTags` / `availableTagsLoading`. |
| **Rule 3 — Test Double Pattern** | ✅ Pass | `OwnerRepository` is a cross-library dependency, so using `FakeOwnerRepository` (shipped in PR #358) is the correct Test Double pattern per Rule 3's cross-feature isolation guidance. The real `GlobalSearchBloc` and real `GlobalSearchRepository` / `TagRepository` chains should remain wired with `FakeSupabaseWrapper`; verify the BLoC test module does not also fake those. |
| **Rule 5 — UI/Business Logic Separation** | ✅ Pass | `_filterAvailableOwners()` (in-memory filter on `_availableOwners`) is correctly placed in the BLoC, not the UI. The state carries pre-filtered `availableOwners` so widgets remain passive. `_onAvailableOwnersRequested` guards with `_availableOwnersFetched` so the UI simply dispatches the event without any "has data?" check. Clean separation maintained. |
| **Rule 6 — Stream Lifecycle** | ✅ Pass | No `StreamController`s or manual subscriptions introduced. All event handlers are synchronous or `await`-based inside the Bloc's managed `Emitter`. `_availableOwnersFetched` cache prevents network thrashing (consistent with "Optimistic / cache-first" guidance from Rule 6). |

---

## Review Summary

> No blocking issues found. The items below are minor verification points for the author.

| Issue Name | Description | Status | Notes |
|------------|-------------|--------|-------|
| Single-owner API limitation | `filterByOwner` passes only the lexicographically first selected owner id (`_selectedOwnerIds.toList()..sort()).first`). The inline comment documents this limitation. Confirm there is a YouTrack story tracking the multi-owner API upgrade, or that the current UX only allows single selection. | Agree, Documented | Single-owner is the intended current scope; the inline comment at the `filterByOwner` call site documents the limitation and the deterministic (sorted) selection. No further action for this PR. |
| `_availableOwnersFetched` never invalidated | The cache is set to `true` on first successful fetch and never reset (except via `GlobalSearchReset`). If a user's accessible owners change mid-session (e.g., project ownership transferred), the filter sheet will show stale data. Confirm this is an acceptable trade-off for the current scope, or add a TTL/invalidation mechanism. | Agree, Acceptable Trade-off | Mirrors the existing `_availableTagsFetched` cache-for-session-lifetime behavior; reset only on `GlobalSearchReset`, consistent with the established tag pattern. No invalidation mechanism added. |
| `_onAvailableOwnersRequested` resets `_ownerSearchQuery` | On every sheet open, `_ownerSearchQuery` is reset to `''` regardless of whether a fetch occurs. This is intentional UX (clean slate on re-open), but verify it aligns with the product spec — tag filtering preserves `_tagSearchQuery` across openings by comparison. | Agree, Confirmed Consistent | Verified `_onAvailableTagsRequested` resets `_tagSearchQuery = ''` identically on every sheet open — the owner implementation matches the existing tag behavior exactly, not a divergence. |

---

## Verification Checklist

- [x] PR is M-size (188 production lines) — within threshold, no split required
- [x] All four new events follow `GlobalSearchEvent` naming pattern (Rule 2)
- [x] `GlobalSearchOwnersLoadFailure` follows the established terminal-state pattern
- [x] `_filterAvailableOwners()` is in the BLoC, not in any widget — UI/business separation maintained (Rule 5)
- [x] No `StreamController`s or dangling subscriptions introduced (Rule 6)
- [x] `_availableOwnersFetched` caching prevents redundant network calls on repeated sheet openings (Rule 6 — no network thrashing)
- [x] Owner filter is cleared on `GlobalSearchReset` alongside tags and query fields
- [x] `GlobalSearchModule` imports `OwnerLibraryModule` and injects `ownerRepository` into `GlobalSearchBloc` via Modular
- [x] Confirmed BLoC tests use `FakeOwnerRepository` for `OwnerRepository` while `GlobalSearchRepository` and `TagRepository` remain wired through the real chain with `FakeSupabaseWrapper` (Rule 3 cross-feature isolation)
- [x] Confirmed single-owner is the intended current behaviour; limitation documented inline at the `filterByOwner` call site
- [x] Confirmed `_ownerSearchQuery` reset-on-open matches the existing `_tagSearchQuery` reset-on-open behaviour in `_onAvailableTagsRequested`
