### PR TITLE
fix: resolve forbid_modular_get_outside_module and no_direct_instantiation lint errors

### DIFF
--- a/lib/features/dashboard/presentation/widgets/projects_bottom_sheet.dart
+++ b/lib/features/dashboard/presentation/widgets/projects_bottom_sheet.dart
@@ -18,6 +18,7 @@ const double _kProjectsSearchIconSize = CoreSpacing.space5;
 /// [ProjectDropdownSelected] and dismisses the sheet. Loading, error (with a
 /// cached fallback), and empty states are all rendered inline.
 class ProjectsBottomSheet extends StatefulWidget {
+  /// The bloc that manages project selection and loading state.
   final ProjectDropdownBloc bloc;
 
   const ProjectsBottomSheet({super.key, required this.bloc});

--- a/lib/features/dashboard/presentation/widgets/projects_bottom_sheet.dart
+++ b/lib/features/dashboard/presentation/widgets/projects_bottom_sheet.dart
@@ -4,7 +4,6 @@ import 'package:construculator/libraries/extensions/extensions.dart';
 import 'package:construculator/libraries/project/domain/entities/project_entity.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:flutter_modular/flutter_modular.dart';
 import 'package:ripplearc_coreui/ripplearc_coreui.dart';
 
 const int _kProjectsSkeletonItemCount = 4;
@@ -19,14 +18,16 @@ const double _kProjectsSearchIconSize = CoreSpacing.space5;
 /// [ProjectDropdownSelected] and dismisses the sheet. Loading, error (with a
 /// cached fallback), and empty states are all rendered inline.
 class ProjectsBottomSheet extends StatefulWidget {
-  const ProjectsBottomSheet({super.key});
+  final ProjectDropdownBloc bloc;
+
+  const ProjectsBottomSheet({super.key, required this.bloc});
 
   /// Shows the projects bottom sheet using [CoreQuickSheet].
-  static Future<void> show(BuildContext context) {
+  static Future<void> show(BuildContext context, ProjectDropdownBloc bloc) {
     return CoreQuickSheet.show<void>(
       context: context,
       useSafeArea: true,
-      child: const ProjectsBottomSheet(),
+      child: ProjectsBottomSheet(bloc: bloc),
     );
   }
 
@@ -41,7 +42,7 @@ class _ProjectsBottomSheetState extends State<ProjectsBottomSheet> {
   @override
   void initState() {
     super.initState();
-    _bloc = Modular.get<ProjectDropdownBloc>();
+    _bloc = widget.bloc;
     if (_bloc.state is! ProjectDropdownLoadSuccess) {
       _bloc.add(const ProjectDropdownStarted());
     }

--- a/lib/features/estimation/estimation_routes_module.dart
+++ b/lib/features/estimation/estimation_routes_module.dart
@@ -4,6 +4,7 @@ import 'package:construculator/features/estimation/presentation/pages/cost_estim
 import 'package:construculator/libraries/auth/auth_library_module.dart';
 import 'package:construculator/libraries/auth/interfaces/auth_manager.dart';
 import 'package:construculator/libraries/router/guards/auth_guard.dart';
+import 'package:construculator/libraries/router/interfaces/app_router.dart';
 import 'package:construculator/libraries/router/routes/estimation_routes.dart';
 import 'package:flutter_modular/flutter_modular.dart';
 
@@ -36,7 +37,10 @@ class EstimationRoutesModule extends Module {
           );
         }
 
-        return CostEstimationDetailsPage(estimationId: estimationId);
+        return CostEstimationDetailsPage(
+          estimationId: estimationId,
+          router: Modular.get<AppRouter>(),
+        );
       },
     );
   }

--- a/lib/features/estimation/presentation/pages/cost_estimation_details_page.dart
+++ b/lib/features/estimation/presentation/pages/cost_estimation_details_page.dart
@@ -2,7 +2,6 @@ import 'package:construculator/features/estimation/presentation/widgets/cost_est
 import 'package:construculator/libraries/extensions/extensions.dart';
 import 'package:construculator/libraries/router/interfaces/app_router.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_modular/flutter_modular.dart';
 import 'package:ripplearc_coreui/ripplearc_coreui.dart';
 
 /// The cost estimation details page.
@@ -12,9 +11,13 @@ import 'package:ripplearc_coreui/ripplearc_coreui.dart';
 /// costs, and a bottom bar with lock and preview actions.
 class CostEstimationDetailsPage extends StatelessWidget {
   final String estimationId;
-  final _router = Modular.get<AppRouter>();
+  final AppRouter router;
 
-  CostEstimationDetailsPage({super.key, required this.estimationId});
+  const CostEstimationDetailsPage({
+    super.key,
+    required this.estimationId,
+    required this.router,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -43,7 +46,7 @@ class CostEstimationDetailsPage extends StatelessWidget {
               size: 24,
               visualDensity: VisualDensity.compact,
               semanticLabel: l10n.backLabel,
-              onTap: _router.pop,
+              onTap: router.pop,
             ),
             // TODO: [CA-154] [Cost Estimation] Implement Rename Estimation Logic https://ripplearc.youtrack.cloud/issue/CA-154/Cost-Estimation-Implement-Rename-Estimation-Logic
             title: Row(

--- a/lib/features/estimation/presentation/pages/cost_estimation_details_page.dart
+++ b/lib/features/estimation/presentation/pages/cost_estimation_details_page.dart
@@ -11,6 +11,8 @@ import 'package:ripplearc_coreui/ripplearc_coreui.dart';
 /// costs, and a bottom bar with lock and preview actions.
 class CostEstimationDetailsPage extends StatelessWidget {
   final String estimationId;
+
+  /// Router used for navigation (e.g. popping this page).
   final AppRouter router;
 
   const CostEstimationDetailsPage({

--- a/lib/features/global_search/global_search_module.dart
+++ b/lib/features/global_search/global_search_module.dart
@@ -10,6 +10,7 @@ import 'package:construculator/libraries/estimation/data/estimation_tile_provide
 import 'package:construculator/libraries/estimation/domain/estimation_tile_provider.dart';
 import 'package:construculator/libraries/owner/owner_library_module.dart';
 import 'package:construculator/libraries/router/guards/auth_guard.dart';
+import 'package:construculator/libraries/router/interfaces/app_router.dart';
 import 'package:construculator/libraries/router/routes/global_search_routes.dart';
 import 'package:construculator/libraries/supabase/supabase_module.dart';
 import 'package:construculator/libraries/tag/tag_library_module.dart';
@@ -58,7 +59,10 @@ class GlobalSearchModule extends Module {
     r.child(
       globalSearchPageRoute,
       guards: [AuthGuard(() => Modular.get<AuthManager>())],
-      child: (_) => const GlobalSearchPage(),
+      child: (_) => GlobalSearchPage(
+        router: Modular.get<AppRouter>(),
+        blocFactory: () => Modular.get<GlobalSearchBloc>(),
+      ),
     );
   }
 }

--- a/lib/features/global_search/presentation/pages/global_search_page.dart
+++ b/lib/features/global_search/presentation/pages/global_search_page.dart
@@ -6,7 +6,6 @@ import 'package:construculator/libraries/extensions/extensions.dart';
 import 'package:construculator/libraries/router/interfaces/app_router.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:flutter_modular/flutter_modular.dart';
 import 'package:ripplearc_coreui/ripplearc_coreui.dart';
 
 /// The Global Search screen.
@@ -14,7 +13,14 @@ import 'package:ripplearc_coreui/ripplearc_coreui.dart';
 /// Provides a search input field, filter chips (Tags, Modified, Type),
 /// a recent searches section, and an empty state when no recent searches exist.
 class GlobalSearchPage extends StatefulWidget {
-  const GlobalSearchPage({super.key});
+  final AppRouter router;
+  final GlobalSearchBloc Function() blocFactory;
+
+  const GlobalSearchPage({
+    super.key,
+    required this.router,
+    required this.blocFactory,
+  });
 
   @override
   State<GlobalSearchPage> createState() => _GlobalSearchPageState();
@@ -22,7 +28,6 @@ class GlobalSearchPage extends StatefulWidget {
 
 class _GlobalSearchPageState extends State<GlobalSearchPage> {
   late final TextEditingController _searchController = TextEditingController();
-  late final AppRouter _router = Modular.get<AppRouter>();
   GlobalSearchReady? _lastReady;
 
   @override
@@ -67,7 +72,7 @@ class _GlobalSearchPageState extends State<GlobalSearchPage> {
       button: true,
       child: GestureDetector(
         key: const Key('global_search_back_button'),
-        onTap: () => _router.pop(),
+        onTap: () => widget.router.pop(),
         child: ConstrainedBox(
           constraints: const BoxConstraints(
             minWidth: CoreSpacing.space12,
@@ -187,8 +192,7 @@ class _GlobalSearchPageState extends State<GlobalSearchPage> {
     final l10n = context.l10n;
 
     return BlocProvider(
-      create: (_) =>
-          Modular.get<GlobalSearchBloc>()..add(const GlobalSearchStarted()),
+      create: (_) => widget.blocFactory()..add(const GlobalSearchStarted()),
       child: Builder(
         builder: (innerContext) => Scaffold(
           backgroundColor: colors.pageBackground,

--- a/lib/features/global_search/presentation/pages/global_search_page.dart
+++ b/lib/features/global_search/presentation/pages/global_search_page.dart
@@ -13,7 +13,10 @@ import 'package:ripplearc_coreui/ripplearc_coreui.dart';
 /// Provides a search input field, filter chips (Tags, Modified, Type),
 /// a recent searches section, and an empty state when no recent searches exist.
 class GlobalSearchPage extends StatefulWidget {
+  /// Router used for navigation (e.g. popping this page).
   final AppRouter router;
+
+  /// Factory that produces a fresh [GlobalSearchBloc] instance for each navigation.
   final GlobalSearchBloc Function() blocFactory;
 
   const GlobalSearchPage({

--- a/test/app/shell/app_shell_page_test.dart
+++ b/test/app/shell/app_shell_page_test.dart
@@ -78,6 +78,7 @@ void main() {
     );
 
     Modular.init(ShellModule(appBootstrap));
+    addTearDown(Modular.destroy);
     // Pre-bind DashboardModule so AuthNotifier, AuthManager, AppRouter, and
     // RecentEstimationsBloc are resolvable when AppShellPage is constructed.
     Modular.bindModule(DashboardModule(appBootstrap));

--- a/test/features/dashboard/projects_bottom_sheet_test_harness.dart
+++ b/test/features/dashboard/projects_bottom_sheet_test_harness.dart
@@ -32,7 +32,7 @@ class ProjectsBottomSheetTestHarness {
       locale: const Locale('en'),
       localizationsDelegates: AppLocalizations.localizationsDelegates,
       supportedLocales: AppLocalizations.supportedLocales,
-      home: const Scaffold(body: ProjectsBottomSheet()),
+      home: Scaffold(body: ProjectsBottomSheet(bloc: bloc)),
     );
   }
 

--- a/test/features/dashboard/widgets/accessibility/projects_bottom_sheet_a11y_test.dart
+++ b/test/features/dashboard/widgets/accessibility/projects_bottom_sheet_a11y_test.dart
@@ -31,7 +31,7 @@ void main() {
       locale: const Locale('en'),
       localizationsDelegates: AppLocalizations.localizationsDelegates,
       supportedLocales: AppLocalizations.supportedLocales,
-      home: const Scaffold(body: ProjectsBottomSheet()),
+      home: Scaffold(body: ProjectsBottomSheet(bloc: bloc)),
     );
   }
 

--- a/test/features/global_search/screenshots/global_search_page_screenshot_test.dart
+++ b/test/features/global_search/screenshots/global_search_page_screenshot_test.dart
@@ -3,6 +3,7 @@ import 'package:construculator/features/global_search/global_search_module.dart'
 import 'package:construculator/features/global_search/presentation/bloc/global_search_bloc/global_search_bloc.dart';
 import 'package:construculator/features/global_search/presentation/pages/global_search_page.dart';
 import 'package:construculator/l10n/generated/app_localizations.dart';
+import 'package:construculator/libraries/router/interfaces/app_router.dart';
 import 'package:construculator/libraries/router/testing/router_test_module.dart';
 import 'package:construculator/libraries/supabase/database_constants.dart';
 import 'package:construculator/libraries/supabase/interfaces/supabase_wrapper.dart';
@@ -75,7 +76,10 @@ void main() {
         locale: const Locale('en'),
         localizationsDelegates: AppLocalizations.localizationsDelegates,
         supportedLocales: AppLocalizations.supportedLocales,
-        home: const GlobalSearchPage(),
+        home: GlobalSearchPage(
+          router: Modular.get<AppRouter>(),
+          blocFactory: () => Modular.get<GlobalSearchBloc>(),
+        ),
       ),
     );
     await tester.pumpAndSettle();

--- a/test/features/global_search/screenshots/global_search_tags_filter_sheet_screenshot_test.dart
+++ b/test/features/global_search/screenshots/global_search_tags_filter_sheet_screenshot_test.dart
@@ -4,6 +4,7 @@ import 'package:construculator/features/global_search/presentation/bloc/global_s
 import 'package:construculator/features/global_search/presentation/pages/global_search_page.dart';
 import 'package:construculator/features/global_search/presentation/widgets/global_search_tags_filter_sheet.dart';
 import 'package:construculator/l10n/generated/app_localizations.dart';
+import 'package:construculator/libraries/router/interfaces/app_router.dart';
 import 'package:construculator/libraries/router/testing/router_test_module.dart';
 import 'package:construculator/libraries/supabase/database_constants.dart';
 import 'package:construculator/libraries/supabase/interfaces/supabase_wrapper.dart';
@@ -91,7 +92,10 @@ void main() {
         locale: const Locale('en'),
         localizationsDelegates: AppLocalizations.localizationsDelegates,
         supportedLocales: AppLocalizations.supportedLocales,
-        home: const GlobalSearchPage(),
+        home: GlobalSearchPage(
+          router: Modular.get<AppRouter>(),
+          blocFactory: () => Modular.get<GlobalSearchBloc>(),
+        ),
       ),
     );
     await tester.pumpAndSettle();

--- a/test/features/global_search/widgets/accessibility/global_search_page_a11y_test.dart
+++ b/test/features/global_search/widgets/accessibility/global_search_page_a11y_test.dart
@@ -1,7 +1,9 @@
 import 'package:construculator/app/app_bootstrap.dart';
 import 'package:construculator/features/global_search/global_search_module.dart';
+import 'package:construculator/features/global_search/presentation/bloc/global_search_bloc/global_search_bloc.dart';
 import 'package:construculator/features/global_search/presentation/pages/global_search_page.dart';
 import 'package:construculator/l10n/generated/app_localizations.dart';
+import 'package:construculator/libraries/router/interfaces/app_router.dart';
 import 'package:construculator/libraries/router/testing/router_test_module.dart';
 import 'package:construculator/libraries/supabase/database_constants.dart';
 import 'package:construculator/libraries/supabase/interfaces/supabase_wrapper.dart';
@@ -68,7 +70,10 @@ void main() {
       home: Builder(
         builder: (context) {
           buildContext = context;
-          return const GlobalSearchPage();
+          return GlobalSearchPage(
+            router: Modular.get<AppRouter>(),
+            blocFactory: () => Modular.get<GlobalSearchBloc>(),
+          );
         },
       ),
       locale: const Locale('en'),

--- a/test/features/global_search/widgets/global_search_tags_filter_sheet_test.dart
+++ b/test/features/global_search/widgets/global_search_tags_filter_sheet_test.dart
@@ -3,6 +3,7 @@ import 'package:construculator/features/global_search/global_search_module.dart'
 import 'package:construculator/features/global_search/presentation/pages/global_search_page.dart';
 import 'package:construculator/features/global_search/presentation/widgets/global_search_tags_filter_sheet.dart';
 import 'package:construculator/l10n/generated/app_localizations.dart';
+import 'package:construculator/libraries/router/interfaces/app_router.dart';
 import 'package:construculator/libraries/router/testing/router_test_module.dart';
 import 'package:construculator/libraries/supabase/database_constants.dart';
 import 'package:construculator/libraries/supabase/interfaces/supabase_wrapper.dart';
@@ -79,7 +80,10 @@ void main() {
         home: Builder(
           builder: (context) {
             buildContext = context;
-            return const GlobalSearchPage();
+            return GlobalSearchPage(
+              router: Modular.get<AppRouter>(),
+              blocFactory: () => Modular.get<GlobalSearchBloc>(),
+            );
           },
         ),
       ),

--- a/test/features/global_search/widgets/global_search_tags_filter_sheet_test.dart
+++ b/test/features/global_search/widgets/global_search_tags_filter_sheet_test.dart
@@ -1,5 +1,6 @@
 import 'package:construculator/app/app_bootstrap.dart';
 import 'package:construculator/features/global_search/global_search_module.dart';
+import 'package:construculator/features/global_search/presentation/bloc/global_search_bloc/global_search_bloc.dart';
 import 'package:construculator/features/global_search/presentation/pages/global_search_page.dart';
 import 'package:construculator/features/global_search/presentation/widgets/global_search_tags_filter_sheet.dart';
 import 'package:construculator/l10n/generated/app_localizations.dart';

--- a/test/features/global_search/widgets/pages/global_search_page_test.dart
+++ b/test/features/global_search/widgets/pages/global_search_page_test.dart
@@ -1,5 +1,6 @@
 import 'package:construculator/app/app_bootstrap.dart';
 import 'package:construculator/features/global_search/global_search_module.dart';
+import 'package:construculator/features/global_search/presentation/bloc/global_search_bloc/global_search_bloc.dart';
 import 'package:construculator/features/global_search/presentation/pages/global_search_page.dart';
 import 'package:construculator/features/global_search/presentation/widgets/global_search_empty_recent_widget.dart';
 import 'package:construculator/features/global_search/presentation/widgets/global_search_recent_searches_list.dart';
@@ -109,7 +110,12 @@ void main() {
 
   Future<void> renderPage(WidgetTester tester) async {
     await tester.pumpWidget(
-      makeTestableWidget(child: const GlobalSearchPage()),
+      makeTestableWidget(
+        child: GlobalSearchPage(
+          router: router,
+          blocFactory: () => Modular.get<GlobalSearchBloc>(),
+        ),
+      ),
     );
     await tester.pumpAndSettle();
   }


### PR DESCRIPTION
## Summary

- Replace `Modular.get<T>()` calls in non-module files with constructor injection for `CurrentProjectNotifier`, `ProjectDropdownBloc`, `AppRouter`, and `GlobalSearchBloc`
- Update `ShellModule`, `EstimationRoutesModule`, and `GlobalSearchModule` to pass injected deps when constructing pages
- Update all affected tests to supply the injected dependencies; replace direct `RecentEstimationsBloc`/`WatchRecentEstimationsUseCase` construction in `app_shell_page_test.dart` with `Modular.init(ShellModule) + Modular.bindModule(DashboardModule)`

## Test plan

- [ ] `fvm dart run custom_lint` → No issues found
- [ ] `fvm flutter test test/app/shell/app_shell_page_test.dart` → All 12 tests pass
- [ ] `fvm flutter test test/features/global_search/` → passes
- [ ] `fvm flutter test test/features/dashboard/` → passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)