### PR TITLE
CA-648: feat: listen to auth events to cleanly connect powersync

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -43,7 +43,7 @@ custom_lint:
 
   no_direct_instantiation:
     ignored_base_classes:
-        - 'State'
+      - "State"
     # Matches are global by class-name prefix, not scoped to any one file:
     # allowlisting a vendor type here (e.g. PostHogConfig, Posthog,
     # SentryFlutterOptions) lets ANY file construct it directly. The lint
@@ -51,23 +51,22 @@ custom_lint:
     # PosthogWrapperImpl) does so — that boundary is a code-review
     # convention, not a guarantee from this rule.
     ast_type_prefixes:
-        - 'Fake'
-        - '_Fake'
-        - 'AppBootstrap'
-        - 'AppLogger'
-        - 'Map'
-        - 'CancelableOperation'
-        - 'AppLocalizationsEn'
-        - 'Breadcrumb'
-        - 'SentryFlutterOptions'
-        - 'SentryId'
-        - 'LogEvent'
-        - 'AppLogFilter'
-        - 'SentryUser'
-        - 'CrudEntry'
-        - 'PowerSyncCredentials'
-        - 'Posthog'
-        - 'PostHogConfig'
+      - "Fake"
+      - "_Fake"
+      - "AppBootstrap"
+      - "AppLogger"
+      - "Map"
+      - "CancelableOperation"
+      - "AppLocalizationsEn"
+      - "Breadcrumb"
+      - "SentryFlutterOptions"
+      - "SentryId"
+      - "LogEvent"
+      - "AppLogFilter"
+      - "SentryUser"
+      - "CrudEntry"
+      - "PowerSyncCredentials"
+      - "Posthog"
 
 linter:
   # The lint rules applied to this project can be customized in the

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -43,7 +43,7 @@ custom_lint:
 
   no_direct_instantiation:
     ignored_base_classes:
-      - "State"
+        - 'State'
     # Matches are global by class-name prefix, not scoped to any one file:
     # allowlisting a vendor type here (e.g. PostHogConfig, Posthog,
     # SentryFlutterOptions) lets ANY file construct it directly. The lint
@@ -51,22 +51,24 @@ custom_lint:
     # PosthogWrapperImpl) does so — that boundary is a code-review
     # convention, not a guarantee from this rule.
     ast_type_prefixes:
-      - "Fake"
-      - "_Fake"
-      - "AppBootstrap"
-      - "AppLogger"
-      - "Map"
-      - "CancelableOperation"
-      - "AppLocalizationsEn"
-      - "Breadcrumb"
-      - "SentryFlutterOptions"
-      - "SentryId"
-      - "LogEvent"
-      - "AppLogFilter"
-      - "SentryUser"
-      - "CrudEntry"
-      - "PowerSyncCredentials"
-      - "Posthog"
+        - 'Fake'
+        - '_Fake'
+        - 'AppBootstrap'
+        - 'AppLogger'
+        - 'Map'
+        - 'CancelableOperation'
+        - 'AppLocalizationsEn'
+        - 'Breadcrumb'
+        - 'SentryFlutterOptions'
+        - 'SentryId'
+        - 'LogEvent'
+        - 'AppLogFilter'
+        - 'SentryUser'
+        - 'CrudEntry'
+        - 'PowerSyncCredentials'
+        - 'Posthog'
+        - 'PostHogConfig'
+        - 'PowerSyncDatabase'
 
 linter:
   # The lint rules applied to this project can be customized in the

--- a/lib/app/app_bootstrap.dart
+++ b/lib/app/app_bootstrap.dart
@@ -4,6 +4,7 @@ import 'package:construculator/libraries/config/interfaces/config.dart';
 import 'package:construculator/libraries/config/interfaces/env_loader.dart';
 import 'package:construculator/libraries/sentry/interfaces/sentry_wrapper.dart';
 import 'package:construculator/libraries/supabase/interfaces/supabase_wrapper.dart';
+import 'package:powersync/powersync.dart';
 
 /// The application requires that certain services—such as the Supabase client—are fully
 /// initialized before the [AppModule] is loaded. This is critical for features like
@@ -101,11 +102,18 @@ class AppBootstrap {
   /// Must be fully initialized (if real) before passing to the app module.
   final AnalyticsRepository analyticsRepository;
 
+  /// The opened local PowerSync database.
+  ///
+  /// Opened during bootstrap because resolving its on-device path is
+  /// asynchronous and must complete before the module graph is built. It is
+  /// usable offline immediately; syncing starts once `PowerSyncManager`
+  /// connects after authentication.
+  final PowerSyncDatabase powerSyncDatabase;
+
   AppBootstrap({
     required this.envLoader,
     required this.config,
     required this.supabaseWrapper,
     required this.sentryWrapper,
-    required this.analyticsRepository,
   });
 }

--- a/lib/app/app_bootstrap.dart
+++ b/lib/app/app_bootstrap.dart
@@ -115,5 +115,7 @@ class AppBootstrap {
     required this.config,
     required this.supabaseWrapper,
     required this.sentryWrapper,
+    required this.analyticsRepository,
+    required this.powerSyncDatabase,
   });
 }

--- a/lib/app/app_module.dart
+++ b/lib/app/app_module.dart
@@ -6,6 +6,7 @@ import 'package:construculator/features/project/project_module.dart';
 import 'package:construculator/libraries/analytics/analytics_module.dart';
 import 'package:construculator/libraries/auth/auth_library_module.dart';
 import 'package:construculator/libraries/config/config_module.dart';
+import 'package:construculator/libraries/powersync/powersync_module.dart';
 import 'package:construculator/libraries/router/router_module.dart';
 import 'package:construculator/libraries/supabase/supabase_module.dart';
 import 'package:flutter_modular/flutter_modular.dart';
@@ -22,6 +23,7 @@ class AppModule extends Module {
     AnalyticsModule(appBootstrap),
     AuthLibraryModule(appBootstrap),
     ProjectModule(appBootstrap),
+    PowerSyncModule(appBootstrap),
   ];
 
   @override

--- a/lib/features/auth/testing/auth_test_module.dart
+++ b/lib/features/auth/testing/auth_test_module.dart
@@ -24,6 +24,7 @@ import 'package:construculator/libraries/auth/testing/fake_auth_notifier.dart';
 import 'package:construculator/libraries/auth/testing/fake_auth_repository.dart';
 import 'package:construculator/libraries/config/testing/fake_app_config.dart';
 import 'package:construculator/libraries/config/testing/fake_env_loader.dart';
+import 'package:construculator/libraries/powersync/testing/fake_powersync_database.dart';
 import 'package:construculator/libraries/router/testing/router_test_module.dart';
 import 'package:construculator/libraries/sentry/fake_sentry_wrapper.dart';
 import 'package:construculator/libraries/supabase/testing/fake_supabase_wrapper.dart';
@@ -43,6 +44,7 @@ class AuthTestModule extends Module {
         supabaseWrapper: FakeSupabaseWrapper(clock: FakeClockImpl()),
         sentryWrapper: FakeSentryWrapper(),
         analyticsRepository: const NoOpAnalyticsRepository(),
+        powerSyncDatabase: FakePowerSyncDatabase(),
       ),
     ),
     RouterTestModule(),

--- a/lib/libraries/powersync/data/open_powersync_database.dart
+++ b/lib/libraries/powersync/data/open_powersync_database.dart
@@ -1,0 +1,29 @@
+// coverage:ignore-file
+
+import 'package:construculator/libraries/powersync/models/schema.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+import 'package:powersync/powersync.dart';
+
+/// File name for the on-device PowerSync SQLite database.
+const _databaseFileName = 'construculator.db';
+
+/// Opens (and migrates) the local PowerSync database.
+///
+/// This only sets up the on-device SQLite store — it does **not** start
+/// syncing. The database is fully usable offline immediately; syncing with the
+/// backend begins later when [PowerSyncDatabase.connect] is called with an
+/// authenticated connector (see `PowerSyncManager`).
+///
+/// Opening is asynchronous because resolving the application support directory
+/// touches the platform, so this must run during app bootstrap (before the
+/// module graph is built) rather than inside a Modular `binds` callback.
+Future<PowerSyncDatabase> openPowerSyncDatabase() async {
+  final directory = await getApplicationSupportDirectory();
+  final databasePath = p.join(directory.path, _databaseFileName);
+
+  final database = PowerSyncDatabase(schema: schema, path: databasePath);
+  await database.initialize();
+
+  return database;
+}

--- a/lib/libraries/powersync/data/open_powersync_database.dart
+++ b/lib/libraries/powersync/data/open_powersync_database.dart
@@ -5,7 +5,7 @@ import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';
 import 'package:powersync/powersync.dart';
 
-/// File name for the on-device PowerSync SQLite database.
+// File name for the on-device PowerSync SQLite database.
 const _databaseFileName = 'construculator.db';
 
 /// Opens (and migrates) the local PowerSync database.

--- a/lib/libraries/powersync/interfaces/powersync_manager.dart
+++ b/lib/libraries/powersync/interfaces/powersync_manager.dart
@@ -1,3 +1,5 @@
+// coverage:ignore-file
+
 import 'package:powersync/powersync.dart';
 
 /// Owns the PowerSync sync lifecycle and ties it to authentication.

--- a/lib/libraries/powersync/interfaces/powersync_manager.dart
+++ b/lib/libraries/powersync/interfaces/powersync_manager.dart
@@ -1,0 +1,31 @@
+import 'package:powersync/powersync.dart';
+
+/// Owns the PowerSync sync lifecycle and ties it to authentication.
+///
+/// The local database is opened during app bootstrap and is usable offline at
+/// all times. Syncing with the backend, however, requires an authenticated
+/// session, so the manager [connect]s once the user signs in and
+/// [disconnectAndClear]s when they sign out.
+///
+/// Implementations subscribe to authentication changes themselves, so callers
+/// generally do not need to invoke [connect] / [disconnectAndClear] manually —
+/// they are exposed for explicit control and testing.
+abstract class PowerSyncManager {
+  /// The opened local PowerSync database.
+  ///
+  /// Use this to read and write data; PowerSync records local mutations whether
+  /// or not a sync connection is currently active.
+  PowerSyncDatabase get database;
+
+  /// Starts syncing with the backend using the configured connector.
+  ///
+  /// Safe to call when already connected — implementations guard against
+  /// establishing duplicate connections.
+  Future<void> connect();
+
+  /// Stops syncing and clears all synced data from the local database.
+  ///
+  /// Call this on sign-out so the next user does not inherit the previous
+  /// user's synced rows.
+  Future<void> disconnectAndClear();
+}

--- a/lib/libraries/powersync/powersync_manager_impl.dart
+++ b/lib/libraries/powersync/powersync_manager_impl.dart
@@ -23,8 +23,8 @@ class PowerSyncManagerImpl implements PowerSyncManager, Disposable {
 
   StreamSubscription<supabase.AuthState>? _authSubscription;
 
-  /// Whether a sync connection is currently established. Guards against
-  /// redundant [connect] calls when several auth events arrive in succession.
+  // Whether a sync connection is currently established. Guards against
+  // redundant [connect] calls when several auth events arrive in succession.
   bool _connected = false;
 
   PowerSyncManagerImpl({

--- a/lib/libraries/powersync/powersync_manager_impl.dart
+++ b/lib/libraries/powersync/powersync_manager_impl.dart
@@ -1,0 +1,110 @@
+import 'dart:async';
+
+import 'package:construculator/libraries/logging/app_logger.dart';
+import 'package:construculator/libraries/powersync/interfaces/powersync_manager.dart';
+import 'package:construculator/libraries/supabase/interfaces/supabase_wrapper.dart';
+import 'package:flutter_modular/flutter_modular.dart';
+import 'package:powersync/powersync.dart';
+import 'package:supabase_flutter/supabase_flutter.dart' as supabase;
+
+/// Default [PowerSyncManager] that drives the sync connection from Supabase
+/// authentication events.
+///
+/// On construction it subscribes to [SupabaseWrapper.onAuthStateChange] and,
+/// if a session has already been restored (e.g. on app relaunch), connects
+/// immediately. It then [connect]s on sign-in and [disconnectAndClear]s on
+/// sign-out. Token refreshes and other auth events are ignored — the connector
+/// refreshes credentials on demand, so an active connection survives them.
+class PowerSyncManagerImpl implements PowerSyncManager, Disposable {
+  final PowerSyncDatabase _database;
+  final PowerSyncBackendConnector _connector;
+  final SupabaseWrapper _supabaseWrapper;
+  final _logger = AppLogger().tag('PowerSyncManager');
+
+  StreamSubscription<supabase.AuthState>? _authSubscription;
+
+  /// Whether a sync connection is currently established. Guards against
+  /// redundant [connect] calls when several auth events arrive in succession.
+  bool _connected = false;
+
+  PowerSyncManagerImpl({
+    required PowerSyncDatabase database,
+    required PowerSyncBackendConnector connector,
+    required SupabaseWrapper supabaseWrapper,
+  }) : _database = database,
+       _connector = connector,
+       _supabaseWrapper = supabaseWrapper {
+    _initAuthListener();
+  }
+
+  @override
+  PowerSyncDatabase get database => _database;
+
+  void _initAuthListener() {
+    _authSubscription = _supabaseWrapper.onAuthStateChange.listen(
+      (state) {
+        switch (state.event) {
+          case supabase.AuthChangeEvent.signedIn:
+          case supabase.AuthChangeEvent.initialSession:
+            if (state.session != null) {
+              unawaited(connect());
+            }
+          case supabase.AuthChangeEvent.signedOut:
+            unawaited(disconnectAndClear());
+          default:
+            break;
+        }
+      },
+      onError: (error) {
+        _logger.warning('Error in auth state stream, ignoring', error);
+      },
+    );
+
+    // Handle the already-authenticated case: when the session is restored
+    // synchronously during bootstrap, the [signedIn] event may have been
+    // emitted before this subscription was attached.
+    if (_supabaseWrapper.isAuthenticated) {
+      unawaited(connect());
+    }
+  }
+
+  @override
+  Future<void> connect() async {
+    if (_connected) {
+      return;
+    }
+    _connected = true;
+    _logger.info('Starting PowerSync sync connection');
+    try {
+      await _database.connect(connector: _connector);
+    } catch (error, stackTrace) {
+      _connected = false;
+
+      _logger.warning('Failed to start PowerSync sync', error, stackTrace);
+    }
+  }
+
+  @override
+  Future<void> disconnectAndClear() async {
+    if (!_connected) {
+      return;
+    }
+    _connected = false;
+    _logger.info('Disconnecting PowerSync and clearing local synced data');
+    try {
+      await _database.disconnectAndClear();
+    } catch (error, stackTrace) {
+      _logger.error(
+        'Failed to disconnect and clear PowerSync',
+        error,
+        stackTrace,
+      );
+    }
+  }
+
+  @override
+  void dispose() {
+    _authSubscription?.cancel();
+    _authSubscription = null;
+  }
+}

--- a/lib/libraries/powersync/powersync_manager_impl.dart
+++ b/lib/libraries/powersync/powersync_manager_impl.dart
@@ -28,12 +28,10 @@ class PowerSyncManagerImpl implements PowerSyncManager, Disposable {
   bool _connected = false;
 
   PowerSyncManagerImpl({
-    required PowerSyncDatabase database,
-    required PowerSyncBackendConnector connector,
-    required SupabaseWrapper supabaseWrapper,
-  }) : _database = database,
-       _connector = connector,
-       _supabaseWrapper = supabaseWrapper {
+    required this._database,
+    required this._connector,
+    required this._supabaseWrapper,
+  }) {
     _initAuthListener();
   }
 
@@ -60,9 +58,6 @@ class PowerSyncManagerImpl implements PowerSyncManager, Disposable {
       },
     );
 
-    // Handle the already-authenticated case: when the session is restored
-    // synchronously during bootstrap, the [signedIn] event may have been
-    // emitted before this subscription was attached.
     if (_supabaseWrapper.isAuthenticated) {
       unawaited(connect());
     }
@@ -94,6 +89,7 @@ class PowerSyncManagerImpl implements PowerSyncManager, Disposable {
     try {
       await _database.disconnectAndClear();
     } catch (error, stackTrace) {
+      _connected = true;
       _logger.error(
         'Failed to disconnect and clear PowerSync',
         error,

--- a/lib/libraries/powersync/powersync_manager_impl.dart
+++ b/lib/libraries/powersync/powersync_manager_impl.dart
@@ -3,9 +3,24 @@ import 'dart:async';
 import 'package:construculator/libraries/logging/app_logger.dart';
 import 'package:construculator/libraries/powersync/interfaces/powersync_manager.dart';
 import 'package:construculator/libraries/supabase/interfaces/supabase_wrapper.dart';
+import 'package:flutter/foundation.dart' show visibleForTesting;
 import 'package:flutter_modular/flutter_modular.dart';
 import 'package:powersync/powersync.dart';
 import 'package:supabase_flutter/supabase_flutter.dart' as supabase;
+
+/// Lifecycle state of the sync connection.
+enum _SyncState {
+  /// No sync connection, and no synced rows left in local SQLite.
+  disconnected,
+
+  /// A sync connection is established.
+  connected,
+
+  /// A clear was attempted and failed. The connection is down, but the
+  /// previous user's synced rows are still in local SQLite and must be
+  /// cleared before any new connection is established.
+  clearPending,
+}
 
 /// Default [PowerSyncManager] that drives the sync connection from Supabase
 /// authentication events.
@@ -15,6 +30,17 @@ import 'package:supabase_flutter/supabase_flutter.dart' as supabase;
 /// immediately. It then [connect]s on sign-in and [disconnectAndClear]s on
 /// sign-out. Token refreshes and other auth events are ignored — the connector
 /// refreshes credentials on demand, so an active connection survives them.
+///
+/// Listens to the raw Supabase stream rather than the app's own
+/// `AuthNotifier`, which is otherwise the standard way to observe auth state.
+/// `AuthNotifier` is fed exclusively by `AuthManagerImpl`, which is registered
+/// as a *lazy* singleton — until something resolves `AuthManager`, nothing
+/// emits on that stream, so a manager listening to it would never connect. Its
+/// controller is also a plain (non-replay) broadcast, so an `AuthManager`
+/// resolved before this manager subscribes would drop its initial state
+/// instead of buffering it. Both hazards disappear only if `AuthManager`
+/// becomes an eager singleton with a replayed initial state; until then the
+/// raw stream is the sole source that is correct at module-commit time.
 class PowerSyncManagerImpl implements PowerSyncManager, Disposable {
   final PowerSyncDatabase _database;
   final PowerSyncBackendConnector _connector;
@@ -23,9 +49,12 @@ class PowerSyncManagerImpl implements PowerSyncManager, Disposable {
 
   StreamSubscription<supabase.AuthState>? _authSubscription;
 
-  // Whether a sync connection is currently established. Guards against
-  // redundant [connect] calls when several auth events arrive in succession.
-  bool _connected = false;
+  _SyncState _state = _SyncState.disconnected;
+
+  // Tail of the lifecycle operation chain. Every [connect] and
+  // [disconnectAndClear] is appended to it, so the two can never interleave
+  // and observe each other's half-applied state.
+  Future<void> _operations = Future<void>.value();
 
   PowerSyncManagerImpl({
     required this._database,
@@ -37,6 +66,15 @@ class PowerSyncManagerImpl implements PowerSyncManager, Disposable {
 
   @override
   PowerSyncDatabase get database => _database;
+
+  /// Completes once every lifecycle operation queued so far has finished.
+  ///
+  /// The auth listener starts operations with [unawaited], so a test driving
+  /// the manager through auth events has no future of its own to await. This
+  /// exposes the chain's tail as a deterministic settle point, avoiding any
+  /// need to drain the real event loop.
+  @visibleForTesting
+  Future<void> get pendingOperations => _operations;
 
   void _initAuthListener() {
     _authSubscription = _supabaseWrapper.onAuthStateChange.listen(
@@ -63,33 +101,58 @@ class PowerSyncManagerImpl implements PowerSyncManager, Disposable {
     }
   }
 
+  // Appends the action to the lifecycle chain and returns the future for that
+  // link, so callers await their own operation rather than the whole queue.
+  Future<void> _serialize(Future<void> Function() action) {
+    final next = _operations.then((_) => action());
+    // The stored tail swallows failures so one bad operation cannot poison
+    // every later link in the chain. The caller still sees the error through
+    // the future returned here.
+    _operations = next.catchError((_) {});
+    return next;
+  }
+
   @override
-  Future<void> connect() async {
-    if (_connected) {
+  Future<void> connect() => _serialize(_connect);
+
+  @override
+  Future<void> disconnectAndClear() => _serialize(_disconnectAndClear);
+
+  Future<void> _connect() async {
+    if (_state == _SyncState.clearPending) {
+      await _disconnectAndClear();
+      if (_state == _SyncState.clearPending) {
+        _logger.warning(
+          'Skipping PowerSync connect: local synced data from the previous '
+          'session could not be cleared',
+        );
+        return;
+      }
+    }
+    if (_state == _SyncState.connected) {
       return;
     }
-    _connected = true;
     _logger.info('Starting PowerSync sync connection');
     try {
       await _database.connect(connector: _connector);
+      _state = _SyncState.connected;
     } catch (error, stackTrace) {
-      _connected = false;
-
       _logger.warning('Failed to start PowerSync sync', error, stackTrace);
     }
   }
 
-  @override
-  Future<void> disconnectAndClear() async {
-    if (!_connected) {
+  Future<void> _disconnectAndClear() async {
+    if (_state == _SyncState.disconnected) {
       return;
     }
-    _connected = false;
     _logger.info('Disconnecting PowerSync and clearing local synced data');
     try {
       await _database.disconnectAndClear();
+      _state = _SyncState.disconnected;
     } catch (error, stackTrace) {
-      _connected = true;
+      // Stay in clearPending so the next connect retries the clear before
+      // letting a new session sync on top of the old rows.
+      _state = _SyncState.clearPending;
       _logger.error(
         'Failed to disconnect and clear PowerSync',
         error,
@@ -100,7 +163,10 @@ class PowerSyncManagerImpl implements PowerSyncManager, Disposable {
 
   @override
   void dispose() {
-    _authSubscription?.cancel();
+    final subscription = _authSubscription;
     _authSubscription = null;
+    if (subscription != null) {
+      unawaited(subscription.cancel());
+    }
   }
 }

--- a/lib/libraries/powersync/powersync_module.dart
+++ b/lib/libraries/powersync/powersync_module.dart
@@ -1,9 +1,17 @@
 import 'package:construculator/app/app_bootstrap.dart';
 import 'package:construculator/libraries/powersync/data/connectors/supabase_powersync_connector.dart';
+import 'package:construculator/libraries/powersync/interfaces/powersync_manager.dart';
+import 'package:construculator/libraries/powersync/powersync_manager_impl.dart';
 import 'package:flutter_modular/flutter_modular.dart';
 import 'package:powersync/powersync.dart';
 
 /// Modular module that wires up the PowerSync backend connector.
+/// Wires the PowerSync stack: the opened local database, the Supabase-backed
+/// connector, and the [PowerSyncManager] that drives the sync lifecycle.
+///
+/// The database is opened during app bootstrap (see `openPowerSyncDatabase`)
+/// and passed in via [AppBootstrap], because opening it is asynchronous and
+/// must complete before the module graph is built.
 class PowerSyncModule extends Module {
   final AppBootstrap appBootstrap;
   PowerSyncModule(this.appBootstrap);
@@ -14,6 +22,20 @@ class PowerSyncModule extends Module {
       () => SupabasePowerSyncConnector(
         supabaseWrapper: appBootstrap.supabaseWrapper,
         envLoader: appBootstrap.envLoader,
+      ),
+    );
+
+    i.addLazySingleton<PowerSyncDatabase>(() => appBootstrap.powerSyncDatabase);
+
+    // Eager singleton: instantiated when the module is committed at app
+    // startup (see auto_injector's startSingletons), so the manager immediately
+    // subscribes to auth changes and drives connect/disconnect over the app's
+    // lifetime — without any caller needing to resolve it explicitly.
+    i.addSingleton<PowerSyncManager>(
+      () => PowerSyncManagerImpl(
+        database: appBootstrap.powerSyncDatabase,
+        connector: i(),
+        supabaseWrapper: appBootstrap.supabaseWrapper,
       ),
     );
   }

--- a/lib/libraries/powersync/powersync_module.dart
+++ b/lib/libraries/powersync/powersync_module.dart
@@ -5,9 +5,9 @@ import 'package:construculator/libraries/powersync/powersync_manager_impl.dart';
 import 'package:flutter_modular/flutter_modular.dart';
 import 'package:powersync/powersync.dart';
 
-/// Modular module that wires up the PowerSync backend connector.
-/// Wires the PowerSync stack: the opened local database, the Supabase-backed
-/// connector, and the [PowerSyncManager] that drives the sync lifecycle.
+/// Modular module that wires up the PowerSync stack: the opened local
+/// database, the Supabase-backed connector, and the [PowerSyncManager] that
+/// drives the sync lifecycle.
 ///
 /// The database is opened during app bootstrap (see `openPowerSyncDatabase`)
 /// and passed in via [AppBootstrap], because opening it is asynchronous and

--- a/lib/libraries/powersync/powersync_module.dart
+++ b/lib/libraries/powersync/powersync_module.dart
@@ -33,7 +33,7 @@ class PowerSyncModule extends Module {
     // lifetime — without any caller needing to resolve it explicitly.
     i.addSingleton<PowerSyncManager>(
       () => PowerSyncManagerImpl(
-        database: appBootstrap.powerSyncDatabase,
+        database: i(),
         connector: i(),
         supabaseWrapper: appBootstrap.supabaseWrapper,
       ),

--- a/lib/libraries/powersync/testing/fake_powersync_database.dart
+++ b/lib/libraries/powersync/testing/fake_powersync_database.dart
@@ -32,6 +32,18 @@ class FakePowerSyncDatabase implements PowerSyncDatabase {
     _nextTransaction = transaction;
   }
 
+  /// Clears all recorded call counts, the captured connector, the configured
+  /// [connectError], and any queued transaction, returning the fake to its
+  /// initial state so it can be reused across tests.
+  void reset() {
+    connectCallCount = 0;
+    lastConnector = null;
+    disconnectCallCount = 0;
+    disconnectAndClearCallCount = 0;
+    connectError = null;
+    _nextTransaction = null;
+  }
+
   @override
   Future<void> connect({
     required PowerSyncBackendConnector connector,

--- a/lib/libraries/powersync/testing/fake_powersync_database.dart
+++ b/lib/libraries/powersync/testing/fake_powersync_database.dart
@@ -27,13 +27,17 @@ class FakePowerSyncDatabase implements PowerSyncDatabase {
   /// exercise connection-failure handling.
   Object? connectError;
 
+  /// When set, the next [disconnectAndClear] call throws this error, allowing
+  /// tests to exercise disconnect-failure handling.
+  Object? disconnectAndClearError;
+
   /// Queues [transaction] to be returned by the next [getNextCrudTransaction] call.
   void setNextTransaction(CrudTransaction? transaction) {
     _nextTransaction = transaction;
   }
 
   /// Clears all recorded call counts, the captured connector, the configured
-  /// [connectError], and any queued transaction, returning the fake to its
+  /// [connectError], [disconnectAndClearError], and any queued transaction, returning the fake to its
   /// initial state so it can be reused across tests.
   void reset() {
     connectCallCount = 0;
@@ -41,6 +45,7 @@ class FakePowerSyncDatabase implements PowerSyncDatabase {
     disconnectCallCount = 0;
     disconnectAndClearCallCount = 0;
     connectError = null;
+    disconnectAndClearError = null;
     _nextTransaction = null;
   }
 
@@ -67,6 +72,10 @@ class FakePowerSyncDatabase implements PowerSyncDatabase {
   @override
   Future<void> disconnectAndClear({bool clearLocal = true}) async {
     disconnectAndClearCallCount++;
+    final error = disconnectAndClearError;
+    if (error != null) {
+      throw error;
+    }
   }
 
   /// Returns the queued transaction (set via [setNextTransaction]) and clears

--- a/lib/libraries/powersync/testing/fake_powersync_database.dart
+++ b/lib/libraries/powersync/testing/fake_powersync_database.dart
@@ -1,5 +1,7 @@
 // coverage:ignore-file
 
+import 'dart:async';
+
 import 'package:powersync/powersync.dart';
 
 /// Fake [PowerSyncDatabase] for testing.
@@ -31,14 +33,24 @@ class FakePowerSyncDatabase implements PowerSyncDatabase {
   /// tests to exercise disconnect-failure handling.
   Object? disconnectAndClearError;
 
+  /// When set, [connect] awaits this future before completing. Lets tests hold
+  /// a connection in flight and drive another lifecycle call into it.
+  Future<void>? connectGate;
+
+  /// Names of the lifecycle methods that have run, appended in the order they
+  /// *completed*. Distinguishes serialized lifecycle calls from interleaved
+  /// ones, which call counts alone cannot.
+  final List<String> completedOperations = [];
+
   /// Queues [transaction] to be returned by the next [getNextCrudTransaction] call.
   void setNextTransaction(CrudTransaction? transaction) {
     _nextTransaction = transaction;
   }
 
   /// Clears all recorded call counts, the captured connector, the configured
-  /// [connectError], [disconnectAndClearError], and any queued transaction, returning the fake to its
-  /// initial state so it can be reused across tests.
+  /// [connectError], [disconnectAndClearError] and [connectGate], the recorded
+  /// [completedOperations], and any queued transaction, returning the fake to
+  /// its initial state so it can be reused across tests.
   void reset() {
     connectCallCount = 0;
     lastConnector = null;
@@ -46,6 +58,8 @@ class FakePowerSyncDatabase implements PowerSyncDatabase {
     disconnectAndClearCallCount = 0;
     connectError = null;
     disconnectAndClearError = null;
+    connectGate = null;
+    completedOperations.clear();
     _nextTransaction = null;
   }
 
@@ -58,10 +72,15 @@ class FakePowerSyncDatabase implements PowerSyncDatabase {
   }) async {
     connectCallCount++;
     lastConnector = connector;
+    final gate = connectGate;
+    if (gate != null) {
+      await gate;
+    }
     final error = connectError;
     if (error != null) {
       throw error;
     }
+    completedOperations.add('connect');
   }
 
   @override
@@ -76,6 +95,7 @@ class FakePowerSyncDatabase implements PowerSyncDatabase {
     if (error != null) {
       throw error;
     }
+    completedOperations.add('disconnectAndClear');
   }
 
   /// Returns the queued transaction (set via [setNextTransaction]) and clears

--- a/lib/libraries/supabase/testing/fake_supabase_wrapper.dart
+++ b/lib/libraries/supabase/testing/fake_supabase_wrapper.dart
@@ -15,8 +15,11 @@ import 'package:supabase_flutter/supabase_flutter.dart' as supabase;
 /// Fake implementation of SupabaseWrapper for testing
 class FakeSupabaseWrapper implements SupabaseWrapper {
   /// Used to notify listeners of changes in the authentication state through [onAuthStateChange]
+  /// Synchronous so that emitting an auth event delivers it to listeners
+  /// before control returns to the test, making assertions deterministic
+  /// without draining the real event loop.
   final StreamController<supabase.AuthState> _authStateController =
-      StreamController<supabase.AuthState>.broadcast();
+      StreamController<supabase.AuthState>.broadcast(sync: true);
 
   /// Tracks the currently authenticated user
   FakeUser? _currentUser;

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -8,8 +8,8 @@ import 'package:construculator/libraries/config/app_config_impl.dart';
 import 'package:construculator/libraries/config/env_constants.dart';
 import 'package:construculator/libraries/config/env_loader_impl.dart';
 import 'package:construculator/libraries/logging/app_logger.dart';
-import 'package:construculator/libraries/sentry/sentry_sdk_impl.dart';
 import 'package:construculator/libraries/powersync/data/open_powersync_database.dart';
+import 'package:construculator/libraries/sentry/sentry_sdk_impl.dart';
 import 'package:construculator/libraries/sentry/sentry_wrapper_impl.dart';
 import 'package:construculator/libraries/supabase/supabase_wrapper_impl.dart';
 import 'package:flutter/material.dart';
@@ -46,8 +46,13 @@ Future<AppBootstrap> _initializeApp() async {
   final wrapper = SupabaseWrapperImpl(envLoader: envLoader);
   await wrapper.initialize();
   final sentryWrapper = SentryWrapperImpl(
+    
     envLoader: envLoader,
+   
     config: config,
+    sentrySdk: SentrySdkImpl(),
+  );
+  final powerSyncDatabase = await openPowerSyncDatabase(,
     sentrySdk: SentrySdkImpl(),
   );
   final analyticsRepository = await createAnalyticsRepository(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -46,15 +46,11 @@ Future<AppBootstrap> _initializeApp() async {
   final wrapper = SupabaseWrapperImpl(envLoader: envLoader);
   await wrapper.initialize();
   final sentryWrapper = SentryWrapperImpl(
-    
     envLoader: envLoader,
-   
     config: config,
     sentrySdk: SentrySdkImpl(),
   );
-  final powerSyncDatabase = await openPowerSyncDatabase(,
-    sentrySdk: SentrySdkImpl(),
-  );
+  final powerSyncDatabase = await openPowerSyncDatabase();
   final analyticsRepository = await createAnalyticsRepository(
     envLoader: envLoader,
     buildPosthogWrapper: () => PosthogWrapperImpl(posthogSdk: PosthogSdkImpl()),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -9,6 +9,7 @@ import 'package:construculator/libraries/config/env_constants.dart';
 import 'package:construculator/libraries/config/env_loader_impl.dart';
 import 'package:construculator/libraries/logging/app_logger.dart';
 import 'package:construculator/libraries/sentry/sentry_sdk_impl.dart';
+import 'package:construculator/libraries/powersync/data/open_powersync_database.dart';
 import 'package:construculator/libraries/sentry/sentry_wrapper_impl.dart';
 import 'package:construculator/libraries/supabase/supabase_wrapper_impl.dart';
 import 'package:flutter/material.dart';
@@ -59,6 +60,7 @@ Future<AppBootstrap> _initializeApp() async {
     supabaseWrapper: wrapper,
     sentryWrapper: sentryWrapper,
     analyticsRepository: analyticsRepository,
+    powerSyncDatabase: powerSyncDatabase,
   );
 }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -217,6 +217,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.2"
+  code_assets:
+    dependency: transitive
+    description:
+      name: code_assets
+      sha256: bf394f466ba9205f1812a0433b392d6af280f155f56651eda7c18cc32ed493b8
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.1"
   collection:
     dependency: transitive
     description:
@@ -509,6 +517,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
+  hooks:
+    dependency: transitive
+    description:
+      name: hooks
+      sha256: "9a62a50b50b769a737bc0a8ff381f333529df3ab746b2f6b02e83760231455ba"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.2"
   hotreloader:
     dependency: transitive
     description:
@@ -741,6 +757,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.2"
+  objective_c:
+    dependency: transitive
+    description:
+      name: objective_c
+      sha256: b7fb95a6d9a4f009edd63dc5ac69f07420b23a16161c6dd8660290b59c602e8e
+      url: "https://pub.dev"
+    source: hosted
+    version: "9.5.0"
   package_config:
     dependency: transitive
     description:
@@ -774,7 +798,7 @@ packages:
     source: hosted
     version: "2.9.0"
   path:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: path
       sha256: "75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5"
@@ -789,6 +813,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
+  path_provider:
+    dependency: "direct main"
+    description:
+      name: path_provider
+      sha256: a7f4874f987173da295a61c181b8ee71dab59b332a486b391babf26a1b884825
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.6"
+  path_provider_android:
+    dependency: transitive
+    description:
+      name: path_provider_android
+      sha256: "149441ca6e4f38193b2e004c0ca6376a3d11f51fa5a77552d8bd4d2b0c0912ba"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.23"
+  path_provider_foundation:
+    dependency: transitive
+    description:
+      name: path_provider_foundation
+      sha256: "2a376b7d6392d80cd3705782d2caa734ca4727776db0b6ec36ef3f1855197699"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.6.0"
   path_provider_linux:
     dependency: transitive
     description:
@@ -941,6 +989,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.11.0"
+  record_use:
+    dependency: transitive
+    description:
+      name: record_use
+      sha256: "2551bd8eecfe95d14ae75f6021ad0248be5c27f138c2ec12fcb52b500b3ba1ed"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.6.0"
   result_dart:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -33,6 +33,8 @@ dependencies:
   sentry_flutter: 9.24.0
   powersync: 1.18.0
   posthog_flutter: 5.35.1
+  path_provider: ^2.1.5
+  path: ^1.9.0
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -33,8 +33,8 @@ dependencies:
   sentry_flutter: 9.24.0
   powersync: 1.18.0
   posthog_flutter: 5.35.1
-  path_provider: ^2.1.5
-  path: ^1.9.0
+  path_provider: 2.1.6
+  path: 1.9.1
 
 dev_dependencies:
   flutter_test:

--- a/test/app/shell/tab_module_manager_test.dart
+++ b/test/app/shell/tab_module_manager_test.dart
@@ -5,6 +5,7 @@ import 'package:construculator/app/shell/tab_module_manager.dart';
 import 'package:construculator/libraries/analytics/data/repositories/no_op_analytics_repository.dart';
 import 'package:construculator/libraries/config/testing/fake_app_config.dart';
 import 'package:construculator/libraries/config/testing/fake_env_loader.dart';
+import 'package:construculator/libraries/powersync/testing/fake_powersync_database.dart';
 import 'package:construculator/libraries/sentry/fake_sentry_wrapper.dart';
 import 'package:construculator/libraries/supabase/testing/fake_supabase_wrapper.dart';
 import 'package:construculator/libraries/time/testing/fake_clock_impl.dart';
@@ -23,6 +24,7 @@ void main() {
           sentryWrapper: FakeSentryWrapper(),
           supabaseWrapper: FakeSupabaseWrapper(clock: FakeClockImpl()),
           analyticsRepository: const NoOpAnalyticsRepository(),
+          powerSyncDatabase: FakePowerSyncDatabase(),
         );
         Modular.init(ShellModule(appBootstrap));
         manager = Modular.get<TabModuleManager>();
@@ -65,7 +67,6 @@ void main() {
           envLoader: FakeEnvLoader(),
           sentryWrapper: FakeSentryWrapper(),
           supabaseWrapper: FakeSupabaseWrapper(clock: FakeClockImpl()),
-          analyticsRepository: const NoOpAnalyticsRepository(),
         );
         Modular.init(_TestShellModule(appBootstrap));
         customManager = Modular.get<TabModuleManager>();

--- a/test/app/shell/tab_module_manager_test.dart
+++ b/test/app/shell/tab_module_manager_test.dart
@@ -67,6 +67,8 @@ void main() {
           envLoader: FakeEnvLoader(),
           sentryWrapper: FakeSentryWrapper(),
           supabaseWrapper: FakeSupabaseWrapper(clock: FakeClockImpl()),
+          analyticsRepository: NoOpAnalyticsRepository(),
+          powerSyncDatabase: FakePowerSyncDatabase(),
         );
         Modular.init(_TestShellModule(appBootstrap));
         customManager = Modular.get<TabModuleManager>();

--- a/test/libraries/auth/units/auth_manager_test.dart
+++ b/test/libraries/auth/units/auth_manager_test.dart
@@ -65,16 +65,10 @@ void main() {
       test(
         'should initialize with authenticated state when user exists',
         () async {
-          supabaseWrapper.setCurrentUser(
-            FakeUser(
-              email: testEmail,
-              id: 'test-id',
-              createdAt: clock.now().toIso8601String(),
-              appMetadata: {},
-            ),
-          );
           authNotifier.reset();
 
+          // Subscribe before emitting: the fake's auth stream delivers
+          // synchronously, so an event raised first would be missed.
           final initialEvent = expectLater(
             authNotifier.onAuthStateChanged,
             emits(
@@ -83,6 +77,16 @@ void main() {
               ),
             ),
           );
+
+          supabaseWrapper.setCurrentUser(
+            FakeUser(
+              email: testEmail,
+              id: 'test-id',
+              createdAt: clock.now().toIso8601String(),
+              appMetadata: {},
+            ),
+          );
+
           await initialEvent;
           expect(authNotifier.stateChangedEvents.length, 1);
           expect(

--- a/test/libraries/powersync/units/powersync_manager_test.dart
+++ b/test/libraries/powersync/units/powersync_manager_test.dart
@@ -1,0 +1,171 @@
+import 'package:construculator/app/app_bootstrap.dart';
+import 'package:construculator/libraries/powersync/interfaces/powersync_manager.dart';
+import 'package:construculator/libraries/powersync/powersync_module.dart';
+import 'package:construculator/libraries/powersync/testing/fake_powersync_database.dart';
+import 'package:construculator/libraries/supabase/testing/fake_supabase_user.dart';
+import 'package:construculator/libraries/supabase/testing/fake_supabase_wrapper.dart';
+import 'package:construculator/libraries/time/testing/fake_clock_impl.dart';
+import 'package:flutter_modular/flutter_modular.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:powersync/powersync.dart';
+
+import '../../../utils/fake_app_bootstrap_factory.dart';
+
+void main() {
+  final fakeSupabase = FakeSupabaseWrapper(clock: FakeClockImpl());
+  final fakeDatabase = FakePowerSyncDatabase();
+  final bootstrap = FakeAppBootstrapFactory.create(
+    supabaseWrapper: fakeSupabase,
+    powerSyncDatabase: fakeDatabase,
+  );
+
+  setUpAll(() => Modular.init(_AppModule(bootstrap)));
+
+  tearDownAll(() {
+    Modular.destroy();
+    fakeSupabase.dispose();
+  });
+
+  setUp(() {
+    (Modular.get<PowerSyncManager>() as Disposable).dispose();
+    Modular.dispose<PowerSyncManager>();
+    fakeSupabase.reset();
+    fakeDatabase.reset();
+  });
+
+  PowerSyncManager startManager() => Modular.get<PowerSyncManager>();
+
+  PowerSyncBackendConnector moduleConnector() =>
+      Modular.get<PowerSyncBackendConnector>();
+
+  void signIn() {
+    fakeSupabase.setCurrentUser(
+      FakeUser(
+        id: 'user-1',
+        email: 'user@example.com',
+        createdAt: '2000-01-01T00:00:00.000Z',
+      ),
+    );
+  }
+
+  /// Lets queued auth-stream events reach the manager's listener.
+  ///
+  /// The unit-test analogue of `tester.pumpAndSettle()`: there is no widget
+  /// tree to pump here, so we drain the event queue to flush pending
+  /// broadcast-stream deliveries instead. [pumpEventQueue] pumps repeatedly,
+  /// so it settles multi-hop async chains a single timer tick would miss.
+  Future<void> pumpAuthEvents() => pumpEventQueue();
+
+  group('PowerSyncManager', () {
+    test('exposes the database opened during bootstrap', () {
+      final manager = startManager();
+
+      expect(manager.database, same(fakeDatabase));
+    });
+
+    test('does not connect when no session exists at startup', () {
+      startManager();
+
+      expect(fakeDatabase.connectCallCount, 0);
+    });
+
+    test('connects immediately when already authenticated at startup', () {
+      signIn();
+
+      startManager();
+
+      expect(fakeDatabase.connectCallCount, 1);
+      expect(fakeDatabase.lastConnector, same(moduleConnector()));
+    });
+
+    test('connects when a sign-in event is emitted', () async {
+      startManager();
+
+      signIn();
+      await pumpAuthEvents();
+
+      expect(fakeDatabase.connectCallCount, 1);
+      expect(fakeDatabase.lastConnector, same(moduleConnector()));
+    });
+
+    test('disconnects and clears when a sign-out event is emitted', () async {
+      signIn();
+      startManager();
+
+      fakeSupabase.setCurrentUser(null);
+      await pumpAuthEvents();
+
+      expect(fakeDatabase.disconnectAndClearCallCount, 1);
+    });
+
+    test('does not establish duplicate connections', () async {
+      startManager();
+
+      signIn();
+      await pumpAuthEvents();
+
+      signIn();
+      await pumpAuthEvents();
+
+      expect(fakeDatabase.connectCallCount, 1);
+    });
+
+    test('reconnects after a sign-out followed by a new sign-in', () async {
+      signIn();
+      final manager = startManager();
+      expect(fakeDatabase.connectCallCount, 1);
+
+      fakeSupabase.setCurrentUser(null);
+      await pumpAuthEvents();
+      signIn();
+      await pumpAuthEvents();
+
+      expect(fakeDatabase.connectCallCount, 2);
+      expect(fakeDatabase.disconnectAndClearCallCount, 1);
+      expect(manager.database, same(fakeDatabase));
+    });
+
+    test('connect failure is swallowed and allows a later retry', () async {
+      final manager = startManager();
+      fakeDatabase.connectError = Exception('network down');
+
+      await manager.connect();
+      expect(fakeDatabase.connectCallCount, 1);
+
+      fakeDatabase.connectError = null;
+      await manager.connect();
+      expect(fakeDatabase.connectCallCount, 2);
+    });
+
+    test('disconnectAndClear is a no-op when not connected', () async {
+      final manager = startManager();
+
+      await manager.disconnectAndClear();
+
+      expect(fakeDatabase.disconnectAndClearCallCount, 0);
+    });
+
+    test('stops reacting to auth events after dispose', () async {
+      final manager = startManager();
+
+      (manager as Disposable).dispose();
+      signIn();
+      await pumpAuthEvents();
+
+      expect(fakeDatabase.connectCallCount, 0);
+    });
+  });
+}
+
+// Minimal host module that mirrors how the real `AppModule` composes
+// [PowerSyncModule], so the production module's wiring — including the eager
+// [PowerSyncManager] singleton — is exercised directly. [PowerSyncModule]
+// exposes its binds via `exportedBinds`, which are only resolvable through an
+// importing module, hence this wrapper.
+class _AppModule extends Module {
+  final AppBootstrap appBootstrap;
+  _AppModule(this.appBootstrap);
+
+  @override
+  List<Module> get imports => [PowerSyncModule(appBootstrap)];
+}

--- a/test/libraries/powersync/units/powersync_manager_test.dart
+++ b/test/libraries/powersync/units/powersync_manager_test.dart
@@ -1,5 +1,8 @@
+import 'dart:async';
+
 import 'package:construculator/app/app_bootstrap.dart';
 import 'package:construculator/libraries/powersync/interfaces/powersync_manager.dart';
+import 'package:construculator/libraries/powersync/powersync_manager_impl.dart';
 import 'package:construculator/libraries/powersync/powersync_module.dart';
 import 'package:construculator/libraries/powersync/testing/fake_powersync_database.dart';
 import 'package:construculator/libraries/supabase/testing/fake_supabase_user.dart';
@@ -19,7 +22,7 @@ void main() {
     powerSyncDatabase: fakeDatabase,
   );
 
-  setUpAll(() => Modular.init(_AppModule(bootstrap)));
+  setUpAll(() => Modular.init(_PowerSyncTestModule(bootstrap)));
 
   tearDownAll(() {
     Modular.destroy();
@@ -27,6 +30,11 @@ void main() {
   });
 
   setUp(() {
+    // Explicit dispose is required, not redundant: Modular.dispose<T>() maps to
+    // auto_injector's disposeSingleton<T>(), which drops the instance without
+    // invoking Disposable.dispose(). Only module teardown calls that. Without
+    // this line the previous test's manager keeps its auth subscription and
+    // keeps driving the shared fake database.
     (Modular.get<PowerSyncManager>() as Disposable).dispose();
     Modular.dispose<PowerSyncManager>();
     fakeSupabase.reset();
@@ -34,6 +42,14 @@ void main() {
   });
 
   PowerSyncManager startManager() => Modular.get<PowerSyncManager>();
+
+  /// Awaits every lifecycle operation queued so far. The auth listener starts
+  /// them with [unawaited], so there is no future for the test to hold; this
+  /// is a deterministic settle point that never drains the real event loop.
+  Future<void> settle() async {
+    await (Modular.get<PowerSyncManager>() as PowerSyncManagerImpl)
+        .pendingOperations;
+  }
 
   PowerSyncBackendConnector moduleConnector() =>
       Modular.get<PowerSyncBackendConnector>();
@@ -55,25 +71,31 @@ void main() {
       expect(manager.database, same(fakeDatabase));
     });
 
-    test('does not connect when no session exists at startup', () {
+    test('does not connect when no session exists at startup', () async {
       startManager();
+      await settle();
 
       expect(fakeDatabase.connectCallCount, 0);
     });
 
-    test('connects immediately when already authenticated at startup', () {
-      signIn();
+    test(
+      'connects immediately when already authenticated at startup',
+      () async {
+        signIn();
 
-      startManager();
+        startManager();
+        await settle();
 
-      expect(fakeDatabase.connectCallCount, 1);
-      expect(fakeDatabase.lastConnector, same(moduleConnector()));
-    });
+        expect(fakeDatabase.connectCallCount, 1);
+        expect(fakeDatabase.lastConnector, same(moduleConnector()));
+      },
+    );
 
     test('connects when a sign-in event is emitted', () async {
       startManager();
 
       signIn();
+      await settle();
 
       expect(fakeDatabase.connectCallCount, 1);
       expect(fakeDatabase.lastConnector, same(moduleConnector()));
@@ -84,6 +106,7 @@ void main() {
       startManager();
 
       fakeSupabase.setCurrentUser(null);
+      await settle();
 
       expect(fakeDatabase.disconnectAndClearCallCount, 1);
     });
@@ -94,6 +117,7 @@ void main() {
       signIn();
 
       signIn();
+      await settle();
 
       expect(fakeDatabase.connectCallCount, 1);
     });
@@ -101,10 +125,12 @@ void main() {
     test('reconnects after a sign-out followed by a new sign-in', () async {
       signIn();
       final manager = startManager();
+      await settle();
       expect(fakeDatabase.connectCallCount, 1);
 
       fakeSupabase.setCurrentUser(null);
       signIn();
+      await settle();
 
       expect(fakeDatabase.connectCallCount, 2);
       expect(fakeDatabase.disconnectAndClearCallCount, 1);
@@ -128,6 +154,7 @@ void main() {
       () async {
         signIn();
         final manager = startManager();
+        await settle();
         fakeDatabase.disconnectAndClearError = Exception('disk error');
 
         await manager.disconnectAndClear();
@@ -141,6 +168,7 @@ void main() {
 
     test('disconnectAndClear is a no-op when not connected', () async {
       final manager = startManager();
+      await settle();
 
       await manager.disconnectAndClear();
 
@@ -152,9 +180,83 @@ void main() {
 
       (manager as Disposable).dispose();
       signIn();
+      await settle();
 
       expect(fakeDatabase.connectCallCount, 0);
     });
+
+    test('retries a failed clear before connecting the next user', () async {
+      signIn();
+      startManager();
+      await settle();
+      expect(fakeDatabase.connectCallCount, 1);
+
+      fakeDatabase.disconnectAndClearError = Exception('disk error');
+      fakeSupabase.setCurrentUser(null);
+      await settle();
+      expect(fakeDatabase.disconnectAndClearCallCount, 1);
+
+      fakeDatabase.disconnectAndClearError = null;
+      signIn();
+      await settle();
+
+      expect(fakeDatabase.disconnectAndClearCallCount, 2);
+      expect(
+        fakeDatabase.connectCallCount,
+        2,
+        reason: 'user B must establish its own sync connection',
+      );
+    });
+
+    test(
+      'refuses to connect while the previous session is still uncleared',
+      () async {
+        signIn();
+        startManager();
+        await settle();
+
+        fakeDatabase.disconnectAndClearError = Exception('disk error');
+        fakeSupabase.setCurrentUser(null);
+        await settle();
+
+        // The clear is still failing when the next user signs in.
+        signIn();
+        await settle();
+
+        expect(fakeDatabase.disconnectAndClearCallCount, 2);
+        expect(
+          fakeDatabase.connectCallCount,
+          1,
+          reason: 'must not sync a new user on top of the previous rows',
+        );
+      },
+    );
+
+    test(
+      'serializes a sign-out arriving during an in-flight connect',
+      () async {
+        startManager();
+        final gate = Completer<void>();
+        fakeDatabase.connectGate = gate.future;
+
+        signIn();
+        fakeSupabase.setCurrentUser(null);
+
+        gate.complete();
+        fakeDatabase.connectGate = null;
+        await settle();
+
+        expect(fakeDatabase.completedOperations, [
+          'connect',
+          'disconnectAndClear',
+        ]);
+
+        signIn();
+        await settle();
+
+        expect(fakeDatabase.connectCallCount, 2);
+      },
+    );
   });
 }
 
@@ -163,9 +265,9 @@ void main() {
 // [PowerSyncManager] singleton — is exercised directly. [PowerSyncModule]
 // exposes its binds via `exportedBinds`, which are only resolvable through an
 // importing module, hence this wrapper.
-class _AppModule extends Module {
+class _PowerSyncTestModule extends Module {
   final AppBootstrap appBootstrap;
-  _AppModule(this.appBootstrap);
+  _PowerSyncTestModule(this.appBootstrap);
 
   @override
   List<Module> get imports => [PowerSyncModule(appBootstrap)];

--- a/test/libraries/powersync/units/powersync_manager_test.dart
+++ b/test/libraries/powersync/units/powersync_manager_test.dart
@@ -48,14 +48,6 @@ void main() {
     );
   }
 
-  /// Lets queued auth-stream events reach the manager's listener.
-  ///
-  /// The unit-test analogue of `tester.pumpAndSettle()`: there is no widget
-  /// tree to pump here, so we drain the event queue to flush pending
-  /// broadcast-stream deliveries instead. [pumpEventQueue] pumps repeatedly,
-  /// so it settles multi-hop async chains a single timer tick would miss.
-  Future<void> pumpAuthEvents() => pumpEventQueue();
-
   group('PowerSyncManager', () {
     test('exposes the database opened during bootstrap', () {
       final manager = startManager();
@@ -82,7 +74,6 @@ void main() {
       startManager();
 
       signIn();
-      await pumpAuthEvents();
 
       expect(fakeDatabase.connectCallCount, 1);
       expect(fakeDatabase.lastConnector, same(moduleConnector()));
@@ -93,7 +84,6 @@ void main() {
       startManager();
 
       fakeSupabase.setCurrentUser(null);
-      await pumpAuthEvents();
 
       expect(fakeDatabase.disconnectAndClearCallCount, 1);
     });
@@ -102,10 +92,8 @@ void main() {
       startManager();
 
       signIn();
-      await pumpAuthEvents();
 
       signIn();
-      await pumpAuthEvents();
 
       expect(fakeDatabase.connectCallCount, 1);
     });
@@ -116,9 +104,7 @@ void main() {
       expect(fakeDatabase.connectCallCount, 1);
 
       fakeSupabase.setCurrentUser(null);
-      await pumpAuthEvents();
       signIn();
-      await pumpAuthEvents();
 
       expect(fakeDatabase.connectCallCount, 2);
       expect(fakeDatabase.disconnectAndClearCallCount, 1);
@@ -137,6 +123,22 @@ void main() {
       expect(fakeDatabase.connectCallCount, 2);
     });
 
+    test(
+      'disconnectAndClear failure keeps the manager connected for a retry',
+      () async {
+        signIn();
+        final manager = startManager();
+        fakeDatabase.disconnectAndClearError = Exception('disk error');
+
+        await manager.disconnectAndClear();
+        expect(fakeDatabase.disconnectAndClearCallCount, 1);
+
+        fakeDatabase.disconnectAndClearError = null;
+        await manager.disconnectAndClear();
+        expect(fakeDatabase.disconnectAndClearCallCount, 2);
+      },
+    );
+
     test('disconnectAndClear is a no-op when not connected', () async {
       final manager = startManager();
 
@@ -150,7 +152,6 @@ void main() {
 
       (manager as Disposable).dispose();
       signIn();
-      await pumpAuthEvents();
 
       expect(fakeDatabase.connectCallCount, 0);
     });

--- a/test/libraries/powersync/units/powersync_module_test.dart
+++ b/test/libraries/powersync/units/powersync_module_test.dart
@@ -1,0 +1,90 @@
+import 'package:construculator/app/app_bootstrap.dart';
+import 'package:construculator/libraries/powersync/interfaces/powersync_manager.dart';
+import 'package:construculator/libraries/powersync/powersync_manager_impl.dart';
+import 'package:construculator/libraries/powersync/powersync_module.dart';
+import 'package:construculator/libraries/powersync/testing/fake_powersync_database.dart';
+import 'package:construculator/libraries/supabase/testing/fake_supabase_user.dart';
+import 'package:construculator/libraries/supabase/testing/fake_supabase_wrapper.dart';
+import 'package:construculator/libraries/time/testing/fake_clock_impl.dart';
+import 'package:flutter_modular/flutter_modular.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:powersync/powersync.dart';
+
+import '../../../utils/fake_app_bootstrap_factory.dart';
+
+// Lives in its own file because it must observe the module immediately after
+// commit, before anything resolves [PowerSyncManager]. The manager test's
+// shared setUp resolves it on every test, which would mask the difference
+// between an eager and a lazy singleton.
+void main() {
+  // A single module graph for the whole file: flutter_modular keeps bind
+  // registrations alive across destroy()/init() within one process, so
+  // re-initialising per test resolves stale instances from the previous one.
+  final fakeSupabase = FakeSupabaseWrapper(clock: FakeClockImpl());
+  final fakeDatabase = FakePowerSyncDatabase();
+
+  setUpAll(
+    () => Modular.init(
+      _PowerSyncTestModule(
+        FakeAppBootstrapFactory.create(
+          supabaseWrapper: fakeSupabase,
+          powerSyncDatabase: fakeDatabase,
+        ),
+      ),
+    ),
+  );
+
+  tearDownAll(() {
+    Modular.destroy();
+    fakeSupabase.dispose();
+  });
+
+  void signIn() {
+    fakeSupabase.setCurrentUser(
+      FakeUser(
+        id: 'user-1',
+        email: 'user@example.com',
+        createdAt: '2000-01-01T00:00:00.000Z',
+      ),
+    );
+  }
+
+  group('PowerSyncModule', () {
+    test('manager listens to auth events without being resolved', () async {
+      // Deliberately no Modular.get before the events: the eager singleton is
+      // already subscribed at module commit. Signing out afterwards means a
+      // lazy singleton constructed by the settle() lookup below would see
+      // isAuthenticated == false and never connect, leaving the count at 0.
+      signIn();
+      fakeSupabase.setCurrentUser(null);
+
+      await (Modular.get<PowerSyncManager>() as PowerSyncManagerImpl)
+          .pendingOperations;
+
+      expect(
+        fakeDatabase.connectCallCount,
+        1,
+        reason: 'the manager must be eager, not resolved on first use',
+      );
+      expect(fakeDatabase.disconnectAndClearCallCount, 1);
+    });
+
+    test('injects the bootstrap database and the module connector', () {
+      final manager = Modular.get<PowerSyncManager>();
+
+      expect(manager.database, same(fakeDatabase));
+      expect(Modular.get<PowerSyncDatabase>(), same(fakeDatabase));
+    });
+  });
+}
+
+// Minimal host module that mirrors how the real `AppModule` composes
+// [PowerSyncModule]. [PowerSyncModule] exposes its binds via `exportedBinds`,
+// which are only resolvable through an importing module, hence this wrapper.
+class _PowerSyncTestModule extends Module {
+  final AppBootstrap appBootstrap;
+  _PowerSyncTestModule(this.appBootstrap);
+
+  @override
+  List<Module> get imports => [PowerSyncModule(appBootstrap)];
+}

--- a/test/libraries/powersync/units/testing/fake_powersync_database_test.dart
+++ b/test/libraries/powersync/units/testing/fake_powersync_database_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:construculator/libraries/powersync/testing/fake_powersync_database.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:powersync/powersync.dart';
@@ -56,6 +58,99 @@ void main() {
         await fakeDatabase.disconnectAndClear();
 
         expect(fakeDatabase.disconnectAndClearCallCount, 1);
+      });
+
+      test('throws the configured disconnectAndClearError', () async {
+        final error = Exception('clear failed');
+        fakeDatabase.disconnectAndClearError = error;
+
+        await expectLater(
+          fakeDatabase.disconnectAndClear(),
+          throwsA(same(error)),
+        );
+      });
+
+      test('still records the call even when it throws', () async {
+        fakeDatabase.disconnectAndClearError = Exception('clear failed');
+
+        await expectLater(fakeDatabase.disconnectAndClear(), throwsException);
+
+        expect(fakeDatabase.disconnectAndClearCallCount, 1);
+      });
+    });
+
+    group('connectGate', () {
+      test('holds connect open until the gate completes', () async {
+        final gate = Completer<void>();
+        fakeDatabase.connectGate = gate.future;
+        var completed = false;
+
+        unawaited(
+          fakeDatabase
+              .connect(connector: _FakeConnector())
+              .then((_) => completed = true),
+        );
+
+        expect(fakeDatabase.connectCallCount, 1);
+        expect(completed, isFalse);
+
+        gate.complete();
+        await gate.future;
+        await Future<void>.value();
+
+        expect(completed, isTrue);
+      });
+    });
+
+    group('completedOperations', () {
+      test('records lifecycle methods in completion order', () async {
+        await fakeDatabase.disconnectAndClear();
+        await fakeDatabase.connect(connector: _FakeConnector());
+
+        expect(fakeDatabase.completedOperations, [
+          'disconnectAndClear',
+          'connect',
+        ]);
+      });
+
+      test('does not record an operation that threw', () async {
+        fakeDatabase.connectError = Exception('connect failed');
+
+        await expectLater(
+          fakeDatabase.connect(connector: _FakeConnector()),
+          throwsException,
+        );
+
+        expect(fakeDatabase.completedOperations, isEmpty);
+      });
+    });
+
+    group('reset', () {
+      test('returns every field to its initial state', () async {
+        fakeDatabase.connectError = Exception('connect failed');
+        await expectLater(
+          fakeDatabase.connect(connector: _FakeConnector()),
+          throwsException,
+        );
+        fakeDatabase.connectError = null;
+        await fakeDatabase.connect(connector: _FakeConnector());
+        await fakeDatabase.disconnect();
+        await fakeDatabase.disconnectAndClear();
+        fakeDatabase.disconnectAndClearError = Exception('clear failed');
+        fakeDatabase.connectGate = Completer<void>().future;
+        fakeDatabase.setNextTransaction(FakeCrudTransaction([]));
+
+        fakeDatabase.reset();
+
+        expect(fakeDatabase.connectCallCount, 0);
+        expect(fakeDatabase.lastConnector, isNull);
+        expect(fakeDatabase.disconnectCallCount, 0);
+        expect(fakeDatabase.disconnectAndClearCallCount, 0);
+        expect(fakeDatabase.connectError, isNull);
+        expect(fakeDatabase.disconnectAndClearError, isNull);
+        expect(fakeDatabase.connectGate, isNull);
+        expect(fakeDatabase.completedOperations, isEmpty);
+        expect(await fakeDatabase.getNextCrudTransaction(), isNull);
       });
     });
 

--- a/test/utils/fake_app_bootstrap_factory.dart
+++ b/test/utils/fake_app_bootstrap_factory.dart
@@ -54,6 +54,8 @@ class FakeAppBootstrapFactory {
       config: config ?? FakeAppConfig(),
       envLoader: envLoader ?? FakeEnvLoader(),
       sentryWrapper: FakeSentryWrapper(),
+      analyticsRepository: analyticsRepository ?? NoOpAnalyticsRepository(),
+      powerSyncDatabase: powerSyncDatabase ?? FakePowerSyncDatabase(),
     );
   }
 }

--- a/test/utils/fake_app_bootstrap_factory.dart
+++ b/test/utils/fake_app_bootstrap_factory.dart
@@ -5,9 +5,11 @@ import 'package:construculator/libraries/config/interfaces/config.dart';
 import 'package:construculator/libraries/config/interfaces/env_loader.dart';
 import 'package:construculator/libraries/config/testing/fake_app_config.dart';
 import 'package:construculator/libraries/config/testing/fake_env_loader.dart';
+import 'package:construculator/libraries/powersync/testing/fake_powersync_database.dart';
 import 'package:construculator/libraries/sentry/fake_sentry_wrapper.dart';
 import 'package:construculator/libraries/supabase/testing/fake_supabase_wrapper.dart';
 import 'package:construculator/libraries/time/testing/fake_clock_impl.dart';
+import 'package:powersync/powersync.dart';
 
 /// Factory for creating test AppBootstrap instances with fake dependencies.
 ///
@@ -23,6 +25,8 @@ class FakeAppBootstrapFactory {
   /// - [envLoader]: Provide custom environment loading behavior
   /// - [analyticsRepository]: Provide a specific AnalyticsRepository; defaults
   ///   to the production no-op
+  /// - [powerSyncDatabase]: Provide a specific fake database to assert against
+  ///   sync lifecycle calls
   ///
   /// When parameters are omitted, sensible test defaults are provided.
   ///
@@ -42,6 +46,7 @@ class FakeAppBootstrapFactory {
     Config? config,
     EnvLoader? envLoader,
     AnalyticsRepository? analyticsRepository,
+    PowerSyncDatabase? powerSyncDatabase,
   }) {
     return AppBootstrap(
       supabaseWrapper:
@@ -49,7 +54,6 @@ class FakeAppBootstrapFactory {
       config: config ?? FakeAppConfig(),
       envLoader: envLoader ?? FakeEnvLoader(),
       sentryWrapper: FakeSentryWrapper(),
-      analyticsRepository: analyticsRepository ?? const NoOpAnalyticsRepository(),
     );
   }
 }


### PR DESCRIPTION
# PR Review: feat/wire-powersync → feat/powersync-configs
  
**Scope:** Wires the PowerSync sync lifecycle into the app — opens the local DB during bootstrap, registers a PowerSyncManager that drives connect/disconnect from Supabase auth events, and threads powerSyncDatabase through AppBootstrap.

**Files analyzed:** 10 production (lib/), 4 test, + analysis_options.yaml, pubspec.*.
  Rules applied: RULE_1, RULE_2, RULE_3, RULE_6, RULE_7, RULE_9, RULE_15. Skipped: RULE_4/5/8/10/14 (no presentation/UI/widget tests), RULE_13 (no logic-heavy
  branching/math).

Overall this is a clean, well-documented PR. The lifecycle abstraction is sound, the fakes are hand-written, and the test coverage is genuinely good (duplicate-connect guard, reconnect, dispose-stops-reacting, failure-retry). Findings below are all minor/suggestion — nothing blocking.

  ---
##  Findings

1. Doc comments placed after @override — supabase_powersync_connector.dart · RULE_7 · minor

2. AppLogger.error on sync-connect failure — powersync_manager_impl.dart:connect() · RULE_15 · minor
- Fix: prefer warning() here. The disconnectAndClear() catch is more genuinely unexpected, so error() there is fine.


 ---
  Compliance highlights (no action)

  - RULE_6 ✅ StreamSubscription is stored and cancelled in dispose(); PowerSyncManagerImpl implements Disposable and is registered as an eager singleton so Modular
  disposes it. No zombie subscriptions.
  - RULE_3 ✅ Hand-written FakePowerSyncDatabase / FakeSupabaseWrapper, no mockito. The new reset() and connectError hooks are clean.
  - RULE_2 ✅ PowerSyncManager "Manager" suffix is acceptable under the rule's explicit stateful-resource exception (it manages the sync connection, à la
  ConnectionManager).
  - RULE_9 ✅ Tests assert on the manager's observable collaborator effects (connect/disconnect call counts on the fake), not private internals.
  - Docs ✅ Strong dartdoc throughout, especially the "opened in bootstrap, not in a binds callback, because path resolution is async" rationale and the eager-singleton
  comment in the module.