### PR TITLE
skills: improve the pr review skills

### DIFF
--- a/skills/code-data/SKILL.md
+++ b/skills/code-data/SKILL.md
@@ -19,7 +19,7 @@ disable-model-invocation: false
 
 ## 1. Class Overview
 
-| Class Type | Naming (RULE_2) | Purpose |
+| Class Type | Naming | Purpose |
 |------------|-----------------|---------|
 | **DataSource** (interface) | `{Noun}DataSource` | Contract with **explicit method names** (e.g., `fetchInitialEstimationsByProjectId`) |
 | **RemoteDataSource** | `Remote{Noun}DataSource` | Fetches from API/DB via `SupabaseWrapper` |
@@ -28,7 +28,7 @@ disable-model-invocation: false
 
 ## 2. RemoteDataSource Pattern
 
-Fetch from external source. Log `_logger.debug('Fetched N items')` on success; **always rethrow on error** — RepositoryImpl is the error boundary (RULE_15); do NOT log errors here.
+Fetch from external source. Log `_logger.debug('Fetched N items')` on success; **always rethrow on error** — RepositoryImpl is the error boundary (Sentry Logging); do NOT log errors here.
 
 ## 3. RepositoryImpl Pattern
 
@@ -44,7 +44,7 @@ Implement domain repository interface; delegate to DataSource; map exceptions to
 | `PostgrestException` (critical) | error | `{Feature}Failure(databaseError)` | Critical — unknown PG codes, server errors; log error (Sentry) |
 | Other | error | `UnexpectedFailure()` | Critical — unexpected exceptions; log error (Sentry) |
 
-**RULE_15 — Log once at RepositoryImpl only:**
+**Sentry Logging — Log once at RepositoryImpl only:**
 - **Warning level:** Expected errors; no Sentry event
 - **Error level:** Critical/unexpected errors; sends Sentry event
 
@@ -69,7 +69,7 @@ Implement domain repository interface; delegate to DataSource; map exceptions to
 
 In `{feature}_module.dart`, register DataSource as `addLazySingleton` (inject `SupabaseWrapper`) and RepositoryImpl as `addLazySingleton` (inject DataSource). See `code-domain` skill for the canonical `_registerDependencies` shape.
 
-## 6. Layer Boundaries (RULE_5)
+## 6. Layer Boundaries (UI / Business Separation)
 
 | ❌ Data MUST NOT Import | ✅ Data CAN Import |
 |-------------------------|-------------------|
@@ -88,17 +88,17 @@ In `{feature}_module.dart`, register DataSource as `addLazySingleton` (inject `S
 
 ## Key Principles
 
-1. **Explicit names** — `fetchInitialEstimationsByProjectId`, not `getEstimations` (RULE_2)
+1. **Explicit names** — `fetchInitialEstimationsByProjectId`, not `getEstimations` (Naming & Abstraction)
 2. **Error boundary** — RemoteDataSource rethrows without logging; RepositoryImpl is the error boundary where exceptions become Failures
 3. **DTO ↔ Entity** — DTOs for JSON; Entities for domain; validate/handle invalid JSON
-4. **RULE_15: Log once** — At RepositoryImpl boundary only (don't re-log as errors propagate)
+4. **Sentry Logging: Log once** — At RepositoryImpl boundary only (don't re-log as errors propagate)
 5. **Never throw from repository** — Always `Either<Failure, T>`. Use `package:construculator/libraries/either/either.dart` for `Either` and `package:construculator/libraries/errors/failures.dart` for `Failure` — **do NOT import `dartz`**.
 
 ## References
 
-- **RULE_2:** `skills/rules/02-naming-conventions.md`
-- **RULE_5:** `skills/rules/05-ui-business-separation.md`
-- **RULE_15:** Sentry logging at boundaries
+- **Naming & Abstraction:** `skills/rules/02-naming-conventions.md`
+- **UI / Business Separation:** `skills/rules/05-ui-business-separation.md`
+- **Sentry Logging:** Sentry logging at boundaries
 - **Examples:** `lib/features/global_search/data/data_source/remote_global_search_data_source.dart`, `lib/features/global_search/data/repositories/global_search_repository_impl.dart`
 - `write-tests` skill — Unit tests for data layer with fakes
 

--- a/skills/code-domain/SKILL.md
+++ b/skills/code-domain/SKILL.md
@@ -22,10 +22,10 @@ disable-model-invocation: false
 | Class Type | Naming | Signature | Responsibilities | Forbidden |
 |------------|--------|-----------|------------------|-----------|
 | **UseCase** | `{Verb}{Noun}UseCase` | `Future<Either<Failure, T>> call(Param p)` | Single business operation; delegates to repository | Business logic implementation (delegate to repository) |
-| **Repository** | `{Noun}Repository` (abstract) | `Future<Either<Failure, T>> methodNameByScope(Param p)` | Data access contract with **explicit names** (RULE_2) | Implementation details (data sources, SDKs) |
+| **Repository** | `{Noun}Repository` (abstract) | `Future<Either<Failure, T>> methodNameByScope(Param p)` | Data access contract with **explicit names** (Naming & Abstraction) | Implementation details (data sources, SDKs) |
 | **Service** | `{Noun}Service` | `Future<Either<Failure, T>> methodName(Param p)` | Coordinates multiple repositories | Direct data access (use repositories) |
 
-**Examples of explicit repository names (RULE_2):**
+**Examples of explicit repository names (Naming & Abstraction):**
 - ✅ `fetchInitialEstimationsByProjectId`, `loadMoreLogs`, `hasMoreLogs`
 - ❌ `getEstimations`, `fetchData`, `load`
 
@@ -47,7 +47,7 @@ void _registerDependencies(Injector i) {
 }
 ```
 
-## Layer Boundaries (RULE_5)
+## Layer Boundaries (UI / Business Separation)
 
 | ❌ Domain MUST NOT Import | ✅ Domain CAN Import |
 |---------------------------|---------------------|
@@ -67,18 +67,18 @@ void _registerDependencies(Injector i) {
 
 ### 🔴 Non-Negotiable (Must Follow)
 1. **Pure business logic** — No UI, no data source knowledge
-2. **No layer violations** — Domain MUST NOT import Flutter, data layer, or presentation layer (see RULE_5)
+2. **No layer violations** — Domain MUST NOT import Flutter, data layer, or presentation layer (see UI / Business Separation)
 3. **Either, never throw** — Always return `Either<Failure, T>`, never throw exceptions. Use `package:construculator/libraries/either/either.dart` for `Either` and `package:construculator/libraries/errors/failures.dart` for `Failure` — **do NOT import `dartz`**. Before writing interface signatures, identify all failure cases: search `lib/features/{feature}/domain/` for an existing `{Feature}Failure` — reuse it if found, otherwise note that `code-data` must create it.
 
 ### 🟡 Core Patterns (Always Apply)
 4. **UseCases orchestrate** — Delegate to repositories; don't implement business rules
-5. **Explicit repository names** — Use `fetchInitialByProjectId`, not `get` (RULE_2)
+5. **Explicit repository names** — Use `fetchInitialByProjectId`, not `get` (Naming & Abstraction)
 6. **Dartdoc required** — Document parameters, return types, edge cases
 
 ## References
 
-- **RULE_2:** `skills/rules/02-naming-conventions.md`
-- **RULE_5:** `skills/rules/05-ui-business-separation.md`
+- **Naming & Abstraction:** `skills/rules/02-naming-conventions.md`
+- **UI / Business Separation:** `skills/rules/05-ui-business-separation.md`
 - **Examples:** `lib/features/auth/domain/usecases/login_usecase.dart`, `lib/features/estimation/domain/repositories/cost_estimation_log_repository.dart`
 - **Next:** `code-data` (implements repository interfaces)
 - `write-tests` skill — Unit tests for domain layer

--- a/skills/code-integration/SKILL.md
+++ b/skills/code-integration/SKILL.md
@@ -28,12 +28,12 @@ disable-model-invocation: false
 
 ## Wrapper Pattern Classes
 
-| Class Type | Naming (RULE_2) | Signature | Responsibilities | Type Boundary |
+| Class Type | Naming | Signature | Responsibilities | Type Boundary |
 |------------|-----------------|-----------|------------------|---------------|
 | **Wrapper** | `{SDK}Wrapper` | Concrete class with SDK-specific methods | Wraps SDK client; maps SDK types ↔ domain types; handles SDK errors | **Only place SDK types appear** |
 | **Interface** (optional) | `{SDK}WrapperInterface` | Abstract class with domain types only | Domain-facing contract when abstraction needed | Domain sees this |
 | **Failure** | `{SDK}Failure extends Failure` | `{SDK}ErrorType errorType` | SDK-specific error types (timeout, auth, rate limit, etc.) | Domain error type |
-| **Fake** (test) | `Fake{SDK}Client` | `implements sdk.{SDK}Client` | Faithful re-implementation of the SDK client interface; injected in place of the real SDK in tests; exposes configurable fields to control responses and errors per-test (RULE_3) | Test boundary |
+| **Fake** (test) | `Fake{SDK}Client` | `implements sdk.{SDK}Client` | Faithful re-implementation of the SDK client interface; injected in place of the real SDK in tests; exposes configurable fields to control responses and errors per-test (Test Double Pattern) | Test boundary |
 
 **Pattern:** Create wrapper in `lib/libraries/{sdk}/{sdk}_wrapper.dart` that domain code depends on directly (or via optional interface).
 
@@ -43,7 +43,7 @@ disable-model-invocation: false
 |---------------|-----------|--------------|-------|
 | SDK-specific (e.g., `sdk.{SDK}Exception`) | error | `{SDK}Failure(errorType: ...)` | Map SDK error codes to domain types |
 | `TimeoutException` | warning | `{SDK}Failure(timeout)` | Expected error |
-| Other | error | `UnexpectedFailure()` | RULE_15: Log once at wrapper boundary |
+| Other | error | `UnexpectedFailure()` | Sentry Logging: Log once at wrapper boundary |
 
 
 ## Dependency Registration
@@ -58,7 +58,7 @@ Create `lib/libraries/{sdk}/_{sdk}_module.dart` extending `Module`. In `binds(In
 - `lib/libraries/{sdk}/{sdk}_wrapper.dart`
 - `lib/libraries/{sdk}/_{sdk}_module.dart`
 - `lib/libraries/{sdk}/domain/{sdk}_failure.dart`
-- `test/libraries/{sdk}/fake_{sdk}_client.dart` (RULE_3: fake, not mock)
+- `test/libraries/{sdk}/fake_{sdk}_client.dart` (Test Double Pattern: fake, not mock)
 - `test/libraries/{sdk}/{sdk}_wrapper_test.dart`
 - Updated: `lib/app/app_module.dart` (import `{SDK}Module`)
 
@@ -67,13 +67,13 @@ Create `lib/libraries/{sdk}/_{sdk}_module.dart` extending `Module`. In `binds(In
 1. **Domain isolation** — Wrapper is boundary; domain never imports SDK directly
 2. **Wrapper is type translation layer** — SDK types → Domain types
 3. **Error translation** — SDK exceptions → Domain Failures at wrapper boundary. `{SDK}Failure extends Failure` and `UnexpectedFailure` both come from `package:construculator/libraries/errors/failures.dart`
-4. **Testability** — Fake SDK client (RULE_3), test wrapper mapping logic
+4. **Testability** — Fake SDK client (Test Double Pattern), test wrapper mapping logic
 
 ## References
 
-- **RULE_2:** `skills/rules/02-naming-conventions.md`
-- **RULE_3:** `skills/rules/03-test-double-pattern.md`
-- **RULE_15:** Sentry logging at boundaries
+- **Naming & Abstraction:** `skills/rules/02-naming-conventions.md`
+- **Test Double Pattern:** `skills/rules/03-test-double-pattern.md`
+- **Sentry Logging:** Sentry logging at boundaries
 - **Clean Architecture:** Domain depends on wrappers, not SDKs
 - **Example:** `lib/libraries/supabase/supabase_wrapper.dart`
 - `write-tests` skill — Wrapper tests with fake SDK clients

--- a/skills/code-presentation/SKILL.md
+++ b/skills/code-presentation/SKILL.md
@@ -21,7 +21,7 @@ If the input context from `plan-implementation` is incomplete or missing, respon
 
 ## 1. Class Overview
 
-| Class Type | Naming (RULE_2) | Purpose | Location |
+| Class Type | Naming | Purpose | Location |
 |------------|-----------------|---------|----------|
 | **Page** | `{Feature}Page` | Top-level screen with route; contains BLoC provider | `presentation/pages/{feature}_page.dart` |
 | **BLoC** | `{Feature}Bloc` | State coordinator; emits states based on events | `presentation/bloc/{feature}_bloc/{feature}_bloc.dart` |
@@ -34,7 +34,7 @@ If the input context from `plan-implementation` is incomplete or missing, respon
 Top-level screen; provides BLoC; builds UI tree. Pages are **passive** — they display state, they don't decide what it means.
 
 **BuildContext extensions** (always use these — never hardcode):
-- Localization (RULE_10): `context.l10n.keyName` (not `S.of(context)`)
+- Localization: `context.l10n.keyName` (not `S.of(context)`)
 - Colors: `context.colorTheme.primary` / `.pageBackground`
 - Typography: `context.textTheme.bodyMediumRegular` / `.titleLargeBold`
 
@@ -44,20 +44,20 @@ Top-level screen; provides BLoC; builds UI tree. Pages are **passive** — they 
 
 Coordinate UI state; handle events; emit states. BLoC is **not** a business rule engine.
 
-- **RULE_12:** State derivation lives here, not in widgets (`total`, `isValid`, `filteredItems`).
-- **RULE_5:** BLoC orchestrates UseCases; never implements business logic.
+- **State Derivation:** State derivation lives here, not in widgets (`total`, `isValid`, `filteredItems`).
+- **UI / Business Separation:** BLoC orchestrates UseCases; never implements business logic.
 - Events = user actions (`SubmitPressed`) or lifecycle (`PageLoaded`); States = UI representations (`Loading`, `Success`, `Error`). Transition with `emit()`.
-- **Error handling:** Catch UseCase failures; emit error states with localized messages (RULE_10).
+- **Error handling:** Catch UseCase failures; emit error states with localized messages (Localization).
 
 ## 4. Widget Pattern
 
-Reusable UI components; data via constructor; no state management. Widgets are **dumb presenters** (RULE_5) — zero business logic, no state derivation, no UseCase calls. Use CoreUI only (RULE_4), `context.l10n` for text (RULE_10), `context.colorTheme` / `context.textTheme` for styling. Prefer `const` constructors.
+Reusable UI components; data via constructor; no state management. Widgets are **dumb presenters** (UI / Business Separation) — zero business logic, no state derivation, no UseCase calls. Use CoreUI only (CoreUI Components), `context.l10n` for text (Localization), `context.colorTheme` / `context.textTheme` for styling. Prefer `const` constructors.
 
 ## 5. Dependency Registration
 
 In `{feature}_module.dart`, register BLoCs as transient: `i.add<{Feature}Bloc>(() => {Feature}Bloc(useCase: i()));`. See `code-domain` skill for canonical module pattern.
 
-## 6. Layer Boundaries (RULE_5)
+## 6. Layer Boundaries (UI / Business Separation)
 
 | ❌ Presentation MUST NOT | ✅ Presentation CAN |
 |-------------------------|-------------------|
@@ -79,13 +79,13 @@ In `{feature}_module.dart`, register BLoCs as transient: `i.add<{Feature}Bloc>((
 ## Priority Rules (Critical to Follow)
 
 ### 🔴 Non-Negotiable
-1. **Zero business logic** — Presentation must not implement business rules; always call UseCases (RULE_5)
-2. **Localization & Theming** — All user-facing text via `context.l10n`; use `context.colorTheme` and `context.textTheme` for colors/typography (RULE_10)
-3. **CoreUI Only** — Use `ripplearc_coreui` components; avoid direct `Material` widgets (RULE_4)
+1. **Zero business logic** — Presentation must not implement business rules; always call UseCases (UI / Business Separation)
+2. **Localization & Theming** — All user-facing text via `context.l10n`; use `context.colorTheme` and `context.textTheme` for colors/typography (Localization)
+3. **CoreUI Only** — Use `ripplearc_coreui` components; avoid direct `Material` widgets (CoreUI Components)
 
 ### 🟡 Core Patterns (Always Apply)
 4. **Pages are passive** — Pages display BLoC-provided state and do not contain logic
-5. **BLoC coordinates state** — Derive computed values and state transitions in BLoC (RULE_12)
+5. **BLoC coordinates state** — Derive computed values and state transitions in BLoC (State Derivation)
 6. **Routing (three-tier model):**
    - Tab switching (within shell): receive `AppShellBloc` as a constructor prop and call `appShellBloc.add(AppShellTabSelected(tab))` — `AppShellBloc` is not in the widget tree as a `BlocProvider`, so `context.read<AppShellBloc>()` will not work
    - Full-screen (above shell): `_router.push(...)` — resolve as `final _router = Modular.get<AppRouter>();` class field
@@ -95,11 +95,11 @@ In `{feature}_module.dart`, register BLoCs as transient: `i.add<{Feature}Bloc>((
 
 ## References
 
-- **RULE_4:** `skills/rules/04-coreui-components.md` — CoreUI components
-- **RULE_5:** `skills/rules/05-ui-business-separation.md` — No business logic in UI + State derivation in BLoC
-- **RULE_7:** `skills/rules/07-self-documenting-code.md` — Comments explain why
-- **RULE_10:** `skills/rules/10-localization.md` — All user-facing text
-- **RULE_12:** `skills/rules/12-state-derivation.md` — Derive in BLoC, not widgets
+- **CoreUI Components:** `skills/rules/04-coreui-components.md` — CoreUI components
+- **UI / Business Separation:** `skills/rules/05-ui-business-separation.md` — No business logic in UI + State derivation in BLoC
+- **Self-Documenting Code:** `skills/rules/07-self-documenting-code.md` — Comments explain why
+- **Localization:** `skills/rules/10-localization.md` — All user-facing text
+- **State Derivation:** `skills/rules/12-state-derivation.md` — Derive in BLoC, not widgets
 - **CoreUI API:** `skills/references/coreui-api.md`
 - **Examples:** `lib/features/auth/presentation/`, `lib/features/project/presentation/`
 - `write-tests` skill — Widget tests for pages

--- a/skills/plan-implementation/SKILL.md
+++ b/skills/plan-implementation/SKILL.md
@@ -2,7 +2,7 @@
 name: plan-implementation
 description: |
   Stage 2: Implementation Planning - Decide what to create before writing code.
-  Applies RULE_1 (digestible PRs), RULE_2 (naming), checks CoreUI availability.
+  Applies the Digestible PR and Naming & Abstraction rules; checks CoreUI availability.
 
   Trigger: "plan implementation" (implementation planning intent), "plan this feature" (ticket-to-file planning intent), "what files do we need for implementation"
 
@@ -46,7 +46,7 @@ Agent's blueprint phase before coding. Outputs: file paths, class names, depende
    - Do not ask for info that is unambiguous from the ticket context
    - If multiple layers are touched, ask for all their inputs together before proceeding
 
-3. **Apply RULE_2** (naming conventions) → Load `skills/rules/02-naming-conventions.md`
+3. **Apply Naming & Abstraction** (naming conventions) → Load `skills/rules/02-naming-conventions.md`
    - Use suffix table + decision tree to name all classes
    - Apply abstraction naming: abstract at UI/domain, explicit at data layer
    - Output: precise class names with responsibilities
@@ -62,15 +62,15 @@ Agent's blueprint phase before coding. Outputs: file paths, class names, depende
      data/data_source/      → remote|local_{noun}_data_source.dart
    ```
 
-5. **Check CoreUI availability** (if presentation layer touched) → See RULE_4
+5. **Check CoreUI availability** (if presentation layer touched) → See CoreUI Components
    - Identify required components from ticket (buttons, inputs, icons, cards, etc.)
    - Check `skills/references/coreui-api.md` (⚠️ may be outdated - use as quick reference only)
    - **Source of truth:** https://github.com/ripplearc/coreui#readme (always check live README)
-   - If component missing: flag as blocker with RULE_4-compliant options only:
+   - If component missing: flag as blocker with CoreUI-compliant options only:
      1. Use existing CoreUI component with custom layout
      2. Request CoreUI team to add it
      3. Build custom component following CoreUI design patterns
-   - ❌ Never suggest "use Material temporarily" (violates RULE_4 Critical severity)
+   - ❌ Never suggest "use Material temporarily" (violates CoreUI Components Critical severity)
 
 6. **Verify dependencies** (no layer violations)
    - BLoC depends on UseCase (not Repository/DataSource)
@@ -78,7 +78,7 @@ Agent's blueprint phase before coding. Outputs: file paths, class names, depende
    - RepositoryImpl depends on DataSource
    - Flag violations if found
 
-7. **Apply RULE_1** (digestible PRs) → Load `skills/rules/01-digestible-pr.md`
+7. **Apply Digestible PR** (digestible PRs) → Load `skills/rules/01-digestible-pr.md`
    - **Estimate production LOC** using this heuristic (before code is written):
 
      | Class Type | Typical LOC |
@@ -117,7 +117,7 @@ Agent's blueprint phase before coding. Outputs: file paths, class names, depende
 ```markdown
 # Plan: CA-123 - Add estimation screen
 
-## Classes (RULE_2 applied)
+## Classes (Naming & Abstraction applied)
 - EstimationPage (lib/features/estimation/presentation/pages/estimation_page.dart)
 - EstimationBloc/Event/State (lib/features/estimation/presentation/bloc/...)
 - GetEstimationsUseCase (lib/features/estimation/domain/usecases/get_estimations_usecase.dart)
@@ -125,9 +125,9 @@ Agent's blueprint phase before coding. Outputs: file paths, class names, depende
 - EstimationRepositoryImpl (lib/features/estimation/data/repositories/...)
 - RemoteEstimationDataSource (lib/features/estimation/data/data_source/...)
 
-## CoreUI Check (RULE_4)
+## CoreUI Check
 ✅ CoreButton, CoreTextField, CoreLoadingIndicator
-❌ CoreCard (BLOCKER) → Options per RULE_4:
+❌ CoreCard (BLOCKER) → Options per CoreUI Components:
   1. Use existing CoreUI component with custom layout
   2. Request CoreUI team to add CoreCard
   3. Build custom CoreCard following CoreUI patterns
@@ -137,7 +137,7 @@ Agent's blueprint phase before coding. Outputs: file paths, class names, depende
 - GetEstimationsUseCase → EstimationRepository ✅
 - EstimationRepositoryImpl → RemoteEstimationDataSource ✅
 
-## PR Strategy (RULE_1)
+## PR Strategy (Digestible PR)
 Estimated: ~420 LOC production code → Split into 2 PRs
 
 PR1 (Domain + Data): ~150 LOC
@@ -155,9 +155,9 @@ PR2 (Presentation): ~270 LOC
 
 ## References
 
-- **RULE_1:** `skills/rules/01-digestible-pr.md` (PR size + split strategies)
-- **RULE_2:** `skills/rules/02-naming-conventions.md` (suffix + abstraction naming)
-- **RULE_4:** `skills/rules/04-coreui-components.md` (CoreUI usage + missing component handling)
+- **Digestible PR:** `skills/rules/01-digestible-pr.md` (PR size + split strategies)
+- **Naming & Abstraction:** `skills/rules/02-naming-conventions.md` (suffix + abstraction naming)
+- **CoreUI Components:** `skills/rules/04-coreui-components.md` (CoreUI usage + missing component handling)
 - **CoreUI API:** `skills/references/coreui-api.md` (quick reference - may be outdated)
 - **CoreUI Source of Truth:** https://github.com/ripplearc/coreui#readme (always check live)
 - **Next skills:** `code-presentation/`, `code-domain/`, `code-data/` (planned — coming in next PR)

--- a/skills/pr-review/SKILL.md
+++ b/skills/pr-review/SKILL.md
@@ -1,343 +1,185 @@
 ---
 name: pr-review
 description: |
-  Modular PR review skill for Flutter/Dart changes.
-  Use when a user asks for a PR review, code review, branch comparison, or
-  asks to check CoreUI, localization, UI/business separation, or test quality.
+  Modular PR review for Flutter/Dart changes. Auto-detects which rules apply to
+  each changed file, applies the full rule set in skills/rules/ (RULE_1–RULE_15),
+  and returns a copy-paste-ready markdown PR description + review table.
 
-  This skill starts with a proof of concept for RULE_4, RULE_5, and RULE_10,
-  while preserving the existing scripts/review_pr.sh workflow during migration.
+  Use when a user asks to review a PR, review a branch, compare branches, or
+  check naming, CoreUI, testing, streams, localization, accessibility, logging,
+  or UI/business separation.
 
   Trigger phrases: "review this PR", "review my PR", "review feat/X to main",
-  "check my branch", "code review", "analyze my changes"
-
+  "check my branch", "code review", "analyze my changes".
 disable-model-invocation: false
-allowed-tools: Bash Read Grep
+allowed-tools: Bash Read Grep Write
 ---
 
 # PR Review Skill
 
-This skill reviews PR changes in a structured way and returns findings in JSON.
-It follows a progressive disclosure model:
-
-1. Use `scripts/collect_changes.sh` to gather changed files.
-2. Auto-detect applicable rules based on file types.
-3. Use `scripts/generate_diff.sh` to fetch diffs for analysis.
-4. Apply rules to identify issues and violations.
-5. Return structured JSON with findings.
-
-## Current POC Scope
-
-This migration starts with three high-signal rules:
+Reviews a branch diff against a base, routes each changed file to only the rules
+that apply, and reports findings. Default output is a markdown document ready to
+paste into a PR (see [Output](#output)).
+
+## Rules
+
+The full rule set lives in `skills/rules/`. Each rule file owns its detection
+patterns (its `Detective` section), severity levels, and fix guidance — load a
+rule only when it's routed to a changed file.
+
+| Rule | Title | Applies to |
+|------|-------|-----------|
+| RULE_1 | Digestible PR | Production-code diff size (PR-level) |
+| RULE_2 | Naming & Abstraction | `lib/**/*.dart` |
+| RULE_3 | Test Double Pattern | `test/**/*.dart` |
+| RULE_4 | CoreUI Components | `**/presentation/`, `lib/app/` |
+| RULE_5 | UI / Business Separation | `**/presentation/`, `lib/app/` |
+| RULE_6 | Stream Lifecycle | Stream-owning `lib/**` (Repo/DataSource/BLoC/Service) |
+| RULE_7 | Self-Documenting Code | `lib/**/*.dart` |
+| RULE_8 | Widget Test Finders | `test/**/widgets/`, `testWidgets(` |
+| RULE_9 | Unit Test Behavior | `test/features/**` unit tests |
+| RULE_10 | Localization | `**/presentation/`, `lib/app/` |
+| RULE_13 | Mutation Testing | **Gated:** logic-heavy domain/data files |
+| RULE_14 | Accessibility | **Gated:** user-facing UI + `*_a11y_test.dart` |
+| RULE_15 | Sentry Logging | `lib/**` using `AppLogger` |
+
+`RULE_11`→`RULE_2` and `RULE_12`→`RULE_5` are deprecated; if a user passes them,
+map transparently and note it in `rules_skipped`.
+
+## Input
+
+| Field | Required | Default | Notes |
+|-------|----------|---------|-------|
+| `pr_branch` | yes | — | branch with changes |
+| `base_branch` | no | `main` | target branch |
+| `rules` | no | all | force a subset, e.g. `["RULE_2","RULE_6"]` |
+| `output_format` | no | `markdown` | `markdown` \| `json` \| `both` |
+| `output_dir` | no | `reviews/` | directory (repo-root-relative) the `.md` review file is written to |
+| `max_file_size_kb` | no | `100` | skip larger files (1–1000) |
+
+On missing/invalid input, return an error object (see [Errors](#errors)).
+
+## Workflow
+
+1. **Collect** changed files — pipe `{"pr_branch","base_branch"}` into
+   `scripts/collect_changes.sh`. It already excludes generated (`*.g.dart`,
+   `*.freezed.dart`, …) and binary files, so every returned file is relevant.
+   No files → return empty issues with all rules in `rules_skipped`.
+
+2. **Route** each file to rules using the *Applies to* column above. Path-based
+   buckets come from `scripts/filter_files.sh`; content-derived buckets
+   (`stream_owning`, `logic_heavy`, `logger_using`) are confirmed by grepping the
+   file (e.g. `grep -lE "StreamController|\.listen\(" …`, `grep -l "AppLogger" …`).
+   RULE_1 always runs once over the production-code diff size.
+
+3. **Gate** RULE_13 and RULE_14:
+   - RULE_13 only if a logic-heavy file (3+ branches / math / data transforms)
+     changed — else skip: `"No logic-heavy code changed"`.
+   - RULE_14 only if an interactive presentation file changed; then require a
+     matching `*_a11y_test.dart` update and flag if missing — else skip:
+     `"No user-facing UI changed"`.
+   If the user passed `rules`, apply only those (after the 11→2 / 12→5 mapping);
+   record the rest in `rules_skipped` with reason `"User specified rules: [...]"`.
+
+4. **Apply** each routed rule: `cat` its module from `skills/rules/`, read the
+   file (`git show "$PR_BRANCH:path"`), get diff context via
+   `scripts/generate_diff.sh`, and use the rule's own detection patterns. Record
+   each violation as an issue: `file`, `line`, `snippet` (3 lines context),
+   `severity`, `suggested_fix`, and `references` (the rule module + any relevant
+   `skills/references/*.md`).
+
+5. **Compile** statistics (counts by severity and rule) and build the output
+   object below.
+
+Any rule with an empty routed bucket is skipped with a reason. Cache file
+contents to avoid re-reading.
+
+## Output
+
+The findings are modeled as JSON matching `schemas/output.schema.json`:
+`summary`, `metadata`, `issues[]`, `rules_applied`, `rules_skipped[]`,
+`next_steps`, `statistics`.
+
+Each issue: `{ id, name, description, rule, severity, file, line, snippet,
+suggested_fix, references[] }` with severity ∈ `critical|major|minor|suggestion`.
+
+**`markdown` (default) / `both`** — render the JSON as one self-contained
+document the user pastes straight into the PR. Output *only* the markdown (no
+outer code fence, no JSON), derive every value from the computed issues, and
+leave `Status`/`Notes` blank for the author. With zero issues, omit the table
+and write `✅ No issues found — all applied rules passed.` With `both`, emit the
+JSON, then `---`, then the markdown. With `json`, skip the markdown.
+
+````markdown
+# PR Review: <pr_branch> → <base_branch>
+
+## 📝 PR Description
+
+<2–4 plain-language sentences on what this PR does and why — no rule jargon.>
+
+**Type:** <Feature | Bugfix | Refactor | Chore | Test | Docs> ·
+**Size:** <XS | S | M | L> (<N> production lines) ·
+**Rules applied:** <rule IDs>
 
-- RULE_4: CoreUI Components Usage
-- RULE_5: UI & Business Logic Separation
-- RULE_10: Localization Usage
+### What changed
+- <key change tied to a concrete file/feature>
+- <key change>
 
-## Input Contract
+---
 
-Required:
-- `pr_branch`: branch containing changes (e.g., "feat/login")
+## 🔍 Review Summary
 
-Optional:
-- `base_branch`: target branch, defaults to `main`
-- `rules`: optional list of rule IDs to force (e.g., ["RULE_4", "RULE_5"])
-- `output_format`: `json`, `markdown`, or `both`, defaults to `json`
-- `max_file_size_kb`: skip files larger than this (1-1000), defaults to 100
+> Found <N> issue(s): <X> 🔴 critical · <Y> 🟠 major · <Z> 🟡 minor · <W> 🔵 suggestion — across <M> file(s).
 
-## Agent Execution Workflow
+| # | Issue | Severity | Location | Description | Suggested Fix | Status | Notes |
+|---|-------|----------|----------|-------------|---------------|--------|-------|
+| 1 | <name> | 🔴 Critical | `<file>:<line>` | <what & why> | <fix> | | |
 
-### Step 1: Parse and Validate Input
+**Status (author fills):** ✅ Addressed · 📋 Future Story (add YouTrack ID) ·
+❌ Disagree (justify) · 🔄 In Progress
 
-Extract parameters from user request and validate against input schema:
-
-```
-- pr_branch (required): string, non-empty
-- base_branch (optional): string, defaults to "main"
-- rules (optional): array of ["RULE_4", "RULE_5", "RULE_10"]
-- output_format (optional): enum [json, markdown, both], defaults to "json"
-- max_file_size_kb (optional): number 1-1000, defaults to 100
-
-If any required field is missing or invalid, return error JSON:
-{
-  "error": "Field X is required/invalid",
-  "code": "MISSING_REQUIRED_FIELD" | "INVALID_ENUM" | "PARSE_ERROR",
-  "suggestions": ["How to fix"]
-}
-```
+<!-- Skipped: RULE_X (reason), RULE_Y (reason) -->
+````
 
-### Step 2: Collect Changed Files
-
-Run `bash skills/pr-review/scripts/collect_changes.sh` with input:
+Sort rows by severity (critical→suggestion) then file; number the `#` column;
+collapse newlines and escape `|` as `\|` in cells; omit `:<line>` for PR-level
+issues (RULE_1); build the blockquote from `statistics.by_severity`.
 
-```bash
-echo '{"pr_branch": "'"$PR_BRANCH"'", "base_branch": "'"$BASE_BRANCH"'"}' | \
-  bash skills/pr-review/scripts/collect_changes.sh
-```
-
-Expected output:
-```json
-{
-  "files": [
-    {"path": "lib/features/auth/login.dart", "status": "M"},
-    {"path": "lib/features/auth/login_screen.dart", "status": "A"},
-    ...
-  ]
-}
-```
+### Saving the review file
 
-**Handle errors:**
-- If script returns `{"error": "..."}`, abort and return error to user
-- If no files changed, return empty issues list with `rules_skipped` = all rules
+Whenever the output includes markdown (`markdown` or `both`), **also persist it to a
+file** — don't only print it. Steps:
 
-### Step 3: Filter Applicable Files
-
-Filter changed files to only presentation files (these are the only files applicable to POC rules):
-
-```bash
-echo "{\"files\": [$FILES_JSON], \"pattern\": \"lib/features/**/presentation/\"}" | \
-  bash skills/pr-review/scripts/filter_files.sh
-```
-
-Also filter `lib/app/presentation/` files:
-
-```bash
-echo "{\"files\": [$REMAINING_FILES], \"pattern\": \"lib/app/presentation/\"}" | \
-  bash skills/pr-review/scripts/filter_files.sh
-```
-
-Merge and deduplicate the two filter outputs into a single presentation file list before continuing. Example (pseudo):
-
-```bash
-# outputA and outputB are JSON arrays returned by filter_files.sh
-# merge, dedupe:
-jq -s 'add | unique_by(.path)' outputA.json outputB.json > presentation_files.json
-```
-
-Expected output:
-```json
-{
-  "files": [
-    {"path": "lib/features/auth/presentation/login_screen.dart"},
-    {"path": "lib/app/presentation/app_widget.dart"}
-  ]
-}
-```
-
-**Result:** Reduced file set ready for rule application. If no presentation files, `rules_skipped` = all 3 rules.
-
-### Step 4: Auto-Detect Applicable Rules
-
-Based on changed file paths, determine which rules to apply:
-
-**Rule Selection Logic:**
-
-```
-For filtered presentation files (already filtered in Step 3):
-  → Always apply RULE_4 (CoreUI Components)
-  → Always apply RULE_5 (UI/Business Logic Separation)
-  → Always apply RULE_10 (Localization)
-
-If user specified --rules argument:
-  → Override and apply only specified rules
-
-If no presentation files were filtered:
-  → All 3 rules are skipped with reason "No presentation files changed"
-```
-
-**Example:**
-- Input: 14 files changed across project
-- After filtering (Step 3): 2 presentation files
-- Rules applied: [RULE_4, RULE_5, RULE_10]
-- All 3 rules run against both files
-
-**If user overrides with specific rules:**
-```
-Input: {"rules": ["RULE_4"]}
-→ Only RULE_4 runs on filtered presentation files
-→ RULE_5, RULE_10 tracked as skipped: {"rule": "RULE_5", "reason": "User specified rules: [RULE_4]"}
-```
-
-### Step 5: Load Rule Modules
-
-For each applicable rule, load the rule file from shared rules directory and extract detection patterns:
-
-```bash
-cat skills/rules/04-coreui-components.md
-cat skills/rules/05-ui-business-separation.md
-cat skills/rules/10-localization.md
-```
-
-**Note:** All rules are now in the shared `skills/rules/` directory and can be referenced by any skill.
-
-Each rule module provides:
-- Detection patterns (regex or semantic patterns)
-- Severity levels (critical, major, minor, suggestion)
-- Suggested fixes
-- References and examples
-
-### Step 6: Apply Rules to Filtered Files
-
-For each filtered presentation file and applicable rule:
-
-**6a. Read file content** (if not already cached):
-```bash
-git show infra/agentic-skills:lib/features/auth/presentation/login_screen.dart
-```
-
-**6b. Generate diff** for context:
-```bash
-echo '{
-  "pr_branch": "infra/agentic-skills",
-  "base_branch": "main",
-  "file": "lib/features/auth/presentation/login_screen.dart",
-  "context_lines": 3
-}' | bash skills/pr-review/scripts/generate_diff.sh
-```
-
-**6c. Search for violations** using grep patterns defined in rule:
-
-For RULE_4, search for:
-- `EdgeInsets\.(all|symmetric|only)\((?!CoreSpacing)` → Hardcoded spacing
-- `Icons\.` → Material icons (not CoreUI)
-- `ElevatedButton|TextFormField|AppBar` → Material components
-- `Colors\.` → Hardcoded colors
-
-**6d. Extract issue details** for each violation found:
-- File path
-- Line number(s)
-- Snippet with context (3 lines before/after)
-- Severity (based on rule)
-- Suggested fix
-- References to documentation
-
-**6e. Compile issue object:**
-```json
-{
-  "id": "RULE_4-001",
-  "name": "Hardcoded spacing value",
-  "description": "EdgeInsets.all(24.0) should use CoreSpacing constant",
-  "rule": "RULE_4",
-  "severity": "major",
-  "file": "lib/features/auth/presentation/login_screen.dart",
-  "line": 42,
-  "snippet": "Padding(\n  padding: EdgeInsets.all(24.0),  // ← Issue here\n  child: ...",
-  "suggested_fix": "Replace EdgeInsets.all(24.0) with EdgeInsets.all(CoreSpacing.space24)",
-  "references": [
-    "skills/rules/04-coreui-components.md",
-    "skills/references/coreui-api.md#spacing"
-  ]
-}
-```
-
-### Step 7: Compile Statistics
-
-Count issues by severity and rule:
-
-```json
-{
-  "statistics": {
-    "total_issues": 5,
-    "by_severity": {
-      "critical": 0,
-      "major": 2,
-      "minor": 2,
-      "suggestion": 1
-    },
-    "by_rule": {
-      "RULE_4": 3,
-      "RULE_5": 2,
-      "RULE_10": 0
-    },
-    "files_analyzed": 2,
-    "files_with_issues": 2
-  }
-}
-```
-
-### Step 8: Generate Final Output
-
-Compile all issues, metadata, and statistics into output JSON matching `schemas/output.schema.json`:
-
-```json
-{
-  "summary": "Found 5 issues (2 major, 2 minor, 1 suggestion) in 2 files",
-  "metadata": {
-    "pr_branch": "feat/auth",
-    "base_branch": "main",
-    "skill_version": "1.0.0-poc",
-    "timestamp": "2026-04-30T18:24:03Z",
-    "files_changed": 2,
-    "rules_applied": ["RULE_4", "RULE_5", "RULE_10"]
-  },
-  "issues": [...],
-  "rules_applied": ["RULE_4", "RULE_5", "RULE_10"],
-  "rules_skipped": [...],
-  "next_steps": [
-    "Replace hardcoded spacing with CoreSpacing constants",
-    "Move business logic out of LoginScreen widget",
-    "Add localization for user-facing strings"
-  ],
-  "statistics": {...}
-}
-```
-
-If `output_format` is "markdown" or "both", also generate markdown output.
-
-## Error Handling
-
-All scripts return JSON on success or error. Handle these error codes:
-
-```json
-{
-  "error": "Human-readable message",
-  "code": "ERROR_CODE",
-  "details": {"field": "...", "expected": "...", "received": "..."},
-  "suggestions": ["How to fix"]
-}
-```
-
-**Error codes:**
-- `MISSING_REQUIRED_FIELD` - Required input missing
-- `INVALID_ENUM` - Invalid enum value
-- `INVALID_BRANCH` - Branch doesn't exist
-- `GIT_ERROR` - Git command failed
-- `PARSE_ERROR` - Failed to parse JSON
-- `FILE_NOT_FOUND` - File doesn't exist in branch
-
-**Agent behavior on error:**
-- If schema validation fails → Return error, ask user to correct input
-- If git command fails → Return error with branch names to verify
-- If file is too large (> max_file_size_kb) → Skip file, log in rules_skipped
-- If rule module is missing → Return error, file likely deleted
-
-## File Routing
-
-**RULE_4, RULE_5, RULE_10 trigger on:**
-- ✅ `lib/features/**/presentation/*.dart`
-- ✅ `lib/app/presentation/*.dart`
-- ❌ `test/` (test files skip all rules)
-- ❌ `lib/**/*.g.dart`, `*.freezed.dart`, etc. (generated code)
-
-## Output Shape
-
-Return a JSON object matching `schemas/output.schema.json` with:
-
-- `summary` - Human-readable summary of findings
-- `metadata` - Execution metadata (branches, timestamp, version)
-- `issues` - Array of issue objects
-- `rules_applied` - List of rules that ran
-- `rules_skipped` - List of rules with skip reason
-- `next_steps` - Suggested next actions
-- `statistics` - Issue counts by severity/rule
+1. Ensure the output directory exists: `mkdir -p "$OUTPUT_DIR"` (default
+   `reviews/`, repo-root-relative).
+2. Build a slug from the branches by replacing every non-alphanumeric character
+   (including `/`) with `-`: `<pr_slug>__to__<base_slug>.md`. Example:
+   `feat/power-sync-wrappers` → `feat-power-sync-wrappers`, base
+   `feat/wire-powersync` → `feat-wire-powersync`, so the file is
+   `reviews/feat-power-sync-wrappers__to__feat-wire-powersync.md`.
+3. Write the exact rendered markdown document (the same content described above,
+   no outer code fence) to that path with the `Write` tool, overwriting any
+   existing file for the same branch pair.
+4. Report the written file path to the user, then show the markdown inline.
+
+For `output_format: json` (no markdown), skip file creation. The `reviews/`
+directory is a working artifact — assume it may be git-ignored; create it if
+missing rather than failing.
+
+## Errors
+
+Scripts and this skill return JSON on failure:
+`{ "error", "code", "details?", "suggestions" }`.
+
+Codes: `MISSING_REQUIRED_FIELD`, `INVALID_ENUM`, `INVALID_BRANCH`, `GIT_ERROR`,
+`PARSE_ERROR`, `FILE_NOT_FOUND`. On a git/branch failure, return the branch names
+to verify; oversized files are skipped and noted in `rules_skipped`; a missing
+rule module means the file was likely deleted.
 
 ## Notes
 
-- Keep the existing `scripts/review_pr.sh` available during the transition.
-- Expand the rule set incrementally after the POC is validated on real PRs.
-- All scripts are idempotent and can be run multiple times without side effects.
-- Agent should cache file contents to minimize disk I/O.
+- Scripts are idempotent. The legacy monolithic `scripts/review_pr.sh` is
+  retired; keep it only as a historical reference for detection patterns.
+- Always record gate results (RULE_13/RULE_14) in `rules_applied` or
+  `rules_skipped` so coverage is auditable.
 
-- Deprecation note: `scripts/review_pr.sh` is kept for backward compatibility during
-  the POC. Remove or retire the script after the POC has been validated on several
-  real PRs (for example, "remove after POC is validated on N real PRs or by YYYY-MM-DD").

--- a/skills/pr-review/SKILL.md
+++ b/skills/pr-review/SKILL.md
@@ -2,8 +2,8 @@
 name: pr-review
 description: |
   Modular PR review for Flutter/Dart changes. Auto-detects which rules apply to
-  each changed file, applies the full rule set in skills/rules/ (RULE_1–RULE_15),
-  and returns a copy-paste-ready markdown PR description + review table.
+  each changed file, applies the full rule set in skills/rules/ (referenced by
+  name), and returns a copy-paste-ready markdown PR description + review table.
 
   Use when a user asks to review a PR, review a branch, compare branches, or
   check naming, CoreUI, testing, streams, localization, accessibility, logging,
@@ -27,24 +27,25 @@ The full rule set lives in `skills/rules/`. Each rule file owns its detection
 patterns (its `Detective` section), severity levels, and fix guidance — load a
 rule only when it's routed to a changed file.
 
-| Rule | Title | Applies to |
-|------|-------|-----------|
-| RULE_1 | Digestible PR | Production-code diff size (PR-level) |
-| RULE_2 | Naming & Abstraction | `lib/**/*.dart` |
-| RULE_3 | Test Double Pattern | `test/**/*.dart` |
-| RULE_4 | CoreUI Components | `**/presentation/`, `lib/app/` |
-| RULE_5 | UI / Business Separation | `**/presentation/`, `lib/app/` |
-| RULE_6 | Stream Lifecycle | Stream-owning `lib/**` (Repo/DataSource/BLoC/Service) |
-| RULE_7 | Self-Documenting Code | `lib/**/*.dart` |
-| RULE_8 | Widget Test Finders | `test/**/widgets/`, `testWidgets(` |
-| RULE_9 | Unit Test Behavior | `test/features/**` unit tests |
-| RULE_10 | Localization | `**/presentation/`, `lib/app/` |
-| RULE_13 | Mutation Testing | **Gated:** logic-heavy domain/data files |
-| RULE_14 | Accessibility | **Gated:** user-facing UI + `*_a11y_test.dart` |
-| RULE_15 | Sentry Logging | `lib/**` using `AppLogger` |
+| Rule | Applies to |
+|------|-----------|
+| Digestible PR | Production-code diff size (PR-level) |
+| Naming & Abstraction | `lib/**/*.dart` |
+| Test Double Pattern | `test/**/*.dart` |
+| CoreUI Components | `**/presentation/`, `lib/app/` |
+| UI / Business Separation | `**/presentation/`, `lib/app/` |
+| Stream Lifecycle | Stream-owning `lib/**` (Repo/DataSource/BLoC/Service) |
+| Self-Documenting Code | `lib/**/*.dart` |
+| Widget Test Finders | `test/**/widgets/`, `testWidgets(` |
+| Unit Test Behavior | `test/features/**` unit tests |
+| Localization | `**/presentation/`, `lib/app/` |
+| Mutation Testing | **Gated:** logic-heavy domain/data files |
+| Accessibility | **Gated:** user-facing UI + `*_a11y_test.dart` |
+| Sentry Logging | `lib/**` using `AppLogger` |
 
-`RULE_11`→`RULE_2` and `RULE_12`→`RULE_5` are deprecated; if a user passes them,
-map transparently and note it in `rules_skipped`.
+`Abstraction Naming`→`Naming & Abstraction` and `State Derivation`→`UI /
+Business Separation` are deprecated; if a user passes them, map transparently and
+note it in `rules_skipped`.
 
 ## Input
 
@@ -52,7 +53,7 @@ map transparently and note it in `rules_skipped`.
 |-------|----------|---------|-------|
 | `pr_branch` | yes | — | branch with changes |
 | `base_branch` | no | `main` | target branch |
-| `rules` | no | all | force a subset, e.g. `["RULE_2","RULE_6"]` |
+| `rules` | no | all | force a subset by name, e.g. `["Naming & Abstraction","Stream Lifecycle"]` |
 | `output_format` | no | `markdown` | `markdown` \| `json` \| `both` |
 | `output_dir` | no | `reviews/` | directory (repo-root-relative) the `.md` review file is written to |
 | `max_file_size_kb` | no | `100` | skip larger files (1–1000) |
@@ -70,15 +71,16 @@ On missing/invalid input, return an error object (see [Errors](#errors)).
    buckets come from `scripts/filter_files.sh`; content-derived buckets
    (`stream_owning`, `logic_heavy`, `logger_using`) are confirmed by grepping the
    file (e.g. `grep -lE "StreamController|\.listen\(" …`, `grep -l "AppLogger" …`).
-   RULE_1 always runs once over the production-code diff size.
+   `Digestible PR` always runs once over the production-code diff size.
 
-3. **Gate** RULE_13 and RULE_14:
-   - RULE_13 only if a logic-heavy file (3+ branches / math / data transforms)
-     changed — else skip: `"No logic-heavy code changed"`.
-   - RULE_14 only if an interactive presentation file changed; then require a
-     matching `*_a11y_test.dart` update and flag if missing — else skip:
+3. **Gate** `Mutation Testing` and `Accessibility`:
+   - `Mutation Testing` only if a logic-heavy file (3+ branches / math / data
+     transforms) changed — else skip: `"No logic-heavy code changed"`.
+   - `Accessibility` only if an interactive presentation file changed; then require
+     a matching `*_a11y_test.dart` update and flag if missing — else skip:
      `"No user-facing UI changed"`.
-   If the user passed `rules`, apply only those (after the 11→2 / 12→5 mapping);
+   If the user passed `rules`, apply only those (after the `Abstraction Naming`→
+   `Naming & Abstraction` / `State Derivation`→`UI / Business Separation` mapping);
    record the rest in `rules_skipped` with reason `"User specified rules: [...]"`.
 
 4. **Apply** each routed rule: `cat` its module from `skills/rules/`, read the
@@ -119,7 +121,7 @@ JSON, then `---`, then the markdown. With `json`, skip the markdown.
 
 **Type:** <Feature | Bugfix | Refactor | Chore | Test | Docs> ·
 **Size:** <XS | S | M | L> (<N> production lines) ·
-**Rules applied:** <rule IDs>
+**Rules applied:** <rule names>
 
 ### What changed
 - <key change tied to a concrete file/feature>
@@ -138,12 +140,12 @@ JSON, then `---`, then the markdown. With `json`, skip the markdown.
 **Status (author fills):** ✅ Addressed · 📋 Future Story (add YouTrack ID) ·
 ❌ Disagree (justify) · 🔄 In Progress
 
-<!-- Skipped: RULE_X (reason), RULE_Y (reason) -->
+<!-- Skipped: <rule name> (reason), <rule name> (reason) -->
 ````
 
 Sort rows by severity (critical→suggestion) then file; number the `#` column;
 collapse newlines and escape `|` as `\|` in cells; omit `:<line>` for PR-level
-issues (RULE_1); build the blockquote from `statistics.by_severity`.
+issues (`Digestible PR`); build the blockquote from `statistics.by_severity`.
 
 ### Saving the review file
 
@@ -180,6 +182,6 @@ rule module means the file was likely deleted.
 
 - Scripts are idempotent. The legacy monolithic `scripts/review_pr.sh` is
   retired; keep it only as a historical reference for detection patterns.
-- Always record gate results (RULE_13/RULE_14) in `rules_applied` or
-  `rules_skipped` so coverage is auditable.
+- Always record gate results (`Mutation Testing`/`Accessibility`) in
+  `rules_applied` or `rules_skipped` so coverage is auditable.
 

--- a/skills/pr-review/schemas/input.schema.json
+++ b/skills/pr-review/schemas/input.schema.json
@@ -18,29 +18,29 @@
       "items": {
         "type": "string",
         "enum": [
-          "RULE_1",
-          "RULE_2",
-          "RULE_3",
-          "RULE_4",
-          "RULE_5",
-          "RULE_6",
-          "RULE_7",
-          "RULE_8",
-          "RULE_9",
-          "RULE_10",
-          "RULE_13",
-          "RULE_14",
-          "RULE_15"
+          "Digestible PR",
+          "Naming & Abstraction",
+          "Test Double Pattern",
+          "CoreUI Components",
+          "UI / Business Separation",
+          "Stream Lifecycle",
+          "Self-Documenting Code",
+          "Widget Test Finders",
+          "Unit Test Behavior",
+          "Localization",
+          "Mutation Testing",
+          "Accessibility",
+          "Sentry Logging"
         ]
       },
-      "description": "Optional subset of rules to apply. Any active rule ID is valid; RULE_11 and RULE_12 are deprecated (covered by RULE_2 and RULE_5). When omitted, all applicable rules auto-run.",
+      "description": "Optional subset of rules to apply, by name. Any active rule name is valid; \"Abstraction Naming\" and \"State Derivation\" are deprecated (covered by \"Naming & Abstraction\" and \"UI / Business Separation\"). When omitted, all applicable rules auto-run.",
       "default": null
     },
     "output_format": {
       "type": "string",
       "enum": ["json", "markdown", "both"],
       "description": "Preferred output format (json for agent automation, markdown for humans)",
-      "default": "json"
+      "default": "markdown"
     },
     "max_file_size_kb": {
       "type": "number",
@@ -48,6 +48,11 @@
       "maximum": 1000,
       "description": "Skip files larger than this size",
       "default": 100
+    },
+    "output_dir": {
+      "type": "string",
+      "description": "Output directory for the .md review file (repo-root-relative)",
+      "default": "reviews/"
     }
   },
   "additionalProperties": false

--- a/skills/pr-review/schemas/input.schema.json
+++ b/skills/pr-review/schemas/input.schema.json
@@ -17,9 +17,23 @@
       "type": "array",
       "items": {
         "type": "string",
-        "enum": ["RULE_4", "RULE_5", "RULE_10"]
+        "enum": [
+          "RULE_1",
+          "RULE_2",
+          "RULE_3",
+          "RULE_4",
+          "RULE_5",
+          "RULE_6",
+          "RULE_7",
+          "RULE_8",
+          "RULE_9",
+          "RULE_10",
+          "RULE_13",
+          "RULE_14",
+          "RULE_15"
+        ]
       },
-      "description": "Optional subset of POC rules to apply",
+      "description": "Optional subset of rules to apply. Any active rule ID is valid; RULE_11 and RULE_12 are deprecated (covered by RULE_2 and RULE_5). When omitted, all applicable rules auto-run.",
       "default": null
     },
     "output_format": {

--- a/skills/read-ticket/SKILL.md
+++ b/skills/read-ticket/SKILL.md
@@ -42,7 +42,7 @@ Agent's first action when assigned a story. Output primes `plan-implementation` 
    - Unit tests: always
    - Widget tests: if presentation touched
    - Golden tests: if layout-sensitive UI
-   - Mutation tests: if 4+ conditional branches (per RULE_13: `skills/rules/13-mutation-testing.md`)
+   - Mutation tests: if 4+ conditional branches (per Mutation Testing: `skills/rules/13-mutation-testing.md`)
    - Accessibility tests: if critical flow
 
 5. **Flag ambiguities**

--- a/skills/references/architecture-layers.md
+++ b/skills/references/architecture-layers.md
@@ -1,6 +1,6 @@
 # Architecture Layers Reference
 
-This reference defines the responsibility boundaries and directory conventions for Flutter Clean Architecture. Used by RULE_2 (Naming Conventions) and RULE_5 (UI/Business Separation).
+This reference defines the responsibility boundaries and directory conventions for Flutter Clean Architecture. Used by Naming & Abstraction (Naming Conventions) and UI / Business Separation (UI/Business Separation).
 
 ---
 
@@ -56,14 +56,14 @@ This reference defines the responsibility boundaries and directory conventions f
 - ❌ Direct database or API calls
 - ❌ State derivations (use selectors in BLoC instead)
 
-**Naming:** Abstract, user-facing names (see RULE_2)
+**Naming:** Abstract, user-facing names (see Naming & Abstraction)
 - `LoginPage` (not `SupabaseAuthPage`)
 - `EstimationBloc` (not `PostgresEstimationBloc`)
 
 **Related Rules:**
-- RULE_2: Naming Conventions
-- RULE_5: UI/Business Separation
-- RULE_4: CoreUI Components
+- Naming & Abstraction: Naming Conventions
+- UI / Business Separation: UI/Business Separation
+- CoreUI Components: CoreUI Components
 
 ---
 
@@ -90,14 +90,14 @@ This reference defines the responsibility boundaries and directory conventions f
 - ❌ External library dependencies (HTTP, DB)
 - ❌ Implementation details
 
-**Naming:** Business-focused, technology-agnostic (see RULE_2)
+**Naming:** Business-focused, technology-agnostic (see Naming & Abstraction)
 - `GetEstimationsUseCase` (not `FetchFromSupabaseUseCase`)
 - `Estimation` entity (not `EstimationDto`)
 - `EstimationRepository` interface (implementation is in data/)
 
 **Related Rules:**
-- RULE_2: Naming Conventions
-- RULE_3: Test Double Pattern
+- Naming & Abstraction: Naming Conventions
+- Test Double Pattern: Test Double Pattern
 
 ---
 
@@ -123,16 +123,16 @@ This reference defines the responsibility boundaries and directory conventions f
 - ❌ UI rendering
 - ❌ Direct user interaction
 
-**Naming:** Technology-aware, concrete (see RULE_2)
+**Naming:** Technology-aware, concrete (see Naming & Abstraction)
 - `EstimationRepositoryImpl` (implements `EstimationRepository`)
 - `RemoteEstimationDataSource` (uses Supabase)
 - `LocalEstimationDataSource` (uses SQLite)
 - `EstimationDto` (JSON/database schema)
 
 **Related Rules:**
-- RULE_2: Naming Conventions
-- RULE_3: Test Double Pattern
-- RULE_15: Sentry Logging (log at boundaries)
+- Naming & Abstraction: Naming Conventions
+- Test Double Pattern: Test Double Pattern
+- Sentry Logging: Sentry Logging (log at boundaries)
 
 ---
 
@@ -351,7 +351,7 @@ class SaveEstimationUseCase {
 
 ## References
 
-- RULE_2: Naming Conventions (class naming by layer)
-- RULE_5: UI/Business Separation (what belongs in UI vs Domain)
+- Naming & Abstraction: Naming Conventions (class naming by layer)
+- UI / Business Separation: UI/Business Separation (what belongs in UI vs Domain)
 - [Flutter Clean Architecture](https://resocoder.com/2019/08/27/flutter-tdd-clean-architecture-course-1-explanation-project-structure/)
 - [Uncle Bob's Clean Architecture](https://blog.cleancoder.com/uncle-bob/2012/08/13/the-clean-architecture.html)

--- a/skills/rules/01-digestible-pr.md
+++ b/skills/rules/01-digestible-pr.md
@@ -1,7 +1,7 @@
 # RULE 1: Digestible PR
 
-## Rule ID
-RULE_1
+## Name
+Digestible PR
 
 ## Category
 Code Review & PR Structure

--- a/skills/rules/02-naming-conventions.md
+++ b/skills/rules/02-naming-conventions.md
@@ -1,7 +1,7 @@
 # RULE 2: Naming Conventions & Abstraction Levels
 
-## Rule ID
-RULE_2
+## Name
+Naming & Abstraction
 
 ## Category
 Architecture & Design
@@ -137,5 +137,5 @@ abstract class EstimationDataSource {
 
 ## References
 
-- [RULE_2 Gist: Class Naming Convention](https://gist.github.com/ripplearcgit/89f05e4f83e087f63148bbbb1d99a178)
-- Related: RULE_5 (UI/Business Separation) — places classes in the right layer.
+- [Naming & Abstraction Gist: Class Naming Convention](https://gist.github.com/ripplearcgit/89f05e4f83e087f63148bbbb1d99a178)
+- Related: UI / Business Separation — places classes in the right layer.

--- a/skills/rules/03-test-double-pattern.md
+++ b/skills/rules/03-test-double-pattern.md
@@ -1,7 +1,7 @@
 # RULE 3: Test Double Pattern
 
-## Rule ID
-RULE_3
+## Name
+Test Double Pattern
 
 ## Category
 Testing Strategy
@@ -140,5 +140,5 @@ See `docs/Testing/Fakes.md` for the full decision matrix and `FakeSupabaseWrappe
 ## References
 
 - [Test Double Pattern Gist](https://gist.github.com/ripplearcgit/89687b7414f62a8c042b16b52e9ceb0b)
-- Related: RULE_8 (Widget Test Finders), RULE_9 (Unit Test Behavior)
+- Related: Widget Test Finders, Unit Test Behavior
 - Existing fakes: `test/utils/fake_app_bootstrap_factory.dart`, `test/utils/a11y/` (helpers).

--- a/skills/rules/04-coreui-components.md
+++ b/skills/rules/04-coreui-components.md
@@ -1,7 +1,7 @@
 # RULE 4: CoreUI Components Usage
 
-## Rule ID
-RULE_4
+## Name
+CoreUI Components
 
 ## Category
 UI Components

--- a/skills/rules/05-ui-business-separation.md
+++ b/skills/rules/05-ui-business-separation.md
@@ -1,7 +1,7 @@
 # RULE 5: UI Logic Separation & Clean Presentation
 
-## Rule ID
-RULE_5
+## Name
+UI / Business Separation
 
 ## Category
 Architecture & Presentation Layer
@@ -81,6 +81,6 @@ Move all business logic, validation, coordination, and state derivation into the
 
 ## References
 
-- [RULE_5 Gist: UI & Business Logic Separation](https://gist.github.com/ripplearcgit/f190fecc8f7124e511cb01283f9fbc31)
+- [UI / Business Separation Gist: UI & Business Logic Separation](https://gist.github.com/ripplearcgit/f190fecc8f7124e511cb01283f9fbc31)
 - [Architecture Layers Reference](../references/architecture-layers.md)
-- Related: RULE_2 (Naming Conventions) - ensures classes in right layer
+- Related: Naming & Abstraction (Naming Conventions) - ensures classes in right layer

--- a/skills/rules/06-stream-lifecycle.md
+++ b/skills/rules/06-stream-lifecycle.md
@@ -1,7 +1,7 @@
 # RULE 6: Stream Lifecycle & Performance
 
-## Rule ID
-RULE_6
+## Name
+Stream Lifecycle
 
 ## Category
 Performance & Memory Management
@@ -96,6 +96,6 @@ Do I need to expose a stream of data?
 
 ## References
 
-- [RULE_6 Gist: Stream Performance](https://gist.github.com/ripplearcgit/7818b412bf5fbe06269e0c3830e136f5)
+- [Stream Lifecycle Gist: Stream Performance](https://gist.github.com/ripplearcgit/7818b412bf5fbe06269e0c3830e136f5)
 - [Dart Streams Documentation](https://dart.dev/tutorials/language/streams)
 - [RxDart Documentation](https://pub.dev/packages/rxdart)

--- a/skills/rules/07-self-documenting-code.md
+++ b/skills/rules/07-self-documenting-code.md
@@ -1,7 +1,7 @@
 # RULE 7: Self-Documenting & Clean Code
 
-## Rule ID
-RULE_7
+## Name
+Self-Documenting Code
 
 ## Category
 Code Quality & Maintainability

--- a/skills/rules/08-widget-test-finders.md
+++ b/skills/rules/08-widget-test-finders.md
@@ -1,7 +1,7 @@
 # RULE 8: Widget Test Finders & Behavior
 
-## Rule ID
-RULE_8
+## Name
+Widget Test Finders
 
 ## Category
 Testing - Widget Tests
@@ -78,7 +78,7 @@ testWidgets('shows error message on invalid email', (tester) async {
   await tester.tap(find.byKey(const Key('submit_button')));
   await tester.pumpAndSettle();
 
-  expect(find.text(l10n().invalidEmailError), findsOneWidget); // RULE_10
+  expect(find.text(l10n().invalidEmailError), findsOneWidget); // Localization
 });
 ```
 
@@ -128,7 +128,7 @@ Test inputs by Key, taps by Key, assertions on user-visible text (always via `l1
 
 - [Flutter Widget Testing Guide](https://flutter.dev/docs/cookbook/testing/widget/introduction)
 - Review Script Lines: 360-386 in `scripts/review_pr.sh`
-- Related: RULE_9 (same principle for unit tests), RULE_10 (localized strings in assertions)
+- Related: Unit Test Behavior (same principle for unit tests), Localization (localized strings in assertions)
 
 ## Notes
 

--- a/skills/rules/09-unit-test-behavior.md
+++ b/skills/rules/09-unit-test-behavior.md
@@ -1,7 +1,7 @@
 # RULE 9: Unit Tests — Behavior Over Implementation
 
-## Rule ID
-RULE_9
+## Name
+Unit Test Behavior
 
 ## Category
 Testing - Unit Tests
@@ -40,7 +40,7 @@ What aspect of this class am I testing?
 ├─ Side effects (DB/API writes)?     → Verify data written to fake boundary ✅
 ├─ Error handling?                   → Trigger error, assert on error output ✅
 ├─ Private method called?            → DON'T TEST — implementation detail ❌
-└─ Method call count?                → DON'T TEST — use fakes (RULE_3), not mocks ❌
+└─ Method call count?                → DON'T TEST — use fakes (Test Double Pattern), not mocks ❌
 ```
 
 ### Canonical Examples
@@ -113,13 +113,13 @@ Apply the same shape for error paths (trigger via fake, assert on returned `Left
 | `verify(mockRepo.save(any))` | Assert on fake boundary state instead | Critical |
 | `calculator._privateMethod()` | Test public API that uses it | Critical |
 | `expect(bloc._cache.length, 5)` | Assert on emitted state instead | Major |
-| `when(mock.method()).thenReturn(...)` | Use fakes (RULE_3) | Critical |
+| `when(mock.method()).thenReturn(...)` | Use fakes (Test Double Pattern) | Critical |
 | No `expect()` in test body | Add assertions on observable outputs | Major |
 | Test breaks on behavior-preserving refactor | Test is coupled to implementation; rewrite against public API | Major |
 
 ### Review Questions
 
-1. Does this test use `verify()` or `when()`? → Violation (use fakes per RULE_3).
+1. Does this test use `verify()` or `when()`? → Violation (use fakes per Test Double Pattern).
 2. Does this test access private methods/fields (`._name`)? → Violation.
 3. Would this test break if we refactored without changing behavior? → Coupled to implementation.
 4. Does this test assert on something a caller would observe? → If no, it's testing implementation.
@@ -128,7 +128,7 @@ Apply the same shape for error paths (trigger via fake, assert on returned `Left
 
 ## Summary: Suggested Fixes
 
-1. **Remove mocks** — replace with fakes (RULE_3).
+1. **Remove mocks** — replace with fakes (Test Double Pattern).
 2. **Test public APIs only** — drop tests of private methods/state.
 3. **Assert on outputs** — return values, emitted states, boundary effects.
 4. **Make tests refactor-safe** — pass after internal refactoring.
@@ -136,7 +136,7 @@ Apply the same shape for error paths (trigger via fake, assert on returned `Left
 ## References
 
 - Review Script Lines: 391-403 in `scripts/review_pr.sh`
-- Related: RULE_3 (Test Double Pattern), RULE_8 (Widget Test Finders)
+- Related: Test Double Pattern, Widget Test Finders
 
 ## Notes
 

--- a/skills/rules/10-localization.md
+++ b/skills/rules/10-localization.md
@@ -1,7 +1,7 @@
 # RULE 10: Localization Usage
 
-## Rule ID
-RULE_10
+## Name
+Localization
 
 ## Category
 Localization

--- a/skills/rules/11-abstraction-naming.md
+++ b/skills/rules/11-abstraction-naming.md
@@ -1,26 +1,26 @@
-# RULE 11: Abstraction-Based Naming (MERGED)
+# Abstraction Naming (MERGED)
 
-> **⚠️ This rule has been merged into RULE_2: Naming Conventions**
+> **⚠️ This rule has been merged into `Naming & Abstraction`**
 >
 > **Location:** `skills/rules/02-naming-conventions.md`
 >
-> **Section:** "Abstraction Naming (original RULE_11)"
+> **Section:** "Part 2: Abstraction-Level Naming"
 
-## Rule ID
-RULE_11 (Deprecated - use RULE_2)
+## Name
+Abstraction Naming (Deprecated - use Naming & Abstraction)
 
 ## Migration Note
 
-RULE_11 (Abstraction-Based Naming) and RULE_2 (Class Naming Conventions) have been merged because they both address naming practices. The combined rule now covers:
+`Abstraction Naming` and `Naming & Abstraction` (formerly Class Naming Conventions) have been merged because they both address naming practices. The combined rule now covers:
 
-1. **Class naming patterns** (original RULE_2) - UseCase, Service, Repository, etc.
-2. **Abstraction naming** (original RULE_11) - How abstract or concrete names should be based on layer
+1. **Class naming patterns** - UseCase, Service, Repository, etc.
+2. **Abstraction naming** - How abstract or concrete names should be based on layer
 
 ## Where to Find This Content Now
 
-All content from RULE_11 is now in:
+All content from `Abstraction Naming` is now in:
 - **File:** `skills/rules/02-naming-conventions.md`
-- **Section:** Lines 200+ under "Abstraction Naming (original RULE_11)"
+- **Section:** "Part 2: Abstraction-Level Naming"
 
 Key topics covered:
 - Abstract names in UI/Domain layers (e.g., `LoginScreen`, not `SupabaseAuthScreen`)
@@ -36,9 +36,10 @@ Key topics covered:
 | Domain | Abstract (business-focused) | `GetUserUseCase` |
 | Data | Concrete (technology-aware) | `RemoteUserDataSource` (Supabase) |
 
-## For Skills Referencing RULE_11
+## For Skills Referencing Abstraction Naming
 
-If your skill references `RULE_11`, update to reference `RULE_2` instead:
+If your skill references `Abstraction Naming`, update to reference
+`Naming & Abstraction` instead:
 
 ```bash
 # Old reference
@@ -46,7 +47,7 @@ cat skills/rules/11-abstraction-naming.md
 
 # New reference
 cat skills/rules/02-naming-conventions.md
-# Look for section: "Abstraction Naming (original RULE_11)"
+# Look for section: "Part 2: Abstraction-Level Naming"
 ```
 
 ---

--- a/skills/rules/12-state-derivation.md
+++ b/skills/rules/12-state-derivation.md
@@ -1,26 +1,26 @@
-# RULE 12: No State Derivation in UI (MERGED)
+# State Derivation (MERGED)
 
-> **⚠️ This rule has been merged into RULE_5: UI & Business Logic Separation**
+> **⚠️ This rule has been merged into `UI / Business Separation`**
 >
 > **Location:** `skills/rules/05-ui-business-separation.md`
 >
-> **Section:** "State Derivation (original RULE_12)"
+> **Section:** "Core Principle 2: No State Derivation"
 
-## Rule ID
-RULE_12 (Deprecated - use RULE_5)
+## Name
+State Derivation (Deprecated - use UI / Business Separation)
 
 ## Migration Note
 
-RULE_12 (No State Derivation in UI) and RULE_5 (UI & Business Logic Separation) have been merged because both enforce UI purity. The combined rule now covers:
+`State Derivation` and `UI / Business Separation` have been merged because both enforce UI purity. The combined rule now covers:
 
-1. **Business logic separation** (original RULE_5) - No validation, coordination, or decisions in UI
-2. **State derivation** (original RULE_12) - No calculations, transformations, or derived values in UI
+1. **Business logic separation** - No validation, coordination, or decisions in UI
+2. **State derivation** - No calculations, transformations, or derived values in UI
 
 ## Where to Find This Content Now
 
-All content from RULE_12 is now in:
+All content from `State Derivation` is now in:
 - **File:** `skills/rules/05-ui-business-separation.md`
-- **Section:** Lines 130+ under "Core Principle 2: No State Derivation (original RULE_12)"
+- **Section:** "Core Principle 2: No State Derivation"
 
 Key topics covered:
 - Widget must not calculate or transform state
@@ -54,9 +54,10 @@ Widget build(BuildContext context) {
 }
 ```
 
-## For Skills Referencing RULE_12
+## For Skills Referencing State Derivation
 
-If your skill references `RULE_12`, update to reference `RULE_5` instead:
+If your skill references `State Derivation`, update to reference
+`UI / Business Separation` instead:
 
 ```bash
 # Old reference
@@ -64,7 +65,7 @@ cat skills/rules/12-state-derivation.md
 
 # New reference
 cat skills/rules/05-ui-business-separation.md
-# Look for section: "Core Principle 2: No State Derivation (original RULE_12)"
+# Look for section: "Core Principle 2: No State Derivation"
 ```
 
 ## Detection Patterns

--- a/skills/rules/13-mutation-testing.md
+++ b/skills/rules/13-mutation-testing.md
@@ -1,7 +1,7 @@
 # RULE 13: Mutation Testing for Logic-Heavy Changes
 
-## Rule ID
-RULE_13
+## Name
+Mutation Testing
 
 ## Category
 Testing - Quality Assurance

--- a/skills/rules/14-accessibility-testing.md
+++ b/skills/rules/14-accessibility-testing.md
@@ -1,7 +1,7 @@
 # RULE 14: Accessibility (A11y) Testing
 
-## Rule ID
-RULE_14
+## Name
+Accessibility
 
 ## Category
 Testing - Accessibility

--- a/skills/rules/15-sentry-logging.md
+++ b/skills/rules/15-sentry-logging.md
@@ -1,7 +1,7 @@
 # RULE 15: Judicious Sentry Error Reporting
 
-## Rule ID
-RULE_15
+## Name
+Sentry Logging
 
 ## Category
 Error Handling & Monitoring
@@ -147,7 +147,7 @@ Inside a `catch` block, branch on the error code/type before choosing a log leve
 
 - [Sentry Best Practices](https://docs.sentry.io/platforms/flutter/best-practices/)
 - Review Script Lines: 519-539 in `scripts/review_pr.sh`
-- Related: RULE_5 (UI/Business separation), `code-data` skill (error mapping table)
+- Related: UI / Business Separation, `code-data` skill (error mapping table)
 
 ## Notes
 

--- a/skills/write-tests-mutation/SKILL.md
+++ b/skills/write-tests-mutation/SKILL.md
@@ -97,7 +97,7 @@ If score ≥ threshold (`<threshold failure>` from the XML) → done. If score i
 
 ## References
 
-- **RULE_13:** `skills/rules/13-mutation-testing.md`
+- **Mutation Testing:** `skills/rules/13-mutation-testing.md`
 - **Example config:** `test/features/estimations/mutations/add_cost_estimation_usecase.xml`
 - **CI runner:** `scripts/run_check.sh` (`run_mutation_tests` function, line 202)
 - **CI docs:** `docs/Testing/CI-Scripts.md` — "Mutation testing behavior" section

--- a/skills/write-tests/SKILL.md
+++ b/skills/write-tests/SKILL.md
@@ -51,11 +51,11 @@ Test real coordination: RepositoryImpl delegates to DataSource; DataSource calls
 
 ### Page Tests
 
-Create a `makeTestableWidget` helper that wraps the page in `BlocProvider` + `MaterialApp` with `createTestTheme()`, `locale: const Locale('en')`, and `AppLocalizations` delegates. Seed `fakeSupabase` before pumping. Use `pumpAndSettle()` after pump. Find text via `lookupAppLocalizations(const Locale('en'))` — never hardcoded strings (RULE_10).
+Create a `makeTestableWidget` helper that wraps the page in `BlocProvider` + `MaterialApp` with `createTestTheme()`, `locale: const Locale('en')`, and `AppLocalizations` delegates. Seed `fakeSupabase` before pumping. Use `pumpAndSettle()` after pump. Find text via `lookupAppLocalizations(const Locale('en'))` — never hardcoded strings (Localization).
 
 ### Widget Interaction Tests
 
-Pump the page, interact using `tester.enterText` (find by key, RULE_8) and `tester.tap` (find by `l10n` string), `pumpAndSettle()` after each action, then assert the resulting state.
+Pump the page, interact using `tester.enterText` (find by key, Widget Test Finders) and `tester.tap` (find by `l10n` string), `pumpAndSettle()` after each action, then assert the resulting state.
 
 ## 4. Test Module Setup
 
@@ -109,9 +109,9 @@ See `skills/write-tests/REFERENCE.md` for Dart examples: invalid inputs, error s
 
 ## References
 
-- **RULE_3:** `skills/rules/03-test-double-pattern.md` — Use fakes, never mocks
-- **RULE_8:** `skills/rules/08-widget-test-finders.md` — Semantic finders
-- **RULE_9:** `skills/rules/09-unit-test-behavior.md` — Test behavior, not implementation
+- **Test Double Pattern:** `skills/rules/03-test-double-pattern.md` — Use fakes, never mocks
+- **Widget Test Finders:** `skills/rules/08-widget-test-finders.md` — Semantic finders
+- **Unit Test Behavior:** `skills/rules/09-unit-test-behavior.md` — Test behavior, not implementation
 - **Testing Docs:** `docs/Testing/Fakes.md`, `docs/Testing/Directories.md`, `docs/Testing/Accessibility-Testing.md`
 - **Examples:** `test/features/auth/units/blocs/`, `test/features/auth/widgets/pages/`
 - **Next:** `write-tests-golden` (gated — screenshot tests for UI changes)


### PR DESCRIPTION
This pull request expands the set of valid rule IDs in the `skills/pr-review/schemas/input.schema.json` schema and updates the description for clarity. Now, more rules can be specified as input, and the documentation explains the deprecation of certain rules.

**Schema improvements:**

* Expanded the allowed `enum` values for rule IDs from just three (`RULE_4`, `RULE_5`, `RULE_10`) to a broader set (`RULE_1` through `RULE_10`, `RULE_13`, `RULE_14`, `RULE_15`), allowing more rules to be specified as input.
* Updated the description to clarify that any active rule ID is valid, and that `RULE_11` and `RULE_12` are deprecated (now covered by `RULE_2` and `RULE_5`). Also explained that omitting this field will auto-run all applicable rules.