### PR TITLE
CA-163: Add CreateProjectBloc

### DIFF
--- a/lib/features/dashboard/dashboard_module.dart
+++ b/lib/features/dashboard/dashboard_module.dart
@@ -1,6 +1,7 @@
 import 'package:construculator/app/app_bootstrap.dart';
 import 'package:construculator/app/shell/app_shell_bloc/app_shell_bloc.dart';
 import 'package:construculator/features/dashboard/domain/usecases/watch_recent_estimations_usecase.dart';
+import 'package:construculator/features/dashboard/presentation/bloc/create_project_bloc/create_project_bloc.dart';
 import 'package:construculator/features/dashboard/presentation/bloc/dashboard_bloc/dashboard_bloc.dart';
 import 'package:construculator/features/dashboard/presentation/bloc/project_settings_bloc/project_settings_bloc.dart';
 import 'package:construculator/features/dashboard/presentation/bloc/recent_estimations_bloc/recent_estimations_bloc.dart';
@@ -46,6 +47,9 @@ class DashboardModule extends Module {
     );
     i.add<ProjectSettingsBloc>(
       () => ProjectSettingsBloc(repository: i()),
+    );
+    i.add<CreateProjectBloc>(
+      () => CreateProjectBloc(repository: i()),
     );
   }
 

--- a/lib/features/dashboard/presentation/bloc/create_project_bloc/create_project_bloc.dart
+++ b/lib/features/dashboard/presentation/bloc/create_project_bloc/create_project_bloc.dart
@@ -1,0 +1,34 @@
+import 'package:construculator/libraries/errors/failures.dart';
+import 'package:construculator/libraries/project/domain/entities/project_entity.dart';
+import 'package:construculator/libraries/project/domain/repositories/project_setting_repository.dart';
+import 'package:equatable/equatable.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+part 'create_project_event.dart';
+part 'create_project_state.dart';
+
+/// Manages [ProjectSettingRepository.createProject] and exposes states for
+/// the in-progress, success, and failure outcomes of project creation.
+class CreateProjectBloc extends Bloc<CreateProjectEvent, CreateProjectState> {
+  final ProjectSettingRepository _repository;
+
+  CreateProjectBloc({required ProjectSettingRepository repository})
+      : _repository = repository,
+        super(const CreateProjectInitial()) {
+    on<CreateProjectSubmitted>(_onSubmitted);
+  }
+
+  Future<void> _onSubmitted(
+    CreateProjectSubmitted event,
+    Emitter<CreateProjectState> emit,
+  ) async {
+    // Diverges from DASH-023: CreateProjectWithMembersUseCase (validation +
+    // transaction + addMembers) deferred until the Members Module exists.
+    emit(const CreateProjectInProgress());
+    final result = await _repository.createProject(event.project);
+    result.fold(
+      (failure) => emit(CreateProjectFailure(failure: failure)),
+      (project) => emit(CreateProjectSuccess(project: project)),
+    );
+  }
+}

--- a/lib/features/dashboard/presentation/bloc/create_project_bloc/create_project_event.dart
+++ b/lib/features/dashboard/presentation/bloc/create_project_bloc/create_project_event.dart
@@ -1,0 +1,20 @@
+part of 'create_project_bloc.dart';
+
+/// Base event for [CreateProjectBloc].
+abstract class CreateProjectEvent extends Equatable {
+  const CreateProjectEvent();
+
+  @override
+  List<Object?> get props => [];
+}
+
+/// Submits [project] for creation.
+class CreateProjectSubmitted extends CreateProjectEvent {
+  /// The project to create.
+  final Project project;
+
+  const CreateProjectSubmitted(this.project);
+
+  @override
+  List<Object?> get props => [project];
+}

--- a/lib/features/dashboard/presentation/bloc/create_project_bloc/create_project_state.dart
+++ b/lib/features/dashboard/presentation/bloc/create_project_bloc/create_project_state.dart
@@ -1,0 +1,41 @@
+part of 'create_project_bloc.dart';
+
+/// Base state for [CreateProjectBloc].
+abstract class CreateProjectState extends Equatable {
+  const CreateProjectState();
+
+  @override
+  List<Object?> get props => [];
+}
+
+/// The initial state before any creation has been requested.
+class CreateProjectInitial extends CreateProjectState {
+  const CreateProjectInitial();
+}
+
+/// Emitted while a create request is in flight.
+class CreateProjectInProgress extends CreateProjectState {
+  const CreateProjectInProgress();
+}
+
+/// Emitted when the project is successfully created.
+class CreateProjectSuccess extends CreateProjectState {
+  /// The created project as persisted.
+  final Project project;
+
+  const CreateProjectSuccess({required this.project});
+
+  @override
+  List<Object?> get props => [project];
+}
+
+/// Emitted when project creation fails.
+class CreateProjectFailure extends CreateProjectState {
+  /// The failure describing what went wrong.
+  final Failure failure;
+
+  const CreateProjectFailure({required this.failure});
+
+  @override
+  List<Object?> get props => [failure];
+}

--- a/test/features/dashboard/units/blocs/create_project_bloc_test.dart
+++ b/test/features/dashboard/units/blocs/create_project_bloc_test.dart
@@ -1,0 +1,118 @@
+import 'package:bloc_test/bloc_test.dart';
+import 'package:construculator/app/app_bootstrap.dart';
+import 'package:construculator/features/dashboard/dashboard_module.dart';
+import 'package:construculator/features/dashboard/presentation/bloc/create_project_bloc/create_project_bloc.dart';
+import 'package:construculator/libraries/errors/failures.dart';
+import 'package:construculator/libraries/project/domain/entities/enums.dart';
+import 'package:construculator/libraries/project/domain/entities/project_entity.dart';
+import 'package:construculator/libraries/project/domain/project_error_type.dart';
+import 'package:construculator/libraries/project/domain/repositories/project_setting_repository.dart';
+import 'package:construculator/libraries/project/testing/fake_project_setting_repository.dart';
+import 'package:flutter_modular/flutter_modular.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../../../../utils/fake_app_bootstrap_factory.dart';
+
+void main() {
+  group('CreateProjectBloc', () {
+    late FakeProjectSettingRepository fakeRepository;
+
+    const testProjectId = 'project-id-1';
+    const testProjectName = 'Test Project';
+    const testCreatorUserId = 'user-1';
+
+    final tDate = DateTime(2025, 1, 1, 8, 0);
+    late Project tProject;
+
+    // Modular is initialised once; each test receives a fresh
+    // FakeProjectSettingRepository via replaceInstance so no state bleeds
+    // between tests. Modular.get<CreateProjectBloc>() returns a new instance
+    // per call because the binding uses i.add (not addLazySingleton).
+    setUpAll(() {
+      final bootstrap = FakeAppBootstrapFactory.create();
+      Modular.init(_CreateProjectBlocTestModule(bootstrap));
+    });
+
+    tearDownAll(() {
+      Modular.dispose();
+    });
+
+    setUp(() {
+      Modular.replaceInstance<ProjectSettingRepository>(
+        FakeProjectSettingRepository(),
+      );
+      fakeRepository = Modular.get<ProjectSettingRepository>()
+          as FakeProjectSettingRepository;
+
+      tProject = Project(
+        id: testProjectId,
+        projectName: testProjectName,
+        creatorUserId: testCreatorUserId,
+        createdAt: tDate,
+        updatedAt: tDate,
+        status: ProjectStatus.active,
+      );
+    });
+
+    test('initial state is CreateProjectInitial', () {
+      final bloc = Modular.get<CreateProjectBloc>();
+      expect(bloc.state, const CreateProjectInitial());
+      bloc.close();
+    });
+
+    group('CreateProjectSubmitted', () {
+      blocTest<CreateProjectBloc, CreateProjectState>(
+        'emits [InProgress, Success] on create success',
+        build: () => Modular.get<CreateProjectBloc>(),
+        act: (bloc) => bloc.add(CreateProjectSubmitted(tProject)),
+        expect: () => [
+          const CreateProjectInProgress(),
+          isA<CreateProjectSuccess>()
+              .having((s) => s.project.id, 'project.id', testProjectId)
+              .having(
+                (s) => s.project.projectName,
+                'project.projectName',
+                testProjectName,
+              )
+              .having(
+                (s) => s.project.creatorUserId,
+                'project.creatorUserId',
+                testCreatorUserId,
+              ),
+        ],
+        verify: (_) {
+          expect(fakeRepository.getMethodCallsFor('createProject'), hasLength(1));
+        },
+      );
+
+      blocTest<CreateProjectBloc, CreateProjectState>(
+        'emits [InProgress, Failure] on create failure',
+        build: () {
+          fakeRepository.shouldFailOnCreate = true;
+          fakeRepository.failureToReturn = const ProjectFailure(
+            errorType: ProjectErrorType.connectionError,
+          );
+          return Modular.get<CreateProjectBloc>();
+        },
+        act: (bloc) => bloc.add(CreateProjectSubmitted(tProject)),
+        expect: () => [
+          const CreateProjectInProgress(),
+          isA<CreateProjectFailure>().having(
+            (s) => s.failure,
+            'failure',
+            isA<ProjectFailure>(),
+          ),
+        ],
+      );
+    });
+  });
+}
+
+class _CreateProjectBlocTestModule extends Module {
+  final AppBootstrap bootstrap;
+
+  _CreateProjectBlocTestModule(this.bootstrap);
+
+  @override
+  List<Module> get imports => [DashboardModule(bootstrap)];
+}


### PR DESCRIPTION
# Pull Request Review: CA-163 — Add CreateProjectBloc

**Source Branch:** `CA-163-feat/create-project-bloc`
**Target Branch:** `main`
**Date:** 2026-06-24

## Summary

This PR introduces `CreateProjectBloc`, a new BLoC that wraps `ProjectSettingRepository.createProject` and exposes `CreateProjectInitial` / `CreateProjectInProgress` / `CreateProjectSuccess` / `CreateProjectFailure` states for a single `CreateProjectSubmitted` event. The implementation mirrors the existing `ProjectSettingsBloc` pattern exactly (direct repository injection, no use case), and is registered as a factory binding in `DashboardModule`. This is a deliberate, documented divergence from the DASH-023 design doc's `CreateProjectWithMembersUseCase`, which requires infrastructure (`ProjectMemberRepository`, `projectRepository.transaction()`, `ValidationFailure`, `ProjectParams`) that does not yet exist in the codebase and is tracked separately under the Members Module (CA-290). UI wiring of the "Create Project" action remains out of scope (owned by CA-116).

## Changes Overview

| Category | Value |
|---|---|
| Files changed | 5 (4 added, 1 modified) |
| Production files | 4 |
| Test files | 1 |
| Production line insertions | ~99 |
| Test line insertions | 118 |
| PR Size (production code only) | **S** (50–100 lines) |

## Rule-Based Review

| Rule | Status | Notes |
|---|---|---|
| Rule 1 — Digestible PR | ✅ Pass | ~99 production lines (S). Single, clear purpose: one BLoC + DI registration. No further splitting needed. |
| Rule 2 — Class Naming Convention | ✅ Pass | `CreateProjectBloc` + `CreateProjectEvent` + `CreateProjectState` follow the `NounBloc`/`NounEvent`/`NounState` pattern. No `Helper`/`Util` suffixes introduced. |
| Rule 3 — Test Double Pattern | ✅ Pass | Test uses the real `CreateProjectBloc` resolved through real `DashboardModule`/Modular DI, with only the external dependency (`ProjectSettingRepository`) swapped for `FakeProjectSettingRepository`. No mocks/stubs used. |
| Rule 5 — UI & Business Logic Separation | ✅ Pass (N/A) | No UI code in this PR. The bloc only dispatches repository calls and emits states; no UI exists yet to evaluate. |
| Rule 6 — Stream-Based Performance & Lifecycle | ✅ Pass | No `StreamController`s or manual subscriptions introduced. `CreateProjectBloc` has a single event handler with no async listeners requiring manual cleanup. |
