### PR TITLE
CA-727: test: add a11y coverage for active tag dismiss chip

### DIFF
--- a/test/features/global_search/widgets/accessibility/global_search_page_a11y_test.dart
+++ b/test/features/global_search/widgets/accessibility/global_search_page_a11y_test.dart
@@ -267,6 +267,11 @@ void main() {
           checkTapTargetSize: true,
           checkLabeledTapTarget: true,
           setupAfterPump: (t) async {
+            // GlobalSearchBloc is registered as a factory (i.add), so every
+            // pumpWidget starts with a fresh bloc and GlobalSearchStarted
+            // resets selectedTags to empty — the chip is never pre-populated
+            // here. This guard is a safety net in case registration ever
+            // changes to a singleton; it is not a currently reachable path.
             if (find
                 .byKey(const Key('active_tag_chip_Roofing'))
                 .evaluate()

--- a/test/features/global_search/widgets/accessibility/global_search_page_a11y_test.dart
+++ b/test/features/global_search/widgets/accessibility/global_search_page_a11y_test.dart
@@ -248,8 +248,40 @@ void main() {
       },
     );
 
-    // TODO: [CA-727] Add a11y coverage (tap-target size + semantic label) for
-    // the active tag dismiss chips ('active_tag_chip_$tag').
-    // https://ripplearc.youtrack.cloud/issue/CA-727
+    testWidgets(
+      'meets a11y guidelines for active tag dismiss chip in both themes',
+      (tester) async {
+        fakeSupabase.addTableData(DatabaseConstants.tagsTable, [
+          {
+            DatabaseConstants.idColumn: 'tag-Roofing',
+            DatabaseConstants.nameColumn: 'Roofing',
+          },
+        ]);
+
+        await setupA11yTest(tester);
+
+        await expectMeetsTapTargetAndLabelGuidelinesForEachTheme(
+          tester,
+          (theme) => makeTestableWidget(theme: theme),
+          find.byKey(const Key('active_tag_chip_Roofing')),
+          checkTapTargetSize: true,
+          checkLabeledTapTarget: true,
+          setupAfterPump: (t) async {
+            if (find
+                .byKey(const Key('active_tag_chip_Roofing'))
+                .evaluate()
+                .isNotEmpty) {
+              return;
+            }
+            await t.tap(find.byKey(const Key('global_search_tags_filter_chip')));
+            await t.pumpAndSettle();
+            await t.tap(find.byKey(const Key('tag_filter_item_Roofing')));
+            await t.pump();
+            await t.tap(find.byKey(const Key('tags_filter_apply_button')));
+            await t.pumpAndSettle();
+          },
+        );
+      },
+    );
   });
 }


### PR DESCRIPTION
## Summary

Adds a tap-target size + semantic label a11y test for the active tag dismiss chip (`active_tag_chip_$tag`) rendered by `_buildTagsFilterChips` in `global_search_page.dart`, closing the gap left by PR #336 (CA-173b) which only covered the empty-state `global_search_tags_filter_chip`. Removes the stale `// TODO: [CA-727]` comment.

The BLoC is seeded with a non-empty `selectedTags` state by driving the real UI flow (open tags sheet → select a tag → apply), matching the existing pattern in `global_search_tags_filter_sheet_test.dart` rather than reaching into BLoC internals.

Stacked on #377 (CA-170b) — diff base is `CA-170b-feat/date-filter-bloc-ui`, not `main`.

## Changes Overview

| Category | Value |
|---|---|
| Files changed | 1 (test only) |
| Production line insertions | 0 |
| Test line insertions | ~35 |
| PR Size | XS |

## Test plan

- [x] `flutter analyze` clean on changed file
- [x] `ripplearc_linter` custom rules clean on changed file
- [x] New test passes in both light and dark themes (asserts tap-target size + labeled tap target)
- [x] Full `global_search` unit/widget/a11y suite passes (golden/screenshot tests fail locally outside Docker as expected — unrelated pre-existing drift)