### PR TITLE
CA-688: feat: add history/suggestions methods to ProjectSearchDataSource

### DIFF
--- a/lib/libraries/project/data/data_source/interfaces/project_search_data_source.dart
+++ b/lib/libraries/project/data/data_source/interfaces/project_search_data_source.dart
@@ -18,4 +18,36 @@ abstract class ProjectSearchDataSource {
     String? filterByTag,
     String? filterByOwner,
   });
+
+  /// Persists [searchTerm] as a recent project-search entry for [userId].
+  ///
+  /// [hasResults] should be `true` only when the caller has confirmed the
+  /// search returned at least one result. Repeat saves of the same term
+  /// increment the per-term count rather than producing duplicates.
+  ///
+  /// Does nothing when [userId] is empty or [searchTerm] is empty/whitespace.
+  Future<void> saveRecentProjectSearch({
+    required String userId,
+    required String searchTerm,
+    bool hasResults = false,
+  });
+
+  /// Returns [userId]'s recent project-search terms, most recently used first.
+  ///
+  /// Implementations may cap the number of entries returned. Returns an empty
+  /// list when [userId] is empty.
+  Future<List<String>> getRecentProjectSearches({required String userId});
+
+  /// Removes [searchTerm] from [userId]'s recent project-search history.
+  ///
+  /// Does nothing when [userId] is empty or [searchTerm] is empty/whitespace.
+  Future<void> deleteRecentProjectSearch({
+    required String userId,
+    required String searchTerm,
+  });
+
+  /// Returns up to 10 personalized project-search suggestion terms for [userId].
+  ///
+  /// Returns an empty list when [userId] is empty or no suggestions exist.
+  Future<List<String>> getProjectSearchSuggestions({required String userId});
 }

--- a/lib/libraries/project/data/data_source/remote_project_search_data_source.dart
+++ b/lib/libraries/project/data/data_source/remote_project_search_data_source.dart
@@ -73,4 +73,167 @@ class RemoteProjectSearchDataSource implements ProjectSearchDataSource {
       rethrow;
     }
   }
+
+  @override
+  Future<void> saveRecentProjectSearch({
+    required String userId,
+    required String searchTerm,
+    bool hasResults = false,
+  }) async {
+    final normalized = searchTerm.toLowerCase().trim();
+    if (userId.trim().isEmpty || normalized.isEmpty) {
+      _logger.debug('Empty userId or searchTerm — skipping save');
+      return;
+    }
+
+    try {
+      _logger.debug(
+        'Saving recent project search: $normalized for userId: $userId, '
+        'hasResults: $hasResults',
+      );
+
+      await _supabaseWrapper.upsert(
+        table: DatabaseConstants.projectSearchHistoryTable,
+        data: {
+          DatabaseConstants.userIdColumn: userId,
+          DatabaseConstants.searchTermColumn: normalized,
+          DatabaseConstants.hasResultsColumn: hasResults,
+          // search_count intentionally omitted — incremented atomically by the
+          // BEFORE UPDATE trigger on conflict.
+          // created_at intentionally omitted — DB DEFAULT handles insert; the
+          // trigger preserves OLD.created_at on conflict update.
+        },
+        onConflict: DatabaseConstants.projectSearchHistoryUpsertConflictColumns,
+      );
+    } on supabase.PostgrestException catch (error, stackTrace) {
+      _logger.warning(
+        'Supabase error while saving recent project search: $normalized, error: $error',
+        stackTrace.toString(),
+      );
+      rethrow;
+    } catch (error, stackTrace) {
+      _logger.warning(
+        'Unexpected error while saving recent project search: $normalized, error: $error',
+        stackTrace.toString(),
+      );
+      rethrow;
+    }
+  }
+
+  @override
+  Future<List<String>> getRecentProjectSearches({
+    required String userId,
+  }) async {
+    if (userId.trim().isEmpty) {
+      _logger.debug('Empty userId — skipping recent project search fetch');
+      return [];
+    }
+
+    try {
+      _logger.debug('Fetching recent project searches for userId: $userId');
+
+      final rows = await _supabaseWrapper.selectMatch(
+        table: DatabaseConstants.projectSearchHistoryTable,
+        filters: {DatabaseConstants.userIdColumn: userId},
+        orderBy: DatabaseConstants.updatedAtColumn,
+        ascending: false,
+      );
+
+      return rows
+          .map(
+            (row) => row[DatabaseConstants.searchTermColumn]?.toString() ?? '',
+          )
+          .where((term) => term.isNotEmpty)
+          // TODO: [CA-722] Replace in-memory .take() with a DB-level limit
+          // once SupabaseWrapper.selectMatch supports a limit parameter.
+          // https://ripplearc.youtrack.cloud/issue/CA-722
+          .take(DatabaseConstants.recentProjectSearchesMaxResults)
+          .toList();
+    } on supabase.PostgrestException catch (error, stackTrace) {
+      _logger.warning(
+        'Supabase error while fetching recent project searches for userId: $userId, error: $error',
+        stackTrace.toString(),
+      );
+      rethrow;
+    } catch (error, stackTrace) {
+      _logger.warning(
+        'Unexpected error while fetching recent project searches for userId: $userId, error: $error',
+        stackTrace.toString(),
+      );
+      rethrow;
+    }
+  }
+
+  @override
+  Future<void> deleteRecentProjectSearch({
+    required String userId,
+    required String searchTerm,
+  }) async {
+    final normalized = searchTerm.toLowerCase().trim();
+    if (userId.trim().isEmpty || normalized.isEmpty) {
+      _logger.debug('Empty userId or searchTerm — skipping delete');
+      return;
+    }
+
+    try {
+      _logger.debug(
+        'Deleting recent project search: $normalized for userId: $userId',
+      );
+
+      await _supabaseWrapper.deleteMatch(
+        table: DatabaseConstants.projectSearchHistoryTable,
+        filters: {
+          DatabaseConstants.userIdColumn: userId,
+          DatabaseConstants.searchTermColumn: normalized,
+        },
+      );
+    } on supabase.PostgrestException catch (error, stackTrace) {
+      _logger.warning(
+        'Supabase error while deleting recent project search: $normalized, error: $error',
+        stackTrace.toString(),
+      );
+      rethrow;
+    } catch (error, stackTrace) {
+      _logger.warning(
+        'Unexpected error while deleting recent project search: $normalized, error: $error',
+        stackTrace.toString(),
+      );
+      rethrow;
+    }
+  }
+
+  @override
+  Future<List<String>> getProjectSearchSuggestions({
+    required String userId,
+  }) async {
+    if (userId.trim().isEmpty) {
+      _logger.debug('Empty userId — skipping project search suggestions fetch');
+      return [];
+    }
+
+    try {
+      _logger.debug('Fetching project search suggestions for userId: $userId');
+
+      final response = await _supabaseWrapper.rpc<List<dynamic>>(
+        DatabaseConstants.projectSearchSuggestionsRpcFunction,
+        params: {
+          DatabaseConstants.projectSearchSuggestionsUserIdParam: userId,
+        },
+      );
+
+      return response.whereType<String>().toList();
+    } on supabase.PostgrestException catch (error, stackTrace) {
+      _logger.warning(
+        'Supabase error while fetching project search suggestions for userId: $userId, error: $error',
+        stackTrace.toString(),
+      );
+      rethrow;
+    } catch (error, stackTrace) {
+      _logger.warning(
+        'Unexpected error while fetching project search suggestions for userId: $userId, error: $error',
+        stackTrace.toString(),
+      );
+      rethrow;
+    }
+  }
 }

--- a/lib/libraries/supabase/database_constants.dart
+++ b/lib/libraries/supabase/database_constants.dart
@@ -20,6 +20,11 @@ class DatabaseConstants {
   static const String searchHistoryTable = 'search_history';
   static const String tagsTable = 'tags';
 
+  /// Table storing per-user project search history. Fully isolated from
+  /// [searchHistoryTable] (which serves Global Search) — neither feature reads
+  /// from nor writes to the other's table.
+  static const String projectSearchHistoryTable = 'project_search_history';
+
   // RPC function names
   static const String globalSearchRpcFunction = 'global_search';
   static const String searchSuggestionsRpcFunction = 'get_search_suggestions';
@@ -30,6 +35,16 @@ class DatabaseConstants {
   /// the authenticated caller can access; identity is derived from the
   /// Supabase auth session JWT, so no explicit user id param is required.
   static const String projectOwnersRpcFunction = 'get_project_owners';
+
+  /// RPC returning up to 10 personalized project-search suggestion terms for
+  /// the authenticated user. Backend enforces `user_id == auth.uid()` and
+  /// raises `42501` on mismatch.
+  static const String projectSearchSuggestionsRpcFunction =
+      'get_project_search_suggestions';
+
+  /// Parameter name for the `user_id` argument of
+  /// [projectSearchSuggestionsRpcFunction].
+  static const String projectSearchSuggestionsUserIdParam = 'user_id';
 
   // RPC param values
   /// The scope value passed to the [globalSearchRpcFunction] RPC to restrict
@@ -73,6 +88,17 @@ class DatabaseConstants {
   /// Used with [SupabaseWrapper.upsert] onConflict parameter.
   static const String searchHistoryUpsertConflictColumns =
       '$userIdColumn,$searchTermColumn,$scopeColumn';
+
+  /// Unique constraint columns for [projectSearchHistoryTable] upsert.
+  /// Used with [SupabaseWrapper.upsert] onConflict parameter.
+  static const String projectSearchHistoryUpsertConflictColumns =
+      '$userIdColumn,$searchTermColumn';
+
+  /// Maximum number of recent project-search entries returned by
+  /// [ProjectSearchDataSource.getRecentProjectSearches]. Caps the in-memory
+  /// result size; row-count bounding at the DB level is delegated to a future
+  /// `limit` parameter on [SupabaseWrapper.selectMatch].
+  static const int recentProjectSearchesMaxResults = 50;
 
   // User profile columns (id field uses the shared idColumn above)
   static const String credentialIdColumn = 'credential_id';

--- a/test/libraries/project/units/data/data_source/remote_project_search_data_source_test.dart
+++ b/test/libraries/project/units/data/data_source/remote_project_search_data_source_test.dart
@@ -272,5 +272,466 @@ void main() {
         );
       });
     });
+
+    group('saveRecentProjectSearch', () {
+      test('upserts normalized term against project_search_history', () async {
+        await dataSource.saveRecentProjectSearch(
+          userId: 'user-1',
+          searchTerm: '  Foundation  ',
+          hasResults: true,
+        );
+
+        final calls = supabaseWrapper.getMethodCallsFor('upsert');
+        expect(calls, hasLength(1));
+        expect(
+          calls.first['table'],
+          equals(DatabaseConstants.projectSearchHistoryTable),
+        );
+        expect(
+          calls.first['onConflict'],
+          equals(DatabaseConstants.projectSearchHistoryUpsertConflictColumns),
+        );
+
+        final data = calls.first['data'] as Map<String, dynamic>;
+        expect(data[DatabaseConstants.userIdColumn], equals('user-1'));
+        expect(data[DatabaseConstants.searchTermColumn], equals('foundation'));
+        expect(data[DatabaseConstants.hasResultsColumn], isTrue);
+        expect(data.containsKey(DatabaseConstants.searchCountColumn), isFalse);
+        expect(data.containsKey(DatabaseConstants.createdAtColumn), isFalse);
+      });
+
+      test('defaults hasResults to false when not provided', () async {
+        await dataSource.saveRecentProjectSearch(
+          userId: 'user-1',
+          searchTerm: 'wall',
+        );
+
+        final data = supabaseWrapper.getMethodCallsFor('upsert').first['data']
+            as Map<String, dynamic>;
+        expect(data[DatabaseConstants.hasResultsColumn], isFalse);
+      });
+
+      test('does nothing when userId is empty', () async {
+        await dataSource.saveRecentProjectSearch(
+          userId: '',
+          searchTerm: 'wall',
+        );
+
+        expect(supabaseWrapper.getMethodCallsFor('upsert'), isEmpty);
+      });
+
+      test('does nothing when userId is whitespace only', () async {
+        await dataSource.saveRecentProjectSearch(
+          userId: '   ',
+          searchTerm: 'wall',
+        );
+
+        expect(supabaseWrapper.getMethodCallsFor('upsert'), isEmpty);
+      });
+
+      test('does nothing when searchTerm is empty', () async {
+        await dataSource.saveRecentProjectSearch(
+          userId: 'user-1',
+          searchTerm: '',
+        );
+
+        expect(supabaseWrapper.getMethodCallsFor('upsert'), isEmpty);
+      });
+
+      test('does nothing when searchTerm is whitespace only', () async {
+        await dataSource.saveRecentProjectSearch(
+          userId: 'user-1',
+          searchTerm: '   ',
+        );
+
+        expect(supabaseWrapper.getMethodCallsFor('upsert'), isEmpty);
+      });
+
+      test('rethrows PostgrestException when upsert throws', () async {
+        supabaseWrapper.shouldThrowOnUpsert = true;
+        supabaseWrapper.upsertExceptionType = SupabaseExceptionType.postgrest;
+        supabaseWrapper.upsertErrorMessage = 'DB error';
+
+        await expectLater(
+          () => dataSource.saveRecentProjectSearch(
+            userId: 'user-1',
+            searchTerm: 'wall',
+          ),
+          throwsA(isA<supabase.PostgrestException>()),
+        );
+      });
+
+      test('rethrows SocketException when upsert throws', () async {
+        supabaseWrapper.shouldThrowOnUpsert = true;
+        supabaseWrapper.upsertExceptionType = SupabaseExceptionType.socket;
+        supabaseWrapper.upsertErrorMessage = 'Network';
+
+        await expectLater(
+          () => dataSource.saveRecentProjectSearch(
+            userId: 'user-1',
+            searchTerm: 'wall',
+          ),
+          throwsA(isA<SocketException>()),
+        );
+      });
+
+      test('rethrows TimeoutException when upsert throws', () async {
+        supabaseWrapper.shouldThrowOnUpsert = true;
+        supabaseWrapper.upsertExceptionType = SupabaseExceptionType.timeout;
+        supabaseWrapper.upsertErrorMessage = 'Timeout';
+
+        await expectLater(
+          () => dataSource.saveRecentProjectSearch(
+            userId: 'user-1',
+            searchTerm: 'wall',
+          ),
+          throwsA(isA<TimeoutException>()),
+        );
+      });
+    });
+
+    group('getRecentProjectSearches', () {
+      test(
+        'returns most-recent-first list of terms from project_search_history',
+        () async {
+          supabaseWrapper.addTableData(
+            DatabaseConstants.projectSearchHistoryTable,
+            [
+              {
+                DatabaseConstants.userIdColumn: 'user-1',
+                DatabaseConstants.searchTermColumn: 'older',
+                DatabaseConstants.updatedAtColumn: '2024-01-01T00:00:00.000Z',
+              },
+              {
+                DatabaseConstants.userIdColumn: 'user-1',
+                DatabaseConstants.searchTermColumn: 'newer',
+                DatabaseConstants.updatedAtColumn: '2024-06-01T00:00:00.000Z',
+              },
+            ],
+          );
+
+          final result = await dataSource.getRecentProjectSearches(
+            userId: 'user-1',
+          );
+
+          expect(result, equals(['newer', 'older']));
+
+          final calls = supabaseWrapper.getMethodCallsFor('selectMatch');
+          expect(calls, hasLength(1));
+          expect(
+            calls.first['table'],
+            equals(DatabaseConstants.projectSearchHistoryTable),
+          );
+          expect(
+            calls.first['orderBy'],
+            equals(DatabaseConstants.updatedAtColumn),
+          );
+          expect(calls.first['ascending'], isFalse);
+          final filters = calls.first['filters'] as Map<String, dynamic>;
+          expect(filters[DatabaseConstants.userIdColumn], equals('user-1'));
+        },
+      );
+
+      test('drops rows with null or empty search_term', () async {
+        supabaseWrapper.addTableData(
+          DatabaseConstants.projectSearchHistoryTable,
+          [
+            {
+              DatabaseConstants.userIdColumn: 'user-1',
+              DatabaseConstants.searchTermColumn: 'kept',
+              DatabaseConstants.updatedAtColumn: '2024-06-01T00:00:00.000Z',
+            },
+            {
+              DatabaseConstants.userIdColumn: 'user-1',
+              DatabaseConstants.searchTermColumn: '',
+              DatabaseConstants.updatedAtColumn: '2024-05-01T00:00:00.000Z',
+            },
+            {
+              DatabaseConstants.userIdColumn: 'user-1',
+              DatabaseConstants.searchTermColumn: null,
+              DatabaseConstants.updatedAtColumn: '2024-04-01T00:00:00.000Z',
+            },
+          ],
+        );
+
+        final result = await dataSource.getRecentProjectSearches(
+          userId: 'user-1',
+        );
+
+        expect(result, equals(['kept']));
+      });
+
+      test(
+        'caps results at recentProjectSearchesMaxResults',
+        () async {
+          final overLimit =
+              DatabaseConstants.recentProjectSearchesMaxResults + 5;
+          supabaseWrapper.addTableData(
+            DatabaseConstants.projectSearchHistoryTable,
+            List.generate(
+              overLimit,
+              (i) => {
+                DatabaseConstants.userIdColumn: 'user-1',
+                DatabaseConstants.searchTermColumn: 'term-$i',
+                DatabaseConstants.updatedAtColumn:
+                    '2024-01-01T00:00:00.000Z',
+              },
+            ),
+          );
+
+          final result = await dataSource.getRecentProjectSearches(
+            userId: 'user-1',
+          );
+
+          expect(
+            result,
+            hasLength(DatabaseConstants.recentProjectSearchesMaxResults),
+          );
+        },
+      );
+
+      test('returns empty list without calling wrapper when userId empty', () async {
+        final result = await dataSource.getRecentProjectSearches(userId: '');
+
+        expect(result, isEmpty);
+        expect(supabaseWrapper.getMethodCallsFor('selectMatch'), isEmpty);
+      });
+
+      test(
+        'returns empty list without calling wrapper when userId is whitespace only',
+        () async {
+          final result = await dataSource.getRecentProjectSearches(
+            userId: '   ',
+          );
+
+          expect(result, isEmpty);
+          expect(supabaseWrapper.getMethodCallsFor('selectMatch'), isEmpty);
+        },
+      );
+
+      test('rethrows PostgrestException when selectMatch throws', () async {
+        supabaseWrapper.shouldThrowOnSelectMatch = true;
+        supabaseWrapper.selectMatchExceptionType =
+            SupabaseExceptionType.postgrest;
+        supabaseWrapper.selectMatchErrorMessage = 'DB error';
+
+        await expectLater(
+          () => dataSource.getRecentProjectSearches(userId: 'user-1'),
+          throwsA(isA<supabase.PostgrestException>()),
+        );
+      });
+
+      test('rethrows TimeoutException when selectMatch throws', () async {
+        supabaseWrapper.shouldThrowOnSelectMatch = true;
+        supabaseWrapper.selectMatchExceptionType =
+            SupabaseExceptionType.timeout;
+        supabaseWrapper.selectMatchErrorMessage = 'Timeout';
+
+        await expectLater(
+          () => dataSource.getRecentProjectSearches(userId: 'user-1'),
+          throwsA(isA<TimeoutException>()),
+        );
+      });
+
+      test('rethrows SocketException when selectMatch throws', () async {
+        supabaseWrapper.shouldThrowOnSelectMatch = true;
+        supabaseWrapper.selectMatchExceptionType =
+            SupabaseExceptionType.socket;
+        supabaseWrapper.selectMatchErrorMessage = 'Network';
+
+        await expectLater(
+          () => dataSource.getRecentProjectSearches(userId: 'user-1'),
+          throwsA(isA<SocketException>()),
+        );
+      });
+    });
+
+    group('deleteRecentProjectSearch', () {
+      test(
+        'deletes against project_search_history with normalized term',
+        () async {
+          await dataSource.deleteRecentProjectSearch(
+            userId: 'user-1',
+            searchTerm: '  Foundation  ',
+          );
+
+          final calls = supabaseWrapper.getMethodCallsFor('deleteMatch');
+          expect(calls, hasLength(1));
+          expect(
+            calls.first['table'],
+            equals(DatabaseConstants.projectSearchHistoryTable),
+          );
+          final filters = calls.first['filters'] as Map<String, dynamic>;
+          expect(filters[DatabaseConstants.userIdColumn], equals('user-1'));
+          expect(
+            filters[DatabaseConstants.searchTermColumn],
+            equals('foundation'),
+          );
+        },
+      );
+
+      test('does nothing when userId is empty', () async {
+        await dataSource.deleteRecentProjectSearch(
+          userId: '',
+          searchTerm: 'wall',
+        );
+
+        expect(supabaseWrapper.getMethodCallsFor('deleteMatch'), isEmpty);
+      });
+
+      test('does nothing when userId is whitespace only', () async {
+        await dataSource.deleteRecentProjectSearch(
+          userId: '   ',
+          searchTerm: 'wall',
+        );
+
+        expect(supabaseWrapper.getMethodCallsFor('deleteMatch'), isEmpty);
+      });
+
+      test('does nothing when searchTerm is empty', () async {
+        await dataSource.deleteRecentProjectSearch(
+          userId: 'user-1',
+          searchTerm: '',
+        );
+
+        expect(supabaseWrapper.getMethodCallsFor('deleteMatch'), isEmpty);
+      });
+
+      test('does nothing when searchTerm is whitespace only', () async {
+        await dataSource.deleteRecentProjectSearch(
+          userId: 'user-1',
+          searchTerm: '   ',
+        );
+
+        expect(supabaseWrapper.getMethodCallsFor('deleteMatch'), isEmpty);
+      });
+
+      test('rethrows PostgrestException when deleteMatch throws', () async {
+        supabaseWrapper.shouldThrowOnDeleteMatch = true;
+        supabaseWrapper.deleteMatchExceptionType =
+            SupabaseExceptionType.postgrest;
+        supabaseWrapper.deleteMatchErrorMessage = 'DB error';
+
+        await expectLater(
+          () => dataSource.deleteRecentProjectSearch(
+            userId: 'user-1',
+            searchTerm: 'wall',
+          ),
+          throwsA(isA<supabase.PostgrestException>()),
+        );
+      });
+
+      test('rethrows SocketException when deleteMatch throws', () async {
+        supabaseWrapper.shouldThrowOnDeleteMatch = true;
+        supabaseWrapper.deleteMatchExceptionType =
+            SupabaseExceptionType.socket;
+        supabaseWrapper.deleteMatchErrorMessage = 'Network';
+
+        await expectLater(
+          () => dataSource.deleteRecentProjectSearch(
+            userId: 'user-1',
+            searchTerm: 'wall',
+          ),
+          throwsA(isA<SocketException>()),
+        );
+      });
+
+      test('rethrows TimeoutException when deleteMatch throws', () async {
+        supabaseWrapper.shouldThrowOnDeleteMatch = true;
+        supabaseWrapper.deleteMatchExceptionType =
+            SupabaseExceptionType.timeout;
+        supabaseWrapper.deleteMatchErrorMessage = 'Timeout';
+
+        await expectLater(
+          () => dataSource.deleteRecentProjectSearch(
+            userId: 'user-1',
+            searchTerm: 'wall',
+          ),
+          throwsA(isA<TimeoutException>()),
+        );
+      });
+    });
+
+    group('getProjectSearchSuggestions', () {
+      test('returns string suggestions from RPC, dropping non-strings', () async {
+        supabaseWrapper.setRpcResponse(
+          DatabaseConstants.projectSearchSuggestionsRpcFunction,
+          <dynamic>['foundation', 'wall', 42, null, 'steel'],
+        );
+
+        final result = await dataSource.getProjectSearchSuggestions(
+          userId: 'user-1',
+        );
+
+        expect(result, equals(['foundation', 'wall', 'steel']));
+
+        final calls = supabaseWrapper.getMethodCallsFor('rpc');
+        expect(calls, hasLength(1));
+        expect(
+          calls.first['functionName'] ?? calls.first['function'],
+          equals(DatabaseConstants.projectSearchSuggestionsRpcFunction),
+        );
+        final params = calls.first['params'] as Map<String, dynamic>?;
+        expect(params, isNotNull);
+        expect(
+          params![DatabaseConstants.projectSearchSuggestionsUserIdParam],
+          equals('user-1'),
+        );
+      });
+
+      test('returns empty list without calling RPC when userId is empty', () async {
+        final result = await dataSource.getProjectSearchSuggestions(
+          userId: '',
+        );
+
+        expect(result, isEmpty);
+        expect(supabaseWrapper.getMethodCallsFor('rpc'), isEmpty);
+      });
+
+      test(
+        'returns empty list without calling RPC when userId is whitespace only',
+        () async {
+          final result = await dataSource.getProjectSearchSuggestions(
+            userId: '   ',
+          );
+
+          expect(result, isEmpty);
+          expect(supabaseWrapper.getMethodCallsFor('rpc'), isEmpty);
+        },
+      );
+
+      test('rethrows PostgrestException when RPC throws', () async {
+        supabaseWrapper.shouldThrowOnRpc = true;
+        supabaseWrapper.rpcExceptionType = SupabaseExceptionType.postgrest;
+        supabaseWrapper.rpcErrorMessage = 'DB error';
+
+        await expectLater(
+          () => dataSource.getProjectSearchSuggestions(userId: 'user-1'),
+          throwsA(isA<supabase.PostgrestException>()),
+        );
+      });
+
+      test('rethrows TimeoutException when RPC throws', () async {
+        supabaseWrapper.shouldThrowOnRpc = true;
+        supabaseWrapper.rpcExceptionType = SupabaseExceptionType.timeout;
+        supabaseWrapper.rpcErrorMessage = 'Timeout';
+
+        await expectLater(
+          () => dataSource.getProjectSearchSuggestions(userId: 'user-1'),
+          throwsA(isA<TimeoutException>()),
+        );
+      });
+
+      test('rethrows SocketException when RPC throws', () async {
+        supabaseWrapper.shouldThrowOnRpc = true;
+        supabaseWrapper.rpcExceptionType = SupabaseExceptionType.socket;
+        supabaseWrapper.rpcErrorMessage = 'Network';
+
+        await expectLater(
+          () => dataSource.getProjectSearchSuggestions(userId: 'user-1'),
+          throwsA(isA<SocketException>()),
+        );
+      });
+    });
   });
 }

--- a/test/libraries/project/units/data/data_source/remote_project_search_data_source_test.dart
+++ b/test/libraries/project/units/data/data_source/remote_project_search_data_source_test.dart
@@ -668,7 +668,7 @@ void main() {
         final calls = supabaseWrapper.getMethodCallsFor('rpc');
         expect(calls, hasLength(1));
         expect(
-          calls.first['functionName'] ?? calls.first['function'],
+          calls.first['functionName'],
           equals(DatabaseConstants.projectSearchSuggestionsRpcFunction),
         );
         final params = calls.first['params'] as Map<String, dynamic>?;


### PR DESCRIPTION
## Summary

This PR extends `RemoteProjectSearchDataSource` with four history/suggestions methods, additive to the existing `fetchProjectsBySearchQuery`: `saveRecentProjectSearch` upserts into the `project_search_history` table; `getRecentProjectSearches` returns terms most-recent-first, capped client-side at `recentProjectSearchesMaxResults` (CA-722 tracks moving the cap to a DB-level `limit` once `SupabaseWrapper.selectMatch` supports one); `deleteRecentProjectSearch` removes a single term; `getProjectSearchSuggestions` calls the `get_project_search_suggestions` RPC. The corresponding `ProjectSearchDataSource` interface methods and `database_constants.dart` entries are added in lockstep — the interface and its sole implementer must change together for the build to compile, which is why this PR (not the repository layer) lands first in the stack. `project_search_history` is fully isolated from Global Search's `search_history` table; neither feature reads or writes the other's data. Re-lands work from CA-688 that was previously reviewed and merged into a sibling branch but never reached `main` (see the CA-688 comment for the root-cause writeup).

---

## Changes Overview

### Impact Stats

| Category | Value |
|---|---|
| **Total Additions** | 682 |
| **Total Deletions** | 0 |
| **Changed Files** | 4 |
| **Production Files (lib/)** | 3 (`project_search_data_source.dart`, `remote_project_search_data_source.dart`, `database_constants.dart`) |
| **Test Files** | 1 (`remote_project_search_data_source_test.dart`) |
| **Production Line Changes** | 221 (`project_search_data_source.dart`: 32, `remote_project_search_data_source.dart`: 163, `database_constants.dart`: 26) |
| **PR Size Classification** | **L** (200+ production lines) |

> Slightly over the 200-line **M** threshold (`skills/rules/01-digestible-pr.md`). The interface and its sole implementer are inseparable for compilation — extending the interface alone leaves `RemoteProjectSearchDataSource` as a non-abstract class missing 4 method implementations. Shipping as one cohesive PR rather than an artificially broken split.

---

### Rule-Based Review

| Rule | Status | Notes |
|------|--------|-------|
| **Rule 1** — Digestible PR | ⚠️ **Over M, justified** | 221 production lines. Cohesive, mechanical CRUD-style addition (4 methods following the exact pattern of the existing `fetchProjectsBySearchQuery` and `RemoteGlobalSearchDataSource`'s equivalent history methods); can't be split without an intermediate non-compiling commit. |
| **Rule 2** — Naming Conventions | ✅ **Pass** | `RemoteProjectSearchDataSource` keeps the `Remote` prefix; method names (`saveRecentProjectSearch`, `getRecentProjectSearches`, `deleteRecentProjectSearch`, `getProjectSearchSuggestions`) mirror `RemoteGlobalSearchDataSource`'s established naming for the same operations. No forbidden suffixes. |
| **Rule 3** — Test Double Pattern | ✅ **Pass** | Tests exercise the real `RemoteProjectSearchDataSource` against `FakeSupabaseWrapper` — no mocks. Each new method has a full rethrow matrix (Postgrest/Socket/Timeout) plus empty-input guard tests. |
| **Rule 6** — Stream Lifecycle | ✅ **N/A** | No `StreamController` or manual `.listen()` introduced. |
| **Rule 15** — Sentry Logging | ✅ **Pass** | New methods use `.warning()` for both `PostgrestException` and generic catch paths, consistent with the existing `fetchProjectsBySearchQuery` pattern and lower severity than the global-search equivalent's `.error()` — these are less-critical history-table operations. |