### PR TITLE
CA-688: feat: add history/suggestions methods to ProjectSearchRepository

### DIFF
--- a/lib/libraries/project/data/repositories/project_search_repository_impl.dart
+++ b/lib/libraries/project/data/repositories/project_search_repository_impl.dart
@@ -110,4 +110,88 @@ class ProjectSearchRepositoryImpl implements ProjectSearchRepository {
       return Left(_handleError(e, 'searching projects'));
     }
   }
+
+  @override
+  Future<Either<Failure, void>> saveRecentProjectSearch({
+    required String userId,
+    required String searchTerm,
+    bool hasResults = false,
+  }) async {
+    if (userId.trim().isEmpty || searchTerm.trim().isEmpty) {
+      return Right(null);
+    }
+
+    try {
+      _logger.debug(
+        'Saving recent project search: $searchTerm, hasResults: $hasResults',
+      );
+      await _dataSource.saveRecentProjectSearch(
+        userId: userId,
+        searchTerm: searchTerm,
+        hasResults: hasResults,
+      );
+      return Right(null);
+    } catch (e) {
+      return Left(_handleError(e, 'saving recent project search'));
+    }
+  }
+
+  @override
+  Future<Either<Failure, List<String>>> getRecentProjectSearches({
+    required String userId,
+  }) async {
+    if (userId.trim().isEmpty) {
+      return Right([]);
+    }
+
+    try {
+      _logger.debug('Fetching recent project searches for userId: $userId');
+      final terms = await _dataSource.getRecentProjectSearches(userId: userId);
+      _logger.debug('Fetched ${terms.length} recent project searches');
+      return Right(terms);
+    } catch (e) {
+      return Left(_handleError(e, 'fetching recent project searches'));
+    }
+  }
+
+  @override
+  Future<Either<Failure, void>> deleteRecentProjectSearch({
+    required String userId,
+    required String searchTerm,
+  }) async {
+    if (userId.trim().isEmpty || searchTerm.trim().isEmpty) {
+      return Right(null);
+    }
+
+    try {
+      _logger.debug('Deleting recent project search: $searchTerm');
+      await _dataSource.deleteRecentProjectSearch(
+        userId: userId,
+        searchTerm: searchTerm,
+      );
+      return Right(null);
+    } catch (e) {
+      return Left(_handleError(e, 'deleting recent project search'));
+    }
+  }
+
+  @override
+  Future<Either<Failure, List<String>>> getProjectSearchSuggestions({
+    required String userId,
+  }) async {
+    if (userId.trim().isEmpty) {
+      return Right([]);
+    }
+
+    try {
+      _logger.debug('Fetching project search suggestions for userId: $userId');
+      final suggestions = await _dataSource.getProjectSearchSuggestions(
+        userId: userId,
+      );
+      _logger.debug('Fetched ${suggestions.length} project search suggestions');
+      return Right(suggestions);
+    } catch (e) {
+      return Left(_handleError(e, 'fetching project search suggestions'));
+    }
+  }
 }

--- a/lib/libraries/project/data/repositories/project_search_repository_impl.dart
+++ b/lib/libraries/project/data/repositories/project_search_repository_impl.dart
@@ -63,7 +63,7 @@ class ProjectSearchRepositoryImpl implements ProjectSearchRepository {
       if (postgresErrorCode == PostgresErrorCode.connectionFailure ||
           postgresErrorCode == PostgresErrorCode.unableToConnect ||
           postgresErrorCode == PostgresErrorCode.connectionDoesNotExist) {
-        _logger.warning(
+        _logger.error(
           'PostgreSQL connection error $operation: '
           'code=${error.code}, message=${error.message}, '
           'details=${error.details}, hint=${error.hint}',
@@ -118,7 +118,7 @@ class ProjectSearchRepositoryImpl implements ProjectSearchRepository {
     bool hasResults = false,
   }) async {
     if (userId.trim().isEmpty || searchTerm.trim().isEmpty) {
-      return Right(null);
+      return const Right(null);
     }
 
     try {
@@ -130,7 +130,7 @@ class ProjectSearchRepositoryImpl implements ProjectSearchRepository {
         searchTerm: searchTerm,
         hasResults: hasResults,
       );
-      return Right(null);
+      return const Right(null);
     } catch (e) {
       return Left(_handleError(e, 'saving recent project search'));
     }
@@ -160,7 +160,7 @@ class ProjectSearchRepositoryImpl implements ProjectSearchRepository {
     required String searchTerm,
   }) async {
     if (userId.trim().isEmpty || searchTerm.trim().isEmpty) {
-      return Right(null);
+      return const Right(null);
     }
 
     try {
@@ -169,7 +169,7 @@ class ProjectSearchRepositoryImpl implements ProjectSearchRepository {
         userId: userId,
         searchTerm: searchTerm,
       );
-      return Right(null);
+      return const Right(null);
     } catch (e) {
       return Left(_handleError(e, 'deleting recent project search'));
     }

--- a/lib/libraries/project/domain/repositories/project_search_repository.dart
+++ b/lib/libraries/project/domain/repositories/project_search_repository.dart
@@ -22,4 +22,41 @@ abstract class ProjectSearchRepository {
     String? filterByTag,
     String? filterByOwner,
   });
+
+  /// Persists [searchTerm] as a recent project-search entry for [userId].
+  ///
+  /// [hasResults] should be `true` only when the caller has confirmed the
+  /// search returned at least one result. Repeat saves of the same term are
+  /// de-duplicated rather than creating multiple entries.
+  ///
+  /// Returns `Right` (void) when [userId] is empty or [searchTerm] is
+  /// empty/whitespace — no failure is raised for these inputs.
+  Future<Either<Failure, void>> saveRecentProjectSearch({
+    required String userId,
+    required String searchTerm,
+    bool hasResults = false,
+  });
+
+  /// Returns [userId]'s recent project-search terms, most recently used first.
+  ///
+  /// Returns `Right([])` when [userId] is empty.
+  Future<Either<Failure, List<String>>> getRecentProjectSearches({
+    required String userId,
+  });
+
+  /// Removes [searchTerm] from [userId]'s recent project-search history.
+  ///
+  /// Returns `Right` (void) when [userId] is empty or [searchTerm] is
+  /// empty/whitespace.
+  Future<Either<Failure, void>> deleteRecentProjectSearch({
+    required String userId,
+    required String searchTerm,
+  });
+
+  /// Returns up to 10 personalized project-search suggestion terms for [userId].
+  ///
+  /// Returns `Right([])` when [userId] is empty or no suggestions exist.
+  Future<Either<Failure, List<String>>> getProjectSearchSuggestions({
+    required String userId,
+  });
 }

--- a/lib/libraries/project/testing/fake_project_search_repository.dart
+++ b/lib/libraries/project/testing/fake_project_search_repository.dart
@@ -13,13 +13,48 @@ class FakeProjectSearchRepository implements ProjectSearchRepository {
 
   final List<Project> _searchResults = [];
 
+  /// Recent search terms returned by [getRecentProjectSearches] on success.
+  final List<String> _recentSearches = [];
+
+  /// Suggestion terms returned by [getProjectSearchSuggestions] on success.
+  final List<String> _suggestions = [];
+
   /// Controls whether [searchProjects] throws an exception.
   bool shouldThrowOnSearchProjects = false;
 
   /// Used to specify the type of exception thrown by [searchProjects].
   SupabaseExceptionType? searchProjectsExceptionType;
 
-  /// Used to specify the Postgres error code thrown by [searchProjects].
+  /// Controls whether [saveRecentProjectSearch] throws an exception.
+  bool shouldThrowOnSaveRecent = false;
+
+  /// Used to specify the type of exception thrown by
+  /// [saveRecentProjectSearch].
+  SupabaseExceptionType? saveRecentExceptionType;
+
+  /// Controls whether [getRecentProjectSearches] throws an exception.
+  bool shouldThrowOnGetRecent = false;
+
+  /// Used to specify the type of exception thrown by
+  /// [getRecentProjectSearches].
+  SupabaseExceptionType? getRecentExceptionType;
+
+  /// Controls whether [deleteRecentProjectSearch] throws an exception.
+  bool shouldThrowOnDeleteRecent = false;
+
+  /// Used to specify the type of exception thrown by
+  /// [deleteRecentProjectSearch].
+  SupabaseExceptionType? deleteRecentExceptionType;
+
+  /// Controls whether [getProjectSearchSuggestions] throws an exception.
+  bool shouldThrowOnGetSuggestions = false;
+
+  /// Used to specify the type of exception thrown by
+  /// [getProjectSearchSuggestions].
+  SupabaseExceptionType? getSuggestionsExceptionType;
+
+  /// Used to specify the Postgres error code shared across all configured
+  /// PostgrestException paths.
   PostgresErrorCode? postgrestErrorCode;
 
   /// Controls whether operations should be delayed.
@@ -57,14 +92,116 @@ class FakeProjectSearchRepository implements ProjectSearchRepository {
     }
 
     if (shouldThrowOnSearchProjects) {
-      return Left(_failureForConfiguredException());
+      return Left(_failureForConfiguredException(searchProjectsExceptionType));
     }
 
     return Right(List<Project>.from(_searchResults));
   }
 
-  Failure _failureForConfiguredException() {
-    switch (searchProjectsExceptionType) {
+  @override
+  Future<Either<Failure, void>> saveRecentProjectSearch({
+    required String userId,
+    required String searchTerm,
+    bool hasResults = false,
+  }) async {
+    if (shouldDelayOperations) {
+      await completer?.future;
+    }
+
+    _methodCalls.add({
+      'method': 'saveRecentProjectSearch',
+      'userId': userId,
+      'searchTerm': searchTerm,
+      'hasResults': hasResults,
+    });
+
+    if (userId.trim().isEmpty || searchTerm.trim().isEmpty) {
+      return Right(null);
+    }
+
+    if (shouldThrowOnSaveRecent) {
+      return Left(_failureForConfiguredException(saveRecentExceptionType));
+    }
+
+    return Right(null);
+  }
+
+  @override
+  Future<Either<Failure, List<String>>> getRecentProjectSearches({
+    required String userId,
+  }) async {
+    if (shouldDelayOperations) {
+      await completer?.future;
+    }
+
+    _methodCalls.add({
+      'method': 'getRecentProjectSearches',
+      'userId': userId,
+    });
+
+    if (userId.trim().isEmpty) {
+      return Right([]);
+    }
+
+    if (shouldThrowOnGetRecent) {
+      return Left(_failureForConfiguredException(getRecentExceptionType));
+    }
+
+    return Right(List<String>.from(_recentSearches));
+  }
+
+  @override
+  Future<Either<Failure, void>> deleteRecentProjectSearch({
+    required String userId,
+    required String searchTerm,
+  }) async {
+    if (shouldDelayOperations) {
+      await completer?.future;
+    }
+
+    _methodCalls.add({
+      'method': 'deleteRecentProjectSearch',
+      'userId': userId,
+      'searchTerm': searchTerm,
+    });
+
+    if (userId.trim().isEmpty || searchTerm.trim().isEmpty) {
+      return Right(null);
+    }
+
+    if (shouldThrowOnDeleteRecent) {
+      return Left(_failureForConfiguredException(deleteRecentExceptionType));
+    }
+
+    return Right(null);
+  }
+
+  @override
+  Future<Either<Failure, List<String>>> getProjectSearchSuggestions({
+    required String userId,
+  }) async {
+    if (shouldDelayOperations) {
+      await completer?.future;
+    }
+
+    _methodCalls.add({
+      'method': 'getProjectSearchSuggestions',
+      'userId': userId,
+    });
+
+    if (userId.trim().isEmpty) {
+      return Right([]);
+    }
+
+    if (shouldThrowOnGetSuggestions) {
+      return Left(_failureForConfiguredException(getSuggestionsExceptionType));
+    }
+
+    return Right(List<String>.from(_suggestions));
+  }
+
+  Failure _failureForConfiguredException(SupabaseExceptionType? type) {
+    switch (type) {
       case SupabaseExceptionType.timeout:
         return SearchFailure(errorType: SearchErrorType.timeoutError);
       case SupabaseExceptionType.socket:
@@ -95,6 +232,20 @@ class FakeProjectSearchRepository implements ProjectSearchRepository {
       ..addAll(projects);
   }
 
+  /// Sets the terms returned by [getRecentProjectSearches] on success.
+  void setRecentSearches(List<String> terms) {
+    _recentSearches
+      ..clear()
+      ..addAll(terms);
+  }
+
+  /// Sets the terms returned by [getProjectSearchSuggestions] on success.
+  void setSuggestions(List<String> terms) {
+    _suggestions
+      ..clear()
+      ..addAll(terms);
+  }
+
   /// Returns a list of all method calls.
   List<Map<String, dynamic>> getMethodCalls() => List.from(_methodCalls);
 
@@ -118,10 +269,20 @@ class FakeProjectSearchRepository implements ProjectSearchRepository {
   void reset() {
     shouldThrowOnSearchProjects = false;
     searchProjectsExceptionType = null;
+    shouldThrowOnSaveRecent = false;
+    saveRecentExceptionType = null;
+    shouldThrowOnGetRecent = false;
+    getRecentExceptionType = null;
+    shouldThrowOnDeleteRecent = false;
+    deleteRecentExceptionType = null;
+    shouldThrowOnGetSuggestions = false;
+    getSuggestionsExceptionType = null;
     postgrestErrorCode = null;
     shouldDelayOperations = false;
     completer = null;
     _searchResults.clear();
+    _recentSearches.clear();
+    _suggestions.clear();
     _methodCalls.clear();
   }
 }

--- a/test/libraries/project/units/data/repositories/project_search_repository_impl_test.dart
+++ b/test/libraries/project/units/data/repositories/project_search_repository_impl_test.dart
@@ -443,5 +443,455 @@ void main() {
         },
       );
     });
+
+    // -----------------------------------------------------------------------
+    // Shared error-matrix scenarios — used by all four history/suggestion
+    // methods. Each scenario configures the FakeSupabaseWrapper and asserts
+    // the mapped Failure on the Either<Left>.
+    // -----------------------------------------------------------------------
+
+    void configureWrapperToThrowOn({
+      required FakeSupabaseWrapper wrapper,
+      required _WrapperOp op,
+      required SupabaseExceptionType type,
+      PostgresErrorCode? postgresCode,
+    }) {
+      switch (op) {
+        case _WrapperOp.rpc:
+          wrapper.shouldThrowOnRpc = true;
+          wrapper.rpcExceptionType = type;
+          wrapper.rpcErrorMessage = 'rpc error';
+        case _WrapperOp.upsert:
+          wrapper.shouldThrowOnUpsert = true;
+          wrapper.upsertExceptionType = type;
+          wrapper.upsertErrorMessage = 'upsert error';
+        case _WrapperOp.selectMatch:
+          wrapper.shouldThrowOnSelectMatch = true;
+          wrapper.selectMatchExceptionType = type;
+          wrapper.selectMatchErrorMessage = 'select error';
+        case _WrapperOp.deleteMatch:
+          wrapper.shouldThrowOnDeleteMatch = true;
+          wrapper.deleteMatchExceptionType = type;
+          wrapper.deleteMatchErrorMessage = 'delete error';
+      }
+      wrapper.postgrestErrorCode = postgresCode;
+    }
+
+    /// Asserts that [action] maps the given thrown exception to [expected].
+    Future<void> assertMappedFailure({
+      required _WrapperOp op,
+      required SupabaseExceptionType throwType,
+      PostgresErrorCode? postgresCode,
+      required Future<Either<Failure, Object?>> Function() action,
+      required Failure expected,
+    }) async {
+      configureWrapperToThrowOn(
+        wrapper: fakeSupabaseWrapper,
+        op: op,
+        type: throwType,
+        postgresCode: postgresCode,
+      );
+      final result = await action();
+      _expectLeft(result, (failure) => expect(failure, expected));
+    }
+
+    /// Runs the full _handleError matrix against [action].
+    void runErrorMatrix({
+      required String label,
+      required _WrapperOp op,
+      required Future<Either<Failure, Object?>> Function() action,
+    }) {
+      test('$label — TimeoutException → timeoutError failure', () async {
+        await assertMappedFailure(
+          op: op,
+          throwType: SupabaseExceptionType.timeout,
+          action: action,
+          expected: SearchFailure(errorType: SearchErrorType.timeoutError),
+        );
+      });
+
+      test('$label — SocketException → connectionError failure', () async {
+        await assertMappedFailure(
+          op: op,
+          throwType: SupabaseExceptionType.socket,
+          action: action,
+          expected: SearchFailure(errorType: SearchErrorType.connectionError),
+        );
+      });
+
+      test('$label — TypeError → parsingError failure', () async {
+        await assertMappedFailure(
+          op: op,
+          throwType: SupabaseExceptionType.type,
+          action: action,
+          expected: SearchFailure(errorType: SearchErrorType.parsingError),
+        );
+      });
+
+      test(
+        '$label — PostgrestException(noDataFound) → notFoundError failure',
+        () async {
+          await assertMappedFailure(
+            op: op,
+            throwType: SupabaseExceptionType.postgrest,
+            postgresCode: PostgresErrorCode.noDataFound,
+            action: action,
+            expected: SearchFailure(errorType: SearchErrorType.notFoundError),
+          );
+        },
+      );
+
+      test(
+        '$label — PostgrestException(connectionFailure) → connectionError failure',
+        () async {
+          await assertMappedFailure(
+            op: op,
+            throwType: SupabaseExceptionType.postgrest,
+            postgresCode: PostgresErrorCode.connectionFailure,
+            action: action,
+            expected: SearchFailure(
+              errorType: SearchErrorType.connectionError,
+            ),
+          );
+        },
+      );
+
+      test(
+        '$label — PostgrestException(unableToConnect) → connectionError failure',
+        () async {
+          await assertMappedFailure(
+            op: op,
+            throwType: SupabaseExceptionType.postgrest,
+            postgresCode: PostgresErrorCode.unableToConnect,
+            action: action,
+            expected: SearchFailure(
+              errorType: SearchErrorType.connectionError,
+            ),
+          );
+        },
+      );
+
+      test(
+        '$label — PostgrestException(connectionDoesNotExist) → connectionError failure',
+        () async {
+          await assertMappedFailure(
+            op: op,
+            throwType: SupabaseExceptionType.postgrest,
+            postgresCode: PostgresErrorCode.connectionDoesNotExist,
+            action: action,
+            expected: SearchFailure(
+              errorType: SearchErrorType.connectionError,
+            ),
+          );
+        },
+      );
+
+      test(
+        '$label — PostgrestException(unhandled code) → unexpectedDatabaseError failure',
+        () async {
+          await assertMappedFailure(
+            op: op,
+            throwType: SupabaseExceptionType.postgrest,
+            postgresCode: PostgresErrorCode.uniqueViolation,
+            action: action,
+            expected: SearchFailure(
+              errorType: SearchErrorType.unexpectedDatabaseError,
+            ),
+          );
+        },
+      );
+
+      test('$label — unknown error → UnexpectedFailure', () async {
+        configureWrapperToThrowOn(
+          wrapper: fakeSupabaseWrapper,
+          op: op,
+          type: SupabaseExceptionType.unknown,
+        );
+        final result = await action();
+        _expectLeft(
+          result,
+          (failure) => expect(failure, isA<UnexpectedFailure>()),
+        );
+      });
+    }
+
+    group('saveRecentProjectSearch', () {
+      test('returns Right(null) on success and upserts via wrapper', () async {
+        final result = await repository.saveRecentProjectSearch(
+          userId: testUserId,
+          searchTerm: 'foundation',
+          hasResults: true,
+        );
+
+        expect(result.isRight(), isTrue);
+        expect(fakeSupabaseWrapper.getMethodCallsFor('upsert'), hasLength(1));
+      });
+
+      test('returns Right(null) without upsert when userId is empty', () async {
+        final result = await repository.saveRecentProjectSearch(
+          userId: '',
+          searchTerm: 'foundation',
+        );
+
+        expect(result.isRight(), isTrue);
+        expect(fakeSupabaseWrapper.getMethodCallsFor('upsert'), isEmpty);
+      });
+
+      test(
+        'returns Right(null) without upsert when userId is whitespace only',
+        () async {
+          final result = await repository.saveRecentProjectSearch(
+            userId: '   ',
+            searchTerm: 'foundation',
+          );
+
+          expect(result.isRight(), isTrue);
+          expect(fakeSupabaseWrapper.getMethodCallsFor('upsert'), isEmpty);
+        },
+      );
+
+      test(
+        'returns Right(null) without upsert when searchTerm is empty',
+        () async {
+          final result = await repository.saveRecentProjectSearch(
+            userId: testUserId,
+            searchTerm: '',
+          );
+
+          expect(result.isRight(), isTrue);
+          expect(fakeSupabaseWrapper.getMethodCallsFor('upsert'), isEmpty);
+        },
+      );
+
+      test(
+        'returns Right(null) without upsert when searchTerm is whitespace only',
+        () async {
+          final result = await repository.saveRecentProjectSearch(
+            userId: testUserId,
+            searchTerm: '   ',
+          );
+
+          expect(result.isRight(), isTrue);
+          expect(fakeSupabaseWrapper.getMethodCallsFor('upsert'), isEmpty);
+        },
+      );
+
+      runErrorMatrix(
+        label: 'saveRecentProjectSearch',
+        op: _WrapperOp.upsert,
+        action: () => repository.saveRecentProjectSearch(
+          userId: testUserId,
+          searchTerm: 'wall',
+        ),
+      );
+    });
+
+    group('getRecentProjectSearches', () {
+      test('returns Right with terms in wrapper order on success', () async {
+        fakeSupabaseWrapper.addTableData(
+          DatabaseConstants.projectSearchHistoryTable,
+          [
+            {
+              DatabaseConstants.userIdColumn: testUserId,
+              DatabaseConstants.searchTermColumn: 'older',
+              DatabaseConstants.updatedAtColumn: '2024-01-01T00:00:00.000Z',
+            },
+            {
+              DatabaseConstants.userIdColumn: testUserId,
+              DatabaseConstants.searchTermColumn: 'newer',
+              DatabaseConstants.updatedAtColumn: '2024-06-01T00:00:00.000Z',
+            },
+          ],
+        );
+
+        final result = await repository.getRecentProjectSearches(
+          userId: testUserId,
+        );
+
+        expect(result.isRight(), isTrue);
+        _expectRight(
+          result,
+          (terms) => expect(terms, equals(['newer', 'older'])),
+        );
+      });
+
+      test(
+        'returns Right([]) without selectMatch when userId is empty',
+        () async {
+          final result = await repository.getRecentProjectSearches(userId: '');
+
+          expect(result.isRight(), isTrue);
+          _expectRight(result, (terms) => expect(terms, isEmpty));
+          expect(
+            fakeSupabaseWrapper.getMethodCallsFor('selectMatch'),
+            isEmpty,
+          );
+        },
+      );
+
+      test(
+        'returns Right([]) without selectMatch when userId is whitespace only',
+        () async {
+          final result = await repository.getRecentProjectSearches(
+            userId: '   ',
+          );
+
+          expect(result.isRight(), isTrue);
+          _expectRight(result, (terms) => expect(terms, isEmpty));
+          expect(
+            fakeSupabaseWrapper.getMethodCallsFor('selectMatch'),
+            isEmpty,
+          );
+        },
+      );
+
+      runErrorMatrix(
+        label: 'getRecentProjectSearches',
+        op: _WrapperOp.selectMatch,
+        action: () => repository.getRecentProjectSearches(userId: testUserId),
+      );
+    });
+
+    group('deleteRecentProjectSearch', () {
+      test('returns Right(null) on success and deletes via wrapper', () async {
+        final result = await repository.deleteRecentProjectSearch(
+          userId: testUserId,
+          searchTerm: 'wall',
+        );
+
+        expect(result.isRight(), isTrue);
+        expect(
+          fakeSupabaseWrapper.getMethodCallsFor('deleteMatch'),
+          hasLength(1),
+        );
+      });
+
+      test(
+        'returns Right(null) without delete when userId is empty',
+        () async {
+          final result = await repository.deleteRecentProjectSearch(
+            userId: '',
+            searchTerm: 'wall',
+          );
+
+          expect(result.isRight(), isTrue);
+          expect(
+            fakeSupabaseWrapper.getMethodCallsFor('deleteMatch'),
+            isEmpty,
+          );
+        },
+      );
+
+      test(
+        'returns Right(null) without delete when userId is whitespace only',
+        () async {
+          final result = await repository.deleteRecentProjectSearch(
+            userId: '   ',
+            searchTerm: 'wall',
+          );
+
+          expect(result.isRight(), isTrue);
+          expect(
+            fakeSupabaseWrapper.getMethodCallsFor('deleteMatch'),
+            isEmpty,
+          );
+        },
+      );
+
+      test(
+        'returns Right(null) without delete when searchTerm is empty',
+        () async {
+          final result = await repository.deleteRecentProjectSearch(
+            userId: testUserId,
+            searchTerm: '',
+          );
+
+          expect(result.isRight(), isTrue);
+          expect(
+            fakeSupabaseWrapper.getMethodCallsFor('deleteMatch'),
+            isEmpty,
+          );
+        },
+      );
+
+      test(
+        'returns Right(null) without delete when searchTerm is whitespace only',
+        () async {
+          final result = await repository.deleteRecentProjectSearch(
+            userId: testUserId,
+            searchTerm: '   ',
+          );
+
+          expect(result.isRight(), isTrue);
+          expect(
+            fakeSupabaseWrapper.getMethodCallsFor('deleteMatch'),
+            isEmpty,
+          );
+        },
+      );
+
+      runErrorMatrix(
+        label: 'deleteRecentProjectSearch',
+        op: _WrapperOp.deleteMatch,
+        action: () => repository.deleteRecentProjectSearch(
+          userId: testUserId,
+          searchTerm: 'wall',
+        ),
+      );
+    });
+
+    group('getProjectSearchSuggestions', () {
+      test('returns Right with string suggestions on success', () async {
+        fakeSupabaseWrapper.setRpcResponse(
+          DatabaseConstants.projectSearchSuggestionsRpcFunction,
+          <dynamic>['foundation', 'wall', 42, null, 'steel'],
+        );
+
+        final result = await repository.getProjectSearchSuggestions(
+          userId: testUserId,
+        );
+
+        expect(result.isRight(), isTrue);
+        _expectRight(
+          result,
+          (terms) => expect(terms, equals(['foundation', 'wall', 'steel'])),
+        );
+      });
+
+      test(
+        'returns Right([]) without RPC when userId is empty',
+        () async {
+          final result = await repository.getProjectSearchSuggestions(
+            userId: '',
+          );
+
+          expect(result.isRight(), isTrue);
+          _expectRight(result, (terms) => expect(terms, isEmpty));
+          expect(fakeSupabaseWrapper.getMethodCallsFor('rpc'), isEmpty);
+        },
+      );
+
+      test(
+        'returns Right([]) without RPC when userId is whitespace only',
+        () async {
+          final result = await repository.getProjectSearchSuggestions(
+            userId: '   ',
+          );
+
+          expect(result.isRight(), isTrue);
+          _expectRight(result, (terms) => expect(terms, isEmpty));
+          expect(fakeSupabaseWrapper.getMethodCallsFor('rpc'), isEmpty);
+        },
+      );
+
+      runErrorMatrix(
+        label: 'getProjectSearchSuggestions',
+        op: _WrapperOp.rpc,
+        action: () =>
+            repository.getProjectSearchSuggestions(userId: testUserId),
+      );
+    });
   });
 }
+
+enum _WrapperOp { rpc, upsert, selectMatch, deleteMatch }


### PR DESCRIPTION
## Summary

This PR extends `ProjectSearchRepositoryImpl` with `saveRecentProjectSearch`, `getRecentProjectSearches`, `deleteRecentProjectSearch`, and `getProjectSearchSuggestions`, additive to the existing `searchProjects` and consuming the datasource methods landed in #386. Error mapping reuses the existing `_handleError` pattern (Timeout/Socket/TypeError/PostgrestException → typed `SearchFailure`), mirroring `GlobalSearchRepositoryImpl`'s equivalent. `FakeProjectSearchRepository` is extended to mirror the real implementation's empty-input guards, with per-method `shouldThrowOn*`/`*ExceptionType` configuration fields so tests can target failures precisely. Re-lands work from CA-688 that was previously reviewed and merged into a sibling branch but never reached `main`.

---

## Changes Overview

### Impact Stats

| Category | Value |
|---|---|
| **Total Additions** | 736 |
| **Total Deletions** | 4 |
| **Changed Files** | 4 |
| **Production Files (lib/)** | 3 (`project_search_repository_impl.dart`, `project_search_repository.dart`, `fake_project_search_repository.dart`) |
| **Test Files** | 1 (`project_search_repository_impl_test.dart`) |
| **Production Line Changes** | 121 cap-relevant (`project_search_repository_impl.dart`: 84, `project_search_repository.dart`: 37) + 165 in `fake_project_search_repository.dart` (test-double infrastructure, excluded from size classification) |
| **PR Size Classification** | **M** (100–200 production lines) |

> `fake_project_search_repository.dart` lives under `testing/` and mirrors the interface 1:1 — treated as test infrastructure, not hand-designed business logic, consistent with how test files are excluded from `skills/rules/01-digestible-pr.md`'s line count.

---

### Rule-Based Review

| Rule | Status | Notes |
|------|--------|-------|
| **Rule 1** — Digestible PR | ✅ **Pass** | **M** size on cap-relevant production code. Single clear purpose — repository-layer history/suggestions methods consuming #386. |
| **Rule 2** — Naming Conventions | ✅ **Pass** | `ProjectSearchRepository`/`ProjectSearchRepositoryImpl` keep the established `Repository`/`RepositoryImpl` suffix pair. Method names match the datasource layer 1:1. No forbidden suffixes. |
| **Rule 3** — Test Double Pattern | ✅ **Pass** | Tests exercise the real `ProjectSearchRepositoryImpl` → real `RemoteProjectSearchDataSource` against `FakeSupabaseWrapper` — no mocks. A shared `runErrorMatrix` helper (mirroring `GlobalSearchRepositoryImpl`'s test pattern) exercises every `_handleError` branch per method without duplicating boilerplate. |
| **Rule 5** — UI/Business Separation | ✅ **N/A** | No presentation-layer code introduced. |
| **Rule 6** — Stream Lifecycle | ✅ **N/A** | No `StreamController` or manual `.listen()` introduced. |