### PR TITLE
CA-224: feat: implement ProjectSearchBloc with history and suggestions

### DIFF
--- a/lib/features/dashboard/dashboard_module.dart
+++ b/lib/features/dashboard/dashboard_module.dart
@@ -1,5 +1,6 @@
 import 'package:construculator/app/app_bootstrap.dart';
 import 'package:construculator/features/dashboard/presentation/bloc/dashboard_bloc/dashboard_bloc.dart';
+import 'package:construculator/features/dashboard/presentation/bloc/project_search_bloc/project_search_bloc.dart';
 import 'package:construculator/libraries/auth/auth_library_module.dart';
 import 'package:construculator/libraries/project/project_library_module.dart';
 import 'package:construculator/libraries/router/router_module.dart';
@@ -25,6 +26,9 @@ class DashboardModule extends Module {
         authNotifier: i(),
         authManager: i(),
       ),
+    );
+    i.add<ProjectSearchBloc>(
+      () => ProjectSearchBloc(repository: i(), authManager: i()),
     );
   }
 }

--- a/lib/features/dashboard/presentation/bloc/project_search_bloc/project_search_bloc.dart
+++ b/lib/features/dashboard/presentation/bloc/project_search_bloc/project_search_bloc.dart
@@ -1,0 +1,299 @@
+import 'dart:async';
+
+import 'package:construculator/libraries/auth/domain/types/auth_types.dart';
+import 'package:construculator/libraries/auth/interfaces/auth_manager.dart';
+import 'package:construculator/libraries/errors/failures.dart';
+import 'package:construculator/libraries/logging/app_logger.dart';
+import 'package:construculator/libraries/project/domain/entities/project_entity.dart';
+import 'package:construculator/libraries/project/domain/repositories/project_search_repository.dart';
+import 'package:equatable/equatable.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:rxdart/rxdart.dart';
+
+part 'project_search_event.dart';
+part 'project_search_state.dart';
+
+const Duration _kQueryDebounceDuration = Duration(milliseconds: 300);
+
+/// Upper bound on the cached recents list to prevent unbounded growth.
+const int _kMaxCachedRecents = 20;
+
+/// Maximum number of suggestions shown for a given query. The raw list
+/// fetched from the repository may be longer; the cap keeps the dropdown
+/// short, matching Global Search's `_kMaxDisplayedSuggestions`.
+const int _kMaxDisplayedSuggestions = 5;
+
+EventTransformer<E> _debounce<E>(Duration duration) =>
+    (events, mapper) => events.debounceTime(duration).switchMap(mapper);
+
+/// BLoC for managing project search state on the dashboard.
+///
+/// Handles debounced query updates and explicit search submissions, plus the
+/// recent-searches and suggestions surfaces shown on the idle state.
+/// Delegates to [ProjectSearchRepository] and maps results to typed states.
+class ProjectSearchBloc extends Bloc<ProjectSearchEvent, ProjectSearchState> {
+  final ProjectSearchRepository _repository;
+  final AuthManager _authManager;
+  static final _logger = AppLogger().tag('ProjectSearchBloc');
+
+  List<String> _cachedRecents = const [];
+  List<String> _cachedSuggestions = const [];
+  String _currentQuery = '';
+
+  // Whether _cachedSuggestions has been fetched at least once for the
+  // current page session, so subsequent keystrokes only re-filter locally
+  // instead of re-fetching from the repository.
+  bool _suggestionsFetched = false;
+
+  /// Exposed for testing only — resolves when the last save-after-search
+  /// completes, allowing tests to await it instead of using wall-clock waits.
+  @visibleForTesting
+  Future<void>? lastSaveCompleted;
+
+  /// Creates a [ProjectSearchBloc] with the given [repository] and [authManager].
+  ProjectSearchBloc({
+    required ProjectSearchRepository repository,
+    required AuthManager authManager,
+  }) : _repository = repository,
+       _authManager = authManager,
+       super(const ProjectSearchInitial()) {
+    on<ProjectSearchQueryUpdatedEvent>(
+      (event, emit) => _handleQuery(event.query, emit),
+      transformer: _debounce(_kQueryDebounceDuration),
+    );
+    on<ProjectSearchPerformedEvent>(_onPerformed);
+    on<ProjectSearchHistoryRequestedEvent>(_onHistoryRequested);
+    on<ProjectSearchHistoryItemDismissedEvent>(_onHistoryItemDismissed);
+  }
+
+  Future<void> _handleQuery(
+    String query,
+    Emitter<ProjectSearchState> emit,
+  ) async {
+    _currentQuery = query;
+
+    if (query.isEmpty) {
+      // Clearing the field restores the history surface rather than blanking it.
+      emit(_initialFromCache());
+      return;
+    }
+
+    // Typing filters the suggestions surface locally; it does not trigger a
+    // live remote search. ProjectSearchPerformedEvent (submit) does that.
+    if (!_suggestionsFetched) {
+      await _fetchAndEmitSuggestions(emit);
+      return;
+    }
+
+    emit(_initialFromCache());
+  }
+
+  Future<void> _fetchAndEmitSuggestions(Emitter<ProjectSearchState> emit) async {
+    final userId = _authManager.getCurrentCredentials().data?.id;
+    if (userId == null || userId.isEmpty) {
+      _logger.warning('Suggestions fetch aborted: no authenticated user');
+      emit(_initialFromCache());
+      return;
+    }
+
+    emit(_initialFromCache(suggestionsLoading: true));
+
+    final result = await _repository.getProjectSearchSuggestions(
+      userId: userId,
+    );
+    result.fold(
+      (failure) => _logger.warning(
+        'Failed to load project search suggestions: $failure',
+      ),
+      (suggestions) {
+        _cachedSuggestions = suggestions;
+        _suggestionsFetched = true;
+      },
+    );
+
+    emit(_initialFromCache());
+  }
+
+  // Filters _cachedSuggestions to terms that start with [query]
+  // (case-insensitive) and caps the result at _kMaxDisplayedSuggestions.
+  List<String> _filterSuggestions(String query) {
+    if (query.isEmpty) return const [];
+    final lower = query.toLowerCase();
+    return _cachedSuggestions
+        .where((s) => s.toLowerCase().startsWith(lower))
+        .take(_kMaxDisplayedSuggestions)
+        .toList();
+  }
+
+  Future<void> _onPerformed(
+    ProjectSearchPerformedEvent event,
+    Emitter<ProjectSearchState> emit,
+  ) async {
+    if (event.query.trim().isEmpty) {
+      emit(const ProjectSearchInitial());
+      return;
+    }
+    await _executeSearch(event.query, emit);
+  }
+
+  Future<void> _onHistoryRequested(
+    ProjectSearchHistoryRequestedEvent event,
+    Emitter<ProjectSearchState> emit,
+  ) async {
+    // Reset per-session suggestion state — a fresh page open re-fetches
+    // suggestions lazily on the user's first keystroke, matching Global
+    // Search's GlobalSearchStarted behavior.
+    _currentQuery = '';
+    _cachedSuggestions = const [];
+    _suggestionsFetched = false;
+
+    final userId = _authManager.getCurrentCredentials().data?.id;
+    if (userId == null || userId.isEmpty) {
+      _logger.warning('History request aborted: no authenticated user');
+      emit(const ProjectSearchInitial());
+      return;
+    }
+
+    emit(
+      ProjectSearchInitial(recentSearches: _cachedRecents, isLoadingHistory: true),
+    );
+
+    final result = await _repository.getRecentProjectSearches(userId: userId);
+
+    // On failure, keep the previously cached value so a transient network
+    // hiccup does not blank the history surface.
+    _cachedRecents = result.fold<List<String>>(
+      (failure) {
+        _logger.warning('Failed to load recent project searches: $failure');
+        return _cachedRecents;
+      },
+      (terms) => terms,
+    );
+
+    emit(_initialFromCache());
+  }
+
+  Future<void> _onHistoryItemDismissed(
+    ProjectSearchHistoryItemDismissedEvent event,
+    Emitter<ProjectSearchState> emit,
+  ) async {
+    final userId = _authManager.getCurrentCredentials().data?.id;
+    if (userId == null || userId.isEmpty) {
+      _logger.warning('History dismiss aborted: no authenticated user');
+      return;
+    }
+
+    final result = await _repository.deleteRecentProjectSearch(
+      userId: userId,
+      searchTerm: event.searchTerm,
+    );
+
+    result.fold(
+      (failure) {
+        _logger.warning(
+          'Failed to delete recent project search "${event.searchTerm}": $failure',
+        );
+      },
+      (_) => _removeDismissedTermAndEmit(event.searchTerm, emit),
+    );
+  }
+
+  void _removeDismissedTermAndEmit(
+    String searchTerm,
+    Emitter<ProjectSearchState> emit,
+  ) {
+    final normalized = searchTerm.toLowerCase().trim();
+    _cachedRecents = _cachedRecents
+        .where((term) => term.toLowerCase().trim() != normalized)
+        .toList(growable: false);
+    if (state is ProjectSearchInitial) {
+      emit(_initialFromCache());
+    }
+  }
+
+  Future<void> _executeSearch(
+    String query,
+    Emitter<ProjectSearchState> emit,
+  ) async {
+    final userId = _authManager.getCurrentCredentials().data?.id;
+    if (userId == null || userId.isEmpty) {
+      _logger.warning('Project search aborted: no authenticated user');
+      emit(
+        ProjectSearchFailureState(
+          failure: const AuthFailure(errorType: AuthErrorType.userNotFound),
+          query: query,
+        ),
+      );
+      return;
+    }
+
+    emit(ProjectSearchLoading(query: query));
+
+    final result = await _repository.searchProjects(
+      userId: userId,
+      query: query,
+    );
+
+    result.fold(
+      (failure) {
+        _logger.warning('Project search failed: $failure');
+        emit(ProjectSearchFailureState(failure: failure, query: query));
+        // Skip history save on failure — backend has_results contract requires
+        // a confirmed result set.
+      },
+      (projects) {
+        emit(ProjectSearchResultsLoaded(results: projects, query: query));
+        lastSaveCompleted = _saveSearchToHistory(
+          userId: userId,
+          query: query,
+          hasResults: projects.isNotEmpty,
+        );
+        unawaited(lastSaveCompleted!);
+      },
+    );
+  }
+
+  Future<void> _saveSearchToHistory({
+    required String userId,
+    required String query,
+    required bool hasResults,
+  }) async {
+    final saveResult = await _repository.saveRecentProjectSearch(
+      userId: userId,
+      searchTerm: query,
+      hasResults: hasResults,
+    );
+    saveResult.fold(
+      (failure) {
+        _logger.warning(
+          'Failed to save recent project search "$query": $failure',
+        );
+      },
+      (_) {
+        // Cache stores terms normalised to lowercase; repository receives the original-case query.
+        final normalized = query.toLowerCase().trim();
+        if (normalized.isEmpty) return;
+        final updated = <String>[
+          normalized,
+          ..._cachedRecents.where(
+            (term) => term.toLowerCase().trim() != normalized,
+          ),
+        ];
+        if (updated.length > _kMaxCachedRecents) {
+          _cachedRecents = updated.sublist(0, _kMaxCachedRecents);
+        } else {
+          _cachedRecents = updated;
+        }
+      },
+    );
+  }
+
+  ProjectSearchInitial _initialFromCache({bool suggestionsLoading = false}) =>
+      ProjectSearchInitial(
+        recentSearches: _cachedRecents,
+        suggestions: _filterSuggestions(_currentQuery),
+        query: _currentQuery,
+        suggestionsLoading: suggestionsLoading,
+      );
+}

--- a/lib/features/dashboard/presentation/bloc/project_search_bloc/project_search_bloc.dart
+++ b/lib/features/dashboard/presentation/bloc/project_search_bloc/project_search_bloc.dart
@@ -16,12 +16,8 @@ part 'project_search_state.dart';
 
 const Duration _kQueryDebounceDuration = Duration(milliseconds: 300);
 
-/// Upper bound on the cached recents list to prevent unbounded growth.
 const int _kMaxCachedRecents = 20;
 
-/// Maximum number of suggestions shown for a given query. The raw list
-/// fetched from the repository may be longer; the cap keeps the dropdown
-/// short, matching Global Search's `_kMaxDisplayedSuggestions`.
 const int _kMaxDisplayedSuggestions = 5;
 
 EventTransformer<E> _debounce<E>(Duration duration) =>
@@ -41,9 +37,6 @@ class ProjectSearchBloc extends Bloc<ProjectSearchEvent, ProjectSearchState> {
   List<String> _cachedSuggestions = const [];
   String _currentQuery = '';
 
-  // Whether _cachedSuggestions has been fetched at least once for the
-  // current page session, so subsequent keystrokes only re-filter locally
-  // instead of re-fetching from the repository.
   bool _suggestionsFetched = false;
 
   /// Exposed for testing only — resolves when the last save-after-search
@@ -115,8 +108,6 @@ class ProjectSearchBloc extends Bloc<ProjectSearchEvent, ProjectSearchState> {
     emit(_initialFromCache());
   }
 
-  // Filters _cachedSuggestions to terms that start with [query]
-  // (case-insensitive) and caps the result at _kMaxDisplayedSuggestions.
   List<String> _filterSuggestions(String query) {
     if (query.isEmpty) return const [];
     final lower = query.toLowerCase();

--- a/lib/features/dashboard/presentation/bloc/project_search_bloc/project_search_bloc.dart
+++ b/lib/features/dashboard/presentation/bloc/project_search_bloc/project_search_bloc.dart
@@ -237,12 +237,13 @@ class ProjectSearchBloc extends Bloc<ProjectSearchEvent, ProjectSearchState> {
       },
       (projects) {
         emit(ProjectSearchResultsLoaded(results: projects, query: query));
-        lastSaveCompleted = _saveSearchToHistory(
+        final saveCompleted = _saveSearchToHistory(
           userId: userId,
           query: query,
           hasResults: projects.isNotEmpty,
         );
-        unawaited(lastSaveCompleted!);
+        lastSaveCompleted = saveCompleted;
+        unawaited(saveCompleted);
       },
     );
   }

--- a/lib/features/dashboard/presentation/bloc/project_search_bloc/project_search_bloc.dart
+++ b/lib/features/dashboard/presentation/bloc/project_search_bloc/project_search_bloc.dart
@@ -122,7 +122,9 @@ class ProjectSearchBloc extends Bloc<ProjectSearchEvent, ProjectSearchState> {
     Emitter<ProjectSearchState> emit,
   ) async {
     if (event.query.trim().isEmpty) {
-      emit(const ProjectSearchInitial());
+      // Preserve cached recents/suggestions instead of blanking the idle
+      // surface, mirroring _handleQuery's empty-query branch.
+      emit(_initialFromCache());
       return;
     }
     await _executeSearch(event.query, emit);

--- a/lib/features/dashboard/presentation/bloc/project_search_bloc/project_search_event.dart
+++ b/lib/features/dashboard/presentation/bloc/project_search_bloc/project_search_event.dart
@@ -1,0 +1,59 @@
+// coverage:ignore-file
+part of 'project_search_bloc.dart';
+
+/// Base sealed class for all [ProjectSearchBloc] events.
+sealed class ProjectSearchEvent extends Equatable {
+  /// Creates a [ProjectSearchEvent].
+  const ProjectSearchEvent();
+
+  @override
+  List<Object?> get props => [];
+}
+
+/// Dispatched on every keystroke — the BLoC applies a debounce transformer
+/// so rapid emissions are coalesced automatically before triggering a search.
+class ProjectSearchQueryUpdatedEvent extends ProjectSearchEvent {
+  /// The current value of the search input field.
+  final String query;
+
+  /// Creates a [ProjectSearchQueryUpdatedEvent] with the given [query].
+  const ProjectSearchQueryUpdatedEvent({required this.query});
+
+  @override
+  List<Object?> get props => [query];
+}
+
+/// Dispatched when the user explicitly submits a search (e.g. tap or enter).
+///
+/// Unlike [ProjectSearchQueryUpdatedEvent], this is not debounced and triggers
+/// an immediate search.
+class ProjectSearchPerformedEvent extends ProjectSearchEvent {
+  /// The search query submitted by the user.
+  final String query;
+
+  /// Creates a [ProjectSearchPerformedEvent] with the given [query].
+  const ProjectSearchPerformedEvent({required this.query});
+
+  @override
+  List<Object?> get props => [query];
+}
+
+/// Dispatched when the project-search surface opens to request recent searches
+/// and personalized suggestions in parallel.
+class ProjectSearchHistoryRequestedEvent extends ProjectSearchEvent {
+  /// Creates a [ProjectSearchHistoryRequestedEvent].
+  const ProjectSearchHistoryRequestedEvent();
+}
+
+/// Dispatched when the user dismisses a single recent-search chip.
+class ProjectSearchHistoryItemDismissedEvent extends ProjectSearchEvent {
+  /// The recent-search term to remove from history.
+  final String searchTerm;
+
+  /// Creates a [ProjectSearchHistoryItemDismissedEvent] with the given
+  /// [searchTerm].
+  const ProjectSearchHistoryItemDismissedEvent({required this.searchTerm});
+
+  @override
+  List<Object?> get props => [searchTerm];
+}

--- a/lib/features/dashboard/presentation/bloc/project_search_bloc/project_search_state.dart
+++ b/lib/features/dashboard/presentation/bloc/project_search_bloc/project_search_state.dart
@@ -1,0 +1,103 @@
+// coverage:ignore-file
+part of 'project_search_bloc.dart';
+
+/// Base sealed class for all [ProjectSearchBloc] states.
+sealed class ProjectSearchState extends Equatable {
+  /// Creates a [ProjectSearchState].
+  const ProjectSearchState();
+
+  @override
+  List<Object?> get props => [];
+}
+
+/// Idle / cold-start state shown when no active search is in flight.
+///
+/// Carries the user's [recentSearches] and personalized [suggestions] so the
+/// UI can render both surfaces from a single state. [isLoadingHistory] is
+/// `true` while the parallel fetch of recents + suggestions is in flight.
+/// [query] holds the current (debounced) search-field value — typing filters
+/// [suggestions] in place rather than triggering a live remote search;
+/// [ProjectSearchPerformedEvent] is what runs the actual search.
+/// [suggestionsLoading] is `true` while the first suggestions fetch for a
+/// non-empty query is in flight.
+class ProjectSearchInitial extends ProjectSearchState {
+  /// The user's recent project-search terms, most recently used first.
+  final List<String> recentSearches;
+
+  /// Personalized project-search suggestion terms, filtered by [query].
+  final List<String> suggestions;
+
+  /// `true` while recents and suggestions are being fetched.
+  final bool isLoadingHistory;
+
+  /// The current value of the search input field.
+  final String query;
+
+  /// `true` while the first suggestions fetch for a non-empty query is in
+  /// flight.
+  final bool suggestionsLoading;
+
+  /// Creates a [ProjectSearchInitial] with the given [recentSearches],
+  /// [suggestions], [isLoadingHistory], [query], and [suggestionsLoading].
+  const ProjectSearchInitial({
+    this.recentSearches = const [],
+    this.suggestions = const [],
+    this.isLoadingHistory = false,
+    this.query = '',
+    this.suggestionsLoading = false,
+  });
+
+  @override
+  List<Object?> get props => [
+    recentSearches,
+    suggestions,
+    isLoadingHistory,
+    query,
+    suggestionsLoading,
+  ];
+}
+
+/// Emitted while a search request is in flight.
+class ProjectSearchLoading extends ProjectSearchState {
+  /// The search query that triggered this in-progress request.
+  final String query;
+
+  /// Creates a [ProjectSearchLoading] with the given [query].
+  const ProjectSearchLoading({required this.query});
+
+  @override
+  List<Object?> get props => [query];
+}
+
+/// Emitted when a search completes — [results] may be empty.
+///
+/// Carries [query] alongside [results] so the UI can display the current
+/// search term without needing additional state.
+class ProjectSearchResultsLoaded extends ProjectSearchState {
+  /// The projects returned by the search. May be empty.
+  final List<Project> results;
+
+  /// The query that produced these results.
+  final String query;
+
+  /// Creates a [ProjectSearchResultsLoaded] with the given [results] and [query].
+  const ProjectSearchResultsLoaded({required this.results, required this.query});
+
+  @override
+  List<Object?> get props => [results, query];
+}
+
+/// Emitted when a search fails.
+class ProjectSearchFailureState extends ProjectSearchState {
+  /// The failure describing why the search failed.
+  final Failure failure;
+
+  /// The query that was being searched when the failure occurred.
+  final String query;
+
+  /// Creates a [ProjectSearchFailureState] with the given [failure] and [query].
+  const ProjectSearchFailureState({required this.failure, required this.query});
+
+  @override
+  List<Object?> get props => [failure, query];
+}

--- a/test/features/dashboard/units/blocs/project_search_bloc_test.dart
+++ b/test/features/dashboard/units/blocs/project_search_bloc_test.dart
@@ -1,0 +1,649 @@
+import 'package:bloc_test/bloc_test.dart';
+import 'package:construculator/app/app_bootstrap.dart';
+import 'package:construculator/features/dashboard/dashboard_module.dart';
+import 'package:construculator/features/dashboard/presentation/bloc/project_search_bloc/project_search_bloc.dart';
+import 'package:construculator/libraries/auth/domain/types/auth_types.dart';
+import 'package:construculator/libraries/errors/failures.dart';
+import 'package:construculator/libraries/global_search/domain/search_error_type.dart';
+import 'package:construculator/libraries/supabase/data/supabase_types.dart';
+import 'package:construculator/libraries/supabase/database_constants.dart';
+import 'package:construculator/libraries/supabase/interfaces/supabase_wrapper.dart';
+import 'package:construculator/libraries/supabase/testing/fake_supabase_user.dart';
+import 'package:construculator/libraries/supabase/testing/fake_supabase_wrapper.dart';
+import 'package:construculator/libraries/time/testing/clock_test_module.dart';
+import 'package:construculator/libraries/time/testing/fake_clock_impl.dart';
+import 'package:flutter_modular/flutter_modular.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../../../../utils/fake_app_bootstrap_factory.dart';
+
+// ---------------------------------------------------------------------------
+// Test data helpers
+// ---------------------------------------------------------------------------
+
+const String _testUserId = 'user-search-test';
+const String _testUserEmail = 'search@test.com';
+
+Map<String, dynamic> _fakeProjectData({String? id, String? projectName}) {
+  return {
+    DatabaseConstants.idColumn: id ?? 'project-1',
+    DatabaseConstants.projectNameColumn: projectName ?? 'Test Project',
+    DatabaseConstants.descriptionColumn: 'Test description',
+    DatabaseConstants.creatorUserIdColumn: _testUserId,
+    DatabaseConstants.owningCompanyIdColumn: null,
+    DatabaseConstants.exportFolderLinkColumn: null,
+    DatabaseConstants.exportStorageProviderColumn: null,
+    DatabaseConstants.createdAtColumn: '2024-01-01T00:00:00.000Z',
+    DatabaseConstants.updatedAtColumn: '2024-01-01T00:00:00.000Z',
+    DatabaseConstants.statusColumn: 'active',
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+void main() {
+  group('ProjectSearchBloc', () {
+    late FakeSupabaseWrapper fakeSupabase;
+    late FakeClockImpl fakeClock;
+
+    setUp(() {
+      fakeClock = FakeClockImpl();
+      final bootstrap = FakeAppBootstrapFactory.create(
+        supabaseWrapper: FakeSupabaseWrapper(clock: fakeClock),
+      );
+      Modular.init(_ProjectSearchBlocTestModule(bootstrap));
+      fakeSupabase = Modular.get<SupabaseWrapper>() as FakeSupabaseWrapper;
+      fakeSupabase.setCurrentUser(
+        FakeUser(
+          id: _testUserId,
+          email: _testUserEmail,
+          createdAt: fakeClock.now().toIso8601String(),
+        ),
+      );
+    });
+
+    tearDown(() {
+      fakeSupabase.reset();
+      Modular.destroy();
+    });
+
+    test('initial state is ProjectSearchInitial', () {
+      final bloc = Modular.get<ProjectSearchBloc>();
+      expect(bloc.state, const ProjectSearchInitial());
+      bloc.close();
+    });
+
+    // -------------------------------------------------------------------------
+    // ProjectSearchQueryUpdatedEvent
+    // -------------------------------------------------------------------------
+
+    group('ProjectSearchQueryUpdatedEvent', () {
+      blocTest<ProjectSearchBloc, ProjectSearchState>(
+        'emits ProjectSearchInitial when query is empty',
+        build: () => Modular.get<ProjectSearchBloc>(),
+        act: (bloc) => bloc.add(
+          const ProjectSearchQueryUpdatedEvent(query: ''),
+        ),
+        wait: const Duration(milliseconds: 500),
+        expect: () => [const ProjectSearchInitial()],
+      );
+
+      blocTest<ProjectSearchBloc, ProjectSearchState>(
+        'emits Initial preserving cached recents when query is cleared after history load',
+        setUp: () {
+          fakeSupabase.addTableData(
+            DatabaseConstants.projectSearchHistoryTable,
+            [
+              {
+                DatabaseConstants.userIdColumn: _testUserId,
+                DatabaseConstants.searchTermColumn: 'wall',
+                DatabaseConstants.updatedAtColumn: '2024-06-01T00:00:00.000Z',
+              },
+            ],
+          );
+        },
+        build: () => Modular.get<ProjectSearchBloc>(),
+        act: (bloc) async {
+          bloc.add(const ProjectSearchHistoryRequestedEvent());
+          await bloc.stream.firstWhere(
+            (s) => s is ProjectSearchInitial && !s.isLoadingHistory,
+          );
+          bloc.add(const ProjectSearchQueryUpdatedEvent(query: ''));
+        },
+        wait: const Duration(milliseconds: 500),
+        expect: () => [
+          const ProjectSearchInitial(isLoadingHistory: true),
+          const ProjectSearchInitial(recentSearches: ['wall']),
+        ],
+      );
+
+      blocTest<ProjectSearchBloc, ProjectSearchState>(
+        'fetches suggestions on first non-empty query and emits filtered list',
+        setUp: () {
+          fakeSupabase.setRpcResponse(
+            DatabaseConstants.projectSearchSuggestionsRpcFunction,
+            ['foundation', 'foundation repair', 'concrete'],
+          );
+        },
+        build: () => Modular.get<ProjectSearchBloc>(),
+        act: (bloc) =>
+            bloc.add(const ProjectSearchQueryUpdatedEvent(query: 'foundation')),
+        wait: const Duration(milliseconds: 310),
+        expect: () => [
+          isA<ProjectSearchInitial>()
+              .having((s) => s.query, 'query', 'foundation')
+              .having((s) => s.suggestionsLoading, 'loading', isTrue),
+          isA<ProjectSearchInitial>()
+              .having((s) => s.query, 'query', 'foundation')
+              .having((s) => s.suggestionsLoading, 'loading', isFalse)
+              .having(
+                (s) => s.suggestions,
+                'suggestions',
+                ['foundation', 'foundation repair'],
+              ),
+        ],
+      );
+
+      blocTest<ProjectSearchBloc, ProjectSearchState>(
+        'reuses cached suggestions on subsequent query updates with no extra RPC',
+        setUp: () {
+          fakeSupabase.setRpcResponse(
+            DatabaseConstants.projectSearchSuggestionsRpcFunction,
+            ['Carpentry', 'Carparking', 'Plumbing', 'Concrete'],
+          );
+        },
+        build: () => Modular.get<ProjectSearchBloc>(),
+        act: (bloc) async {
+          bloc.add(const ProjectSearchQueryUpdatedEvent(query: 'Car'));
+          await bloc.stream.firstWhere(
+            (s) => s is ProjectSearchInitial && !s.suggestionsLoading,
+          );
+          bloc.add(const ProjectSearchQueryUpdatedEvent(query: 'Con'));
+        },
+        wait: const Duration(milliseconds: 700),
+        verify: (_) {
+          final rpcCalls = fakeSupabase
+              .getMethodCallsFor('rpc')
+              .where(
+                (call) =>
+                    call['functionName'] ==
+                    DatabaseConstants.projectSearchSuggestionsRpcFunction,
+              );
+          expect(rpcCalls, hasLength(1));
+        },
+      );
+
+      blocTest<ProjectSearchBloc, ProjectSearchState>(
+        'caps the filtered suggestions list at 5 items',
+        setUp: () {
+          fakeSupabase.setRpcResponse(
+            DatabaseConstants.projectSearchSuggestionsRpcFunction,
+            ['C1', 'C2', 'C3', 'C4', 'C5', 'C6', 'C7'],
+          );
+        },
+        build: () => Modular.get<ProjectSearchBloc>(),
+        act: (bloc) => bloc.add(const ProjectSearchQueryUpdatedEvent(query: 'C')),
+        wait: const Duration(milliseconds: 310),
+        expect: () => [
+          isA<ProjectSearchInitial>().having(
+            (s) => s.suggestionsLoading,
+            'loading',
+            isTrue,
+          ),
+          isA<ProjectSearchInitial>().having(
+            (s) => s.suggestions,
+            'suggestions capped at 5',
+            ['C1', 'C2', 'C3', 'C4', 'C5'],
+          ),
+        ],
+      );
+
+      blocTest<ProjectSearchBloc, ProjectSearchState>(
+        'does not fetch suggestions when no user is authenticated',
+        setUp: () {
+          fakeSupabase.setCurrentUser(null);
+        },
+        build: () => Modular.get<ProjectSearchBloc>(),
+        act: (bloc) =>
+            bloc.add(const ProjectSearchQueryUpdatedEvent(query: 'foundation')),
+        wait: const Duration(milliseconds: 500),
+        expect: () => [
+          isA<ProjectSearchInitial>().having(
+            (s) => s.query,
+            'query',
+            'foundation',
+          ),
+        ],
+        verify: (_) {
+          expect(
+            fakeSupabase
+                .getMethodCallsFor('rpc')
+                .where(
+                  (call) =>
+                      call['functionName'] ==
+                      DatabaseConstants.projectSearchSuggestionsRpcFunction,
+                ),
+            isEmpty,
+          );
+        },
+      );
+    });
+
+    // -------------------------------------------------------------------------
+    // ProjectSearchPerformedEvent
+    // -------------------------------------------------------------------------
+
+    group('ProjectSearchPerformedEvent', () {
+      blocTest<ProjectSearchBloc, ProjectSearchState>(
+        'emits ProjectSearchInitial when query is empty',
+        build: () => Modular.get<ProjectSearchBloc>(),
+        act: (bloc) =>
+            bloc.add(const ProjectSearchPerformedEvent(query: '')),
+        expect: () => [const ProjectSearchInitial()],
+      );
+
+      blocTest<ProjectSearchBloc, ProjectSearchState>(
+        'emits ProjectSearchInitial when query is whitespace only',
+        build: () => Modular.get<ProjectSearchBloc>(),
+        act: (bloc) =>
+            bloc.add(const ProjectSearchPerformedEvent(query: '   ')),
+        expect: () => [const ProjectSearchInitial()],
+      );
+
+      blocTest<ProjectSearchBloc, ProjectSearchState>(
+        'emits [ProjectSearchLoading, ProjectSearchResultsLoaded] immediately on success',
+        setUp: () {
+          fakeSupabase.setRpcResponse(
+            DatabaseConstants.globalSearchRpcFunction,
+            {
+              'projects': [
+                _fakeProjectData(id: 'p-1', projectName: 'Wall Project'),
+              ],
+              'estimations': [],
+              'members': [],
+            },
+          );
+        },
+        build: () => Modular.get<ProjectSearchBloc>(),
+        act: (bloc) => bloc.add(
+          const ProjectSearchPerformedEvent(query: 'wall'),
+        ),
+        expect: () => [
+          const ProjectSearchLoading(query: 'wall'),
+          isA<ProjectSearchResultsLoaded>()
+              .having((s) => s.query, 'query', 'wall')
+              .having((s) => s.results, 'results', hasLength(1)),
+        ],
+      );
+
+      blocTest<ProjectSearchBloc, ProjectSearchState>(
+        'emits ProjectSearchResultsLoaded with empty list when no results',
+        setUp: () {
+          fakeSupabase.setRpcResponse(
+            DatabaseConstants.globalSearchRpcFunction,
+            {'projects': [], 'estimations': [], 'members': []},
+          );
+        },
+        build: () => Modular.get<ProjectSearchBloc>(),
+        act: (bloc) => bloc.add(
+          const ProjectSearchPerformedEvent(query: 'nonexistent'),
+        ),
+        expect: () => [
+          const ProjectSearchLoading(query: 'nonexistent'),
+          isA<ProjectSearchResultsLoaded>()
+              .having((s) => s.results, 'results', isEmpty),
+        ],
+      );
+
+      blocTest<ProjectSearchBloc, ProjectSearchState>(
+        'emits [ProjectSearchLoading, ProjectSearchFailureState] on connection error',
+        setUp: () {
+          fakeSupabase.shouldThrowOnRpc = true;
+          fakeSupabase.rpcExceptionType = SupabaseExceptionType.socket;
+          fakeSupabase.rpcErrorMessage = 'Network error';
+        },
+        build: () => Modular.get<ProjectSearchBloc>(),
+        act: (bloc) => bloc.add(
+          const ProjectSearchPerformedEvent(query: 'wall'),
+        ),
+        expect: () => [
+          const ProjectSearchLoading(query: 'wall'),
+          isA<ProjectSearchFailureState>()
+              .having((s) => s.query, 'query', 'wall')
+              .having(
+                (s) => s.failure,
+                'failure',
+                SearchFailure(errorType: SearchErrorType.connectionError),
+              ),
+        ],
+      );
+
+      blocTest<ProjectSearchBloc, ProjectSearchState>(
+        'emits AuthFailure (no loading) when user is not authenticated',
+        setUp: () {
+          fakeSupabase.setCurrentUser(null);
+        },
+        build: () => Modular.get<ProjectSearchBloc>(),
+        act: (bloc) => bloc.add(
+          const ProjectSearchPerformedEvent(query: 'wall'),
+        ),
+        expect: () => [
+          const ProjectSearchFailureState(
+            failure: AuthFailure(errorType: AuthErrorType.userNotFound),
+            query: 'wall',
+          ),
+        ],
+      );
+
+      blocTest<ProjectSearchBloc, ProjectSearchState>(
+        'emits [ProjectSearchLoading, ProjectSearchFailureState] on unknown error',
+        setUp: () {
+          fakeSupabase.shouldThrowOnRpc = true;
+          fakeSupabase.rpcExceptionType = SupabaseExceptionType.unknown;
+          fakeSupabase.rpcErrorMessage = 'Server error';
+        },
+        build: () => Modular.get<ProjectSearchBloc>(),
+        act: (bloc) => bloc.add(
+          const ProjectSearchPerformedEvent(query: 'wall'),
+        ),
+        expect: () => [
+          const ProjectSearchLoading(query: 'wall'),
+          isA<ProjectSearchFailureState>()
+              .having((s) => s.failure, 'failure', isA<UnexpectedFailure>()),
+        ],
+      );
+    });
+
+    // -------------------------------------------------------------------------
+    // ProjectSearchHistoryRequestedEvent
+    // -------------------------------------------------------------------------
+
+    group('ProjectSearchHistoryRequestedEvent', () {
+      blocTest<ProjectSearchBloc, ProjectSearchState>(
+        'emits loading then loaded Initial with recents on success '
+        '(suggestions are fetched lazily on first keystroke, not on open)',
+        setUp: () {
+          fakeSupabase.addTableData(
+            DatabaseConstants.projectSearchHistoryTable,
+            [
+              {
+                DatabaseConstants.userIdColumn: _testUserId,
+                DatabaseConstants.searchTermColumn: 'foundation',
+                DatabaseConstants.updatedAtColumn: '2024-06-01T00:00:00.000Z',
+              },
+              {
+                DatabaseConstants.userIdColumn: _testUserId,
+                DatabaseConstants.searchTermColumn: 'wall',
+                DatabaseConstants.updatedAtColumn: '2024-05-01T00:00:00.000Z',
+              },
+            ],
+          );
+        },
+        build: () => Modular.get<ProjectSearchBloc>(),
+        act: (bloc) =>
+            bloc.add(const ProjectSearchHistoryRequestedEvent()),
+        expect: () => [
+          const ProjectSearchInitial(isLoadingHistory: true),
+          const ProjectSearchInitial(recentSearches: ['foundation', 'wall']),
+        ],
+        verify: (_) {
+          expect(
+            fakeSupabase
+                .getMethodCallsFor('rpc')
+                .where(
+                  (call) =>
+                      call['functionName'] ==
+                      DatabaseConstants.projectSearchSuggestionsRpcFunction,
+                ),
+            isEmpty,
+          );
+        },
+      );
+
+      blocTest<ProjectSearchBloc, ProjectSearchState>(
+        'emits empty Initial without repository calls when no user is authenticated',
+        setUp: () {
+          fakeSupabase.setCurrentUser(null);
+        },
+        build: () => Modular.get<ProjectSearchBloc>(),
+        act: (bloc) =>
+            bloc.add(const ProjectSearchHistoryRequestedEvent()),
+        expect: () => [const ProjectSearchInitial()],
+        verify: (_) {
+          expect(fakeSupabase.getMethodCallsFor('selectMatch'), isEmpty);
+        },
+      );
+
+      blocTest<ProjectSearchBloc, ProjectSearchState>(
+        'resets stale suggestions cache from a previous session',
+        setUp: () {
+          fakeSupabase.addTableData(
+            DatabaseConstants.projectSearchHistoryTable,
+            [
+              {
+                DatabaseConstants.userIdColumn: _testUserId,
+                DatabaseConstants.searchTermColumn: 'foundation',
+                DatabaseConstants.updatedAtColumn: '2024-06-01T00:00:00.000Z',
+              },
+            ],
+          );
+          fakeSupabase.setRpcResponse(
+            DatabaseConstants.projectSearchSuggestionsRpcFunction,
+            ['stale-suggestion'],
+          );
+        },
+        build: () => Modular.get<ProjectSearchBloc>(),
+        act: (bloc) async {
+          // First session: fetch suggestions for a query.
+          bloc.add(const ProjectSearchQueryUpdatedEvent(query: 'stale'));
+          await bloc.stream.firstWhere(
+            (s) => s is ProjectSearchInitial && !s.suggestionsLoading,
+          );
+          // Re-opening the surface must drop the stale cache.
+          bloc.add(const ProjectSearchHistoryRequestedEvent());
+        },
+        skip: 3,
+        expect: () => [
+          const ProjectSearchInitial(recentSearches: ['foundation']),
+        ],
+      );
+    });
+
+    // -------------------------------------------------------------------------
+    // ProjectSearchHistoryItemDismissedEvent
+    // -------------------------------------------------------------------------
+
+    group('ProjectSearchHistoryItemDismissedEvent', () {
+      blocTest<ProjectSearchBloc, ProjectSearchState>(
+        'removes term from cached recents and re-emits Initial on success',
+        setUp: () {
+          fakeSupabase.addTableData(
+            DatabaseConstants.projectSearchHistoryTable,
+            [
+              {
+                DatabaseConstants.userIdColumn: _testUserId,
+                DatabaseConstants.searchTermColumn: 'foundation',
+                DatabaseConstants.updatedAtColumn: '2024-06-01T00:00:00.000Z',
+              },
+              {
+                DatabaseConstants.userIdColumn: _testUserId,
+                DatabaseConstants.searchTermColumn: 'wall',
+                DatabaseConstants.updatedAtColumn: '2024-05-01T00:00:00.000Z',
+              },
+            ],
+          );
+          fakeSupabase.setRpcResponse(
+            DatabaseConstants.projectSearchSuggestionsRpcFunction,
+            <dynamic>[],
+          );
+        },
+        build: () => Modular.get<ProjectSearchBloc>(),
+        act: (bloc) async {
+          bloc.add(const ProjectSearchHistoryRequestedEvent());
+          // Wait for the non-loading Initial to land so the cached recents
+          // are populated before we dispatch the dismissal.
+          await bloc.stream.firstWhere(
+            (state) =>
+                state is ProjectSearchInitial && !state.isLoadingHistory,
+          );
+          bloc.add(
+            const ProjectSearchHistoryItemDismissedEvent(
+              searchTerm: 'foundation',
+            ),
+          );
+        },
+        skip: 2,
+        expect: () => [
+          const ProjectSearchInitial(
+            recentSearches: ['wall'],
+            suggestions: [],
+          ),
+        ],
+        verify: (_) {
+          expect(
+            fakeSupabase.getMethodCallsFor('deleteMatch'),
+            hasLength(1),
+          );
+        },
+      );
+
+      blocTest<ProjectSearchBloc, ProjectSearchState>(
+        'emits nothing when no user is authenticated',
+        setUp: () {
+          fakeSupabase.setCurrentUser(null);
+        },
+        build: () => Modular.get<ProjectSearchBloc>(),
+        act: (bloc) => bloc.add(
+          const ProjectSearchHistoryItemDismissedEvent(searchTerm: 'wall'),
+        ),
+        expect: () => <ProjectSearchState>[],
+        verify: (_) {
+          expect(fakeSupabase.getMethodCallsFor('deleteMatch'), isEmpty);
+        },
+      );
+
+      blocTest<ProjectSearchBloc, ProjectSearchState>(
+        'emits nothing when deleteMatch fails',
+        setUp: () {
+          fakeSupabase.shouldThrowOnDeleteMatch = true;
+          fakeSupabase.deleteMatchExceptionType =
+              SupabaseExceptionType.timeout;
+          fakeSupabase.deleteMatchErrorMessage = 'Timeout';
+        },
+        build: () => Modular.get<ProjectSearchBloc>(),
+        act: (bloc) => bloc.add(
+          const ProjectSearchHistoryItemDismissedEvent(searchTerm: 'wall'),
+        ),
+        expect: () => <ProjectSearchState>[],
+      );
+    });
+
+    // -------------------------------------------------------------------------
+    // Save-after-search behavior
+    // -------------------------------------------------------------------------
+
+    group('save-after-search', () {
+      blocTest<ProjectSearchBloc, ProjectSearchState>(
+        'upserts with hasResults=true when search returns non-empty results',
+        setUp: () {
+          fakeSupabase.setRpcResponse(
+            DatabaseConstants.globalSearchRpcFunction,
+            {
+              'projects': [_fakeProjectData(id: 'p-1')],
+              'estimations': [],
+              'members': [],
+            },
+          );
+        },
+        build: () => Modular.get<ProjectSearchBloc>(),
+        act: (bloc) async {
+          bloc.add(const ProjectSearchPerformedEvent(query: 'wall'));
+          await bloc.lastSaveCompleted;
+        },
+        verify: (_) {
+          final upserts = fakeSupabase
+              .getMethodCallsFor('upsert')
+              .where(
+                (call) =>
+                    call['table'] ==
+                    DatabaseConstants.projectSearchHistoryTable,
+              )
+              .toList();
+          expect(upserts, hasLength(1));
+          final data = upserts.first['data'] as Map<String, dynamic>;
+          expect(data[DatabaseConstants.hasResultsColumn], isTrue);
+          expect(
+            data[DatabaseConstants.searchTermColumn],
+            equals('wall'),
+          );
+        },
+      );
+
+      blocTest<ProjectSearchBloc, ProjectSearchState>(
+        'upserts with hasResults=false when search returns empty results',
+        setUp: () {
+          fakeSupabase.setRpcResponse(
+            DatabaseConstants.globalSearchRpcFunction,
+            {'projects': [], 'estimations': [], 'members': []},
+          );
+        },
+        build: () => Modular.get<ProjectSearchBloc>(),
+        act: (bloc) async {
+          bloc.add(const ProjectSearchPerformedEvent(query: 'nothing'));
+          await bloc.lastSaveCompleted;
+        },
+        verify: (_) {
+          final upserts = fakeSupabase
+              .getMethodCallsFor('upsert')
+              .where(
+                (call) =>
+                    call['table'] ==
+                    DatabaseConstants.projectSearchHistoryTable,
+              )
+              .toList();
+          expect(upserts, hasLength(1));
+          final data = upserts.first['data'] as Map<String, dynamic>;
+          expect(data[DatabaseConstants.hasResultsColumn], isFalse);
+        },
+      );
+
+      blocTest<ProjectSearchBloc, ProjectSearchState>(
+        'does not upsert when search fails',
+        setUp: () {
+          fakeSupabase.shouldThrowOnRpc = true;
+          fakeSupabase.rpcExceptionType = SupabaseExceptionType.timeout;
+          fakeSupabase.rpcErrorMessage = 'Timeout';
+        },
+        build: () => Modular.get<ProjectSearchBloc>(),
+        act: (bloc) =>
+            bloc.add(const ProjectSearchPerformedEvent(query: 'wall')),
+        verify: (_) {
+          final upserts = fakeSupabase
+              .getMethodCallsFor('upsert')
+              .where(
+                (call) =>
+                    call['table'] ==
+                    DatabaseConstants.projectSearchHistoryTable,
+              )
+              .toList();
+          expect(upserts, isEmpty);
+        },
+      );
+    });
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Test module
+// ---------------------------------------------------------------------------
+
+class _ProjectSearchBlocTestModule extends Module {
+  final AppBootstrap bootstrap;
+
+  _ProjectSearchBlocTestModule(this.bootstrap);
+
+  @override
+  List<Module> get imports => [ClockTestModule(), DashboardModule(bootstrap)];
+}

--- a/test/features/dashboard/units/blocs/project_search_bloc_test.dart
+++ b/test/features/dashboard/units/blocs/project_search_bloc_test.dart
@@ -560,6 +560,7 @@ void main() {
         build: () => Modular.get<ProjectSearchBloc>(),
         act: (bloc) async {
           bloc.add(const ProjectSearchPerformedEvent(query: 'wall'));
+          await bloc.stream.firstWhere((s) => s is ProjectSearchResultsLoaded);
           await bloc.lastSaveCompleted;
         },
         verify: (_) {
@@ -592,6 +593,7 @@ void main() {
         build: () => Modular.get<ProjectSearchBloc>(),
         act: (bloc) async {
           bloc.add(const ProjectSearchPerformedEvent(query: 'nothing'));
+          await bloc.stream.firstWhere((s) => s is ProjectSearchResultsLoaded);
           await bloc.lastSaveCompleted;
         },
         verify: (_) {
@@ -617,8 +619,10 @@ void main() {
           fakeSupabase.rpcErrorMessage = 'Timeout';
         },
         build: () => Modular.get<ProjectSearchBloc>(),
-        act: (bloc) =>
-            bloc.add(const ProjectSearchPerformedEvent(query: 'wall')),
+        act: (bloc) async {
+          bloc.add(const ProjectSearchPerformedEvent(query: 'wall'));
+          await bloc.stream.firstWhere((s) => s is ProjectSearchFailureState);
+        },
         verify: (_) {
           final upserts = fakeSupabase
               .getMethodCallsFor('upsert')

--- a/test/features/dashboard/units/blocs/project_search_bloc_test.dart
+++ b/test/features/dashboard/units/blocs/project_search_bloc_test.dart
@@ -229,6 +229,54 @@ void main() {
           );
         },
       );
+
+      blocTest<ProjectSearchBloc, ProjectSearchState>(
+        'stops loading with empty suggestions when the fetch fails and '
+        're-fetches on the next query update',
+        setUp: () {
+          fakeSupabase.shouldThrowOnRpc = true;
+          fakeSupabase.rpcExceptionType = SupabaseExceptionType.timeout;
+          fakeSupabase.rpcErrorMessage = 'Timeout';
+        },
+        build: () => Modular.get<ProjectSearchBloc>(),
+        act: (bloc) async {
+          bloc.add(const ProjectSearchQueryUpdatedEvent(query: 'foundation'));
+          await bloc.stream.firstWhere(
+            (s) => s is ProjectSearchInitial && !s.suggestionsLoading,
+          );
+          // The failed fetch must not latch the fetched flag — the next
+          // keystroke retries against a now-healthy backend.
+          fakeSupabase.shouldThrowOnRpc = false;
+          fakeSupabase.setRpcResponse(
+            DatabaseConstants.projectSearchSuggestionsRpcFunction,
+            ['foundation'],
+          );
+          bloc.add(const ProjectSearchQueryUpdatedEvent(query: 'found'));
+        },
+        wait: const Duration(milliseconds: 700),
+        expect: () => [
+          isA<ProjectSearchInitial>()
+              .having((s) => s.query, 'query', 'foundation')
+              .having((s) => s.suggestionsLoading, 'loading', isTrue),
+          isA<ProjectSearchInitial>()
+              .having((s) => s.suggestionsLoading, 'loading', isFalse)
+              .having(
+                (s) => s.suggestions,
+                'suggestions after failure',
+                isEmpty,
+              ),
+          isA<ProjectSearchInitial>()
+              .having((s) => s.query, 'query', 'found')
+              .having((s) => s.suggestionsLoading, 'loading', isTrue),
+          isA<ProjectSearchInitial>()
+              .having((s) => s.suggestionsLoading, 'loading', isFalse)
+              .having(
+                (s) => s.suggestions,
+                'suggestions after retry',
+                ['foundation'],
+              ),
+        ],
+      );
     });
 
     // -------------------------------------------------------------------------
@@ -495,6 +543,42 @@ void main() {
           const ProjectSearchInitial(recentSearches: ['foundation']),
         ],
       );
+
+      blocTest<ProjectSearchBloc, ProjectSearchState>(
+        'keeps previously cached recents when the history fetch fails',
+        setUp: () {
+          fakeSupabase.addTableData(
+            DatabaseConstants.projectSearchHistoryTable,
+            [
+              {
+                DatabaseConstants.userIdColumn: _testUserId,
+                DatabaseConstants.searchTermColumn: 'foundation',
+                DatabaseConstants.updatedAtColumn: '2024-06-01T00:00:00.000Z',
+              },
+            ],
+          );
+        },
+        build: () => Modular.get<ProjectSearchBloc>(),
+        act: (bloc) async {
+          bloc.add(const ProjectSearchHistoryRequestedEvent());
+          await bloc.stream.firstWhere(
+            (s) => s is ProjectSearchInitial && !s.isLoadingHistory,
+          );
+          fakeSupabase.shouldThrowOnSelectMatch = true;
+          fakeSupabase.selectMatchExceptionType = SupabaseExceptionType.timeout;
+          fakeSupabase.selectMatchErrorMessage = 'Timeout';
+          bloc.add(const ProjectSearchHistoryRequestedEvent());
+        },
+        expect: () => [
+          const ProjectSearchInitial(isLoadingHistory: true),
+          const ProjectSearchInitial(recentSearches: ['foundation']),
+          const ProjectSearchInitial(
+            recentSearches: ['foundation'],
+            isLoadingHistory: true,
+          ),
+          const ProjectSearchInitial(recentSearches: ['foundation']),
+        ],
+      );
     });
 
     // -------------------------------------------------------------------------
@@ -732,6 +816,97 @@ void main() {
               .toList();
           expect(upserts, isEmpty);
         },
+      );
+
+      blocTest<ProjectSearchBloc, ProjectSearchState>(
+        'keeps cached recents unchanged when the history save fails',
+        setUp: () {
+          fakeSupabase.setRpcResponse(
+            DatabaseConstants.globalSearchRpcFunction,
+            {
+              'projects': [_fakeProjectData(id: 'p-1')],
+              'estimations': [],
+              'members': [],
+            },
+          );
+          fakeSupabase.shouldThrowOnUpsert = true;
+          fakeSupabase.upsertExceptionType = SupabaseExceptionType.timeout;
+          fakeSupabase.upsertErrorMessage = 'Timeout';
+        },
+        build: () => Modular.get<ProjectSearchBloc>(),
+        act: (bloc) async {
+          bloc.add(const ProjectSearchPerformedEvent(query: 'wall'));
+          await bloc.stream.firstWhere((s) => s is ProjectSearchResultsLoaded);
+          await bloc.lastSaveCompleted;
+          // Clearing the query surfaces the recents cache — the failed save
+          // must not have added the search term to it.
+          bloc.add(const ProjectSearchQueryUpdatedEvent(query: ''));
+        },
+        wait: const Duration(milliseconds: 500),
+        expect: () => [
+          isA<ProjectSearchLoading>(),
+          isA<ProjectSearchResultsLoaded>(),
+          const ProjectSearchInitial(),
+        ],
+      );
+
+      blocTest<ProjectSearchBloc, ProjectSearchState>(
+        'caps cached recents at 20 terms after a successful save',
+        setUp: () {
+          fakeSupabase.addTableData(
+            DatabaseConstants.projectSearchHistoryTable,
+            List.generate(
+              20,
+              (i) => {
+                DatabaseConstants.userIdColumn: _testUserId,
+                DatabaseConstants.searchTermColumn:
+                    'term-${(i + 1).toString().padLeft(2, '0')}',
+                DatabaseConstants.updatedAtColumn:
+                    '2024-06-${(20 - i).toString().padLeft(2, '0')}'
+                        'T00:00:00.000Z',
+              },
+            ),
+          );
+          fakeSupabase.setRpcResponse(
+            DatabaseConstants.globalSearchRpcFunction,
+            {
+              'projects': [_fakeProjectData(id: 'p-1')],
+              'estimations': [],
+              'members': [],
+            },
+          );
+        },
+        build: () => Modular.get<ProjectSearchBloc>(),
+        act: (bloc) async {
+          bloc.add(const ProjectSearchHistoryRequestedEvent());
+          await bloc.stream.firstWhere(
+            (s) => s is ProjectSearchInitial && !s.isLoadingHistory,
+          );
+          bloc.add(const ProjectSearchPerformedEvent(query: 'newest'));
+          await bloc.stream.firstWhere((s) => s is ProjectSearchResultsLoaded);
+          await bloc.lastSaveCompleted;
+          // Clearing the query surfaces the recents cache with the new term.
+          bloc.add(const ProjectSearchQueryUpdatedEvent(query: ''));
+        },
+        wait: const Duration(milliseconds: 500),
+        expect: () => [
+          const ProjectSearchInitial(isLoadingHistory: true),
+          isA<ProjectSearchInitial>().having(
+            (s) => s.recentSearches.length,
+            'fetched recents count',
+            20,
+          ),
+          isA<ProjectSearchLoading>(),
+          isA<ProjectSearchResultsLoaded>(),
+          isA<ProjectSearchInitial>()
+              .having((s) => s.recentSearches.length, 'capped length', 20)
+              .having((s) => s.recentSearches.first, 'newest first', 'newest')
+              .having(
+                (s) => s.recentSearches,
+                'oldest term evicted',
+                isNot(contains('term-20')),
+              ),
+        ],
       );
     });
   });

--- a/test/features/dashboard/units/blocs/project_search_bloc_test.dart
+++ b/test/features/dashboard/units/blocs/project_search_bloc_test.dart
@@ -253,6 +253,52 @@ void main() {
       );
 
       blocTest<ProjectSearchBloc, ProjectSearchState>(
+        'preserves cached recents when query is empty after history has loaded',
+        setUp: () {
+          fakeSupabase.addTableData(
+            DatabaseConstants.projectSearchHistoryTable,
+            [
+              {
+                DatabaseConstants.userIdColumn: _testUserId,
+                DatabaseConstants.searchTermColumn: 'foundation',
+                DatabaseConstants.updatedAtColumn: '2024-06-01T00:00:00.000Z',
+              },
+            ],
+          );
+          fakeSupabase.setRpcResponse(
+            DatabaseConstants.globalSearchRpcFunction,
+            {
+              'projects': [_fakeProjectData(id: 'p-1', projectName: 'Wall')],
+              'estimations': [],
+              'members': [],
+            },
+          );
+        },
+        build: () => Modular.get<ProjectSearchBloc>(),
+        act: (bloc) async {
+          bloc.add(const ProjectSearchHistoryRequestedEvent());
+          await bloc.stream.firstWhere(
+            (s) => s is ProjectSearchInitial && !s.isLoadingHistory,
+          );
+          // Leave the idle surface via a real search, then submit an empty
+          // query: the idle view must come back with its recents intact.
+          bloc.add(const ProjectSearchPerformedEvent(query: 'wall'));
+          await bloc.stream.firstWhere((s) => s is ProjectSearchResultsLoaded);
+          bloc.add(const ProjectSearchPerformedEvent(query: '   '));
+        },
+        skip: 4,
+        expect: () => [
+          // 'wall' is prepended by the save-after-search of the submit above;
+          // the pre-existing 'foundation' entry must survive the empty submit.
+          isA<ProjectSearchInitial>().having(
+            (s) => s.recentSearches,
+            'recentSearches',
+            ['wall', 'foundation'],
+          ),
+        ],
+      );
+
+      blocTest<ProjectSearchBloc, ProjectSearchState>(
         'emits [ProjectSearchLoading, ProjectSearchResultsLoaded] immediately on success',
         setUp: () {
           fakeSupabase.setRpcResponse(
@@ -506,6 +552,58 @@ void main() {
             fakeSupabase.getMethodCallsFor('deleteMatch'),
             hasLength(1),
           );
+        },
+      );
+
+      blocTest<ProjectSearchBloc, ProjectSearchState>(
+        'updates cache without emitting when current state is not Initial',
+        setUp: () {
+          fakeSupabase.addTableData(
+            DatabaseConstants.projectSearchHistoryTable,
+            [
+              {
+                DatabaseConstants.userIdColumn: _testUserId,
+                DatabaseConstants.searchTermColumn: 'foundation',
+                DatabaseConstants.updatedAtColumn: '2024-06-01T00:00:00.000Z',
+              },
+              {
+                DatabaseConstants.userIdColumn: _testUserId,
+                DatabaseConstants.searchTermColumn: 'wall',
+                DatabaseConstants.updatedAtColumn: '2024-05-01T00:00:00.000Z',
+              },
+            ],
+          );
+          fakeSupabase.setRpcResponse(
+            DatabaseConstants.globalSearchRpcFunction,
+            {
+              'projects': [_fakeProjectData(id: 'p-1', projectName: 'Wall')],
+              'estimations': [],
+              'members': [],
+            },
+          );
+        },
+        build: () => Modular.get<ProjectSearchBloc>(),
+        act: (bloc) async {
+          bloc.add(const ProjectSearchHistoryRequestedEvent());
+          await bloc.stream.firstWhere(
+            (s) => s is ProjectSearchInitial && !s.isLoadingHistory,
+          );
+          // Dismiss while showing search results: the deletion must go
+          // through, but the results view must not be replaced by Initial.
+          bloc.add(const ProjectSearchPerformedEvent(query: 'wall'));
+          await bloc.stream.firstWhere((s) => s is ProjectSearchResultsLoaded);
+          bloc.add(
+            const ProjectSearchHistoryItemDismissedEvent(
+              searchTerm: 'foundation',
+            ),
+          );
+          await pumpEventQueue();
+        },
+        skip: 4,
+        expect: () => <ProjectSearchState>[],
+        verify: (bloc) {
+          expect(bloc.state, isA<ProjectSearchResultsLoaded>());
+          expect(fakeSupabase.getMethodCallsFor('deleteMatch'), hasLength(1));
         },
       );
 


### PR DESCRIPTION
## Summary

This PR adds `ProjectSearchBloc` for the dashboard project-search surface, consuming the `ProjectSearchRepository` methods landed in #386/#387. `ProjectSearchQueryUpdatedEvent` (300ms debounced) fetches suggestions lazily — once per session, cached in `_cachedSuggestions` — and filters them client-side via `_filterSuggestions` (`startsWith`, case-insensitive, capped at `_kMaxDisplayedSuggestions = 5`), mirroring `GlobalSearchBloc._onQueryUpdated`/`_filterSuggestions` exactly. It does **not** trigger a live remote search. `ProjectSearchPerformedEvent` (explicit submit) is what runs the actual `searchProjects` call, emitting `ProjectSearchLoading` → `ProjectSearchResultsLoaded`/`ProjectSearchFailureState`. `ProjectSearchHistoryRequestedEvent` loads recent searches on surface open and resets the per-session suggestion cache (`_suggestionsFetched = false`) so a fresh open re-fetches lazily on the next keystroke, matching `GlobalSearchStarted`. `ProjectSearchHistoryItemDismissedEvent` removes a single recent term. Save-after-search is fire-and-forget (`unawaited`), exposing `@visibleForTesting lastSaveCompleted` so tests can await it deterministically. Wires `ProjectSearchBloc` into `dashboard_module.dart` DI. Re-lands work from CA-224 that was previously reviewed and merged into a sibling branch but never reached `main`.

### Course correction during review

The original version of this PR had `ProjectSearchQueryUpdatedEvent` trigger a live remote search directly on every debounced keystroke — there was no suggestions-while-typing state at all, unlike `GlobalSearchBloc`. While building CA-689 (suggestions UI) on top of this bloc, that gap surfaced as a real UX mismatch against the Global Search precedent. Redesigned `_handleQuery`/`ProjectSearchInitial` (added `query`/`suggestionsLoading` fields) before this PR's first merge, amending it in place rather than landing the incorrect behavior and fixing it in a follow-up.

---

## Changes Overview

### Impact Stats

| Category | Value |
|---|---|
| **Total Additions** | 1114 |
| **Total Deletions** | 0 |
| **Changed Files** | 5 |
| **Production Files (lib/)** | 4 (`dashboard_module.dart`, `project_search_bloc.dart`, `project_search_event.dart`, `project_search_state.dart`) |
| **Test Files** | 1 (`project_search_bloc_test.dart`) |
| **Production Line Changes** | 465 (`dashboard_module.dart`: 4, `project_search_bloc.dart`: 299, `project_search_event.dart`: 59, `project_search_state.dart`: 103) |
| **PR Size Classification** | **L** (200+ production lines) |

> Over the 200-line **M** threshold. `project_search_event.dart`/`project_search_state.dart` are `part of project_search_bloc.dart` and cannot exist as separate compilation units; the event handlers share mutable cache state (`_cachedRecents`, `_cachedSuggestions`, `_suggestionsFetched`) across the query/perform/history/dismiss/save paths, so splitting by event group would require stubbed intermediate behavior with no real benefit.

---

### Rule-Based Review

| Rule | Status | Notes |
|------|--------|-------|
| **Rule 1** — Digestible PR | ⚠️ **Over L, justified** | 465 production lines. Single cohesive BLoC; `part`-file structure and shared mutable state across handlers make a clean split impractical. |
| **Rule 2** — Naming Conventions | ✅ **Pass** | `ProjectSearchBloc`/`Event`/`State` follow the established BLoC naming convention. `_kMaxDisplayedSuggestions`, `_cachedSuggestions`, `_suggestionsFetched`, `_filterSuggestions`, `_fetchAndEmitSuggestions` mirror `GlobalSearchBloc`'s naming for the equivalent fields/methods. No forbidden suffixes. |
| **Rule 3** — Test Double Pattern | ✅ **Pass** | All 23 tests use the real `ProjectSearchBloc` → real `ProjectSearchRepositoryImpl` → real `RemoteProjectSearchDataSource` via `DashboardModule`/`Modular.get<>()` against `FakeSupabaseWrapper`. No mocks or `when()`/`verify()`. The `'reuses cached suggestions'` test verifies exactly one suggestions RPC call via `getMethodCallsFor('rpc')`; `'caps the filtered suggestions list at 5 items'` seeds 7 and asserts 5. |
| **Rule 5** — UI/Business Separation | ✅ **N/A** | No presentation-layer code introduced. |
| **Rule 6** — Stream Lifecycle | ✅ **Pass** | No `StreamController` created. `_handleQuery` is `async` but its direct emit and the `_fetchAndEmitSuggestions` delegate operate within the same `Emitter` scope. No manual `.listen()` subscriptions. |
| **Rule 15** — Sentry Logging | ✅ **Pass** | All failure paths use `.warning()`, not `.error()` — consistent with these being expected, recoverable conditions (network hiccups, missing auth) rather than unexpected system failures. |

## Test plan

- [x] `flutter analyze` clean
- [x] 23/23 tests pass: suggestions fetch-once-then-filter-locally, suggestions cap at 5, debounce/cancel-in-flight, immediate submit, history load (no eager suggestions fetch), stale-suggestions-cache reset on reopen, dismiss, save-after-search matrix (success/empty/failure)