### PR TITLE
CA-748: feat(CUJ-1): implement E2E login test with Patrol

### DIFF
--- a/integration_test/features/auth/cuj_1_login_test.dart
+++ b/integration_test/features/auth/cuj_1_login_test.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:patrol/patrol.dart';
+
+import '../../utils/app_runner.dart';
+import '../../utils/test_config.dart';
+
+void main() {
+  patrolTest(
+    'CUJ-1: Login — returning user lands on the dashboard',
+    ($) async {
+      await startApp($);
+
+      await $(TextField).first.enterText(TestConfig.loginEmail);
+      await $('Continue').tap();
+      await $.pumpAndSettle();
+
+      await $(TextField).first.enterText(TestConfig.loginPassword);
+      await $('Continue').tap();
+      await $.pumpAndSettle();
+
+      await $('Continue').tap();
+      await $.pumpAndSettle();
+
+      expect($(BottomNavigationBar), findsOneWidget);
+    },
+    config: const PatrolTesterConfig(
+      visibleTimeout: Duration(seconds: 15),
+      settleTimeout: Duration(seconds: 10),
+    ),
+  );
+}

--- a/integration_test/features/auth/cuj_1_login_test.dart
+++ b/integration_test/features/auth/cuj_1_login_test.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_test/flutter_test.dart';
 import 'package:patrol/patrol.dart';
+import 'package:ripplearc_coreui/ripplearc_coreui.dart';
 
 import '../../utils/app_runner.dart';
 import '../../utils/test_config.dart';
@@ -11,22 +11,20 @@ void main() {
     ($) async {
       await startApp($);
 
-      await $(TextField).first.enterText(TestConfig.loginEmail);
-      await $('Continue').tap();
-      await $.pumpAndSettle();
+      await $(const Key('login_email_field')).enterText(TestConfig.loginEmail);
+      await $(const Key('login_email_continue_button')).tap();
 
-      await $(TextField).first.enterText(TestConfig.loginPassword);
-      await $('Continue').tap();
-      await $.pumpAndSettle();
+      await $(
+        const Key('login_password_field'),
+      ).enterText(TestConfig.loginPassword);
+      await $(const Key('login_password_continue_button')).tap();
 
-      await $('Continue').tap();
-      await $.pumpAndSettle();
+      // The success modal is a package-owned bottom sheet whose button carries
+      // no key, so it is anchored to the sheet rather than to screen position.
+      await $(BottomSheet).$(CoreButton).tap();
 
-      expect($(BottomNavigationBar), findsOneWidget);
+      await $(const Key('app_shell_bottom_nav_bar')).waitUntilVisible();
     },
-    config: const PatrolTesterConfig(
-      visibleTimeout: Duration(seconds: 15),
-      settleTimeout: Duration(seconds: 10),
-    ),
+    config: const PatrolTesterConfig(visibleTimeout: Duration(seconds: 30)),
   );
 }

--- a/integration_test/patrol_test.dart
+++ b/integration_test/patrol_test.dart
@@ -1,0 +1,5 @@
+import 'features/auth/cuj_1_login_test.dart' as cuj1;
+
+void main() {
+  cuj1.main();
+}

--- a/integration_test/utils/app_runner.dart
+++ b/integration_test/utils/app_runner.dart
@@ -1,0 +1,7 @@
+import 'package:construculator/main.dart' as app;
+import 'package:patrol/patrol.dart';
+
+Future<void> startApp(PatrolIntegrationTester $) async {
+  app.main();
+  await $.pumpAndSettle(timeout: const Duration(seconds: 5));
+}

--- a/integration_test/utils/app_runner.dart
+++ b/integration_test/utils/app_runner.dart
@@ -1,7 +1,19 @@
 import 'package:construculator/main.dart' as app;
 import 'package:patrol/patrol.dart';
 
+/// Boots the real app and renders its first frame.
+///
+/// `app.main()` is awaited deliberately: it loads environment config,
+/// initialises the Supabase wrapper and initialises Sentry before calling
+/// `runApp`. Without the await, a bootstrap failure surfaces as an unhandled
+/// asynchronous error and the test instead fails much later on a missing
+/// widget, which hides the real cause.
+///
+/// Only a single [pump] follows: the app keeps frames scheduled after boot
+/// (PowerSync connects and retries in the background), so waiting for the
+/// frame scheduler to go quiet throws `pumpAndSettle timed out`. Patrol's
+/// finders already pump while they wait for the widget they act on.
 Future<void> startApp(PatrolIntegrationTester $) async {
-  app.main();
-  await $.pumpAndSettle(timeout: const Duration(seconds: 5));
+  await app.main();
+  await $.pump();
 }

--- a/integration_test/utils/test_config.dart
+++ b/integration_test/utils/test_config.dart
@@ -1,0 +1,4 @@
+class TestConfig {
+  static const String loginEmail = 'seeder@example.com';
+  static const String loginPassword = 'Mypass@1';
+}

--- a/integration_test/utils/test_config.dart
+++ b/integration_test/utils/test_config.dart
@@ -1,4 +1,33 @@
+/// Credentials and other fixtures shared by the E2E critical user journeys.
+///
+/// These are not secrets. They identify the account seeded into the local and
+/// CI Supabase stacks by `construculator-backend`'s
+/// `supabase/seeders/sample_data/103_users.sql`, which Supabase re-applies on
+/// every `supabase db reset`. They must never be valid against a hosted
+/// environment — see the E2E CUJ Strategy wiki page for the full invariant.
+///
+/// Each value can be overridden at build time with `--dart-define` so the same
+/// suite can point at a differently seeded stack without a code change:
+///
+/// ```sh
+/// patrol test --dart-define E2E_LOGIN_EMAIL=other@example.com
+/// ```
 class TestConfig {
-  static const String loginEmail = 'seeder@example.com';
-  static const String loginPassword = 'Mypass@1';
+  const TestConfig._();
+
+  /// Email address of the seeded account used by CUJ-1 (login).
+  static const String loginEmail = String.fromEnvironment(
+    'E2E_LOGIN_EMAIL',
+    defaultValue: 'seeder@example.com',
+  );
+
+  /// Password of the seeded account used by CUJ-1 (login).
+  ///
+  /// The seeder creates the `public.users` row but not the matching
+  /// Supabase Auth identity, so this password must currently be set by hand
+  /// when linking the account. Tracked as a Phase 1 gap in the strategy doc.
+  static const String loginPassword = String.fromEnvironment(
+    'E2E_LOGIN_PASSWORD',
+    defaultValue: 'Mypass@1',
+  );
 }

--- a/lib/app/shell/app_shell_page.dart
+++ b/lib/app/shell/app_shell_page.dart
@@ -128,6 +128,7 @@ class _AppShellPageState extends State<AppShellPage> {
             bottomNavigationBar: SafeArea(
               minimum: const EdgeInsets.all(CoreSpacing.space4),
               child: CoreBottomNavBar(
+                key: const Key('app_shell_bottom_nav_bar'),
                 tabs: [
                   BottomNavTab(
                     icon: CoreIcons.calculation,

--- a/lib/features/auth/presentation/pages/enter_password_page.dart
+++ b/lib/features/auth/presentation/pages/enter_password_page.dart
@@ -117,6 +117,7 @@ class _EnterPasswordPageState extends State<EnterPasswordPage> {
                 ),
                 const SizedBox(height: 24),
                 CoreTextField(
+                  key: const Key('login_password_field'),
                   controller: _passwordController,
                   obscureText: !_isPasswordVisible,
                   label: l10n.passwordLabel,
@@ -153,6 +154,7 @@ class _EnterPasswordPageState extends State<EnterPasswordPage> {
                 ),
                 const SizedBox(height: 16),
                 CoreButton(
+                  key: const Key('login_password_continue_button'),
                   onPressed: () => _onLoginButtonPressed(context),
                   isDisabled:
                       !_canPressContinue || state is EnterPasswordSubmitLoading,

--- a/lib/features/auth/presentation/pages/login_with_email_page.dart
+++ b/lib/features/auth/presentation/pages/login_with_email_page.dart
@@ -184,6 +184,7 @@ class _LoginWithEmailPageState extends State<LoginWithEmailPage> {
             ),
             const SizedBox(height: CoreSpacing.space10),
             CoreTextField(
+              key: const Key('login_email_field'),
               controller: _emailController,
               label: l10n.emailLabel,
               hintText: l10n.emailHint,
@@ -193,6 +194,7 @@ class _LoginWithEmailPageState extends State<LoginWithEmailPage> {
             ),
             const SizedBox(height: CoreSpacing.space6),
             CoreButton(
+              key: const Key('login_email_continue_button'),
               isDisabled:
                   !_canPressContinue ||
                   state is LoginWithEmailAvailabilityLoading,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -888,26 +888,26 @@ packages:
     dependency: "direct dev"
     description:
       name: patrol
-      sha256: "3da4d4a5cb9ac5d314d04689638bd6aea995f2e25aa7dcabfcae48706d0d77f4"
+      sha256: "743678f959a4878807efec59d19f8ebd65cc3d6953fdecce6562c987963f30a8"
       url: "https://pub.dev"
     source: hosted
-    version: "4.4.0"
+    version: "4.9.0"
   patrol_finders:
     dependency: transitive
     description:
       name: patrol_finders
-      sha256: ac0bfaf3eaaa6cc3d49c8a365329cc7f4361a5f486f1adb45edc96dbfc854da9
+      sha256: "8608cdacaab90a3b00ecd7b09df11f13a62b01dea13c211b9f13fd86854e103a"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.0"
+    version: "3.6.0"
   patrol_log:
     dependency: transitive
     description:
       name: patrol_log
-      sha256: b3bd2862c15bd6b163763d7d2a80ae07c24af6da07d62d202798ceea327045d7
+      sha256: "3d91c93e8d0ed19cb12d4b27aa24eca7294e0a48d9d8445505c9775feb5fde2d"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.1"
+    version: "0.10.1"
   petitparser:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -49,7 +49,7 @@ dev_dependencies:
   json_serializable: 6.11.2
   custom_lint: 0.8.1
   bloc_test: 10.0.0
-  patrol: 4.4.0
+  patrol: 4.9.0
   integration_test:
     sdk: flutter
 


### PR DESCRIPTION
## Summary

- Adds `integration_test/` directory with Patrol test structure
- `patrol_test.dart`: single entry point that runs all CUJs (currently just CUJ-1)
- `cuj_1_login_test.dart`: end-to-end login flow — enters email → enters password → dismisses success modal → asserts `BottomNavigationBar` is visible on the dashboard
- `test_config.dart`: seeder credentials (`seeder@example.com`)
- `app_runner.dart`: `startApp()` helper that boots the real app via `app.main()` before each test

Depends on #400 (Patrol infrastructure).

## Test plan

- [ ] Connect Android emulator and run `adb reverse tcp:54321 tcp:54321 && adb reverse tcp:8081 tcp:8081`
- [ ] `patrol test --target integration_test/features/auth/cuj_1_login_test.dart --flavor fishfood --dart-define ENVIRONMENT=dev`
- [ ] Test passes: app reaches the dashboard after logging in with seeder credentials
- [ ] iOS: same test passes on simulator (no `adb reverse` needed)