### PR TITLE
CA-114: feat(dashboard): navigate to project settings from projects sheet

### DIFF
--- a/lib/features/dashboard/presentation/bloc/project_dropdown_bloc/project_dropdown_bloc.dart
+++ b/lib/features/dashboard/presentation/bloc/project_dropdown_bloc/project_dropdown_bloc.dart
@@ -4,6 +4,7 @@ import 'dart:collection';
 import 'package:construculator/libraries/auth/interfaces/auth_manager.dart';
 import 'package:construculator/libraries/errors/failures.dart';
 import 'package:construculator/libraries/project/domain/entities/project_entity.dart';
+import 'package:construculator/libraries/project/domain/permission_constants.dart';
 import 'package:construculator/libraries/project/domain/repositories/project_repository.dart';
 import 'package:equatable/equatable.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -43,6 +44,18 @@ class ProjectDropdownBloc
     _projectsSubscription?.cancel();
     return super.close();
   }
+
+  // Pre-computes the view_project permission per project so the UI never
+  // queries the repository itself.
+  Set<String> _settingsAccessibleIds(List<Project> projects) => projects
+      .where(
+        (project) => _projectRepository.hasProjectPermission(
+          project.id,
+          PermissionConstants.viewProject,
+        ),
+      )
+      .map((project) => project.id)
+      .toSet();
 
   Future<void> _onStarted(
     ProjectDropdownStarted event,
@@ -111,6 +124,7 @@ class ProjectDropdownBloc
         projects: event.projects,
         selectedProject: selectedProject,
         searchQuery: searchQuery,
+        settingsAccessibleProjectIds: _settingsAccessibleIds(event.projects),
       ),
     );
   }
@@ -128,6 +142,9 @@ class ProjectDropdownBloc
       searchQuery: currentState is ProjectDropdownLoadSuccess
           ? currentState.searchQuery
           : '',
+      settingsAccessibleProjectIds: currentState is ProjectDropdownLoadSuccess
+          ? currentState.settingsAccessibleProjectIds
+          : const {},
     ));
   }
 

--- a/lib/features/dashboard/presentation/bloc/project_dropdown_bloc/project_dropdown_bloc.dart
+++ b/lib/features/dashboard/presentation/bloc/project_dropdown_bloc/project_dropdown_bloc.dart
@@ -45,8 +45,6 @@ class ProjectDropdownBloc
     return super.close();
   }
 
-  // Pre-computes the view_project permission per project so the UI never
-  // queries the repository itself.
   Set<String> _settingsAccessibleIds(List<Project> projects) => projects
       .where(
         (project) => _projectRepository.hasProjectPermission(

--- a/lib/features/dashboard/presentation/bloc/project_dropdown_bloc/project_dropdown_state.dart
+++ b/lib/features/dashboard/presentation/bloc/project_dropdown_bloc/project_dropdown_state.dart
@@ -44,10 +44,16 @@ class ProjectDropdownLoadSuccess extends ProjectDropdownState {
   /// The active case-insensitive search query applied to [projects].
   final String searchQuery;
 
+  /// IDs of projects the current user may open settings for, pre-computed by
+  /// the BLoC from the `view_project` permission so the UI renders the flag
+  /// without deriving it.
+  final Set<String> settingsAccessibleProjectIds;
+
   ProjectDropdownLoadSuccess({
     required List<Project> projects,
     required this.selectedProject,
     this.searchQuery = '',
+    this.settingsAccessibleProjectIds = const {},
   }) : projects = UnmodifiableListView<Project>(List<Project>.from(projects));
 
   /// The projects matching [searchQuery]; equals [projects] when the query is
@@ -58,16 +64,24 @@ class ProjectDropdownLoadSuccess extends ProjectDropdownState {
   ProjectDropdownLoadSuccess copyWith({
     Project? selectedProject,
     String? searchQuery,
+    Set<String>? settingsAccessibleProjectIds,
   }) {
     return ProjectDropdownLoadSuccess(
       projects: projects.toList(),
       selectedProject: selectedProject ?? this.selectedProject,
       searchQuery: searchQuery ?? this.searchQuery,
+      settingsAccessibleProjectIds:
+          settingsAccessibleProjectIds ?? this.settingsAccessibleProjectIds,
     );
   }
 
   @override
-  List<Object?> get props => [projects, selectedProject, searchQuery];
+  List<Object?> get props => [
+    projects,
+    selectedProject,
+    searchQuery,
+    settingsAccessibleProjectIds,
+  ];
 }
 
 /// State emitted when loading projects fails.
@@ -80,10 +94,16 @@ class ProjectDropdownLoadFailure extends ProjectDropdownState {
   final UnmodifiableListView<Project> cachedProjects;
   final String searchQuery;
 
+  /// IDs of projects the current user may open settings for, pre-computed by
+  /// the BLoC from the `view_project` permission so the UI renders the flag
+  /// without deriving it.
+  final Set<String> settingsAccessibleProjectIds;
+
   ProjectDropdownLoadFailure({
     required this.failure,
     List<Project> cachedProjects = const [],
     this.searchQuery = '',
+    this.settingsAccessibleProjectIds = const {},
   }) : cachedProjects = UnmodifiableListView<Project>(
          List<Project>.from(cachedProjects),
        );
@@ -92,5 +112,10 @@ class ProjectDropdownLoadFailure extends ProjectDropdownState {
       _filterByQuery(cachedProjects.toList(), searchQuery);
 
   @override
-  List<Object?> get props => [failure, cachedProjects, searchQuery];
+  List<Object?> get props => [
+    failure,
+    cachedProjects,
+    searchQuery,
+    settingsAccessibleProjectIds,
+  ];
 }

--- a/lib/features/dashboard/presentation/widgets/projects_bottom_sheet.dart
+++ b/lib/features/dashboard/presentation/widgets/projects_bottom_sheet.dart
@@ -60,9 +60,7 @@ class _ProjectsBottomSheetState extends State<ProjectsBottomSheet> {
   late final ProjectDropdownBloc _bloc;
   final TextEditingController _searchController = TextEditingController();
 
-  // The ID of the project currently being navigated to via its settings
-  // affordance. While non-null, that project's settings button is disabled.
-  String? _navigatingSettingsProjectId;
+  final Set<String> _navigatingSettingsProjectIds = {};
 
   @override
   void initState() {
@@ -122,7 +120,7 @@ class _ProjectsBottomSheetState extends State<ProjectsBottomSheet> {
       return;
     }
 
-    setState(() => _navigatingSettingsProjectId = project.id);
+    setState(() => _navigatingSettingsProjectIds.add(project.id));
     try {
       await widget.router.pushNamed(fullViewProjectRoute, arguments: project.id);
     } catch (error, stackTrace) {
@@ -140,7 +138,7 @@ class _ProjectsBottomSheetState extends State<ProjectsBottomSheet> {
       }
     } finally {
       if (mounted) {
-        setState(() => _navigatingSettingsProjectId = null);
+        setState(() => _navigatingSettingsProjectIds.remove(project.id));
       }
     }
   }
@@ -319,7 +317,8 @@ class _ProjectsBottomSheetState extends State<ProjectsBottomSheet> {
                       project: project,
                       isSelected: project.id == selectedProjectId,
                       onTap: () => _onProjectSelected(project),
-                      onSettingsTap: _navigatingSettingsProjectId == project.id
+                      onSettingsTap:
+                          _navigatingSettingsProjectIds.contains(project.id)
                           ? null
                           : () => _onProjectSettings(
                               project,

--- a/lib/features/dashboard/presentation/widgets/projects_bottom_sheet.dart
+++ b/lib/features/dashboard/presentation/widgets/projects_bottom_sheet.dart
@@ -56,7 +56,6 @@ class ProjectsBottomSheet extends StatefulWidget {
 class _ProjectsBottomSheetState extends State<ProjectsBottomSheet> {
   static final _logger = AppLogger().tag('ProjectsBottomSheet');
 
-
   late final ProjectDropdownBloc _bloc;
   final TextEditingController _searchController = TextEditingController();
 

--- a/lib/features/dashboard/presentation/widgets/projects_bottom_sheet.dart
+++ b/lib/features/dashboard/presentation/widgets/projects_bottom_sheet.dart
@@ -55,8 +55,14 @@ class ProjectsBottomSheet extends StatefulWidget {
 
 class _ProjectsBottomSheetState extends State<ProjectsBottomSheet> {
   static final _logger = AppLogger().tag('ProjectsBottomSheet');
+
+
   late final ProjectDropdownBloc _bloc;
   final TextEditingController _searchController = TextEditingController();
+
+  // The ID of the project currently being navigated to via its settings
+  // affordance. While non-null, that project's settings button is disabled.
+  String? _navigatingSettingsProjectId;
 
   @override
   void initState() {
@@ -103,17 +109,38 @@ class _ProjectsBottomSheetState extends State<ProjectsBottomSheet> {
     Modular.to.pushNamed(createProjectRoute);
   }
 
-  Future<void> _onProjectSettings(Project project) async {
+  Future<void> _onProjectSettings(
+    Project project, {
+    required bool canView,
+  }) async {
+    if (!canView) {
+      CoreToast.showError(
+        context,
+        context.l10n.projectSettingsPermissionError,
+        context.l10n.closeButton,
+      );
+      return;
+    }
+
+    setState(() => _navigatingSettingsProjectId = project.id);
     try {
       await widget.router.pushNamed(fullViewProjectRoute, arguments: project.id);
-    } catch (e, st) {
-      _logger.warning('Navigation to project details failed', e, st);
+    } catch (error, stackTrace) {
+      _logger.error(
+        'Failed to navigate to project settings',
+        error,
+        stackTrace,
+      );
       if (mounted) {
         CoreToast.showError(
           context,
-          context.l10n.projectDetailsNavigationError,
-          context.l10n.closeLabel,
+          context.l10n.projectSettingsNavigationError,
+          context.l10n.closeButton,
         );
+      }
+    } finally {
+      if (mounted) {
+        setState(() => _navigatingSettingsProjectId = null);
       }
     }
   }
@@ -178,6 +205,7 @@ class _ProjectsBottomSheetState extends State<ProjectsBottomSheet> {
         context,
         projects: state.visibleProjects,
         selectedProjectId: state.selectedProject?.id,
+        settingsAccessibleProjectIds: state.settingsAccessibleProjectIds,
       );
     }
 
@@ -187,6 +215,7 @@ class _ProjectsBottomSheetState extends State<ProjectsBottomSheet> {
           context,
           projects: state.visibleProjects,
           selectedProjectId: null,
+          settingsAccessibleProjectIds: state.settingsAccessibleProjectIds,
           errorBanner: true,
         );
       }
@@ -249,6 +278,7 @@ class _ProjectsBottomSheetState extends State<ProjectsBottomSheet> {
     BuildContext context, {
     required List<Project> projects,
     required String? selectedProjectId,
+    required Set<String> settingsAccessibleProjectIds,
     bool errorBanner = false,
   }) {
     return ConstrainedBox(
@@ -289,7 +319,14 @@ class _ProjectsBottomSheetState extends State<ProjectsBottomSheet> {
                       project: project,
                       isSelected: project.id == selectedProjectId,
                       onTap: () => _onProjectSelected(project),
-                      onSettingsTap: () => _onProjectSettings(project),
+                      onSettingsTap: _navigatingSettingsProjectId == project.id
+                          ? null
+                          : () => _onProjectSettings(
+                              project,
+                              canView: settingsAccessibleProjectIds.contains(
+                                project.id,
+                              ),
+                            ),
                     ),
                   );
                 },

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1782,11 +1782,6 @@
     "description": "Title for the project creation screen app bar",
     "context": "Project creation screen"
   },
-  "projectDetailsNavigationError": "Unable to open project details. Please try again.",
-  "@projectDetailsNavigationError": {
-    "description": "Error toast shown when navigation to the project details screen fails",
-    "context": "Dashboard projects sheet"
-  },
   "addLabourCostButton": "Add labour cost",
   "@addLabourCostButton": {
     "description": "Label for the FAB on the cost estimation details page when the labours tab is active",
@@ -1954,9 +1949,9 @@
     "description": "Toast shown when navigation to project settings fails",
     "context": "Dashboard projects sheet"
   },
-  "projectSettingsPermissionError": "You don't have permission to view this project's settings.",
+  "projectSettingsPermissionError": "You don't have permission to view this project.",
   "@projectSettingsPermissionError": {
-    "description": "Toast shown when the user lacks permission to view project settings",
+    "description": "Toast shown when the user lacks the view_project permission for a project",
     "context": "Dashboard projects sheet"
   }
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1948,6 +1948,16 @@
   "equipmentNameRequiredError": "Equipment name is required",
   "@equipmentNameRequiredError": {
     "description": "Validation error shown below the equipment name field when it is submitted empty"
+  },
+  "projectSettingsNavigationError": "Unable to open project settings. Please try again.",
+  "@projectSettingsNavigationError": {
+    "description": "Toast shown when navigation to project settings fails",
+    "context": "Dashboard projects sheet"
+  },
+  "projectSettingsPermissionError": "You don't have permission to view this project's settings.",
+  "@projectSettingsPermissionError": {
+    "description": "Toast shown when the user lacks permission to view project settings",
+    "context": "Dashboard projects sheet"
   }
 }
 

--- a/lib/l10n/generated/app_localizations.dart
+++ b/lib/l10n/generated/app_localizations.dart
@@ -2128,12 +2128,6 @@ abstract class AppLocalizations {
   /// **'Create a project'**
   String get createProjectScreenTitle;
 
-  /// Error toast shown when navigation to the project details screen fails
-  ///
-  /// In en, this message translates to:
-  /// **'Unable to open project details. Please try again.'**
-  String get projectDetailsNavigationError;
-
   /// Label for the FAB on the cost estimation details page when the labours tab is active
   ///
   /// In en, this message translates to:
@@ -2380,10 +2374,10 @@ abstract class AppLocalizations {
   /// **'Unable to open project settings. Please try again.'**
   String get projectSettingsNavigationError;
 
-  /// Toast shown when the user lacks permission to view project settings
+  /// Toast shown when the user lacks the view_project permission for a project
   ///
   /// In en, this message translates to:
-  /// **'You don\'t have permission to view this project\'s settings.'**
+  /// **'You don\'t have permission to view this project.'**
   String get projectSettingsPermissionError;
 }
 

--- a/lib/l10n/generated/app_localizations.dart
+++ b/lib/l10n/generated/app_localizations.dart
@@ -2373,6 +2373,18 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Equipment name is required'**
   String get equipmentNameRequiredError;
+
+  /// Toast shown when navigation to project settings fails
+  ///
+  /// In en, this message translates to:
+  /// **'Unable to open project settings. Please try again.'**
+  String get projectSettingsNavigationError;
+
+  /// Toast shown when the user lacks permission to view project settings
+  ///
+  /// In en, this message translates to:
+  /// **'You don\'t have permission to view this project\'s settings.'**
+  String get projectSettingsPermissionError;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/generated/app_localizations_en.dart
+++ b/lib/l10n/generated/app_localizations_en.dart
@@ -1127,10 +1127,6 @@ class AppLocalizationsEn extends AppLocalizations {
   String get createProjectScreenTitle => 'Create a project';
 
   @override
-  String get projectDetailsNavigationError =>
-      'Unable to open project details. Please try again.';
-
-  @override
   String get addLabourCostButton => 'Add labour cost';
 
   @override
@@ -1256,5 +1252,5 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get projectSettingsPermissionError =>
-      'You don\'t have permission to view this project\'s settings.';
+      'You don\'t have permission to view this project.';
 }

--- a/lib/l10n/generated/app_localizations_en.dart
+++ b/lib/l10n/generated/app_localizations_en.dart
@@ -1249,4 +1249,12 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get equipmentNameRequiredError => 'Equipment name is required';
+
+  @override
+  String get projectSettingsNavigationError =>
+      'Unable to open project settings. Please try again.';
+
+  @override
+  String get projectSettingsPermissionError =>
+      'You don\'t have permission to view this project\'s settings.';
 }

--- a/lib/libraries/router/testing/fake_router.dart
+++ b/lib/libraries/router/testing/fake_router.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:construculator/libraries/router/interfaces/app_router.dart';
 import 'package:equatable/equatable.dart';
 
@@ -26,11 +28,27 @@ class FakeAppRouter implements AppRouter {
   /// When non-null, [pushNamed] throws this exception instead of recording the call.
   Exception? pushError;
 
+  /// When true, [pushNamed] throws after recording the call, letting tests
+  /// exercise navigation error handling.
+  bool shouldThrowOnPushNamed = false;
+
+  /// When set, [pushNamed] does not complete until this completer does,
+  /// letting tests observe in-flight navigation state.
+  Completer<void>? pushNamedCompleter;
+
+
   @override
   Future<void> pushNamed(String route, {Object? arguments}) async {
     navigationHistory.add(RouteCall(route, arguments));
     final error = pushError;
     if (error != null) throw error;
+    if (shouldThrowOnPushNamed) {
+      throw Exception('FakeAppRouter: pushNamed failed for $route');
+    }
+    final completer = pushNamedCompleter;
+    if (completer != null) {
+      await completer.future;
+    }
   }
 
   @override
@@ -49,5 +67,7 @@ class FakeAppRouter implements AppRouter {
     navigationHistory.clear();
     popCalls = 0;
     pushError = null;
+    shouldThrowOnPushNamed = false;
+    pushNamedCompleter = null;
   }
 }

--- a/lib/libraries/router/testing/fake_router.dart
+++ b/lib/libraries/router/testing/fake_router.dart
@@ -36,7 +36,6 @@ class FakeAppRouter implements AppRouter {
   /// letting tests observe in-flight navigation state.
   Completer<void>? pushNamedCompleter;
 
-
   @override
   Future<void> pushNamed(String route, {Object? arguments}) async {
     navigationHistory.add(RouteCall(route, arguments));

--- a/test/features/dashboard/units/blocs/project_dropdown_bloc_test.dart
+++ b/test/features/dashboard/units/blocs/project_dropdown_bloc_test.dart
@@ -3,6 +3,7 @@ import 'package:construculator/app/app_bootstrap.dart';
 import 'package:construculator/features/dashboard/presentation/bloc/project_dropdown_bloc/project_dropdown_bloc.dart';
 import 'package:construculator/libraries/auth/auth_library_module.dart';
 import 'package:construculator/libraries/errors/failures.dart';
+import 'package:construculator/libraries/project/domain/permission_constants.dart';
 import 'package:construculator/libraries/project/project_library_module.dart';
 import 'package:construculator/libraries/supabase/data/supabase_types.dart';
 import 'package:construculator/libraries/supabase/database_constants.dart';
@@ -689,6 +690,105 @@ void main() {
       );
     });
 
+    group('settingsAccessibleProjectIds', () {
+      blocTest<ProjectDropdownBloc, ProjectDropdownState>(
+        'success state contains only projects granted view_project',
+        build: () {
+          seedProjectsTable([
+            buildProjectMap(
+              id: 'project-1',
+              projectName: 'Granted',
+              creatorUserId: testUserId,
+              updatedAt: DateTime(2025, 1, 2),
+            ),
+            buildProjectMap(
+              id: 'project-2',
+              projectName: 'Denied',
+              creatorUserId: testUserId,
+              updatedAt: DateTime(2025, 1, 1),
+            ),
+          ]);
+          fakeSupabaseWrapper.setProjectPermissions('project-1', [
+            PermissionConstants.viewProject,
+          ]);
+          fakeSupabaseWrapper.setProjectPermissions('project-2', [
+            PermissionConstants.editProject,
+          ]);
+          return Modular.get<ProjectDropdownBloc>();
+        },
+        act: (bloc) async {
+          bloc.add(const ProjectDropdownStarted());
+          await bloc.stream.firstWhere(
+            (s) =>
+                s is ProjectDropdownLoadSuccess ||
+                s is ProjectDropdownLoadFailure,
+          );
+        },
+        expect: () => [
+          const ProjectDropdownLoadInProgress(),
+          isA<ProjectDropdownLoadSuccess>().having(
+            (s) => s.settingsAccessibleProjectIds,
+            'settingsAccessibleProjectIds',
+            {'project-1'},
+          ),
+        ],
+      );
+
+      blocTest<ProjectDropdownBloc, ProjectDropdownState>(
+        'cached failure state preserves settingsAccessibleProjectIds',
+        build: () {
+          seedProjectsTable([
+            buildProjectMap(
+              id: 'project-1',
+              projectName: 'Granted',
+              creatorUserId: testUserId,
+              updatedAt: DateTime(2025, 1, 2),
+            ),
+          ]);
+          fakeSupabaseWrapper.setProjectPermissions('project-1', [
+            PermissionConstants.viewProject,
+          ]);
+          return Modular.get<ProjectDropdownBloc>();
+        },
+        act: (bloc) async {
+          bloc.add(const ProjectDropdownStarted());
+          await bloc.stream.firstWhere((s) => s is ProjectDropdownLoadSuccess);
+          // Make the next watch re-query throw so the stream errors and the
+          // bloc emits a cached failure.
+          fakeSupabaseWrapper.shouldThrowOnSelectMultiple = true;
+          fakeSupabaseWrapper.selectMultipleExceptionType =
+              SupabaseExceptionType.socket;
+          seedProjectsTable([
+            buildProjectMap(
+              id: 'project-1',
+              projectName: 'Granted',
+              creatorUserId: testUserId,
+              updatedAt: DateTime(2025, 1, 3),
+            ),
+          ]);
+          await bloc.stream.firstWhere((s) => s is ProjectDropdownLoadFailure);
+        },
+        expect: () => [
+          const ProjectDropdownLoadInProgress(),
+          isA<ProjectDropdownLoadSuccess>().having(
+            (s) => s.settingsAccessibleProjectIds,
+            'settingsAccessibleProjectIds',
+            {'project-1'},
+          ),
+          isA<ProjectDropdownLoadFailure>()
+              .having(
+                (s) => s.cachedProjects.length,
+                'cachedProjects.length',
+                1,
+              )
+              .having(
+                (s) => s.settingsAccessibleProjectIds,
+                'settingsAccessibleProjectIds',
+                {'project-1'},
+              ),
+        ],
+      );
+    });
   });
 }
 

--- a/test/features/dashboard/widgets/projects_bottom_sheet_test.dart
+++ b/test/features/dashboard/widgets/projects_bottom_sheet_test.dart
@@ -1,10 +1,14 @@
 // ignore_for_file: no_direct_instantiation
+import 'dart:async';
+
 import 'package:construculator/features/dashboard/presentation/bloc/project_dropdown_bloc/project_dropdown_bloc.dart';
 import 'package:construculator/features/dashboard/presentation/widgets/project_list_item.dart';
 import 'package:construculator/l10n/generated/app_localizations.dart';
 import 'package:construculator/libraries/project/domain/entities/enums.dart';
 import 'package:construculator/libraries/project/domain/entities/project_entity.dart';
+import 'package:construculator/libraries/project/domain/permission_constants.dart';
 import 'package:construculator/libraries/router/routes/project_search_routes.dart';
+import 'package:construculator/libraries/router/routes/project_settings_routes.dart';
 import 'package:construculator/libraries/router/testing/fake_router.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -165,21 +169,98 @@ void main() {
     },
   );
 
-  testWidgets('shows error toast when navigation throws', (tester) async {
-    harness.router.pushError = Exception('nav failed');
-    harness.fakeRepository.setAccessibleProjects([
-      buildProject(id: 'project-1', projectName: 'My project'),
-    ]);
 
-    await harness.pumpSheet(tester);
+  group('project settings navigation', () {
+    Finder settingsGear() =>
+        find.bySemanticsLabel(l10n.projectSettingsSemanticLabel);
 
-    // The BLoC auto-selects the first project, so HighlightedProjectItem is
-    // rendered (not ProjectListItem), which uses a VoidCallback-based settings
-    // button rather than ViewProjectDetailsButton. Use the shared semantics
-    // label to tap whichever settings button variant is visible.
-    await tester.tap(find.bySemanticsLabel(l10n.projectSettingsSemanticLabel));
-    await tester.pumpAndSettle();
+    testWidgets(
+      'tapping the settings gear with permission navigates to project settings',
+      (tester) async {
+        harness.fakeRepository.setAccessibleProjects([
+          buildProject(id: 'project-1', projectName: 'My project'),
+        ]);
+        harness.fakeRepository.setProjectPermissions('project-1', [
+          PermissionConstants.viewProject,
+        ]);
 
-    expect(find.text(l10n.projectDetailsNavigationError), findsOneWidget);
+        await harness.pumpSheet(tester);
+
+        await tester.tap(settingsGear());
+        await tester.pump();
+
+        expect(
+          harness.router.navigationHistory,
+          contains(const RouteCall(fullViewProjectRoute, 'project-1')),
+        );
+      },
+    );
+
+    testWidgets(
+      'tapping the settings gear without permission shows a toast and does not navigate',
+      (tester) async {
+        harness.fakeRepository.setAccessibleProjects([
+          buildProject(id: 'project-1', projectName: 'My project'),
+        ]);
+
+        await harness.pumpSheet(tester);
+
+        await tester.tap(settingsGear());
+        await tester.pump();
+
+        expect(find.text(l10n.projectSettingsPermissionError), findsOneWidget);
+        expect(harness.router.navigationHistory, isEmpty);
+      },
+    );
+
+    testWidgets('settings gear is disabled while navigation is in flight', (
+      tester,
+    ) async {
+      harness.fakeRepository.setAccessibleProjects([
+        buildProject(id: 'project-1', projectName: 'My project'),
+      ]);
+      harness.fakeRepository.setProjectPermissions('project-1', [
+        PermissionConstants.viewProject,
+      ]);
+      final completer = Completer<void>();
+      harness.router.pushNamedCompleter = completer;
+
+      await harness.pumpSheet(tester);
+
+      await tester.tap(settingsGear());
+      await tester.pump();
+
+      // While the pushNamed future is pending, the gear's callback is null,
+      // so its semantics (and tappability) are removed.
+      expect(settingsGear(), findsNothing);
+
+      completer.complete();
+      // One pump to flush the resumed future's setState, one to rebuild.
+      await tester.pump();
+      await tester.pump();
+
+      expect(settingsGear(), findsOneWidget);
+    });
+
+    testWidgets(
+      'shows an error toast and re-enables the gear when navigation fails',
+      (tester) async {
+        harness.fakeRepository.setAccessibleProjects([
+          buildProject(id: 'project-1', projectName: 'My project'),
+        ]);
+        harness.fakeRepository.setProjectPermissions('project-1', [
+          PermissionConstants.viewProject,
+        ]);
+        harness.router.shouldThrowOnPushNamed = true;
+
+        await harness.pumpSheet(tester);
+
+        await tester.tap(settingsGear());
+        await tester.pump();
+
+        expect(find.text(l10n.projectSettingsNavigationError), findsOneWidget);
+        expect(settingsGear(), findsOneWidget);
+      },
+    );
   });
 }

--- a/test/features/dashboard/widgets/projects_bottom_sheet_test.dart
+++ b/test/features/dashboard/widgets/projects_bottom_sheet_test.dart
@@ -243,6 +243,48 @@ void main() {
     });
 
     testWidgets(
+      'settings gear for one project stays enabled while another project '
+      'navigation is in flight',
+      (tester) async {
+        harness.fakeRepository.setAccessibleProjects([
+          buildProject(id: 'project-1', projectName: 'First project'),
+          buildProject(id: 'project-2', projectName: 'Second project'),
+        ]);
+        harness.fakeRepository.setProjectPermissions('project-1', [
+          PermissionConstants.viewProject,
+        ]);
+        harness.fakeRepository.setProjectPermissions('project-2', [
+          PermissionConstants.viewProject,
+        ]);
+        final completer = Completer<void>();
+        harness.router.pushNamedCompleter = completer;
+
+        await harness.pumpSheet(tester);
+
+        final project1Gear = find.descendant(
+          of: find.byKey(const ValueKey<String>('project-1')),
+          matching: settingsGear(),
+        );
+        final project2Gear = find.descendant(
+          of: find.byKey(const ValueKey<String>('project-2')),
+          matching: settingsGear(),
+        );
+
+        await tester.tap(project1Gear);
+        await tester.pump();
+
+        // project-1's gear is disabled while its navigation is in flight,
+        // but project-2's gear must remain enabled and tappable.
+        expect(project1Gear, findsNothing);
+        expect(project2Gear, findsOneWidget);
+
+        completer.complete();
+        await tester.pump();
+        await tester.pump();
+      },
+    );
+
+    testWidgets(
       'shows an error toast and re-enables the gear when navigation fails',
       (tester) async {
         harness.fakeRepository.setAccessibleProjects([

--- a/test/libraries/router/units/fake_router_test.dart
+++ b/test/libraries/router/units/fake_router_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:construculator/libraries/router/testing/fake_router.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -51,6 +53,47 @@ void main() {
       expect(router.navigationHistory.length, equals(1));
       expect(router.navigationHistory[0].route, '/dashboard');
       expect(router.navigationHistory[0].arguments, {'page': 'main'});
+    });
+
+    test(
+      'pushNamed throws after recording when shouldThrowOnPushNamed is set',
+      () async {
+        router.shouldThrowOnPushNamed = true;
+
+        await expectLater(router.pushNamed('/home'), throwsA(isA<Exception>()));
+        expect(router.navigationHistory.length, equals(1));
+        expect(router.navigationHistory[0].route, '/home');
+      },
+    );
+
+    test('pushNamed waits for pushNamedCompleter before completing', () async {
+      final completer = Completer<void>();
+      router.pushNamedCompleter = completer;
+
+      var completed = false;
+      final future = router.pushNamed('/home').then((_) => completed = true);
+
+      // The call is recorded immediately, but the future stays pending until
+      // the completer resolves.
+      await null;
+      expect(router.navigationHistory.length, equals(1));
+      expect(completed, isFalse);
+
+      completer.complete();
+      await future;
+      expect(completed, isTrue);
+    });
+
+    test('reset clears pushNamed error and completer knobs', () async {
+      router.shouldThrowOnPushNamed = true;
+      router.pushNamedCompleter = Completer<void>();
+
+      router.reset();
+
+      expect(router.shouldThrowOnPushNamed, isFalse);
+      expect(router.pushNamedCompleter, isNull);
+      await router.pushNamed('/home');
+      expect(router.navigationHistory.length, equals(1));
     });
   });
 


### PR DESCRIPTION
# PR Review: CA-114-feat/project-settings-gear-navigation → main

## 📝 PR Description

Wires the settings gear on each project tile in the dashboard Projects bottom sheet to navigate to the project details screen that already ships on `main` (CA-114 / PRD DASH-008), reusing the existing `fullViewProjectRoute`. `ProjectDropdownBloc` pre-computes which projects the user holds the `view_project` permission for, and the sheet uses that flag to either navigate (disabling that project's gear while the push is in flight) or show a localized permission-denied toast; navigation failures are logged and surfaced via an error toast.

**Type:** Feature ·
**Size:** M (~130 production lines) ·
**Rules applied:** Digestible PR, Naming & Abstraction, Test Double Pattern, CoreUI Components, UI / Business Separation, Self-Documenting Code, Widget Test Finders, Unit Test Behavior, Localization, Sentry Logging

### What changed
- `ProjectsBottomSheet._onProjectSettings` implements permission-gated navigation with per-project in-flight disable (`Set<String>` guard), error logging, and localized toasts (`lib/features/dashboard/presentation/widgets/projects_bottom_sheet.dart`)
- `ProjectDropdownBloc`/states gain `settingsAccessibleProjectIds`, derived once per emit from `ProjectRepository.hasProjectPermission` so the widget never queries the repository (`project_dropdown_bloc.dart`, `project_dropdown_state.dart`)
- Navigation reuses main's existing `fullViewProjectRoute` — no new routes, modules, or screens
- `FakeAppRouter` gains `shouldThrowOnPushNamed` and `pushNamedCompleter` knobs (covered by new fake tests) to exercise failure and in-flight states
- Two new l10n keys: `projectSettingsNavigationError`, `projectSettingsPermissionError`; removes the now-orphaned `projectDetailsNavigationError`
- Tests: bloc tests (permission set on success + preserved on cached failure), sheet widget tests (navigate, denied toast, per-project in-flight disable, failure toast), fake router tests

---

## 🔍 Review Summary

Review rounds 1–3 addressed: private-member comments removed (R1), in-flight guard converted to a per-project `Set<String>` (R1), the parallel `ProjectSettingsRoutesModule` and route/screen additions dropped after #366 and CA-174 landed on main (rebase), orphaned `projectDetailsNavigationError` l10n key removed and permission-toast wording aligned with the `view_project` permission it gates (R2).

Notes for reviewers:
- **UI / Business Separation:** the permission decision is computed in the BLoC (`settingsAccessibleProjectIds`); the widget only renders the pre-calculated flag and chooses toast-vs-navigate.
- **Permission freshness:** `hasProjectPermission` is a synchronous read against the local-JWT permission source — the flag is as fresh as the decoded token, which is the intended gate.
- **Sentry Logging:** one `error()` at the only layer that observes a navigation failure, no duplicate logging.

---

## 🔗 Scope & Relations

- **Base:** `main` (previously stacked on #394; the stack below has fully merged)
- **CA-181 / #366:** merged 2026-07-15 — this PR now reuses its `fullViewProjectRoute` and touches no routing files, resolving the earlier duplicate-feature collision.
- **Real details screen:** built separately under CA-180; this PR only establishes the permission-gated entry point per [CA-114](https://ripplearc.youtrack.cloud/issue/CA-114)/DASH-008.
