### PR TITLE
feat(estimation): land read-only PowerSync read data source (migratio…

### DIFF
--- a/lib/libraries/estimation/data/data_source/interfaces/powersync_cost_estimation_data_source.dart
+++ b/lib/libraries/estimation/data/data_source/interfaces/powersync_cost_estimation_data_source.dart
@@ -1,0 +1,39 @@
+// coverage:ignore-file
+import 'package:construculator/libraries/estimation/data/models/cost_estimate_dto.dart';
+import 'package:construculator/libraries/estimation/domain/enums/estimation_sort_option.dart';
+
+/// Reactive, PowerSync-backed read data source for cost estimations.
+///
+/// Reads go through `watch()` so the UI stays live as sync arrives. Unlike the
+/// request/response [CostEstimationDataSource], this seam owns activation of the
+/// on-demand `user_cost_estimates` sync stream. It returns DTOs (no `Either`)
+/// and always rethrows; the repository is the error boundary. Write operations
+/// (create/delete/rename/lock) are added in later PRs.
+abstract class PowerSyncCostEstimationDataSource {
+  /// Watches the cost estimates for [projectId] from local SQLite, ordered by
+  /// [sortBy] in the given [ascending] direction and optionally capped to
+  /// [limit] rows (null means no cap).
+  ///
+  /// Activates the on-demand `user_cost_estimates` sync stream on the first
+  /// subscription and releases it when that subscription is cancelled. The
+  /// returned stream re-emits on every local or synced change and is the single
+  /// source of truth — callers must not patch results by hand after a write.
+  Stream<List<CostEstimateDto>> watchEstimations({
+    required String projectId,
+    EstimationSortOption sortBy = EstimationSortOption.createdAt,
+    bool ascending = false,
+    int? limit,
+  });
+
+  /// Reads a one-shot snapshot of the cost estimates for [projectId] from local
+  /// SQLite, ordered by [sortBy] in the given [ascending] direction and
+  /// optionally capped to [limit] rows (null means no cap).
+  ///
+  /// Does not activate the sync stream; use [watchEstimations] for live reads.
+  Future<List<CostEstimateDto>> getEstimations({
+    required String projectId,
+    EstimationSortOption sortBy = EstimationSortOption.createdAt,
+    bool ascending = false,
+    int? limit,
+  });
+}

--- a/lib/libraries/estimation/data/data_source/powersync_cost_estimation_data_source_impl.dart
+++ b/lib/libraries/estimation/data/data_source/powersync_cost_estimation_data_source_impl.dart
@@ -1,0 +1,140 @@
+import 'dart:async';
+
+import 'package:construculator/libraries/estimation/data/data_source/interfaces/powersync_cost_estimation_data_source.dart';
+import 'package:construculator/libraries/estimation/data/models/cost_estimate_dto.dart';
+import 'package:construculator/libraries/estimation/domain/enums/estimation_sort_option.dart';
+import 'package:construculator/libraries/logging/app_logger.dart';
+import 'package:construculator/libraries/powersync/interfaces/powersync_database_wrapper.dart';
+
+/// PowerSync-backed [PowerSyncCostEstimationDataSource].
+///
+/// Talks to the [PowerSyncDatabaseWrapper] seam: reads through reactive
+/// `watch()` streams over local SQLite and activates the on-demand
+/// `user_cost_estimates` sync stream lazily on the first watch subscription.
+/// Rows come back as `Map<String, dynamic>` and are mapped to DTOs via
+/// [CostEstimateDto.fromRow], which handles SQLite encodings (e.g. `is_locked`
+/// as `0`/`1`). Write operations are added in later PRs.
+class PowerSyncCostEstimationDataSourceImpl
+    implements PowerSyncCostEstimationDataSource {
+  final PowerSyncDatabaseWrapper _wrapper;
+  static final _logger = AppLogger().tag('PowerSyncCostEstimationDataSource');
+
+  // Local SQLite table backing cost estimates (see `schema.dart`).
+  static const _table = 'cost_estimates';
+
+  // On-demand sync stream gating which estimates sync down; membership and the
+  // `get_cost_estimations` permission are derived from the JWT server-side.
+  static const _syncStreamName = 'user_cost_estimates';
+
+  PowerSyncCostEstimationDataSourceImpl({
+    required PowerSyncDatabaseWrapper wrapper,
+  }) : _wrapper = wrapper;
+
+  @override
+  Stream<List<CostEstimateDto>> watchEstimations({
+    required String projectId,
+    EstimationSortOption sortBy = EstimationSortOption.createdAt,
+    bool ascending = false,
+    int? limit,
+  }) {
+    final sql = _buildSelectSql(
+      sortBy: sortBy,
+      ascending: ascending,
+      limited: limit != null,
+    );
+    final parameters = _selectParameters(projectId, limit);
+
+    // Lazy activation tied to the subscription lifecycle: the on-demand stream
+    // is only synced while someone is actually watching it, and is released on
+    // cancel. The watch() stream remains the single source of truth.
+    return Stream<List<CostEstimateDto>>.multi((controller) async {
+      SyncStreamHandle? handle;
+      StreamSubscription<List<CostEstimateDto>>? subscription;
+      var listenerCancelled = false;
+
+      Future<void> releaseHandle() async {
+        final currentHandle = handle;
+        handle = null;
+        currentHandle?.unsubscribe();
+      }
+
+      controller.onCancel = () async {
+        listenerCancelled = true;
+        await subscription?.cancel();
+        subscription = null;
+        await releaseHandle();
+      };
+
+      _logger.debug(
+        'Activating sync stream "$_syncStreamName" and watching estimates '
+        'for project: $projectId',
+      );
+
+      try {
+        handle = await _wrapper.syncStream(_syncStreamName);
+      } catch (error, stackTrace) {
+        controller.addError(error, stackTrace);
+        await controller.close();
+        return;
+      }
+
+      if (listenerCancelled || !controller.hasListener) {
+        await releaseHandle();
+        return;
+      }
+
+      subscription = _wrapper
+          .watch(sql, parameters: parameters)
+          .map((rows) => rows.map(CostEstimateDto.fromRow).toList())
+          .listen(
+            controller.add,
+            onError: controller.addError,
+            onDone: controller.close,
+          );
+
+      if (listenerCancelled || !controller.hasListener) {
+        await subscription?.cancel();
+        subscription = null;
+        await releaseHandle();
+      }
+    });
+  }
+
+  @override
+  Future<List<CostEstimateDto>> getEstimations({
+    required String projectId,
+    EstimationSortOption sortBy = EstimationSortOption.createdAt,
+    bool ascending = false,
+    int? limit,
+  }) async {
+    final sql = _buildSelectSql(
+      sortBy: sortBy,
+      ascending: ascending,
+      limited: limit != null,
+    );
+    final rows = await _wrapper.getAll(
+      sql,
+      _selectParameters(projectId, limit),
+    );
+    return rows.map(CostEstimateDto.fromRow).toList();
+  }
+
+  String _buildSelectSql({
+    required EstimationSortOption sortBy,
+    required bool ascending,
+    required bool limited,
+  }) {
+    final orderColumn = sortBy == EstimationSortOption.updatedAt
+        ? 'updated_at'
+        : 'created_at';
+    final direction = ascending ? 'ASC' : 'DESC';
+    final limitClause = limited ? ' LIMIT ?' : '';
+    return 'SELECT * FROM $_table WHERE project_id = ? '
+        'ORDER BY $orderColumn $direction$limitClause';
+  }
+
+  List<Object?> _selectParameters(String projectId, int? limit) => [
+    projectId,
+    if (limit != null) limit,
+  ];
+}

--- a/lib/libraries/estimation/data/models/cost_estimate_dto.dart
+++ b/lib/libraries/estimation/data/models/cost_estimate_dto.dart
@@ -156,6 +156,23 @@ class CostEstimateDto extends Equatable {
     );
   }
 
+  /// Creates a [CostEstimateDto] from a PowerSync/SQLite result row.
+  ///
+  /// SQLite has no boolean type, so the `is_locked` column is stored and
+  /// returned as an integer (`0` = false, `1` = true). This factory normalizes
+  /// that encoding to a `bool` before delegating to [CostEstimateDto.fromJson],
+  /// which otherwise expects the Supabase representation where `is_locked` is
+  /// already a boolean. All other columns share the same encoding as the
+  /// Supabase rows (text ids/timestamps, `real`/`integer` numerics).
+  ///
+  /// Throws [TypeError] if required columns are missing or have invalid types.
+  factory CostEstimateDto.fromRow(Map<String, dynamic> row) {
+    return CostEstimateDto.fromJson({
+      ...row,
+      'is_locked': (row['is_locked'] as int? ?? 0) != 0,
+    });
+  }
+
   /// Converts this DTO to a JSON map.
   ///
   /// This method converts the DTO back to the database/API JSON format,

--- a/lib/libraries/estimation/estimation_library_module.dart
+++ b/lib/libraries/estimation/estimation_library_module.dart
@@ -1,8 +1,11 @@
 import 'package:construculator/app/app_bootstrap.dart';
 import 'package:construculator/libraries/estimation/data/data_source/interfaces/cost_estimation_data_source.dart';
+import 'package:construculator/libraries/estimation/data/data_source/interfaces/powersync_cost_estimation_data_source.dart';
+import 'package:construculator/libraries/estimation/data/data_source/powersync_cost_estimation_data_source_impl.dart';
 import 'package:construculator/libraries/estimation/data/data_source/remote_cost_estimation_data_source.dart';
 import 'package:construculator/libraries/estimation/data/repositories/cost_estimation_repository_impl.dart';
 import 'package:construculator/libraries/estimation/domain/repositories/cost_estimation_repository.dart';
+import 'package:construculator/libraries/powersync/powersync_module.dart';
 import 'package:construculator/libraries/supabase/supabase_module.dart';
 import 'package:flutter_modular/flutter_modular.dart';
 
@@ -17,12 +20,19 @@ class EstimationLibraryModule extends Module {
   EstimationLibraryModule(this.appBootstrap);
 
   @override
-  List<Module> get imports => [SupabaseModule(appBootstrap)];
+  List<Module> get imports => [
+    SupabaseModule(appBootstrap),
+    PowerSyncModule(appBootstrap),
+  ];
 
   @override
   void exportedBinds(Injector i) {
     i.addLazySingleton<CostEstimationDataSource>(
       () => RemoteCostEstimationDataSource(supabaseWrapper: i.get()),
+    );
+
+    i.addLazySingleton<PowerSyncCostEstimationDataSource>(
+      () => PowerSyncCostEstimationDataSourceImpl(wrapper: i.get()),
     );
 
     i.addLazySingleton<CostEstimationRepository>(

--- a/lib/libraries/powersync/testing/fake_powersync_database_wrapper.dart
+++ b/lib/libraries/powersync/testing/fake_powersync_database_wrapper.dart
@@ -72,6 +72,11 @@ class FakePowerSyncDatabaseWrapper implements PowerSyncDatabaseWrapper {
   /// (set back to `null`) or [reset] is called.
   Object? syncStreamError;
 
+  /// Optional gate that delays [syncStream] completion until completed by the
+  /// test. Useful for exercising cancellation races while activation is still
+  /// in flight.
+  Completer<void>? syncStreamActivationGate;
+
   /// Scripts [rows] as the result of [getAll] for [sql].
   void stubGetAll(String sql, List<Map<String, dynamic>> rows) {
     _getAllResults[sql] = rows;
@@ -165,6 +170,7 @@ class FakePowerSyncDatabaseWrapper implements PowerSyncDatabaseWrapper {
     if (error != null) {
       throw error;
     }
+    await syncStreamActivationGate?.future;
     return _FakeSyncStreamHandle(() => syncStreamUnsubscribes.add(name));
   }
 
@@ -184,6 +190,7 @@ class FakePowerSyncDatabaseWrapper implements PowerSyncDatabaseWrapper {
     executeError = null;
     writeTransactionError = null;
     syncStreamError = null;
+    syncStreamActivationGate = null;
     _closeWatchControllers();
   }
 

--- a/test/libraries/estimation/mutations/powersync_cost_estimation_data_source.xml
+++ b/test/libraries/estimation/mutations/powersync_cost_estimation_data_source.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mutations version="1.0">
+    <!-- POWERSYNC COST ESTIMATION DATA SOURCE MUTATION TESTING -->
+    <!-- Targets: reactive read data source (watch + snapshot) over local SQLite -->
+
+    <files>
+        <file>lib/libraries/estimation/data/data_source/powersync_cost_estimation_data_source_impl.dart</file>
+    </files>
+
+    <exclude>
+        <!-- Exclude logging statements -->
+        <regex pattern="_logger\.(debug|info|warning|error)\s*\(" dotAll="false"/>
+
+        <!-- Exclude try-catch structure -->
+        <regex pattern="try\s*{" dotAll="false"/>
+        <regex pattern="catch\s*\(" dotAll="false"/>
+
+        <!-- Exclude override annotations -->
+        <regex pattern="@override" dotAll="false"/>
+    </exclude>
+
+    <rules>
+        <!-- RULE 1: In _buildSelectSql, pick the wrong ORDER BY column for sortBy -->
+        <regex pattern="sortBy == EstimationSortOption\.updatedAt\s*\?\s*'updated_at'\s*:\s*'created_at'" dotAll="true" id="ds.sort.wrong_order_column">
+            <mutation text="sortBy == EstimationSortOption.updatedAt ? 'created_at' : 'updated_at'"/>
+        </regex>
+
+        <!-- RULE 2: In _buildSelectSql, invert the sort direction -->
+        <regex pattern="ascending \? 'ASC' : 'DESC'" dotAll="true" id="ds.sort.invert_direction">
+            <mutation text="ascending ? 'DESC' : 'ASC'"/>
+        </regex>
+
+        <!-- RULE 3: In _buildSelectSql, invert the LIMIT clause inclusion -->
+        <regex pattern="limited \? ' LIMIT \?' : ''" dotAll="true" id="ds.sort.invert_limit_clause">
+            <mutation text="limited ? '' : ' LIMIT ?'"/>
+        </regex>
+
+        <!-- RULE 4: In _selectParameters, invert the limit-binding guard -->
+        <regex pattern="if \(limit != null\) limit" dotAll="true" id="ds.params.invert_limit_guard">
+            <mutation text="if (limit == null) limit"/>
+        </regex>
+
+        <!-- RULE 5: In watchEstimations, drop the row->DTO mapping -->
+        <regex pattern="\.map\(\(rows\) =&gt; rows\.map\(CostEstimateDto\.fromRow\)\.toList\(\)\)" dotAll="true" id="ds.watch.skip_row_mapping">
+            <mutation text=".map((rows) =&gt; &lt;CostEstimateDto&gt;[])"/>
+        </regex>
+
+        <!-- RULE 6: In getEstimations, drop the row->DTO mapping -->
+        <regex pattern="return rows\.map\(CostEstimateDto\.fromRow\)\.toList\(\);" dotAll="true" id="ds.snapshot.skip_row_mapping">
+            <mutation text="return &lt;CostEstimateDto&gt;[];"/>
+        </regex>
+
+        <!-- RULE 7: In watchEstimations onCancel, fail to release the sync stream -->
+        <regex pattern="currentHandle\?\.unsubscribe\(\);" dotAll="true" id="ds.watch.skip_stream_release">
+            <mutation text="// currentHandle?.unsubscribe();"/>
+        </regex>
+
+        <!-- RULE 8: In watchEstimations, swallow the sync-stream activation error -->
+        <regex pattern="controller\.addError\(error, stackTrace\);" dotAll="true" id="ds.watch.swallow_activation_error">
+            <mutation text="// controller.addError(error, stackTrace);"/>
+        </regex>
+    </rules>
+
+    <commands>
+        <command group="powersync_cost_estimation_data_source" expected-return="0">flutter test test/libraries/estimation/units/data/data_source/powersync_cost_estimation_data_source_test.dart</command>
+    </commands>
+
+    <threshold failure="85">
+        <rating over="85" name="A"/>
+        <rating over="75" name="B"/>
+        <rating over="65" name="C"/>
+        <rating over="55" name="D"/>
+        <rating over="35" name="E"/>
+        <rating over="0" name="F"/>
+    </threshold>
+</mutations>

--- a/test/libraries/estimation/units/data/data_source/powersync_cost_estimation_data_source_test.dart
+++ b/test/libraries/estimation/units/data/data_source/powersync_cost_estimation_data_source_test.dart
@@ -1,0 +1,237 @@
+import 'dart:async';
+
+import 'package:construculator/app/app_bootstrap.dart';
+import 'package:construculator/libraries/estimation/data/data_source/interfaces/powersync_cost_estimation_data_source.dart';
+import 'package:construculator/libraries/estimation/data/models/cost_estimate_dto.dart';
+import 'package:construculator/libraries/estimation/domain/enums/estimation_sort_option.dart';
+import 'package:construculator/libraries/estimation/estimation_library_module.dart';
+import 'package:construculator/libraries/powersync/interfaces/powersync_database_wrapper.dart';
+import 'package:construculator/libraries/powersync/testing/fake_powersync_database_wrapper.dart';
+import 'package:flutter_modular/flutter_modular.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../../../../../utils/fake_app_bootstrap_factory.dart';
+import '../../../helpers/estimation_test_data_map_factory.dart';
+
+class _TestModule extends Module {
+  final AppBootstrap appBootstrap;
+
+  _TestModule(this.appBootstrap);
+
+  @override
+  List<Module> get imports => [EstimationLibraryModule(appBootstrap)];
+}
+
+void main() {
+  group('PowerSyncCostEstimationDataSource', () {
+    const projectId = testProjectId;
+    const syncStreamName = 'user_cost_estimates';
+    const defaultWatchSql =
+        'SELECT * FROM cost_estimates WHERE project_id = ? '
+        'ORDER BY created_at DESC';
+
+    late FakePowerSyncDatabaseWrapper fakeWrapper;
+    late PowerSyncCostEstimationDataSource dataSource;
+
+    setUpAll(() {
+      fakeWrapper = FakePowerSyncDatabaseWrapper();
+    });
+
+    setUp(() {
+      Modular.init(_TestModule(FakeAppBootstrapFactory.create()));
+      Modular.replaceInstance<PowerSyncDatabaseWrapper>(fakeWrapper);
+      dataSource = Modular.get<PowerSyncCostEstimationDataSource>();
+    });
+
+    tearDown(() {
+      Modular.destroy();
+      fakeWrapper.reset();
+    });
+
+    tearDownAll(() {
+      fakeWrapper.dispose();
+    });
+
+    /// A SQLite-shaped row, where `is_locked` is an integer (0/1) rather than
+    /// the boolean Supabase returns.
+    Map<String, dynamic> sqliteRow({
+      String id = estimateIdDefault,
+      bool locked = false,
+    }) {
+      final row = EstimationTestDataMapFactory.createFakeEstimationData(
+        id: id,
+        lockedByUserId: locked ? userIdDefault : null,
+        lockedAt: locked ? timestampDefault : null,
+      );
+      row['is_locked'] = locked ? 1 : 0;
+      return row;
+    }
+
+    group('watchEstimations', () {
+      test(
+        'activates the on-demand sync stream and maps rows to DTOs',
+        () async {
+          fakeWrapper.emitWatch(defaultWatchSql, [sqliteRow()]);
+
+          final emission = expectLater(
+            dataSource.watchEstimations(projectId: projectId),
+            emits(
+              isA<List<CostEstimateDto>>().having(
+                (dtos) => dtos.single.id,
+                'id',
+                estimateIdDefault,
+              ),
+            ),
+          );
+
+          await emission;
+          expect(fakeWrapper.syncStreamCalls, [syncStreamName]);
+          expect(fakeWrapper.watchCalls.single.sql, defaultWatchSql);
+          expect(fakeWrapper.watchCalls.single.parameters, [projectId]);
+        },
+      );
+
+      test('decodes is_locked integer encoding to a bool DTO', () async {
+        fakeWrapper.emitWatch(defaultWatchSql, [sqliteRow(locked: true)]);
+
+        await expectLater(
+          dataSource.watchEstimations(projectId: projectId),
+          emits(
+            isA<List<CostEstimateDto>>().having(
+              (dtos) => dtos.single.isLocked,
+              'isLocked',
+              isTrue,
+            ),
+          ),
+        );
+      });
+
+      test('builds sort, direction and limit into the watch query', () async {
+        final subscription = dataSource
+            .watchEstimations(
+              projectId: projectId,
+              sortBy: EstimationSortOption.updatedAt,
+              ascending: true,
+              limit: 5,
+            )
+            .listen((_) {});
+        addTearDown(subscription.cancel);
+
+        await pumpEventQueue();
+
+        expect(
+          fakeWrapper.watchCalls.single.sql,
+          'SELECT * FROM cost_estimates WHERE project_id = ? '
+          'ORDER BY updated_at ASC LIMIT ?',
+        );
+        expect(fakeWrapper.watchCalls.single.parameters, [projectId, 5]);
+      });
+
+      test(
+        'releases the sync stream when the subscription is cancelled',
+        () async {
+          final subscription = dataSource
+              .watchEstimations(projectId: projectId)
+              .listen((_) {});
+          await pumpEventQueue();
+
+          expect(fakeWrapper.syncStreamCalls, [syncStreamName]);
+          expect(fakeWrapper.syncStreamUnsubscribes, isEmpty);
+
+          await subscription.cancel();
+
+          expect(fakeWrapper.syncStreamUnsubscribes, [syncStreamName]);
+        },
+      );
+
+      test(
+        'does not start watch when cancelled while syncStream is still pending',
+        () async {
+          fakeWrapper.syncStreamActivationGate = Completer<void>();
+
+          final subscription = dataSource
+              .watchEstimations(projectId: projectId)
+              .listen((_) {});
+          await pumpEventQueue();
+
+          expect(fakeWrapper.syncStreamCalls, [syncStreamName]);
+          expect(fakeWrapper.watchCalls, isEmpty);
+
+          await subscription.cancel();
+          fakeWrapper.syncStreamActivationGate!.complete();
+          await pumpEventQueue();
+
+          expect(fakeWrapper.watchCalls, isEmpty);
+          expect(fakeWrapper.syncStreamUnsubscribes, [syncStreamName]);
+        },
+      );
+
+      test('surfaces a sync-stream activation error on the stream', () async {
+        final error = Exception('activation failed');
+        fakeWrapper.syncStreamError = error;
+
+        await expectLater(
+          dataSource.watchEstimations(projectId: projectId),
+          emitsError(same(error)),
+        );
+      });
+
+      test('forwards watch errors to the stream', () async {
+        final error = Exception('watch failed');
+
+        final emission = expectLater(
+          dataSource.watchEstimations(projectId: projectId),
+          emitsError(same(error)),
+        );
+
+        await pumpEventQueue();
+        fakeWrapper.emitWatchError(defaultWatchSql, error);
+
+        await emission;
+      });
+    });
+
+    group('getEstimations', () {
+      test(
+        'returns mapped DTOs from a one-shot read without activating sync',
+        () async {
+          fakeWrapper.stubGetAll(defaultWatchSql, [sqliteRow()]);
+
+          final result = await dataSource.getEstimations(projectId: projectId);
+
+          expect(result.single.id, estimateIdDefault);
+          expect(fakeWrapper.getAllCalls.single.sql, defaultWatchSql);
+          expect(fakeWrapper.getAllCalls.single.parameters, [projectId]);
+          expect(fakeWrapper.syncStreamCalls, isEmpty);
+        },
+      );
+
+      test('builds sort, direction and limit into the read query', () async {
+        const sortedSql =
+            'SELECT * FROM cost_estimates WHERE project_id = ? '
+            'ORDER BY updated_at ASC LIMIT ?';
+        fakeWrapper.stubGetAll(sortedSql, [sqliteRow()]);
+
+        await dataSource.getEstimations(
+          projectId: projectId,
+          sortBy: EstimationSortOption.updatedAt,
+          ascending: true,
+          limit: 5,
+        );
+
+        expect(fakeWrapper.getAllCalls.single.sql, sortedSql);
+        expect(fakeWrapper.getAllCalls.single.parameters, [projectId, 5]);
+      });
+
+      test('rethrows read errors', () async {
+        final error = Exception('read failed');
+        fakeWrapper.getAllError = error;
+
+        await expectLater(
+          dataSource.getEstimations(projectId: projectId),
+          throwsA(same(error)),
+        );
+      });
+    });
+  });
+}

--- a/test/libraries/estimation/units/data/models/cost_estimate_dto_test.dart
+++ b/test/libraries/estimation/units/data/models/cost_estimate_dto_test.dart
@@ -308,5 +308,43 @@ void main() {
 
       expect(convertedDto, equals(originalDto));
     });
+
+    group('fromRow (SQLite encoding)', () {
+      Map<String, dynamic> sqliteRow({int isLocked = 0}) {
+        return Map<String, dynamic>.from(
+          EstimationTestDataMapFactory.createFakeEstimationData(),
+        )..['is_locked'] = isLocked;
+      }
+
+      test('decodes is_locked integer 1 to a true bool', () {
+        final dto = CostEstimateDto.fromRow(sqliteRow(isLocked: 1));
+
+        expect(dto.isLocked, isTrue);
+      });
+
+      test('decodes is_locked integer 0 to a false bool', () {
+        final dto = CostEstimateDto.fromRow(sqliteRow(isLocked: 0));
+
+        expect(dto.isLocked, isFalse);
+      });
+
+      test('defaults missing is_locked to false', () {
+        final row = Map<String, dynamic>.from(
+          EstimationTestDataMapFactory.createFakeEstimationData(),
+        )..remove('is_locked');
+
+        final dto = CostEstimateDto.fromRow(row);
+
+        expect(dto.isLocked, isFalse);
+      });
+
+      test('maps the remaining columns identically to fromJson', () {
+        final row = sqliteRow(isLocked: 1);
+
+        final expected = CostEstimateDto.fromJson({...row, 'is_locked': true});
+
+        expect(CostEstimateDto.fromRow(row), equals(expected));
+      });
+    });
   });
 }

--- a/test/libraries/powersync/units/testing/fake_powersync_database_wrapper_test.dart
+++ b/test/libraries/powersync/units/testing/fake_powersync_database_wrapper_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:construculator/libraries/powersync/testing/fake_powersync_database_wrapper.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -131,6 +133,23 @@ void main() {
         await fakeWrapper.syncStream('user_cost_estimates');
 
         expect(fakeWrapper.syncStreamCalls, ['user_cost_estimates']);
+      });
+
+      test('can delay activation until the gate completes', () async {
+        fakeWrapper.syncStreamActivationGate = Completer<void>();
+
+        final future = fakeWrapper.syncStream('user_cost_estimates');
+        await pumpEventQueue();
+
+        expect(fakeWrapper.syncStreamCalls, ['user_cost_estimates']);
+        expect(fakeWrapper.syncStreamUnsubscribes, isEmpty);
+
+        fakeWrapper.syncStreamActivationGate!.complete();
+        final handle = await future;
+
+        handle.unsubscribe();
+
+        expect(fakeWrapper.syncStreamUnsubscribes, ['user_cost_estimates']);
       });
 
       test('returned handle records its release on unsubscribe', () async {


### PR DESCRIPTION
# PR Review: PowerSync Cost Estimation Data Source

### 1. PR SUMMARY

This PR introduces a new reactive, PowerSync-backed read data source (`PowerSyncCostEstimationDataSource`) for cost estimations, sitting alongside the existing request/response `CostEstimationDataSource`. It provides `watchEstimations` (live SQLite-backed stream, lazily activating the on-demand `user_cost_estimates` sync stream) and `getEstimations` (one-shot snapshot read, no stream activation). Supporting changes include a `CostEstimateDto.fromRow` factory to normalize SQLite's integer encoding of `is_locked` into a bool, DI wiring in `EstimationLibraryModule`, a test-gate addition (`syncStreamActivationGate`) to the fake wrapper for exercising cancellation races, a mutation-testing config, and thorough unit tests. Write operations are explicitly deferred to later PRs.

## REVIEW SUMMARY

| Issue Name | Description | Status | Notes |
|------------|-------------|--------|-------|
| Silent swallow of subscription-set-to-null race | In `watchEstimations`, if `controller.onCancel` fires and nulls out `subscription` between the `_wrapper.watch(...).listen(...)` call finishing and the `listenerCancelled` check afterward, the cancel path calls `subscription?.cancel()` on a variable that may already reflect the new subscription rather than being coordinated via a single lock/flag  | | This is unlikely to happem, as the suspected race relies on preemption that Dart's single-threaded event loop doesn't permit at that location |
| `fromRow` error contract undocumented edge case | `CostEstimateDto.fromRow` defaults missing `is_locked` to `false` via `(row['is_locked'] as int? ?? 0) != 0`, but if `is_locked` is present and non-null but the wrong runtime type (e.g., a `bool` already, from a mis-migrated row), this throws `TypeError` per the docstring — confirm this is truly desired/tested for that specific shape, since currently tests cover "missing" and correct int cases but not "already-bool" mis-encoding. | |  |
