### PR TITLE
CA-724: refactor(project): migrate FakeProjectUIProvider to libraries/project/testing

### DIFF
--- a/lib/libraries/project/testing/fake_project_ui_provider.dart
+++ b/lib/libraries/project/testing/fake_project_ui_provider.dart
@@ -1,0 +1,45 @@
+import 'package:construculator/libraries/project/presentation/project_ui_provider.dart';
+import 'package:flutter/material.dart';
+
+/// Fake implementation of [ProjectUIProvider] for testing.
+///
+/// Returns a lightweight [FakeProjectAppBar] instead of the real
+/// `ProjectHeaderAppBar`, so shell tests can verify that the project app bar
+/// slot is populated without pulling in the project header's bloc and
+/// notifier dependencies.
+class FakeProjectUIProvider implements ProjectUIProvider {
+  /// Number of times [buildProjectHeaderAppbar] was invoked, so tests can
+  /// assert the shell actually requested the app bar from the provider.
+  int buildProjectHeaderAppbarCallCount = 0;
+
+  /// Clears recorded calls; invoke from `tearDown` when the fake is reused
+  /// across tests.
+  void reset() {
+    buildProjectHeaderAppbarCallCount = 0;
+  }
+
+  @override
+  PreferredSizeWidget buildProjectHeaderAppbar({
+    VoidCallback? onProjectTap,
+    VoidCallback? onSearchTap,
+    VoidCallback? onNotificationTap,
+  }) {
+    buildProjectHeaderAppbarCallCount++;
+    return const PreferredSize(
+      preferredSize: Size.fromHeight(kToolbarHeight),
+      child: FakeProjectAppBar(),
+    );
+  }
+}
+
+/// Placeholder app bar rendered by [FakeProjectUIProvider].
+///
+/// Public so tests can locate it with `find.byType(FakeProjectAppBar)` to
+/// assert the provider-built app bar is shown.
+class FakeProjectAppBar extends StatelessWidget {
+  /// Creates a placeholder app bar that renders nothing.
+  const FakeProjectAppBar({super.key});
+
+  @override
+  Widget build(BuildContext context) => const SizedBox.shrink();
+}

--- a/test/app/shell/app_shell_page_test.dart
+++ b/test/app/shell/app_shell_page_test.dart
@@ -23,6 +23,7 @@ import 'package:construculator/libraries/project/interfaces/current_project_noti
 import 'package:construculator/libraries/project/presentation/project_ui_provider.dart';
 import 'package:construculator/libraries/project/testing/fake_current_project_notifier.dart';
 import 'package:construculator/libraries/project/testing/fake_project_repository.dart';
+import 'package:construculator/libraries/project/testing/fake_project_ui_provider.dart';
 import 'package:construculator/libraries/router/interfaces/app_router.dart';
 import 'package:construculator/libraries/supabase/interfaces/supabase_wrapper.dart';
 import 'package:construculator/libraries/supabase/testing/fake_supabase_user.dart';
@@ -85,7 +86,7 @@ void main() {
     Modular.bindModule(DashboardModule(appBootstrap));
 
     Modular.replaceInstance<CurrentProjectNotifier>(fakeProjectNotifier);
-    Modular.replaceInstance<ProjectUIProvider>(_FakeProjectUIProvider());
+    Modular.replaceInstance<ProjectUIProvider>(FakeProjectUIProvider());
   });
 
   tearDown(() {
@@ -339,7 +340,7 @@ void main() {
       Modular.replaceInstance<CostEstimationRepository>(
         FakeCostEstimationRepository(),
       );
-      Modular.replaceInstance<ProjectUIProvider>(_FakeProjectUIProvider());
+      Modular.replaceInstance<ProjectUIProvider>(FakeProjectUIProvider());
     });
 
     tearDown(() => fakeProjectNotifier.reset());
@@ -380,26 +381,4 @@ void main() {
       },
     );
   });
-}
-
-// TODO: [CA-724] Migrate to lib/libraries/project/testing/fake_project_ui_provider.dart
-class _FakeProjectUIProvider extends ProjectUIProvider {
-  @override
-  PreferredSizeWidget buildProjectHeaderAppbar({
-    VoidCallback? onProjectTap,
-    VoidCallback? onSearchTap,
-    VoidCallback? onNotificationTap,
-  }) {
-    return const PreferredSize(
-      preferredSize: Size.fromHeight(kToolbarHeight),
-      child: _FakeProjectAppBar(),
-    );
-  }
-}
-
-class _FakeProjectAppBar extends StatelessWidget {
-  const _FakeProjectAppBar();
-
-  @override
-  Widget build(BuildContext context) => const SizedBox.shrink();
 }

--- a/test/app/shell/widgets/app_shell_page_app_bar_test.dart
+++ b/test/app/shell/widgets/app_shell_page_app_bar_test.dart
@@ -12,6 +12,7 @@ import 'package:construculator/libraries/auth/domain/types/auth_types.dart';
 import 'package:construculator/libraries/project/interfaces/current_project_notifier.dart';
 import 'package:construculator/libraries/project/presentation/project_ui_provider.dart';
 import 'package:construculator/libraries/project/testing/fake_current_project_notifier.dart';
+import 'package:construculator/libraries/project/testing/fake_project_ui_provider.dart';
 import 'package:construculator/libraries/router/interfaces/app_router.dart';
 import 'package:construculator/libraries/supabase/testing/fake_supabase_user.dart';
 import 'package:construculator/libraries/supabase/testing/fake_supabase_wrapper.dart';
@@ -62,7 +63,7 @@ void main() {
     Modular.init(ShellModule(appBootstrap));
     Modular.bindModule(DashboardModule(appBootstrap));
     Modular.replaceInstance<CurrentProjectNotifier>(fakeProjectNotifier);
-    Modular.replaceInstance<ProjectUIProvider>(_FakeProjectUIProvider());
+    Modular.replaceInstance<ProjectUIProvider>(FakeProjectUIProvider());
   });
 
   tearDown(() => Modular.destroy());
@@ -135,29 +136,7 @@ void main() {
       await tester.pumpWidget(makeApp());
       await tester.pump();
 
-      expect(find.byType(_FakeProjectAppBar), findsOneWidget);
+      expect(find.byType(FakeProjectAppBar), findsOneWidget);
     });
   });
-}
-
-// TODO: [CA-724] Migrate to lib/libraries/project/testing/fake_project_ui_provider.dart
-class _FakeProjectUIProvider extends ProjectUIProvider {
-  @override
-  PreferredSizeWidget buildProjectHeaderAppbar({
-    VoidCallback? onProjectTap,
-    VoidCallback? onSearchTap,
-    VoidCallback? onNotificationTap,
-  }) {
-    return const PreferredSize(
-      preferredSize: Size.fromHeight(kToolbarHeight),
-      child: _FakeProjectAppBar(),
-    );
-  }
-}
-
-class _FakeProjectAppBar extends StatelessWidget {
-  const _FakeProjectAppBar();
-
-  @override
-  Widget build(BuildContext context) => const SizedBox.shrink();
 }


### PR DESCRIPTION
## 📝 PR Description

Two byte-identical private copies of `_FakeProjectUIProvider` (plus its companion `_FakeProjectAppBar`) lived inline in the shell test files. Since `ProjectUIProvider` is owned by `libraries/project/`, this PR migrates the fake to a shared public `FakeProjectUIProvider` in `lib/libraries/project/testing/fake_project_ui_provider.dart` and replaces both inline copies, removing the `// TODO: [CA-724]` markers. `FakeProjectAppBar` is public so tests can keep asserting `find.byType(FakeProjectAppBar)`, and the fake records `buildProjectHeaderAppbarCallCount` with a `reset()` hook, matching the call-tracking convention of the other fakes in that directory.

No testing barrel exists for the project library (per-file imports are its convention), so the fake is imported directly — matching how `fake_current_project_notifier.dart` and the other project fakes are consumed.

**Type:** Refactor ·
**Size:** XS (45 production lines) ·
**Rules applied:** Digestible PR, Naming & Abstraction, Test Double Pattern, Self-Documenting Code, Widget Test Finders

### What changed
- New `lib/libraries/project/testing/fake_project_ui_provider.dart` with public, documented `FakeProjectUIProvider` (call tracking + `reset()`) and `FakeProjectAppBar`
- `test/app/shell/app_shell_page_test.dart` and `test/app/shell/widgets/app_shell_page_app_bar_test.dart` now import the shared fake; inline private copies and CA-724 TODOs deleted
