### PR TITLE
CA-737: feat(global-search): support multi-owner filtering in search API

### DIFF
--- a/lib/features/global_search/data/data_source/remote_global_search_data_source.dart
+++ b/lib/features/global_search/data/data_source/remote_global_search_data_source.dart
@@ -188,7 +188,7 @@ class RemoteGlobalSearchDataSource implements GlobalSearchDataSource {
       'filter_by_tag': params.filterByTag,
       'filter_by_date_from': params.filterByDateFrom?.toIso8601String(),
       'filter_by_date_to': params.filterByDateTo?.toIso8601String(),
-      'filter_by_owner': params.filterByOwner,
+      'filter_by_owners': params.filterByOwners,
       'scope': params.scope?.name,
       'offset': params.pagination.offset,
       'limit': params.pagination.limit,

--- a/lib/features/global_search/data/models/search_params_dto.dart
+++ b/lib/features/global_search/data/models/search_params_dto.dart
@@ -18,7 +18,10 @@ class SearchParamsDto extends Equatable {
 
   /// Inclusive upper bound of the modification-date range filter.
   final DateTime? filterByDateTo;
-  final String? filterByOwner;
+
+  /// Optional owner identifiers forwarded as the RPC's `filter_by_owners`
+  /// array. `null` and an empty list both mean no owner filter.
+  final List<String>? filterByOwners;
   final SearchScopeDto? scope;
   final PaginationParamsDto pagination;
 
@@ -27,7 +30,7 @@ class SearchParamsDto extends Equatable {
     this.filterByTag,
     this.filterByDateFrom,
     this.filterByDateTo,
-    this.filterByOwner,
+    this.filterByOwners,
     this.scope,
     this.pagination = const PaginationParamsDto(),
   });
@@ -39,7 +42,7 @@ class SearchParamsDto extends Equatable {
     Object? filterByTag = _absent,
     Object? filterByDateFrom = _absent,
     Object? filterByDateTo = _absent,
-    Object? filterByOwner = _absent,
+    Object? filterByOwners = _absent,
     Object? scope = _absent,
     PaginationParamsDto? pagination,
   }) {
@@ -48,7 +51,7 @@ class SearchParamsDto extends Equatable {
       filterByTag: filterByTag == _absent ? this.filterByTag : filterByTag as String?,
       filterByDateFrom: filterByDateFrom == _absent ? this.filterByDateFrom : filterByDateFrom as DateTime?,
       filterByDateTo: filterByDateTo == _absent ? this.filterByDateTo : filterByDateTo as DateTime?,
-      filterByOwner: filterByOwner == _absent ? this.filterByOwner : filterByOwner as String?,
+      filterByOwners: filterByOwners == _absent ? this.filterByOwners : filterByOwners as List<String>?,
       scope: scope == _absent ? this.scope : scope as SearchScopeDto?,
       pagination: pagination ?? this.pagination,
     );
@@ -60,7 +63,7 @@ class SearchParamsDto extends Equatable {
     filterByTag,
     filterByDateFrom,
     filterByDateTo,
-    filterByOwner,
+    filterByOwners,
     scope,
     pagination,
   ];

--- a/lib/features/global_search/data/repositories/global_search_repository_impl.dart
+++ b/lib/features/global_search/data/repositories/global_search_repository_impl.dart
@@ -47,7 +47,7 @@ class GlobalSearchRepositoryImpl implements GlobalSearchRepository {
       filterByTag: entity.filterByTag,
       filterByDateFrom: entity.filterByDateFrom,
       filterByDateTo: entity.filterByDateTo,
-      filterByOwner: entity.filterByOwner,
+      filterByOwners: entity.filterByOwners,
       scope: entityScope != null ? _toDataScope(entityScope) : null,
       pagination: PaginationParamsDto(
         offset: entity.pagination.offset,

--- a/lib/features/global_search/domain/entities/search_params_entity.dart
+++ b/lib/features/global_search/domain/entities/search_params_entity.dart
@@ -24,8 +24,9 @@ class SearchParams extends Equatable {
   /// Inclusive upper bound of the modification-date range filter.
   final DateTime? filterByDateTo;
 
-  /// Optional owner identifier to restrict results to items owned by this user.
-  final String? filterByOwner;
+  /// Optional owner identifiers to restrict results to items owned by any of
+  /// these users. `null` and an empty list both mean no owner filter.
+  final List<String>? filterByOwners;
 
   /// Optional scope limiting which areas or entity types are searched.
   final SearchScope? scope;
@@ -38,7 +39,7 @@ class SearchParams extends Equatable {
     this.filterByTag,
     this.filterByDateFrom,
     this.filterByDateTo,
-    this.filterByOwner,
+    this.filterByOwners,
     this.scope,
     this.pagination = const PaginationParams(),
   });
@@ -51,7 +52,7 @@ class SearchParams extends Equatable {
     Object? filterByTag = _absent,
     Object? filterByDateFrom = _absent,
     Object? filterByDateTo = _absent,
-    Object? filterByOwner = _absent,
+    Object? filterByOwners = _absent,
     Object? scope = _absent,
     PaginationParams? pagination,
   }) {
@@ -60,7 +61,7 @@ class SearchParams extends Equatable {
       filterByTag: filterByTag == _absent ? this.filterByTag : filterByTag as String?,
       filterByDateFrom: filterByDateFrom == _absent ? this.filterByDateFrom : filterByDateFrom as DateTime?,
       filterByDateTo: filterByDateTo == _absent ? this.filterByDateTo : filterByDateTo as DateTime?,
-      filterByOwner: filterByOwner == _absent ? this.filterByOwner : filterByOwner as String?,
+      filterByOwners: filterByOwners == _absent ? this.filterByOwners : filterByOwners as List<String>?,
       scope: scope == _absent ? this.scope : scope as SearchScope?,
       pagination: pagination ?? this.pagination,
     );
@@ -72,7 +73,7 @@ class SearchParams extends Equatable {
     filterByTag,
     filterByDateFrom,
     filterByDateTo,
-    filterByOwner,
+    filterByOwners,
     scope,
     pagination,
   ];

--- a/lib/features/global_search/presentation/bloc/global_search_bloc/global_search_bloc.dart
+++ b/lib/features/global_search/presentation/bloc/global_search_bloc/global_search_bloc.dart
@@ -238,12 +238,10 @@ class GlobalSearchBloc extends Bloc<GlobalSearchEvent, GlobalSearchState> {
         filterByTag: _selectedTags.isEmpty
             ? null
             : (_selectedTags.toList()..sort()).first,
-        // SearchParams accepts a single owner; sort for deterministic
-        // selection until CA-737 extends the API to support multi-owner
-        // filtering.
-        filterByOwner: _selectedOwnerIds.isEmpty
+        // Sorted so equal selections always produce the same RPC payload.
+        filterByOwners: _selectedOwnerIds.isEmpty
             ? null
-            : (_selectedOwnerIds.toList()..sort()).first,
+            : (_selectedOwnerIds.toList()..sort()),
         filterByDateFrom: _selectedDateRange?.start,
         filterByDateTo: _selectedDateRange?.end,
       ),

--- a/lib/libraries/project/data/data_source/remote_project_search_data_source.dart
+++ b/lib/libraries/project/data/data_source/remote_project_search_data_source.dart
@@ -44,7 +44,10 @@ class RemoteProjectSearchDataSource implements ProjectSearchDataSource {
           'query': query,
           'filter_by_tag': filterByTag,
           'filter_by_date': filterByDate?.toIso8601String(),
-          'filter_by_owner': filterByOwner,
+          // The RPC takes an owner-id array; this data source still exposes a
+          // single-owner filter, so wrap it. Widening this interface to
+          // multiple owners is tracked in CA-771.
+          'filter_by_owners': filterByOwner == null ? null : [filterByOwner],
           'scope': DatabaseConstants.globalSearchDashboardScope,
           'offset': DatabaseConstants.globalSearchDefaultOffset,
           'limit': DatabaseConstants.globalSearchDefaultLimit,

--- a/test/features/global_search/units/blocs/global_search_bloc_test.dart
+++ b/test/features/global_search/units/blocs/global_search_bloc_test.dart
@@ -624,7 +624,7 @@ void main() {
       );
 
       blocTest<GlobalSearchBloc, GlobalSearchState>(
-        'forwards the alphabetically first selected owner id to the RPC when multiple owners are active',
+        'forwards all selected owner ids to the RPC sorted alphabetically when multiple owners are active',
         setUp: () {
           fakeSupabase.setCurrentUser(
             FakeUser(
@@ -668,10 +668,51 @@ void main() {
           final rpcParams =
               globalSearchCall['params'] as Map<String, dynamic>;
           expect(
-            rpcParams['filter_by_owner'],
-            equals('owner-1'),
+            rpcParams['filter_by_owners'],
+            equals(['owner-1', 'owner-2']),
             reason:
-                'must forward the alphabetically first owner id, not an arbitrary Set element',
+                'must forward every selected owner id, sorted so equal '
+                'selections always produce the same RPC payload',
+          );
+        },
+      );
+
+      blocTest<GlobalSearchBloc, GlobalSearchState>(
+        'forwards a null owner filter to the RPC when no owners are selected',
+        setUp: () {
+          fakeSupabase.setCurrentUser(
+            FakeUser(
+              id: _testUserId,
+              email: _testUserEmail,
+              createdAt: fakeClock.now().toIso8601String(),
+            ),
+          );
+          fakeSupabase.setRpcResponse(
+            DatabaseConstants.globalSearchRpcFunction,
+            {'projects': [], 'estimations': [], 'members': []},
+          );
+        },
+        build: () => Modular.get<GlobalSearchBloc>(),
+        act: (bloc) => bloc.add(const GlobalSearchPerformed(query: 'steel')),
+        expect: () => [
+          const GlobalSearchLoadInProgress(query: 'steel'),
+          isA<GlobalSearchLoadEmpty>(),
+        ],
+        verify: (_) {
+          final rpcCalls = fakeSupabase.getMethodCallsFor('rpc');
+          final globalSearchCall = rpcCalls.firstWhere(
+            (call) =>
+                call['functionName'] ==
+                DatabaseConstants.globalSearchRpcFunction,
+          );
+          final rpcParams =
+              globalSearchCall['params'] as Map<String, dynamic>;
+          expect(
+            rpcParams['filter_by_owners'],
+            isNull,
+            reason:
+                'an empty owner selection must be forwarded as null, the '
+                'backend contract for "no owner filter"',
           );
         },
       );

--- a/test/features/global_search/units/data/data_source/remote_global_search_data_source_test.dart
+++ b/test/features/global_search/units/data/data_source/remote_global_search_data_source_test.dart
@@ -184,7 +184,7 @@ void main() {
             filterByTag: 'construction',
             filterByDateFrom: filterDateFrom,
             filterByDateTo: filterDateTo,
-            filterByOwner: 'owner-1',
+            filterByOwners: const ['owner-1', 'owner-2'],
             scope: SearchScopeDto.estimation,
             pagination: const PaginationParamsDto(offset: 10, limit: 25),
           );
@@ -212,7 +212,10 @@ void main() {
             paramsMap['filter_by_date_to'],
             equals(filterDateTo.toIso8601String()),
           );
-          expect(paramsMap['filter_by_owner'], equals('owner-1'));
+          expect(
+            paramsMap['filter_by_owners'],
+            equals(['owner-1', 'owner-2']),
+          );
           expect(paramsMap['scope'], equals('estimation'));
           expect(paramsMap['offset'], equals(10));
           expect(paramsMap['limit'], equals(25));

--- a/test/features/global_search/units/data/models/search_params_dto_test.dart
+++ b/test/features/global_search/units/data/models/search_params_dto_test.dart
@@ -18,7 +18,7 @@ void main() {
         expect(params.filterByTag, isNull);
         expect(params.filterByDateFrom, isNull);
         expect(params.filterByDateTo, isNull);
-        expect(params.filterByOwner, isNull);
+        expect(params.filterByOwners, isNull);
         expect(params.scope, isNull);
       });
     });
@@ -30,7 +30,7 @@ void main() {
           filterByTag: 'residential',
           filterByDateFrom: DateTime(2025, 3, 1),
           filterByDateTo: DateTime(2025, 3, 31),
-          filterByOwner: 'user-123',
+          filterByOwners: const ['user-123', 'user-456'],
           scope: SearchScopeDto.estimation,
           pagination: const PaginationParamsDto(offset: 20),
         );
@@ -57,14 +57,14 @@ void main() {
           filterByTag: 'residential',
           filterByDateFrom: from,
           filterByDateTo: to,
-          filterByOwner: 'user-123',
+          filterByOwners: const ['user-123', 'user-456'],
           scope: SearchScopeDto.estimation,
         );
 
         expect(copy.filterByTag, 'residential');
         expect(copy.filterByDateFrom, from);
         expect(copy.filterByDateTo, to);
-        expect(copy.filterByOwner, 'user-123');
+        expect(copy.filterByOwners, ['user-123', 'user-456']);
         expect(copy.scope, SearchScopeDto.estimation);
       });
 
@@ -84,7 +84,7 @@ void main() {
           filterByTag: 'residential',
           filterByDateFrom: DateTime(2025, 3, 1),
           filterByDateTo: DateTime(2025, 3, 31),
-          filterByOwner: 'user-123',
+          filterByOwners: const ['user-123'],
           scope: SearchScopeDto.estimation,
         );
 
@@ -92,14 +92,14 @@ void main() {
           filterByTag: null,
           filterByDateFrom: null,
           filterByDateTo: null,
-          filterByOwner: null,
+          filterByOwners: null,
           scope: null,
         );
 
         expect(copy.filterByTag, isNull);
         expect(copy.filterByDateFrom, isNull);
         expect(copy.filterByDateTo, isNull);
-        expect(copy.filterByOwner, isNull);
+        expect(copy.filterByOwners, isNull);
         expect(copy.scope, isNull);
       });
     });
@@ -114,7 +114,7 @@ void main() {
           filterByTag: 'residential',
           filterByDateFrom: from,
           filterByDateTo: to,
-          filterByOwner: 'user-123',
+          filterByOwners: const ['user-123', 'user-456'],
           scope: SearchScopeDto.estimation,
           pagination: const PaginationParamsDto(offset: 20),
         );
@@ -124,7 +124,7 @@ void main() {
           filterByTag: 'residential',
           filterByDateFrom: from,
           filterByDateTo: to,
-          filterByOwner: 'user-123',
+          filterByOwners: const ['user-123', 'user-456'],
           scope: SearchScopeDto.estimation,
           pagination: const PaginationParamsDto(offset: 20),
         );
@@ -135,6 +135,19 @@ void main() {
       test('two instances with different query are not equal', () {
         const params1 = SearchParamsDto(query: 'bridge');
         const params2 = SearchParamsDto(query: 'road');
+
+        expect(params1, isNot(equals(params2)));
+      });
+
+      test('two instances with different owner filters are not equal', () {
+        const params1 = SearchParamsDto(
+          query: 'bridge',
+          filterByOwners: ['user-123'],
+        );
+        const params2 = SearchParamsDto(
+          query: 'bridge',
+          filterByOwners: ['user-456'],
+        );
 
         expect(params1, isNot(equals(params2)));
       });

--- a/test/features/global_search/units/data/repositories/global_search_repository_impl_test.dart
+++ b/test/features/global_search/units/data/repositories/global_search_repository_impl_test.dart
@@ -210,7 +210,7 @@ void main() {
             filterByTag: 'structural',
             filterByDateFrom: filterDateFrom,
             filterByDateTo: filterDateTo,
-            filterByOwner: 'owner-42',
+            filterByOwners: const ['owner-42', 'owner-7'],
             scope: SearchScope.estimation,
             pagination: const PaginationParams(offset: 5, limit: 10),
           );
@@ -231,7 +231,10 @@ void main() {
             rpcParams['filter_by_date_to'],
             equals(filterDateTo.toIso8601String()),
           );
-          expect(rpcParams['filter_by_owner'], equals('owner-42'));
+          expect(
+            rpcParams['filter_by_owners'],
+            equals(['owner-42', 'owner-7']),
+          );
           expect(rpcParams['scope'], equals('estimation'));
           expect(rpcParams['offset'], equals(5));
           expect(rpcParams['limit'], equals(10));

--- a/test/features/global_search/units/domain/entities/search_entities_test.dart
+++ b/test/features/global_search/units/domain/entities/search_entities_test.dart
@@ -39,7 +39,7 @@ void main() {
       expect(base.filterByTag, isNull);
       expect(base.filterByDateFrom, isNull);
       expect(base.filterByDateTo, isNull);
-      expect(base.filterByOwner, isNull);
+      expect(base.filterByOwners, isNull);
       expect(base.scope, isNull);
       expect(base.pagination, const PaginationParams());
     });
@@ -59,13 +59,13 @@ void main() {
         filterByTag: 'urgent',
         filterByDateFrom: from,
         filterByDateTo: to,
-        filterByOwner: 'user-1',
+        filterByOwners: const ['user-1', 'user-2'],
         scope: SearchScope.estimation,
       );
       expect(updated.filterByTag, 'urgent');
       expect(updated.filterByDateFrom, from);
       expect(updated.filterByDateTo, to);
-      expect(updated.filterByOwner, 'user-1');
+      expect(updated.filterByOwners, ['user-1', 'user-2']);
       expect(updated.scope, SearchScope.estimation);
     });
 
@@ -74,20 +74,20 @@ void main() {
         filterByTag: 'tag',
         filterByDateFrom: DateTime(2024),
         filterByDateTo: DateTime(2024, 1, 31),
-        filterByOwner: 'owner',
+        filterByOwners: const ['owner'],
         scope: SearchScope.dashboard,
       );
       final cleared = withFields.copyWith(
         filterByTag: null,
         filterByDateFrom: null,
         filterByDateTo: null,
-        filterByOwner: null,
+        filterByOwners: null,
         scope: null,
       );
       expect(cleared.filterByTag, isNull);
       expect(cleared.filterByDateFrom, isNull);
       expect(cleared.filterByDateTo, isNull);
-      expect(cleared.filterByOwner, isNull);
+      expect(cleared.filterByOwners, isNull);
       expect(cleared.scope, isNull);
     });
 

--- a/test/libraries/project/units/data/data_source/remote_project_search_data_source_test.dart
+++ b/test/libraries/project/units/data/data_source/remote_project_search_data_source_test.dart
@@ -213,7 +213,11 @@ void main() {
         final params = supabaseWrapper.getMethodCallsFor('rpc').first['params']
             as Map<String, dynamic>?;
         expect(params!['filter_by_tag'], equals('structural'));
-        expect(params['filter_by_owner'], equals('owner-42'));
+        expect(
+          params['filter_by_owners'],
+          equals(['owner-42']),
+          reason: 'a single owner must be wrapped in the RPC owner-id array',
+        );
       });
 
       test('ignores estimations and members in RPC response', () async {

--- a/test/libraries/project/units/data/repositories/project_search_repository_impl_test.dart
+++ b/test/libraries/project/units/data/repositories/project_search_repository_impl_test.dart
@@ -223,7 +223,11 @@ void main() {
           equals(filterDate.toIso8601String()),
         );
         expect(params['filter_by_tag'], equals('structural'));
-        expect(params['filter_by_owner'], equals('owner-42'));
+        expect(
+          params['filter_by_owners'],
+          equals(['owner-42']),
+          reason: 'a single owner must be wrapped in the RPC owner-id array',
+        );
         expect(params['scope'], equals('dashboard'));
       });
 


### PR DESCRIPTION
## 📝 PR Description

`GlobalSearchBloc` lets users select multiple project owners in the filter sheet, but `SearchParams` only carried a single `filterByOwner`, so the BLoC forwarded just the alphabetically-first selected owner id as a stopgap. This PR widens the client search contract to `filterByOwners: List<String>?` end-to-end (entity → DTO → repository mapper → RPC params) and removes the stopgap: the BLoC now forwards every selected owner id, sorted so equal selections always produce the same RPC payload.

The backend side is already implemented in `construculator-backend` (migration `37_global_search_multi_owner_filter.sql`, referencing CA-737): the `global_search` RPC replaced `filter_by_owner uuid` with `filter_by_owners uuid[] DEFAULT NULL`, where `NULL` and an empty array both mean "no owner filter". **This PR must not be released before that migration is deployed.** The dashboard project-search data source (`libraries/project`), which calls the same RPC with a single-owner filter, now wraps its value in a one-element array; widening that interface to multiple owners is tracked in CA-771. The parallel single-`filterByTag` limitation is unchanged and tracked in CA-638.

**Type:** Feature ·
**Size:** S (43 production lines) ·
**Rules applied:** Digestible PR, Naming & Abstraction, Test Double Pattern, Self-Documenting Code, Unit Test Behavior, Mutation Testing, UI / Business Separation, Sentry Logging

### What changed
- `search_params_entity.dart` / `search_params_dto.dart`: `String? filterByOwner` → `List<String>? filterByOwners` (docs, `_absent`-sentinel `copyWith`, `props`, equality coverage)
- `global_search_repository_impl.dart` `_toDataParams` and `remote_global_search_data_source.dart` `_toRpcParams`: forward the list as `filter_by_owners`
- `global_search_bloc.dart` `_onPerformed`: CA-737 single-owner stopgap removed; forwards all selected owner ids sorted
- `remote_project_search_data_source.dart`: single owner wrapped as `[filterByOwner]` under `filter_by_owners` (multi-owner widening deferred to CA-771)
- Tests updated across bloc, datasource, repository, DTO, and entity suites; bloc tests pin both the sorted-list and the empty-selection→`null` contracts
