### PR TITLE
CA-722: feat(supabase): add DB-level limit to selectMatch and use it in getRecentProjectSearches

### DIFF
--- a/lib/libraries/project/data/data_source/remote_project_search_data_source.dart
+++ b/lib/libraries/project/data/data_source/remote_project_search_data_source.dart
@@ -140,6 +140,7 @@ class RemoteProjectSearchDataSource implements ProjectSearchDataSource {
         filters: {DatabaseConstants.userIdColumn: userId},
         orderBy: DatabaseConstants.updatedAtColumn,
         ascending: false,
+        limit: DatabaseConstants.recentProjectSearchesMaxResults,
       );
 
       return rows
@@ -147,10 +148,6 @@ class RemoteProjectSearchDataSource implements ProjectSearchDataSource {
             (row) => row[DatabaseConstants.searchTermColumn]?.toString() ?? '',
           )
           .where((term) => term.isNotEmpty)
-          // TODO: [CA-722] Replace in-memory .take() with a DB-level limit
-          // once SupabaseWrapper.selectMatch supports a limit parameter.
-          // https://ripplearc.youtrack.cloud/issue/CA-722
-          .take(DatabaseConstants.recentProjectSearchesMaxResults)
           .toList();
     } on supabase.PostgrestException catch (error, stackTrace) {
       _logger.warning(

--- a/lib/libraries/supabase/database_constants.dart
+++ b/lib/libraries/supabase/database_constants.dart
@@ -95,9 +95,8 @@ class DatabaseConstants {
       '$userIdColumn,$searchTermColumn';
 
   /// Maximum number of recent project-search entries returned by
-  /// [ProjectSearchDataSource.getRecentProjectSearches]. Caps the in-memory
-  /// result size; row-count bounding at the DB level is delegated to a future
-  /// `limit` parameter on [SupabaseWrapper.selectMatch].
+  /// [ProjectSearchDataSource.getRecentProjectSearches]. Rows are bounded at
+  /// the DB level via the `limit` parameter on [SupabaseWrapper.selectMatch].
   static const int recentProjectSearchesMaxResults = 50;
 
   // User profile columns (id field uses the shared idColumn above)

--- a/lib/libraries/supabase/interfaces/supabase_wrapper.dart
+++ b/lib/libraries/supabase/interfaces/supabase_wrapper.dart
@@ -98,12 +98,15 @@ abstract class SupabaseWrapper {
   /// [filters] Map of column → value pairs that must all match
   /// [orderBy] Optional column name to order results by
   /// [ascending] Sort direction when [orderBy] is provided, defaults to true
+  /// [limit] Optional maximum number of rows to return, applied at the
+  /// database level; null means no limit
   Future<List<Map<String, dynamic>>> selectMatch({
     required String table,
     String columns = '*',
     required Map<String, dynamic> filters,
     String? orderBy,
     bool ascending = true,
+    int? limit,
   });
 
   /// Select a set of rows from a table where [filterColumn] value is in [filterValues].

--- a/lib/libraries/supabase/supabase_wrapper_impl.dart
+++ b/lib/libraries/supabase/supabase_wrapper_impl.dart
@@ -127,15 +127,17 @@ class SupabaseWrapperImpl implements SupabaseWrapper {
     required Map<String, dynamic> filters,
     String? orderBy,
     bool ascending = true,
+    int? limit,
   }) async {
     var query = _supabaseClient
         .from(table)
         .select(columns)
         .match(filters.cast<String, Object>());
     if (orderBy != null) {
-      return await query.order(orderBy, ascending: ascending);
+      final ordered = query.order(orderBy, ascending: ascending);
+      return limit != null ? await ordered.limit(limit) : await ordered;
     }
-    return await query;
+    return limit != null ? await query.limit(limit) : await query;
   }
 
   @override

--- a/lib/libraries/supabase/testing/fake_supabase_wrapper.dart
+++ b/lib/libraries/supabase/testing/fake_supabase_wrapper.dart
@@ -483,6 +483,7 @@ class FakeSupabaseWrapper implements SupabaseWrapper {
     required Map<String, dynamic> filters,
     String? orderBy,
     bool ascending = true,
+    int? limit,
   }) async {
     final tableDataSnapshot = List<Map<String, dynamic>>.from(_tables[table] ?? <Map<String, dynamic>>[]);
 
@@ -493,6 +494,7 @@ class FakeSupabaseWrapper implements SupabaseWrapper {
       'filters': Map<String, dynamic>.from(filters),
       if (orderBy != null) 'orderBy': orderBy,
       'ascending': ascending,
+      if (limit != null) 'limit': limit,
     });
 
     if (shouldDelayOperations) {
@@ -531,6 +533,9 @@ class FakeSupabaseWrapper implements SupabaseWrapper {
       });
     }
 
+    if (limit != null) {
+      return results.take(limit).toList();
+    }
     return results;
   }
 

--- a/test/libraries/project/units/data/data_source/remote_project_search_data_source_test.dart
+++ b/test/libraries/project/units/data/data_source/remote_project_search_data_source_test.dart
@@ -466,7 +466,7 @@ void main() {
       });
 
       test(
-        'caps results at recentProjectSearchesMaxResults',
+        'caps results at recentProjectSearchesMaxResults via DB-level limit',
         () async {
           final overLimit =
               DatabaseConstants.recentProjectSearchesMaxResults + 5;
@@ -490,6 +490,13 @@ void main() {
           expect(
             result,
             hasLength(DatabaseConstants.recentProjectSearchesMaxResults),
+          );
+          final call = supabaseWrapper.getMethodCallsFor('selectMatch').single;
+          expect(
+            call['limit'],
+            equals(DatabaseConstants.recentProjectSearchesMaxResults),
+            reason: 'Row-count bounding must happen at the DB level, '
+                'not in memory after fetching all rows',
           );
         },
       );

--- a/test/libraries/supabase/units/fakes/fake_supabase_wrapper_test.dart
+++ b/test/libraries/supabase/units/fakes/fake_supabase_wrapper_test.dart
@@ -1278,6 +1278,7 @@ void main() {
             table: 'items',
             columns: 'id,status',
             filters: {'project_id': 'p1', 'status': 'active'},
+            limit: 3,
           );
 
           final calls = fakeWrapper.getMethodCallsFor('selectMatch');
@@ -1289,6 +1290,45 @@ void main() {
             call['filters'],
             equals({'project_id': 'p1', 'status': 'active'}),
           );
+          expect(call['limit'], equals(3));
+        });
+
+        test('truncates matching rows to limit after ordering', () async {
+          fakeWrapper.addTableData('items', [
+            {'id': '1', 'project_id': 'p1', 'rank': 3},
+            {'id': '2', 'project_id': 'p1', 'rank': 1},
+            {'id': '3', 'project_id': 'p1', 'rank': 2},
+            {'id': '4', 'project_id': 'p2', 'rank': 0},
+          ]);
+
+          final result = await fakeWrapper.selectMatch(
+            table: 'items',
+            filters: {'project_id': 'p1'},
+            orderBy: 'rank',
+            limit: 2,
+          );
+
+          expect(result, hasLength(2));
+          expect(
+            result.map((row) => row['id']),
+            equals(['2', '3']),
+            reason: 'Limit must apply to the ordered rows, not insertion order',
+          );
+        });
+
+        test('returns all matching rows when limit is null', () async {
+          fakeWrapper.addTableData('items', [
+            {'id': '1', 'project_id': 'p1'},
+            {'id': '2', 'project_id': 'p1'},
+            {'id': '3', 'project_id': 'p1'},
+          ]);
+
+          final result = await fakeWrapper.selectMatch(
+            table: 'items',
+            filters: {'project_id': 'p1'},
+          );
+
+          expect(result, hasLength(3));
         });
 
         test('records call before delay completes', () async {


### PR DESCRIPTION
# PR Review: CA-722-feat/select-match-db-limit → CA-689-feat/project-search-suggestions-ui

## 📝 PR Description

`getRecentProjectSearches` used to fetch every matching history row from Supabase and then truncate the list in memory with `.take()`, meaning unbounded rows crossed the network just to be discarded. This PR adds an optional `limit` parameter to `SupabaseWrapper.selectMatch` so the row-count bound is applied by the database itself, and switches the recent-searches data source to use it. Resolves the `TODO: [CA-722]` left in the CA-688 data-source PR.

**Type:** Refactor ·
**Size:** XS (19 production lines) ·
**Rules applied:** Digestible PR, Naming & Abstraction, Self-Documenting Code, Test Double Pattern, Stream Lifecycle, Sentry Logging

### What changed
- `SupabaseWrapper.selectMatch` gains an optional `int? limit` (interface + dartdoc); `SupabaseWrapperImpl` chains PostgREST `.limit()` after ordering so the bound is applied server-side.
- `FakeSupabaseWrapper.selectMatch` mirrors the real semantics: records `limit` in method calls and truncates the ordered result set.
- `RemoteProjectSearchDataSource.getRecentProjectSearches` passes `limit: DatabaseConstants.recentProjectSearchesMaxResults` and drops the in-memory `.take()` + `TODO: [CA-722]` comment.
- Tests: data-source cap test now asserts the limit is forwarded to `selectMatch`; fake-wrapper tests cover limit-after-ordering, null-limit-returns-all, and limit recorded in method calls.

---

## 🔍 Review Summary

> Found 0 issue(s): 0 🔴 critical · 0 🟠 major · 0 🟡 minor · 0 🔵 suggestion — across 6 file(s).

✅ No issues found — all applied rules passed.

**Status (author fills):** ✅ Addressed · 📋 Future Story (add YouTrack ID) ·
❌ Disagree (justify) · 🔄 In Progress

<!-- Skipped: CoreUI Components (no presentation files changed), UI / Business Separation (no presentation files changed), Localization (no presentation files changed), Widget Test Finders (no widget tests changed), Unit Test Behavior (no test/features unit tests changed), Mutation Testing (No logic-heavy code changed), Accessibility (No user-facing UI changed) -->
