### PR TITLE
CA-368 (3/3): wire FAB navigation to CostItemFormScreen

### DIFF
--- a/lib/features/estimation/presentation/pages/cost_estimation_details_page.dart
+++ b/lib/features/estimation/presentation/pages/cost_estimation_details_page.dart
@@ -1,6 +1,7 @@
 import 'package:construculator/features/estimation/presentation/widgets/cost_estimation_details_tab_view.dart';
 import 'package:construculator/libraries/extensions/extensions.dart';
 import 'package:construculator/libraries/router/interfaces/app_router.dart';
+import 'package:construculator/libraries/router/routes/estimation_routes.dart';
 import 'package:flutter/material.dart';
 import 'package:ripplearc_coreui/ripplearc_coreui.dart';
 
@@ -85,7 +86,6 @@ class CostEstimationDetailsPage extends StatelessWidget {
         ),
       ),
       body: const CostEstimationDetailsTabView(),
-      // TODO: [CA-155] [Cost Estimation] Implement Add Material Cost Logic https://ripplearc.youtrack.cloud/issue/CA-155/Cost-Estimation-Implement-Add-Material-Cost-Logic
       floatingActionButton: CoreButton(
         key: const Key('add_material_cost_button'),
         label: l10n.addMaterialCostButton,
@@ -93,7 +93,9 @@ class CostEstimationDetailsPage extends StatelessWidget {
         icon: CoreIconWidget(icon: CoreIcons.add),
         size: CoreButtonSize.medium,
         fullWidth: false,
-        onPressed: () {},
+        onPressed: () => router.pushNamed(
+          '$fullAddMaterialCostRoute/$estimationId',
+        ),
       ),
       bottomNavigationBar: SafeArea(
         child: Container(

--- a/test/features/estimations/widgets/pages/cost_estimation_details_page_test.dart
+++ b/test/features/estimations/widgets/pages/cost_estimation_details_page_test.dart
@@ -66,6 +66,7 @@ void main() {
 
   setUp(() {
     fakeSupabase.reset();
+    (Modular.get<AppRouter>() as FakeAppRouter).reset();
   });
 
   Widget makeApp() {

--- a/test/features/estimations/widgets/pages/cost_estimation_details_page_test.dart
+++ b/test/features/estimations/widgets/pages/cost_estimation_details_page_test.dart
@@ -4,8 +4,9 @@ import 'package:construculator/features/estimation/presentation/widgets/cost_est
 import 'package:construculator/features/project/project_module.dart';
 import 'package:construculator/l10n/generated/app_localizations.dart';
 import 'package:construculator/libraries/auth/auth_library_module.dart';
-
+import 'package:construculator/libraries/router/interfaces/app_router.dart';
 import 'package:construculator/libraries/router/routes/estimation_routes.dart';
+import 'package:construculator/libraries/router/testing/fake_router.dart';
 import 'package:construculator/libraries/router/testing/router_test_module.dart';
 import 'package:construculator/libraries/supabase/testing/fake_supabase_user.dart';
 import 'package:construculator/libraries/supabase/testing/fake_supabase_wrapper.dart';
@@ -181,6 +182,26 @@ void main() {
 
       expect(find.byKey(const Key('add_material_cost_button')), findsOneWidget);
       expect(find.text(l10n.addMaterialCostButton), findsOneWidget);
+    });
+
+    testWidgets('tapping add material cost button navigates to cost item form', (
+      WidgetTester tester,
+    ) async {
+      setUpAuthenticatedUser(
+        credentialId: 'test-credential-id',
+        email: 'test@example.com',
+      );
+
+      await pumpAppAtRoute(tester, testEstimationRoute);
+
+      await tester.tap(find.byKey(const Key('add_material_cost_button')));
+      await tester.pump();
+
+      final fakeRouter = Modular.get<AppRouter>() as FakeAppRouter;
+      expect(
+        fakeRouter.navigationHistory,
+        contains(RouteCall('$fullAddMaterialCostRoute/$testEstimationId', null)),
+      );
     });
 
     testWidgets('displays preview button in bottom bar', (


### PR DESCRIPTION
### 1. PR SUMMARY
Wires the "Add material cost" FAB on `CostEstimationDetailsPage` to navigate to the new `CostItemFormScreen` (introduced in PR #409). Removes the old `CA-155` TODO that was blocking this navigation. Adds a widget test asserting the tap navigates to the correct route.

### 2. REVIEW SUMMARY TABLE

No issues found.

## Test plan
- [ ] New navigation test passes (`cost_estimation_details_page_test.dart`)
- [ ] `fvm dart run custom_lint` — no issues
- [ ] `fvm flutter test test/features/estimations/` — all tests pass