### PR TITLE
CA-293 (1/2): feat: add form section placeholder and Expanded body layout

### DIFF
--- a/lib/features/estimation/presentation/pages/cost_estimation_details_page.dart
+++ b/lib/features/estimation/presentation/pages/cost_estimation_details_page.dart
@@ -1,4 +1,5 @@
 import 'package:construculator/features/estimation/presentation/widgets/cost_estimation_details_tab_view.dart';
+import 'package:construculator/l10n/generated/app_localizations.dart';
 import 'package:construculator/libraries/extensions/extensions.dart';
 import 'package:construculator/libraries/router/interfaces/app_router.dart';
 import 'package:construculator/libraries/router/routes/estimation_routes.dart';
@@ -28,7 +29,7 @@ class CostEstimationDetailsPage extends StatefulWidget {
 }
 
 class _CostEstimationDetailsPageState extends State<CostEstimationDetailsPage> {
-  int _selectedTabIndex = 0;
+  CostEstimationTab _selectedTab = CostEstimationTab.material;
 
   @override
   Widget build(BuildContext context) {
@@ -94,9 +95,9 @@ class _CostEstimationDetailsPageState extends State<CostEstimationDetailsPage> {
         ),
       ),
       body: CostEstimationDetailsTabView(
-        onTabChanged: (index) => setState(() => _selectedTabIndex = index),
+        onTabChanged: (tab) => setState(() => _selectedTab = tab),
       ),
-      floatingActionButton: _buildFab(),
+      floatingActionButton: _buildFab(l10n),
       bottomNavigationBar: SafeArea(
         child: Container(
           padding: const EdgeInsets.symmetric(
@@ -139,10 +140,9 @@ class _CostEstimationDetailsPageState extends State<CostEstimationDetailsPage> {
     );
   }
 
-  Widget _buildFab() {
-    final l10n = context.l10n;
-    return switch (_selectedTabIndex) {
-      1 => CoreButton(
+  Widget _buildFab(AppLocalizations l10n) {
+    return switch (_selectedTab) {
+      CostEstimationTab.labour => CoreButton(
         key: const Key('add_labour_cost_button'),
         label: l10n.addLabourCostButton,
         variant: CoreButtonVariant.secondary,
@@ -153,7 +153,7 @@ class _CostEstimationDetailsPageState extends State<CostEstimationDetailsPage> {
           '$fullAddLabourCostRoute/${widget.estimationId}',
         ),
       ),
-      2 => CoreButton(
+      CostEstimationTab.equipment => CoreButton(
         key: const Key('add_equipment_cost_button'),
         label: l10n.addEquipmentCostButton,
         variant: CoreButtonVariant.secondary,
@@ -164,7 +164,7 @@ class _CostEstimationDetailsPageState extends State<CostEstimationDetailsPage> {
           '$fullAddEquipmentCostRoute/${widget.estimationId}',
         ),
       ),
-      _ => CoreButton(
+      CostEstimationTab.material => CoreButton(
         key: const Key('add_material_cost_button'),
         label: l10n.addMaterialCostButton,
         variant: CoreButtonVariant.secondary,

--- a/lib/features/estimation/presentation/pages/cost_estimation_details_page.dart
+++ b/lib/features/estimation/presentation/pages/cost_estimation_details_page.dart
@@ -8,9 +8,9 @@ import 'package:ripplearc_coreui/ripplearc_coreui.dart';
 /// The cost estimation details page.
 ///
 /// Displays a tabbed view of [CostEstimationDetailsTabView] (Materials,
-/// Labours, Equipments) with a custom app bar, FAB for adding material
-/// costs, and a bottom bar with lock and preview actions.
-class CostEstimationDetailsPage extends StatelessWidget {
+/// Labours, Equipments) with a custom app bar, context-aware FAB for adding
+/// cost items, and a bottom bar with lock and preview actions.
+class CostEstimationDetailsPage extends StatefulWidget {
   final String estimationId;
 
   /// Router used for navigation (e.g. popping this page).
@@ -21,6 +21,14 @@ class CostEstimationDetailsPage extends StatelessWidget {
     required this.estimationId,
     required this.router,
   });
+
+  @override
+  State<CostEstimationDetailsPage> createState() =>
+      _CostEstimationDetailsPageState();
+}
+
+class _CostEstimationDetailsPageState extends State<CostEstimationDetailsPage> {
+  int _selectedTabIndex = 0;
 
   @override
   Widget build(BuildContext context) {
@@ -49,7 +57,7 @@ class CostEstimationDetailsPage extends StatelessWidget {
               size: 24,
               visualDensity: VisualDensity.compact,
               semanticLabel: l10n.backLabel,
-              onTap: router.pop,
+              onTap: widget.router.pop,
             ),
             // TODO: [CA-154] [Cost Estimation] Implement Rename Estimation Logic https://ripplearc.youtrack.cloud/issue/CA-154/Cost-Estimation-Implement-Rename-Estimation-Logic
             title: Row(
@@ -85,18 +93,10 @@ class CostEstimationDetailsPage extends StatelessWidget {
           ),
         ),
       ),
-      body: const CostEstimationDetailsTabView(),
-      floatingActionButton: CoreButton(
-        key: const Key('add_material_cost_button'),
-        label: l10n.addMaterialCostButton,
-        variant: CoreButtonVariant.secondary,
-        icon: CoreIconWidget(icon: CoreIcons.add),
-        size: CoreButtonSize.medium,
-        fullWidth: false,
-        onPressed: () => router.pushNamed(
-          '$fullAddMaterialCostRoute/$estimationId',
-        ),
+      body: CostEstimationDetailsTabView(
+        onTabChanged: (index) => setState(() => _selectedTabIndex = index),
       ),
+      floatingActionButton: _buildFab(),
       bottomNavigationBar: SafeArea(
         child: Container(
           padding: const EdgeInsets.symmetric(
@@ -137,5 +137,44 @@ class CostEstimationDetailsPage extends StatelessWidget {
         ),
       ),
     );
+  }
+
+  Widget _buildFab() {
+    final l10n = context.l10n;
+    return switch (_selectedTabIndex) {
+      1 => CoreButton(
+        key: const Key('add_labour_cost_button'),
+        label: l10n.addLabourCostButton,
+        variant: CoreButtonVariant.secondary,
+        icon: CoreIconWidget(icon: CoreIcons.add),
+        size: CoreButtonSize.medium,
+        fullWidth: false,
+        onPressed: () => widget.router.pushNamed(
+          '$fullAddLabourCostRoute/${widget.estimationId}',
+        ),
+      ),
+      2 => CoreButton(
+        key: const Key('add_equipment_cost_button'),
+        label: l10n.addEquipmentCostButton,
+        variant: CoreButtonVariant.secondary,
+        icon: CoreIconWidget(icon: CoreIcons.add),
+        size: CoreButtonSize.medium,
+        fullWidth: false,
+        onPressed: () => widget.router.pushNamed(
+          '$fullAddEquipmentCostRoute/${widget.estimationId}',
+        ),
+      ),
+      _ => CoreButton(
+        key: const Key('add_material_cost_button'),
+        label: l10n.addMaterialCostButton,
+        variant: CoreButtonVariant.secondary,
+        icon: CoreIconWidget(icon: CoreIcons.add),
+        size: CoreButtonSize.medium,
+        fullWidth: false,
+        onPressed: () => widget.router.pushNamed(
+          '$fullAddMaterialCostRoute/${widget.estimationId}',
+        ),
+      ),
+    };
   }
 }

--- a/lib/features/estimation/presentation/pages/cost_item_form_screen.dart
+++ b/lib/features/estimation/presentation/pages/cost_item_form_screen.dart
@@ -133,7 +133,7 @@ class _CostItemFormScreenState extends State<CostItemFormScreen> {
   }
 
   Widget _buildFormFields() {
-    // TODO: [CA-306] Add form fields for material, labour, and equipment modes
+    // TODO: [CA-306] Add form fields for material, labour, and equipment modes https://ripplearc.youtrack.cloud/issue/CA-306
     return const SizedBox.shrink();
   }
 

--- a/lib/features/estimation/presentation/pages/cost_item_form_screen.dart
+++ b/lib/features/estimation/presentation/pages/cost_item_form_screen.dart
@@ -1,6 +1,5 @@
 import 'package:construculator/features/estimation/domain/entities/cost_item_entity.dart';
 import 'package:construculator/features/estimation/presentation/widgets/cost_item_mode_toggle.dart';
-import 'package:construculator/l10n/generated/app_localizations.dart';
 import 'package:construculator/libraries/extensions/extensions.dart';
 import 'package:construculator/libraries/router/interfaces/app_router.dart';
 import 'package:flutter/material.dart';
@@ -68,7 +67,7 @@ class _CostItemFormScreenState extends State<CostItemFormScreen> {
             children: [
               Flexible(
                 child: Text(
-                  _screenTitle(l10n),
+                  _screenTitle(context),
                   style: textTheme.titleMediumSemiBold.copyWith(
                     color: colorTheme.textHeadline,
                   ),
@@ -91,10 +90,10 @@ class _CostItemFormScreenState extends State<CostItemFormScreen> {
     );
   }
 
-  String _screenTitle(AppLocalizations l10n) => switch (widget.type) {
-    CostItemType.material => l10n.addMaterialCostsScreenTitle,
-    CostItemType.labor => l10n.addLabourCostsScreenTitle,
-    CostItemType.equipment => l10n.addEquipmentCostsScreenTitle,
+  String _screenTitle(BuildContext context) => switch (widget.type) {
+    CostItemType.material => context.l10n.addMaterialCostsScreenTitle,
+    CostItemType.labor => context.l10n.addLabourCostsScreenTitle,
+    CostItemType.equipment => context.l10n.addEquipmentCostsScreenTitle,
   };
 
   Widget _buildBody(BuildContext context) {
@@ -128,9 +127,14 @@ class _CostItemFormScreenState extends State<CostItemFormScreen> {
             ),
           ),
         ),
-        // TODO: [CA-306] [Cost Estimation] Build Manual Cost Calculation Form UI https://ripplearc.youtrack.cloud/issue/CA-306/Cost-Estimation-Build-Manual-Cost-Calculation-Form-UI
+        Expanded(child: _buildFormFields()),
       ],
     );
+  }
+
+  Widget _buildFormFields() {
+    // TODO: [CA-306] Add form fields for material, labour, and equipment modes
+    return const SizedBox.shrink();
   }
 
   Widget _buildBottomBar(BuildContext context) {

--- a/lib/features/estimation/presentation/widgets/cost_estimation_details_tab_view.dart
+++ b/lib/features/estimation/presentation/widgets/cost_estimation_details_tab_view.dart
@@ -2,11 +2,15 @@ import 'package:construculator/libraries/extensions/extensions.dart';
 import 'package:flutter/material.dart';
 import 'package:ripplearc_coreui/ripplearc_coreui.dart';
 
+/// The active tab on the cost estimation details screen.
+enum CostEstimationTab { material, labour, equipment }
+
 /// A tabbed view displaying cost estimation details for Materials, Labours, and Equipments.
 ///
 /// Shows empty states with appropriate messages when no costs have been added for each category.
 class CostEstimationDetailsTabView extends StatefulWidget {
-  final ValueChanged<int>? onTabChanged;
+  /// Called when the user switches tabs, passing the newly active [CostEstimationTab].
+  final ValueChanged<CostEstimationTab>? onTabChanged;
 
   const CostEstimationDetailsTabView({super.key, this.onTabChanged});
 
@@ -38,7 +42,7 @@ class _CostEstimationDetailsTabViewState
                   setState(() {
                     _selectedIndex = index;
                   });
-                  widget.onTabChanged?.call(index);
+                  widget.onTabChanged?.call(CostEstimationTab.values[index]);
                 },
               ),
             ),

--- a/lib/features/estimation/presentation/widgets/cost_estimation_details_tab_view.dart
+++ b/lib/features/estimation/presentation/widgets/cost_estimation_details_tab_view.dart
@@ -6,7 +6,9 @@ import 'package:ripplearc_coreui/ripplearc_coreui.dart';
 ///
 /// Shows empty states with appropriate messages when no costs have been added for each category.
 class CostEstimationDetailsTabView extends StatefulWidget {
-  const CostEstimationDetailsTabView({super.key});
+  final ValueChanged<int>? onTabChanged;
+
+  const CostEstimationDetailsTabView({super.key, this.onTabChanged});
 
   @override
   State<CostEstimationDetailsTabView> createState() =>
@@ -36,6 +38,7 @@ class _CostEstimationDetailsTabViewState
                   setState(() {
                     _selectedIndex = index;
                   });
+                  widget.onTabChanged?.call(index);
                 },
               ),
             ),

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1768,11 +1768,13 @@
   },
   "addLabourCostButton": "Add labour cost",
   "@addLabourCostButton": {
-    "description": "Label for the FAB on the cost estimation details page when the labours tab is active"
+    "description": "Label for the FAB on the cost estimation details page when the labours tab is active",
+    "context": "https://www.figma.com/design/vugaGpii5HfgEQHPbrS3mU/Construculator-Visual-Design?node-id=57363-12305"
   },
   "addEquipmentCostButton": "Add equipment cost",
   "@addEquipmentCostButton": {
-    "description": "Label for the FAB on the cost estimation details page when the equipments tab is active"
+    "description": "Label for the FAB on the cost estimation details page when the equipments tab is active",
+    "context": "https://www.figma.com/design/vugaGpii5HfgEQHPbrS3mU/Construculator-Visual-Design?node-id=57406-17357"
   }
 }
 

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1765,6 +1765,14 @@
   "@projectDetailScreenTitle": {
     "description": "Title shown in the app bar of the project details screen",
     "context": "Project settings"
+  },
+  "addLabourCostButton": "Add labour cost",
+  "@addLabourCostButton": {
+    "description": "Label for the FAB on the cost estimation details page when the labours tab is active"
+  },
+  "addEquipmentCostButton": "Add equipment cost",
+  "@addEquipmentCostButton": {
+    "description": "Label for the FAB on the cost estimation details page when the equipments tab is active"
   }
 }
 

--- a/lib/l10n/generated/app_localizations.dart
+++ b/lib/l10n/generated/app_localizations.dart
@@ -2115,6 +2115,18 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Project Details'**
   String get projectDetailScreenTitle;
+
+  /// Label for the FAB on the cost estimation details page when the labours tab is active
+  ///
+  /// In en, this message translates to:
+  /// **'Add labour cost'**
+  String get addLabourCostButton;
+
+  /// Label for the FAB on the cost estimation details page when the equipments tab is active
+  ///
+  /// In en, this message translates to:
+  /// **'Add equipment cost'**
+  String get addEquipmentCostButton;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/generated/app_localizations_en.dart
+++ b/lib/l10n/generated/app_localizations_en.dart
@@ -1118,4 +1118,10 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get projectDetailScreenTitle => 'Project Details';
+
+  @override
+  String get addLabourCostButton => 'Add labour cost';
+
+  @override
+  String get addEquipmentCostButton => 'Add equipment cost';
 }

--- a/test/features/estimations/widgets/pages/cost_estimation_details_page_test.dart
+++ b/test/features/estimations/widgets/pages/cost_estimation_details_page_test.dart
@@ -231,5 +231,101 @@ void main() {
 
       expect(find.byKey(const Key('lock_icon')), findsOneWidget);
     });
+
+    testWidgets('FAB shows add labour cost after switching to labours tab', (
+      WidgetTester tester,
+    ) async {
+      setUpAuthenticatedUser(
+        credentialId: 'test-credential-id',
+        email: 'test@example.com',
+      );
+
+      await pumpAppAtRoute(tester, testEstimationRoute);
+
+      await tester.tap(find.text(l10n.laboursTab));
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('add_labour_cost_button')), findsOneWidget);
+      expect(find.text(l10n.addLabourCostButton), findsOneWidget);
+    });
+
+    testWidgets('FAB shows add equipment cost after switching to equipments tab', (
+      WidgetTester tester,
+    ) async {
+      setUpAuthenticatedUser(
+        credentialId: 'test-credential-id',
+        email: 'test@example.com',
+      );
+
+      await pumpAppAtRoute(tester, testEstimationRoute);
+
+      await tester.tap(find.text(l10n.equipmentsTab));
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('add_equipment_cost_button')), findsOneWidget);
+      expect(find.text(l10n.addEquipmentCostButton), findsOneWidget);
+    });
+
+    testWidgets('FAB returns to material after switching back to materials tab', (
+      WidgetTester tester,
+    ) async {
+      setUpAuthenticatedUser(
+        credentialId: 'test-credential-id',
+        email: 'test@example.com',
+      );
+
+      await pumpAppAtRoute(tester, testEstimationRoute);
+
+      await tester.tap(find.text(l10n.laboursTab));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text(l10n.materialsTab));
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('add_material_cost_button')), findsOneWidget);
+    });
+
+    testWidgets('tapping add labour cost button navigates to labour cost form', (
+      WidgetTester tester,
+    ) async {
+      setUpAuthenticatedUser(
+        credentialId: 'test-credential-id',
+        email: 'test@example.com',
+      );
+
+      await pumpAppAtRoute(tester, testEstimationRoute);
+
+      await tester.tap(find.text(l10n.laboursTab));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const Key('add_labour_cost_button')));
+      await tester.pump();
+
+      final fakeRouter = Modular.get<AppRouter>() as FakeAppRouter;
+      expect(
+        fakeRouter.navigationHistory,
+        contains(RouteCall('$fullAddLabourCostRoute/$testEstimationId', null)),
+      );
+    });
+
+    testWidgets('tapping add equipment cost button navigates to equipment cost form', (
+      WidgetTester tester,
+    ) async {
+      setUpAuthenticatedUser(
+        credentialId: 'test-credential-id',
+        email: 'test@example.com',
+      );
+
+      await pumpAppAtRoute(tester, testEstimationRoute);
+
+      await tester.tap(find.text(l10n.equipmentsTab));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const Key('add_equipment_cost_button')));
+      await tester.pump();
+
+      final fakeRouter = Modular.get<AppRouter>() as FakeAppRouter;
+      expect(
+        fakeRouter.navigationHistory,
+        contains(RouteCall('$fullAddEquipmentCostRoute/$testEstimationId', null)),
+      );
+    });
   });
 }


### PR DESCRIPTION
## Summary

Prepares `CostItemFormScreen` to receive cost form fields (CA-293):

- Refactors `_screenTitle` to accept `BuildContext` directly instead of a pre-resolved `l10n` value, consistent with how other methods in this file receive context
- Extracts a `_buildFormFields()` stub (returns `SizedBox.shrink()`) with a TODO for CA-306, replacing an inline comment inside `_buildBody`
- Wraps the form-fields area in `Expanded` so the stub fills available vertical space correctly when real fields land

No new widgets added. Tests unchanged — groundwork only; the `MaterialCostFormFields` widget follows in the next PR in this stack.

## Test plan
- [ ] `fvm dart run custom_lint` reports no issues
- [ ] `fvm flutter test` passes