### PR TITLE
CA-293 (2/2): make FAB context-aware and route per cost item tab

### DIFF
--- a/lib/features/estimation/presentation/pages/cost_estimation_details_page.dart
+++ b/lib/features/estimation/presentation/pages/cost_estimation_details_page.dart
@@ -8,9 +8,9 @@ import 'package:ripplearc_coreui/ripplearc_coreui.dart';
 /// The cost estimation details page.
 ///
 /// Displays a tabbed view of [CostEstimationDetailsTabView] (Materials,
-/// Labours, Equipments) with a custom app bar, FAB for adding material
-/// costs, and a bottom bar with lock and preview actions.
-class CostEstimationDetailsPage extends StatelessWidget {
+/// Labours, Equipments) with a custom app bar, context-aware FAB for adding
+/// cost items, and a bottom bar with lock and preview actions.
+class CostEstimationDetailsPage extends StatefulWidget {
   final String estimationId;
 
   /// Router used for navigation (e.g. popping this page).
@@ -21,6 +21,14 @@ class CostEstimationDetailsPage extends StatelessWidget {
     required this.estimationId,
     required this.router,
   });
+
+  @override
+  State<CostEstimationDetailsPage> createState() =>
+      _CostEstimationDetailsPageState();
+}
+
+class _CostEstimationDetailsPageState extends State<CostEstimationDetailsPage> {
+  int _selectedTabIndex = 0;
 
   @override
   Widget build(BuildContext context) {
@@ -49,7 +57,7 @@ class CostEstimationDetailsPage extends StatelessWidget {
               size: 24,
               visualDensity: VisualDensity.compact,
               semanticLabel: l10n.backLabel,
-              onTap: router.pop,
+              onTap: widget.router.pop,
             ),
             // TODO: [CA-154] [Cost Estimation] Implement Rename Estimation Logic https://ripplearc.youtrack.cloud/issue/CA-154/Cost-Estimation-Implement-Rename-Estimation-Logic
             title: Row(
@@ -85,18 +93,10 @@ class CostEstimationDetailsPage extends StatelessWidget {
           ),
         ),
       ),
-      body: const CostEstimationDetailsTabView(),
-      floatingActionButton: CoreButton(
-        key: const Key('add_material_cost_button'),
-        label: l10n.addMaterialCostButton,
-        variant: CoreButtonVariant.secondary,
-        icon: CoreIconWidget(icon: CoreIcons.add),
-        size: CoreButtonSize.medium,
-        fullWidth: false,
-        onPressed: () => router.pushNamed(
-          '$fullAddMaterialCostRoute/$estimationId',
-        ),
+      body: CostEstimationDetailsTabView(
+        onTabChanged: (index) => setState(() => _selectedTabIndex = index),
       ),
+      floatingActionButton: _buildFab(),
       bottomNavigationBar: SafeArea(
         child: Container(
           padding: const EdgeInsets.symmetric(
@@ -137,5 +137,44 @@ class CostEstimationDetailsPage extends StatelessWidget {
         ),
       ),
     );
+  }
+
+  Widget _buildFab() {
+    final l10n = context.l10n;
+    return switch (_selectedTabIndex) {
+      1 => CoreButton(
+        key: const Key('add_labour_cost_button'),
+        label: l10n.addLabourCostButton,
+        variant: CoreButtonVariant.secondary,
+        icon: CoreIconWidget(icon: CoreIcons.add),
+        size: CoreButtonSize.medium,
+        fullWidth: false,
+        onPressed: () => widget.router.pushNamed(
+          '$fullAddLabourCostRoute/${widget.estimationId}',
+        ),
+      ),
+      2 => CoreButton(
+        key: const Key('add_equipment_cost_button'),
+        label: l10n.addEquipmentCostButton,
+        variant: CoreButtonVariant.secondary,
+        icon: CoreIconWidget(icon: CoreIcons.add),
+        size: CoreButtonSize.medium,
+        fullWidth: false,
+        onPressed: () => widget.router.pushNamed(
+          '$fullAddEquipmentCostRoute/${widget.estimationId}',
+        ),
+      ),
+      _ => CoreButton(
+        key: const Key('add_material_cost_button'),
+        label: l10n.addMaterialCostButton,
+        variant: CoreButtonVariant.secondary,
+        icon: CoreIconWidget(icon: CoreIcons.add),
+        size: CoreButtonSize.medium,
+        fullWidth: false,
+        onPressed: () => widget.router.pushNamed(
+          '$fullAddMaterialCostRoute/${widget.estimationId}',
+        ),
+      ),
+    };
   }
 }

--- a/lib/features/estimation/presentation/widgets/cost_estimation_details_tab_view.dart
+++ b/lib/features/estimation/presentation/widgets/cost_estimation_details_tab_view.dart
@@ -6,7 +6,9 @@ import 'package:ripplearc_coreui/ripplearc_coreui.dart';
 ///
 /// Shows empty states with appropriate messages when no costs have been added for each category.
 class CostEstimationDetailsTabView extends StatefulWidget {
-  const CostEstimationDetailsTabView({super.key});
+  final ValueChanged<int>? onTabChanged;
+
+  const CostEstimationDetailsTabView({super.key, this.onTabChanged});
 
   @override
   State<CostEstimationDetailsTabView> createState() =>
@@ -36,6 +38,7 @@ class _CostEstimationDetailsTabViewState
                   setState(() {
                     _selectedIndex = index;
                   });
+                  widget.onTabChanged?.call(index);
                 },
               ),
             ),

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1765,6 +1765,14 @@
   "@projectDetailScreenTitle": {
     "description": "Title shown in the app bar of the project details screen",
     "context": "Project settings"
+  },
+  "addLabourCostButton": "Add labour cost",
+  "@addLabourCostButton": {
+    "description": "Label for the FAB on the cost estimation details page when the labours tab is active"
+  },
+  "addEquipmentCostButton": "Add equipment cost",
+  "@addEquipmentCostButton": {
+    "description": "Label for the FAB on the cost estimation details page when the equipments tab is active"
   }
 }
 

--- a/lib/l10n/generated/app_localizations.dart
+++ b/lib/l10n/generated/app_localizations.dart
@@ -2115,6 +2115,18 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Project Details'**
   String get projectDetailScreenTitle;
+
+  /// Label for the FAB on the cost estimation details page when the labours tab is active
+  ///
+  /// In en, this message translates to:
+  /// **'Add labour cost'**
+  String get addLabourCostButton;
+
+  /// Label for the FAB on the cost estimation details page when the equipments tab is active
+  ///
+  /// In en, this message translates to:
+  /// **'Add equipment cost'**
+  String get addEquipmentCostButton;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/generated/app_localizations_en.dart
+++ b/lib/l10n/generated/app_localizations_en.dart
@@ -1118,4 +1118,10 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get projectDetailScreenTitle => 'Project Details';
+
+  @override
+  String get addLabourCostButton => 'Add labour cost';
+
+  @override
+  String get addEquipmentCostButton => 'Add equipment cost';
 }

--- a/test/features/estimations/widgets/pages/cost_estimation_details_page_test.dart
+++ b/test/features/estimations/widgets/pages/cost_estimation_details_page_test.dart
@@ -231,5 +231,101 @@ void main() {
 
       expect(find.byKey(const Key('lock_icon')), findsOneWidget);
     });
+
+    testWidgets('FAB shows add labour cost after switching to labours tab', (
+      WidgetTester tester,
+    ) async {
+      setUpAuthenticatedUser(
+        credentialId: 'test-credential-id',
+        email: 'test@example.com',
+      );
+
+      await pumpAppAtRoute(tester, testEstimationRoute);
+
+      await tester.tap(find.text(l10n.laboursTab));
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('add_labour_cost_button')), findsOneWidget);
+      expect(find.text(l10n.addLabourCostButton), findsOneWidget);
+    });
+
+    testWidgets('FAB shows add equipment cost after switching to equipments tab', (
+      WidgetTester tester,
+    ) async {
+      setUpAuthenticatedUser(
+        credentialId: 'test-credential-id',
+        email: 'test@example.com',
+      );
+
+      await pumpAppAtRoute(tester, testEstimationRoute);
+
+      await tester.tap(find.text(l10n.equipmentsTab));
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('add_equipment_cost_button')), findsOneWidget);
+      expect(find.text(l10n.addEquipmentCostButton), findsOneWidget);
+    });
+
+    testWidgets('FAB returns to material after switching back to materials tab', (
+      WidgetTester tester,
+    ) async {
+      setUpAuthenticatedUser(
+        credentialId: 'test-credential-id',
+        email: 'test@example.com',
+      );
+
+      await pumpAppAtRoute(tester, testEstimationRoute);
+
+      await tester.tap(find.text(l10n.laboursTab));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text(l10n.materialsTab));
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('add_material_cost_button')), findsOneWidget);
+    });
+
+    testWidgets('tapping add labour cost button navigates to labour cost form', (
+      WidgetTester tester,
+    ) async {
+      setUpAuthenticatedUser(
+        credentialId: 'test-credential-id',
+        email: 'test@example.com',
+      );
+
+      await pumpAppAtRoute(tester, testEstimationRoute);
+
+      await tester.tap(find.text(l10n.laboursTab));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const Key('add_labour_cost_button')));
+      await tester.pump();
+
+      final fakeRouter = Modular.get<AppRouter>() as FakeAppRouter;
+      expect(
+        fakeRouter.navigationHistory,
+        contains(RouteCall('$fullAddLabourCostRoute/$testEstimationId', null)),
+      );
+    });
+
+    testWidgets('tapping add equipment cost button navigates to equipment cost form', (
+      WidgetTester tester,
+    ) async {
+      setUpAuthenticatedUser(
+        credentialId: 'test-credential-id',
+        email: 'test@example.com',
+      );
+
+      await pumpAppAtRoute(tester, testEstimationRoute);
+
+      await tester.tap(find.text(l10n.equipmentsTab));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const Key('add_equipment_cost_button')));
+      await tester.pump();
+
+      final fakeRouter = Modular.get<AppRouter>() as FakeAppRouter;
+      expect(
+        fakeRouter.navigationHistory,
+        contains(RouteCall('$fullAddEquipmentCostRoute/$testEstimationId', null)),
+      );
+    });
   });
 }


### PR DESCRIPTION
### 1. PR SUMMARY

Adds `LabourCostFormFields` — a mode-aware form widget for the Labour cost item screen (CA-293 2/3). In "From cost file" mode: disabled cost file + labour type dropdowns, a calculation method card (Per day / Per hours / Per unit radio options with a static rate row), and conditional text fields whose label updates with the selected method. In "Manually" mode: editable labour type + crew rate fields with the same calc method card (no rate row). Local `LaborCalculationMethodType` state drives the conditional field label. Uses `Wrap` for radio options to handle narrow viewports gracefully. Wires `CostItemFormScreen` to render `LabourCostFormFields` for `CostItemType.labor`.

### 2. REVIEW SUMMARY TABLE

| Issue Name | Description | Status | Notes |
|------------|-------------|--------|-------|
| Dynamic type param | `_conditionalFieldLabel(dynamic l10n)` should take `BuildContext` | ✅ Fixed | Updated call sites and signature in PR 3 review commit |
| A11y test coverage | No a11y tests for calc method card or assign task row | ✅ Fixed | Added `labour_cost_form_fields_a11y_test.dart` in PR 3 review commit |
| Row overflow at narrow viewports | Radio options Row overflows by 146px in a11y test surface (412px) | ✅ Fixed | Changed to `Wrap` in PR 3 review commit |

## Test plan
- [ ] Labour "Manually" mode: labour type text field + crew rate field visible, cost file dropdown hidden
- [ ] Labour "From cost file" mode: disabled cost file + labour type dropdowns visible, crew rate hidden
- [ ] Calc method "Per day" → conditional field shows "No. of days" label
- [ ] Calc method "Per hours" → conditional field shows "No. of hours" label
- [ ] Calc method "Per unit" → conditional field shows "No. of units" label
- [ ] Rate row visible in "From cost file" mode, hidden in "Manually" mode
- [ ] All 17 widget tests pass (`fvm flutter test test/features/estimations/widgets/widgets/labour_cost_form_fields_test.dart`)
- [ ] A11y tests pass (`fvm flutter test test/features/estimations/widgets/accessibility/labour_cost_form_fields_a11y_test.dart`)
- [ ] `fvm dart run custom_lint` reports no issues