### PR TITLE
CA-306: feat: add manual cost item form field widgets

### DIFF
--- a/lib/features/estimation/presentation/pages/cost_item_form_screen.dart
+++ b/lib/features/estimation/presentation/pages/cost_item_form_screen.dart
@@ -1,5 +1,8 @@
 import 'package:construculator/features/estimation/domain/entities/cost_item_entity.dart';
 import 'package:construculator/features/estimation/presentation/widgets/cost_item_mode_toggle.dart';
+import 'package:construculator/features/estimation/presentation/widgets/equipment_cost_form_fields.dart';
+import 'package:construculator/features/estimation/presentation/widgets/labour_cost_form_fields.dart';
+import 'package:construculator/features/estimation/presentation/widgets/material_cost_form_fields.dart';
 import 'package:construculator/libraries/extensions/extensions.dart';
 import 'package:construculator/libraries/router/interfaces/app_router.dart';
 import 'package:flutter/material.dart';
@@ -132,8 +135,11 @@ class _CostItemFormScreenState extends State<CostItemFormScreen> {
   }
 
   Widget _buildFormFields() {
-    // TODO: [CA-306] Add form fields for material, labour, and equipment modes
-    return const SizedBox.shrink();
+    return switch (widget.type) {
+      CostItemType.material => MaterialCostFormFields(fromCostFile: _fromCostFile),
+      CostItemType.labor => LabourCostFormFields(fromCostFile: _fromCostFile),
+      CostItemType.equipment => EquipmentCostFormFields(fromCostFile: _fromCostFile),
+    };
   }
 
   Widget _buildBottomBar(BuildContext context) {

--- a/lib/features/estimation/presentation/widgets/equipment_cost_form_fields.dart
+++ b/lib/features/estimation/presentation/widgets/equipment_cost_form_fields.dart
@@ -1,0 +1,116 @@
+import 'package:construculator/libraries/extensions/extensions.dart';
+import 'package:flutter/material.dart';
+import 'package:ripplearc_coreui/ripplearc_coreui.dart';
+
+class EquipmentCostFormFields extends StatefulWidget {
+  final bool fromCostFile;
+
+  const EquipmentCostFormFields({super.key, required this.fromCostFile});
+
+  @override
+  State<EquipmentCostFormFields> createState() =>
+      _EquipmentCostFormFieldsState();
+}
+
+class _EquipmentCostFormFieldsState extends State<EquipmentCostFormFields> {
+  final _equipmentNameController = TextEditingController();
+  final _unitPriceController = TextEditingController();
+  final _quantityController = TextEditingController();
+
+  @override
+  void dispose() {
+    _equipmentNameController.dispose();
+    _unitPriceController.dispose();
+    _quantityController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SingleChildScrollView(
+      padding: const EdgeInsets.all(CoreSpacing.space4),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          if (widget.fromCostFile)
+            ..._fromCostFileFields(context)
+          else
+            ..._manuallyFields(context),
+          const SizedBox(height: CoreSpacing.space6),
+          // TODO: [CA-336] Add assign task section
+          // TODO: [CA-349] Build Preview Cost File UI (fromCostFile mode only)
+        ],
+      ),
+    );
+  }
+
+  List<Widget> _fromCostFileFields(BuildContext context) {
+    final l10n = context.l10n;
+    final colorTheme = context.colorTheme;
+    return [
+      // TODO: [CA-298] Wire cost file dropdown to CostFileDataSource
+      CoreTextField(
+        key: const Key('cost_file_field'),
+        hintText: l10n.costFilePlaceholder,
+        readOnly: true,
+        enabled: false,
+        suffix: CoreIconWidget(
+          icon: CoreIcons.arrowDropDown,
+          color: colorTheme.iconGrayMid,
+          size: 24,
+        ),
+      ),
+      const SizedBox(height: CoreSpacing.space5),
+      // TODO: [CA-298] Populate equipment type from selected cost file
+      CoreTextField(
+        key: const Key('equipment_type_field'),
+        hintText: l10n.equipmentTypeLabel,
+        readOnly: true,
+        enabled: false,
+        suffix: CoreIconWidget(
+          icon: CoreIcons.arrowDropDown,
+          color: colorTheme.iconGrayMid,
+          size: 24,
+        ),
+      ),
+      const SizedBox(height: CoreSpacing.space5),
+      CoreTextField(
+        key: const Key('quantity_field'),
+        hintText: l10n.quantityLabel,
+        controller: _quantityController,
+        keyboardType: const TextInputType.numberWithOptions(decimal: true),
+      ),
+    ];
+  }
+
+  List<Widget> _manuallyFields(BuildContext context) {
+    final l10n = context.l10n;
+    final colorTheme = context.colorTheme;
+    return [
+      CoreTextField(
+        key: const Key('equipment_name_field'),
+        hintText: l10n.equipmentNameLabel,
+        controller: _equipmentNameController,
+      ),
+      const SizedBox(height: CoreSpacing.space5),
+      CoreTextField(
+        key: const Key('unit_price_field'),
+        hintText: l10n.unitPriceLabel,
+        controller: _unitPriceController,
+        keyboardType: const TextInputType.numberWithOptions(decimal: true),
+        suffix: CoreIconWidget(
+          icon: CoreIcons.dollar,
+          color: colorTheme.textHeadline,
+          size: 24,
+        ),
+      ),
+      const SizedBox(height: CoreSpacing.space5),
+      CoreTextField(
+        key: const Key('quantity_field'),
+        hintText: l10n.quantityLabel,
+        controller: _quantityController,
+        keyboardType: const TextInputType.numberWithOptions(decimal: true),
+      ),
+    ];
+  }
+}

--- a/lib/features/estimation/presentation/widgets/labour_cost_form_fields.dart
+++ b/lib/features/estimation/presentation/widgets/labour_cost_form_fields.dart
@@ -1,0 +1,261 @@
+import 'package:construculator/features/estimation/domain/entities/cost_item_entity.dart';
+import 'package:construculator/libraries/extensions/extensions.dart';
+import 'package:flutter/material.dart';
+import 'package:ripplearc_coreui/ripplearc_coreui.dart';
+
+class LabourCostFormFields extends StatefulWidget {
+  final bool fromCostFile;
+
+  const LabourCostFormFields({super.key, required this.fromCostFile});
+
+  @override
+  State<LabourCostFormFields> createState() => _LabourCostFormFieldsState();
+}
+
+class _LabourCostFormFieldsState extends State<LabourCostFormFields> {
+  LaborCalculationMethodType _calcMethod = LaborCalculationMethodType.perDay;
+  final _labourTypeController = TextEditingController();
+  final _crewRateController = TextEditingController();
+  final _conditionalValueController = TextEditingController();
+  final _crewSizeController = TextEditingController();
+
+  @override
+  void dispose() {
+    _labourTypeController.dispose();
+    _crewRateController.dispose();
+    _conditionalValueController.dispose();
+    _crewSizeController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SingleChildScrollView(
+      padding: const EdgeInsets.all(CoreSpacing.space4),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          if (widget.fromCostFile)
+            ..._fromCostFileFields(context)
+          else
+            ..._manuallyFields(context),
+          const SizedBox(height: CoreSpacing.space6),
+          // TODO: [CA-336] Add assign task section
+        ],
+      ),
+    );
+  }
+
+  List<Widget> _fromCostFileFields(BuildContext context) {
+    final l10n = context.l10n;
+    final colorTheme = context.colorTheme;
+    return [
+      // TODO: [CA-298] Wire cost file dropdown to CostFileDataSource
+      CoreTextField(
+        key: const Key('cost_file_field'),
+        hintText: l10n.costFilePlaceholder,
+        readOnly: true,
+        enabled: false,
+        suffix: CoreIconWidget(
+          icon: CoreIcons.arrowDropDown,
+          color: colorTheme.iconGrayMid,
+          size: 24,
+        ),
+      ),
+      const SizedBox(height: CoreSpacing.space5),
+      // TODO: [CA-298] Populate labour type from selected cost file
+      CoreTextField(
+        key: const Key('labour_type_field'),
+        hintText: l10n.labourTypeLabel,
+        readOnly: true,
+        enabled: false,
+        suffix: CoreIconWidget(
+          icon: CoreIcons.arrowDropDown,
+          color: colorTheme.iconGrayMid,
+          size: 24,
+        ),
+      ),
+      const SizedBox(height: CoreSpacing.space5),
+      _buildCalcMethodCard(context, showRateRow: true),
+      const SizedBox(height: CoreSpacing.space5),
+      CoreTextField(
+        key: const Key('conditional_value_field'),
+        hintText: _conditionalFieldLabel(context),
+        controller: _conditionalValueController,
+        keyboardType: const TextInputType.numberWithOptions(decimal: true),
+      ),
+      const SizedBox(height: CoreSpacing.space5),
+      CoreTextField(
+        key: const Key('crew_size_field'),
+        hintText: l10n.crewSizeLabel,
+        controller: _crewSizeController,
+        keyboardType: TextInputType.number,
+      ),
+    ];
+  }
+
+  List<Widget> _manuallyFields(BuildContext context) {
+    final l10n = context.l10n;
+    final colorTheme = context.colorTheme;
+    return [
+      CoreTextField(
+        key: const Key('labour_type_field'),
+        hintText: l10n.labourTypeLabel,
+        controller: _labourTypeController,
+      ),
+      const SizedBox(height: CoreSpacing.space5),
+      _buildCalcMethodCard(context, showRateRow: false),
+      const SizedBox(height: CoreSpacing.space5),
+      CoreTextField(
+        key: const Key('crew_rate_field'),
+        hintText: l10n.crewRateLabel,
+        controller: _crewRateController,
+        keyboardType: const TextInputType.numberWithOptions(decimal: true),
+        suffix: CoreIconWidget(
+          icon: CoreIcons.dollar,
+          color: colorTheme.textHeadline,
+          size: 24,
+        ),
+      ),
+      const SizedBox(height: CoreSpacing.space5),
+      CoreTextField(
+        key: const Key('conditional_value_field'),
+        hintText: _conditionalFieldLabel(context),
+        controller: _conditionalValueController,
+        keyboardType: const TextInputType.numberWithOptions(decimal: true),
+      ),
+      const SizedBox(height: CoreSpacing.space5),
+      CoreTextField(
+        key: const Key('crew_size_field'),
+        hintText: l10n.crewSizeLabel,
+        controller: _crewSizeController,
+        keyboardType: TextInputType.number,
+      ),
+    ];
+  }
+
+  String _conditionalFieldLabel(BuildContext context) => switch (_calcMethod) {
+    LaborCalculationMethodType.perDay => context.l10n.noOfDaysLabel,
+    LaborCalculationMethodType.perHour => context.l10n.noOfHoursLabel,
+    // TODO: [CA-319] Add Per Unit calculation option
+    LaborCalculationMethodType.perUnit => context.l10n.noOfDaysLabel,
+  };
+
+  Widget _buildCalcMethodCard(BuildContext context, {required bool showRateRow}) {
+    final l10n = context.l10n;
+    final colorTheme = context.colorTheme;
+    final textTheme = context.textTheme;
+    return Container(
+      key: const Key('calc_method_card'),
+      decoration: BoxDecoration(
+        color: colorTheme.pageBackground,
+        borderRadius: BorderRadius.circular(8),
+        boxShadow: CoreShadows.small,
+      ),
+      padding: const EdgeInsets.all(CoreSpacing.space3),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            l10n.calcMethodTitle,
+            style: textTheme.bodyMediumMedium.copyWith(
+              color: colorTheme.textHeadline,
+            ),
+          ),
+          const SizedBox(height: CoreSpacing.space3),
+          Wrap(
+            spacing: CoreSpacing.space8,
+            runSpacing: CoreSpacing.space2,
+            children: [
+              _CalcMethodRadioOption(
+                key: const Key('per_day_option'),
+                label: l10n.perDayOption,
+                isSelected: _calcMethod == LaborCalculationMethodType.perDay,
+                onTap: () => setState(
+                  () => _calcMethod = LaborCalculationMethodType.perDay,
+                ),
+              ),
+              _CalcMethodRadioOption(
+                key: const Key('per_hours_option'),
+                label: l10n.perHoursOption,
+                isSelected: _calcMethod == LaborCalculationMethodType.perHour,
+                onTap: () => setState(
+                  () => _calcMethod = LaborCalculationMethodType.perHour,
+                ),
+              ),
+              // TODO: [CA-319] Add Per Unit calculation option
+            ],
+          ),
+          if (showRateRow) ...[
+            const SizedBox(height: CoreSpacing.space3),
+            // TODO: [CA-298] Wire rate label to CostFileDataSource
+            Row(
+              key: const Key('rate_row'),
+              children: [
+                Text(
+                  'Rate/Day:',
+                  style: textTheme.bodySmallRegular.copyWith(
+                    color: colorTheme.textBody,
+                  ),
+                ),
+                const SizedBox(width: CoreSpacing.space1),
+                Text(
+                  '\$0',
+                  style: textTheme.bodySmallMedium.copyWith(
+                    color: colorTheme.textHeadline,
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+class _CalcMethodRadioOption extends StatelessWidget {
+  final String label;
+  final bool isSelected;
+  final VoidCallback onTap;
+
+  const _CalcMethodRadioOption({
+    super.key,
+    required this.label,
+    required this.isSelected,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final colorTheme = context.colorTheme;
+    final textTheme = context.textTheme;
+    return Semantics(
+      selected: isSelected,
+      button: true,
+      label: label,
+      child: GestureDetector(
+        onTap: onTap,
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            CoreIconWidget(
+              icon: isSelected ? CoreIcons.radioChecked : CoreIcons.radio,
+              color: isSelected ? colorTheme.iconDark : colorTheme.iconGrayMid,
+              size: 24,
+            ),
+            const SizedBox(width: CoreSpacing.space2),
+            Text(
+              label,
+              style: textTheme.bodyMediumRegular.copyWith(
+                color: isSelected
+                    ? colorTheme.textHeadline
+                    : colorTheme.textBody,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/estimation/presentation/widgets/material_cost_form_fields.dart
+++ b/lib/features/estimation/presentation/widgets/material_cost_form_fields.dart
@@ -1,0 +1,189 @@
+import 'package:construculator/libraries/extensions/extensions.dart';
+import 'package:flutter/material.dart';
+import 'package:ripplearc_coreui/ripplearc_coreui.dart';
+
+class MaterialCostFormFields extends StatefulWidget {
+  final bool fromCostFile;
+
+  const MaterialCostFormFields({super.key, required this.fromCostFile});
+
+  @override
+  State<MaterialCostFormFields> createState() => _MaterialCostFormFieldsState();
+}
+
+class _MaterialCostFormFieldsState extends State<MaterialCostFormFields> {
+  bool _showOtherDetails = false;
+  final _materialTypeController = TextEditingController();
+  final _perUnitCostController = TextEditingController();
+  final _quantityController = TextEditingController();
+  final _productLinkController = TextEditingController();
+
+  @override
+  void dispose() {
+    _materialTypeController.dispose();
+    _perUnitCostController.dispose();
+    _quantityController.dispose();
+    _productLinkController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SingleChildScrollView(
+      padding: const EdgeInsets.all(CoreSpacing.space4),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          if (widget.fromCostFile)
+            ..._fromCostFileFields(context)
+          else
+            ..._manuallyFields(context),
+          const SizedBox(height: CoreSpacing.space5),
+          _buildOtherMaterialDetails(context),
+          const SizedBox(height: CoreSpacing.space6),
+          // TODO: [CA-336] Add assign task section
+        ],
+      ),
+    );
+  }
+
+  List<Widget> _fromCostFileFields(BuildContext context) {
+    final l10n = context.l10n;
+    final colorTheme = context.colorTheme;
+    return [
+      // TODO: [CA-298] Wire cost file dropdown to CostFileDataSource
+      CoreTextField(
+        key: const Key('cost_file_field'),
+        hintText: l10n.costFilePlaceholder,
+        readOnly: true,
+        enabled: false,
+        suffix: CoreIconWidget(
+          icon: CoreIcons.arrowDropDown,
+          color: colorTheme.iconGrayMid,
+          size: 24,
+        ),
+      ),
+      const SizedBox(height: CoreSpacing.space5),
+      // TODO: [CA-298] Populate material type from selected cost file
+      CoreTextField(
+        key: const Key('material_type_field'),
+        hintText: l10n.materialTypeLabel,
+        readOnly: true,
+        enabled: false,
+        suffix: CoreIconWidget(
+          icon: CoreIcons.arrowDropDown,
+          color: colorTheme.iconGrayMid,
+          size: 24,
+        ),
+      ),
+      const SizedBox(height: CoreSpacing.space5),
+      CoreTextField(
+        key: const Key('quantity_field'),
+        hintText: l10n.quantityLabel,
+        controller: _quantityController,
+        keyboardType: const TextInputType.numberWithOptions(decimal: true),
+      ),
+    ];
+  }
+
+  List<Widget> _manuallyFields(BuildContext context) {
+    final l10n = context.l10n;
+    final colorTheme = context.colorTheme;
+    return [
+      CoreTextField(
+        key: const Key('material_type_field'),
+        hintText: l10n.materialTypeLabel,
+        controller: _materialTypeController,
+      ),
+      const SizedBox(height: CoreSpacing.space5),
+      CoreTextField(
+        key: const Key('per_unit_cost_field'),
+        hintText: l10n.perUnitCostLabel,
+        controller: _perUnitCostController,
+        keyboardType: const TextInputType.numberWithOptions(decimal: true),
+        suffix: CoreIconWidget(
+          icon: CoreIcons.dollar,
+          color: colorTheme.textHeadline,
+          size: 24,
+        ),
+      ),
+      const SizedBox(height: CoreSpacing.space5),
+      // TODO: [CA-311] Add UOM dropdown
+      CoreTextField(
+        key: const Key('uom_field'),
+        hintText: l10n.uomLabel,
+        readOnly: true,
+        enabled: false,
+        suffix: CoreIconWidget(
+          icon: CoreIcons.arrowDropDown,
+          color: colorTheme.iconGrayMid,
+          size: 24,
+        ),
+      ),
+      const SizedBox(height: CoreSpacing.space5),
+      CoreTextField(
+        key: const Key('quantity_field'),
+        hintText: l10n.quantityLabel,
+        controller: _quantityController,
+        keyboardType: const TextInputType.numberWithOptions(decimal: true),
+      ),
+    ];
+  }
+
+  Widget _buildOtherMaterialDetails(BuildContext context) {
+    final l10n = context.l10n;
+    final colorTheme = context.colorTheme;
+    final textTheme = context.textTheme;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        if (_showOtherDetails) ...[
+          // TODO: [CA-332] Add brand dropdown to other material details
+          CoreTextField(
+            key: const Key('brand_field'),
+            hintText: l10n.brandLabel,
+            readOnly: true,
+            enabled: false,
+            suffix: CoreIconWidget(
+              icon: CoreIcons.arrowDropDown,
+              color: colorTheme.iconGrayMid,
+              size: 24,
+            ),
+          ),
+          const SizedBox(height: CoreSpacing.space3),
+          CoreTextField(
+            key: const Key('product_link_field'),
+            hintText: l10n.productLinkLabel,
+            controller: _productLinkController,
+          ),
+          const SizedBox(height: CoreSpacing.space3),
+        ],
+        Semantics(
+          key: const Key('other_material_details_button'),
+          label: l10n.otherMaterialDetailsButton,
+          button: true,
+          child: GestureDetector(
+            onTap: () => setState(() => _showOtherDetails = !_showOtherDetails),
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                CoreIconWidget(
+                  icon: _showOtherDetails ? CoreIcons.arrowUp : CoreIcons.arrowDown,
+                  color: colorTheme.iconDark,
+                  size: 20,
+                ),
+                const SizedBox(width: CoreSpacing.space1),
+                Text(
+                  l10n.otherMaterialDetailsButton,
+                  style: textTheme.bodyMediumMedium.copyWith(
+                    color: colorTheme.iconDark,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1658,6 +1658,82 @@
   "addEquipmentCostButton": "Add equipment cost",
   "@addEquipmentCostButton": {
     "description": "Label for the FAB on the cost estimation details page when the equipments tab is active"
+  },
+  "costFilePlaceholder": "Select cost file",
+  "@costFilePlaceholder": {
+    "description": "Placeholder text for the cost file dropdown on cost item form screens"
+  },
+  "materialTypeLabel": "Material type*",
+  "@materialTypeLabel": {
+    "description": "Hint label for the material type field on the material cost form"
+  },
+  "quantityLabel": "Quantity*",
+  "@quantityLabel": {
+    "description": "Hint label for the quantity field on material and equipment cost forms"
+  },
+  "perUnitCostLabel": "Per unit cost*",
+  "@perUnitCostLabel": {
+    "description": "Hint label for the per-unit cost field on the material cost form (manually mode)"
+  },
+  "uomLabel": "Unit of measure*",
+  "@uomLabel": {
+    "description": "Hint label for the unit of measure dropdown on the material cost form (manually mode)"
+  },
+  "otherMaterialDetailsButton": "Other material details",
+  "@otherMaterialDetailsButton": {
+    "description": "Toggle button label that expands/collapses the brand and product link fields on the material cost form"
+  },
+  "brandLabel": "Brand",
+  "@brandLabel": {
+    "description": "Hint label for the brand dropdown in the other material details section"
+  },
+  "productLinkLabel": "Product link",
+  "@productLinkLabel": {
+    "description": "Hint label for the product link text field in the other material details section"
+  },
+  "labourTypeLabel": "Labour type*",
+  "@labourTypeLabel": {
+    "description": "Hint label for the labour type field on the labour cost form"
+  },
+  "calcMethodTitle": "Calculation method",
+  "@calcMethodTitle": {
+    "description": "Section title for the calculation method card on the labour cost form"
+  },
+  "perDayOption": "Per day",
+  "@perDayOption": {
+    "description": "Radio option label for the per-day calculation method on the labour cost form"
+  },
+  "perHoursOption": "Per hours",
+  "@perHoursOption": {
+    "description": "Radio option label for the per-hours calculation method on the labour cost form"
+  },
+  "noOfDaysLabel": "No. of days*",
+  "@noOfDaysLabel": {
+    "description": "Hint label for the number-of-days field when the per-day method is selected on the labour cost form"
+  },
+  "noOfHoursLabel": "No. of hours*",
+  "@noOfHoursLabel": {
+    "description": "Hint label for the number-of-hours field when the per-hours method is selected on the labour cost form"
+  },
+  "crewRateLabel": "Crew rate ($)*",
+  "@crewRateLabel": {
+    "description": "Hint label for the crew rate field on the labour cost form (manually mode)"
+  },
+  "crewSizeLabel": "Crew size*",
+  "@crewSizeLabel": {
+    "description": "Hint label for the crew size field on the labour cost form"
+  },
+  "equipmentTypeLabel": "Equipment type*",
+  "@equipmentTypeLabel": {
+    "description": "Hint label for the equipment type dropdown on the equipment cost form (from cost file mode)"
+  },
+  "equipmentNameLabel": "Equipment name*",
+  "@equipmentNameLabel": {
+    "description": "Hint label for the equipment name field on the equipment cost form (manually mode)"
+  },
+  "unitPriceLabel": "Unit price*",
+  "@unitPriceLabel": {
+    "description": "Hint label for the unit price field on the equipment cost form (manually mode)"
   }
 }
 

--- a/lib/l10n/generated/app_localizations.dart
+++ b/lib/l10n/generated/app_localizations.dart
@@ -2007,6 +2007,120 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Add equipment cost'**
   String get addEquipmentCostButton;
+
+  /// Placeholder text for the cost file dropdown on cost item form screens
+  ///
+  /// In en, this message translates to:
+  /// **'Select cost file'**
+  String get costFilePlaceholder;
+
+  /// Hint label for the material type field on the material cost form
+  ///
+  /// In en, this message translates to:
+  /// **'Material type*'**
+  String get materialTypeLabel;
+
+  /// Hint label for the quantity field on material and equipment cost forms
+  ///
+  /// In en, this message translates to:
+  /// **'Quantity*'**
+  String get quantityLabel;
+
+  /// Hint label for the per-unit cost field on the material cost form (manually mode)
+  ///
+  /// In en, this message translates to:
+  /// **'Per unit cost*'**
+  String get perUnitCostLabel;
+
+  /// Hint label for the unit of measure dropdown on the material cost form (manually mode)
+  ///
+  /// In en, this message translates to:
+  /// **'Unit of measure*'**
+  String get uomLabel;
+
+  /// Toggle button label that expands/collapses the brand and product link fields on the material cost form
+  ///
+  /// In en, this message translates to:
+  /// **'Other material details'**
+  String get otherMaterialDetailsButton;
+
+  /// Hint label for the brand dropdown in the other material details section
+  ///
+  /// In en, this message translates to:
+  /// **'Brand'**
+  String get brandLabel;
+
+  /// Hint label for the product link text field in the other material details section
+  ///
+  /// In en, this message translates to:
+  /// **'Product link'**
+  String get productLinkLabel;
+
+  /// Hint label for the labour type field on the labour cost form
+  ///
+  /// In en, this message translates to:
+  /// **'Labour type*'**
+  String get labourTypeLabel;
+
+  /// Section title for the calculation method card on the labour cost form
+  ///
+  /// In en, this message translates to:
+  /// **'Calculation method'**
+  String get calcMethodTitle;
+
+  /// Radio option label for the per-day calculation method on the labour cost form
+  ///
+  /// In en, this message translates to:
+  /// **'Per day'**
+  String get perDayOption;
+
+  /// Radio option label for the per-hours calculation method on the labour cost form
+  ///
+  /// In en, this message translates to:
+  /// **'Per hours'**
+  String get perHoursOption;
+
+  /// Hint label for the number-of-days field when the per-day method is selected on the labour cost form
+  ///
+  /// In en, this message translates to:
+  /// **'No. of days*'**
+  String get noOfDaysLabel;
+
+  /// Hint label for the number-of-hours field when the per-hours method is selected on the labour cost form
+  ///
+  /// In en, this message translates to:
+  /// **'No. of hours*'**
+  String get noOfHoursLabel;
+
+  /// Hint label for the crew rate field on the labour cost form (manually mode)
+  ///
+  /// In en, this message translates to:
+  /// **'Crew rate (\$)*'**
+  String get crewRateLabel;
+
+  /// Hint label for the crew size field on the labour cost form
+  ///
+  /// In en, this message translates to:
+  /// **'Crew size*'**
+  String get crewSizeLabel;
+
+  /// Hint label for the equipment type dropdown on the equipment cost form (from cost file mode)
+  ///
+  /// In en, this message translates to:
+  /// **'Equipment type*'**
+  String get equipmentTypeLabel;
+
+  /// Hint label for the equipment name field on the equipment cost form (manually mode)
+  ///
+  /// In en, this message translates to:
+  /// **'Equipment name*'**
+  String get equipmentNameLabel;
+
+  /// Hint label for the unit price field on the equipment cost form (manually mode)
+  ///
+  /// In en, this message translates to:
+  /// **'Unit price*'**
+  String get unitPriceLabel;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/generated/app_localizations_en.dart
+++ b/lib/l10n/generated/app_localizations_en.dart
@@ -1056,4 +1056,61 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get addEquipmentCostButton => 'Add equipment cost';
+
+  @override
+  String get costFilePlaceholder => 'Select cost file';
+
+  @override
+  String get materialTypeLabel => 'Material type*';
+
+  @override
+  String get quantityLabel => 'Quantity*';
+
+  @override
+  String get perUnitCostLabel => 'Per unit cost*';
+
+  @override
+  String get uomLabel => 'Unit of measure*';
+
+  @override
+  String get otherMaterialDetailsButton => 'Other material details';
+
+  @override
+  String get brandLabel => 'Brand';
+
+  @override
+  String get productLinkLabel => 'Product link';
+
+  @override
+  String get labourTypeLabel => 'Labour type*';
+
+  @override
+  String get calcMethodTitle => 'Calculation method';
+
+  @override
+  String get perDayOption => 'Per day';
+
+  @override
+  String get perHoursOption => 'Per hours';
+
+  @override
+  String get noOfDaysLabel => 'No. of days*';
+
+  @override
+  String get noOfHoursLabel => 'No. of hours*';
+
+  @override
+  String get crewRateLabel => 'Crew rate (\$)*';
+
+  @override
+  String get crewSizeLabel => 'Crew size*';
+
+  @override
+  String get equipmentTypeLabel => 'Equipment type*';
+
+  @override
+  String get equipmentNameLabel => 'Equipment name*';
+
+  @override
+  String get unitPriceLabel => 'Unit price*';
 }

--- a/test/features/estimations/widgets/accessibility/equipment_cost_form_fields_a11y_test.dart
+++ b/test/features/estimations/widgets/accessibility/equipment_cost_form_fields_a11y_test.dart
@@ -1,0 +1,38 @@
+import 'package:construculator/features/estimation/presentation/widgets/equipment_cost_form_fields.dart';
+import 'package:construculator/l10n/generated/app_localizations.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:ripplearc_coreui/ripplearc_coreui.dart';
+
+import '../../../../utils/a11y/a11y_guidelines.dart';
+
+void main() {
+  Widget makeWidget(ThemeData theme, {bool fromCostFile = false}) {
+    return MaterialApp(
+      theme: theme,
+      locale: const Locale('en'),
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: Scaffold(
+        body: EquipmentCostFormFields(fromCostFile: fromCostFile),
+      ),
+    );
+  }
+
+  group('EquipmentCostFormFields – accessibility', () {
+    testWidgets(
+      'a11y: unit price field meets text contrast guidelines in both themes',
+      (tester) async {
+        await setupA11yTest(tester);
+
+        await expectMeetsTapTargetAndLabelGuidelinesForEachTheme(
+          tester,
+          makeWidget,
+          find.byKey(const Key('unit_price_field')),
+          checkTapTargetSize: false,
+          checkLabeledTapTarget: false,
+        );
+      },
+    );
+  });
+}

--- a/test/features/estimations/widgets/accessibility/labour_cost_form_fields_a11y_test.dart
+++ b/test/features/estimations/widgets/accessibility/labour_cost_form_fields_a11y_test.dart
@@ -1,0 +1,52 @@
+import 'package:construculator/features/estimation/presentation/widgets/labour_cost_form_fields.dart';
+import 'package:construculator/l10n/generated/app_localizations.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:ripplearc_coreui/ripplearc_coreui.dart';
+
+import '../../../../utils/a11y/a11y_guidelines.dart';
+
+void main() {
+  Widget makeWidget(ThemeData theme, {bool fromCostFile = false}) {
+    return MaterialApp(
+      theme: theme,
+      locale: const Locale('en'),
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: Scaffold(
+        body: LabourCostFormFields(fromCostFile: fromCostFile),
+      ),
+    );
+  }
+
+  group('LabourCostFormFields – accessibility', () {
+    testWidgets(
+      'a11y: calc method card meets label guidelines in both themes',
+      (tester) async {
+        await setupA11yTest(tester);
+
+        await expectMeetsTapTargetAndLabelGuidelinesForEachTheme(
+          tester,
+          makeWidget,
+          find.byKey(const Key('calc_method_card')),
+          checkTapTargetSize: false,
+          checkLabeledTapTarget: false,
+        );
+      },
+    );
+
+    testWidgets(
+      'a11y: per day radio option has semantic label in both themes',
+      (tester) async {
+        await setupA11yTest(tester);
+
+        await expectMeetsTapTargetAndLabelGuidelinesForEachTheme(
+          tester,
+          makeWidget,
+          find.byKey(const Key('per_day_option')),
+          checkTapTargetSize: false,
+        );
+      },
+    );
+  });
+}

--- a/test/features/estimations/widgets/accessibility/material_cost_form_fields_a11y_test.dart
+++ b/test/features/estimations/widgets/accessibility/material_cost_form_fields_a11y_test.dart
@@ -1,0 +1,37 @@
+import 'package:construculator/features/estimation/presentation/widgets/material_cost_form_fields.dart';
+import 'package:construculator/l10n/generated/app_localizations.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:ripplearc_coreui/ripplearc_coreui.dart';
+
+import '../../../../utils/a11y/a11y_guidelines.dart';
+
+void main() {
+  Widget makeWidget(ThemeData theme, {bool fromCostFile = false}) {
+    return MaterialApp(
+      theme: theme,
+      locale: const Locale('en'),
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: Scaffold(
+        body: MaterialCostFormFields(fromCostFile: fromCostFile),
+      ),
+    );
+  }
+
+  group('MaterialCostFormFields – accessibility', () {
+    testWidgets(
+      'a11y: other material details button meets tap target and label guidelines in both themes',
+      (tester) async {
+        await setupA11yTest(tester);
+
+        await expectMeetsTapTargetAndLabelGuidelinesForEachTheme(
+          tester,
+          makeWidget,
+          find.byKey(const Key('other_material_details_button')),
+          checkTapTargetSize: false,
+        );
+      },
+    );
+  });
+}

--- a/test/features/estimations/widgets/equipment_cost_form_fields_test.dart
+++ b/test/features/estimations/widgets/equipment_cost_form_fields_test.dart
@@ -1,0 +1,97 @@
+import 'package:construculator/features/estimation/presentation/widgets/equipment_cost_form_fields.dart';
+import 'package:construculator/l10n/generated/app_localizations.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:ripplearc_coreui/ripplearc_coreui.dart';
+
+void main() {
+  setUpAll(() {
+    lookupAppLocalizations(const Locale('en'));
+  });
+
+  Widget makeWidget({bool fromCostFile = false}) {
+    return MaterialApp(
+      theme: CoreTheme.light(),
+      locale: const Locale('en'),
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: Scaffold(
+        body: EquipmentCostFormFields(fromCostFile: fromCostFile),
+      ),
+    );
+  }
+
+  group('EquipmentCostFormFields — manually mode', () {
+    testWidgets('shows equipment name field', (tester) async {
+      await tester.pumpWidget(makeWidget());
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('equipment_name_field')), findsOneWidget);
+    });
+
+    testWidgets('shows unit price field with dollar suffix', (tester) async {
+      await tester.pumpWidget(makeWidget());
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('unit_price_field')), findsOneWidget);
+    });
+
+    testWidgets('shows quantity field', (tester) async {
+      await tester.pumpWidget(makeWidget());
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('quantity_field')), findsOneWidget);
+    });
+
+    testWidgets('hides cost file field', (tester) async {
+      await tester.pumpWidget(makeWidget());
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('cost_file_field')), findsNothing);
+    });
+
+    testWidgets('hides equipment type field', (tester) async {
+      await tester.pumpWidget(makeWidget());
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('equipment_type_field')), findsNothing);
+    });
+  });
+
+  group('EquipmentCostFormFields — from cost file mode', () {
+    testWidgets('shows cost file dropdown placeholder', (tester) async {
+      await tester.pumpWidget(makeWidget(fromCostFile: true));
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('cost_file_field')), findsOneWidget);
+    });
+
+    testWidgets('shows equipment type dropdown placeholder', (tester) async {
+      await tester.pumpWidget(makeWidget(fromCostFile: true));
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('equipment_type_field')), findsOneWidget);
+    });
+
+    testWidgets('shows quantity field', (tester) async {
+      await tester.pumpWidget(makeWidget(fromCostFile: true));
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('quantity_field')), findsOneWidget);
+    });
+
+    testWidgets('hides equipment name field', (tester) async {
+      await tester.pumpWidget(makeWidget(fromCostFile: true));
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('equipment_name_field')), findsNothing);
+    });
+
+    testWidgets('hides unit price field', (tester) async {
+      await tester.pumpWidget(makeWidget(fromCostFile: true));
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('unit_price_field')), findsNothing);
+    });
+  });
+}

--- a/test/features/estimations/widgets/labour_cost_form_fields_test.dart
+++ b/test/features/estimations/widgets/labour_cost_form_fields_test.dart
@@ -1,0 +1,148 @@
+import 'package:construculator/features/estimation/presentation/widgets/labour_cost_form_fields.dart';
+import 'package:construculator/l10n/generated/app_localizations.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:ripplearc_coreui/ripplearc_coreui.dart';
+
+void main() {
+  late AppLocalizations l10n;
+
+  setUpAll(() {
+    l10n = lookupAppLocalizations(const Locale('en'));
+  });
+
+  Widget makeWidget({bool fromCostFile = false}) {
+    return MaterialApp(
+      theme: CoreTheme.light(),
+      locale: const Locale('en'),
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: Scaffold(
+        body: LabourCostFormFields(fromCostFile: fromCostFile),
+      ),
+    );
+  }
+
+  group('LabourCostFormFields — manually mode', () {
+    testWidgets('shows labour type text field', (tester) async {
+      await tester.pumpWidget(makeWidget());
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('labour_type_field')), findsOneWidget);
+    });
+
+    testWidgets('shows calc method card', (tester) async {
+      await tester.pumpWidget(makeWidget());
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('calc_method_card')), findsOneWidget);
+    });
+
+    testWidgets('shows crew rate field with dollar suffix', (tester) async {
+      await tester.pumpWidget(makeWidget());
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('crew_rate_field')), findsOneWidget);
+    });
+
+    testWidgets('hides cost file field', (tester) async {
+      await tester.pumpWidget(makeWidget());
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('cost_file_field')), findsNothing);
+    });
+
+    testWidgets('hides rate row inside calc method card', (tester) async {
+      await tester.pumpWidget(makeWidget());
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('rate_row')), findsNothing);
+    });
+
+    testWidgets('shows conditional field with "No. of days" label by default', (
+      tester,
+    ) async {
+      await tester.pumpWidget(makeWidget());
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('conditional_value_field')), findsOneWidget);
+      expect(find.text(l10n.noOfDaysLabel), findsOneWidget);
+    });
+
+    testWidgets('shows crew size field', (tester) async {
+      await tester.pumpWidget(makeWidget());
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('crew_size_field')), findsOneWidget);
+    });
+  });
+
+  group('LabourCostFormFields — from cost file mode', () {
+    testWidgets('shows cost file dropdown placeholder', (tester) async {
+      await tester.pumpWidget(makeWidget(fromCostFile: true));
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('cost_file_field')), findsOneWidget);
+    });
+
+    testWidgets('shows labour type dropdown placeholder', (tester) async {
+      await tester.pumpWidget(makeWidget(fromCostFile: true));
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('labour_type_field')), findsOneWidget);
+    });
+
+    testWidgets('hides crew rate field', (tester) async {
+      await tester.pumpWidget(makeWidget(fromCostFile: true));
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('crew_rate_field')), findsNothing);
+    });
+
+    testWidgets('shows rate row inside calc method card', (tester) async {
+      await tester.pumpWidget(makeWidget(fromCostFile: true));
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('rate_row')), findsOneWidget);
+    });
+  });
+
+  group('LabourCostFormFields — calc method switching', () {
+    testWidgets('per day is selected by default', (tester) async {
+      await tester.pumpWidget(makeWidget());
+      await tester.pumpAndSettle();
+
+      final perDay = tester.getSemantics(find.byKey(const Key('per_day_option')));
+      expect(perDay.hasFlag(SemanticsFlag.isSelected), isTrue);
+    });
+
+    testWidgets('tapping per hours changes conditional field label', (
+      tester,
+    ) async {
+      await tester.pumpWidget(makeWidget());
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byKey(const Key('per_hours_option')));
+      await tester.pumpAndSettle();
+
+      expect(find.text(l10n.noOfHoursLabel), findsOneWidget);
+      expect(find.text(l10n.noOfDaysLabel), findsNothing);
+    });
+
+    testWidgets('per hours option selected after tap', (tester) async {
+      await tester.pumpWidget(makeWidget());
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byKey(const Key('per_hours_option')));
+      await tester.pumpAndSettle();
+
+      final perHours = tester.getSemantics(
+        find.byKey(const Key('per_hours_option')),
+      );
+      final perDay = tester.getSemantics(find.byKey(const Key('per_day_option')));
+      expect(perHours.hasFlag(SemanticsFlag.isSelected), isTrue);
+      expect(perDay.hasFlag(SemanticsFlag.isSelected), isFalse);
+    });
+  });
+}

--- a/test/features/estimations/widgets/material_cost_form_fields_test.dart
+++ b/test/features/estimations/widgets/material_cost_form_fields_test.dart
@@ -1,0 +1,158 @@
+import 'package:construculator/features/estimation/presentation/widgets/material_cost_form_fields.dart';
+import 'package:construculator/l10n/generated/app_localizations.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:ripplearc_coreui/ripplearc_coreui.dart';
+
+void main() {
+  late AppLocalizations l10n;
+
+  setUpAll(() {
+    l10n = lookupAppLocalizations(const Locale('en'));
+  });
+
+  Widget makeWidget({bool fromCostFile = false}) {
+    return MaterialApp(
+      theme: CoreTheme.light(),
+      locale: const Locale('en'),
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: Scaffold(
+        body: MaterialCostFormFields(fromCostFile: fromCostFile),
+      ),
+    );
+  }
+
+  group('MaterialCostFormFields — manually mode', () {
+    testWidgets('shows material type text field', (tester) async {
+      await tester.pumpWidget(makeWidget());
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('material_type_field')), findsOneWidget);
+    });
+
+    testWidgets('shows per unit cost field with dollar suffix', (tester) async {
+      await tester.pumpWidget(makeWidget());
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('per_unit_cost_field')), findsOneWidget);
+    });
+
+    testWidgets('shows UOM dropdown placeholder', (tester) async {
+      await tester.pumpWidget(makeWidget());
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('uom_field')), findsOneWidget);
+    });
+
+    testWidgets('shows quantity field', (tester) async {
+      await tester.pumpWidget(makeWidget());
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('quantity_field')), findsOneWidget);
+    });
+
+    testWidgets('hides cost file field', (tester) async {
+      await tester.pumpWidget(makeWidget());
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('cost_file_field')), findsNothing);
+    });
+
+    testWidgets('brand and product link hidden by default', (tester) async {
+      await tester.pumpWidget(makeWidget());
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('brand_field')), findsNothing);
+      expect(find.byKey(const Key('product_link_field')), findsNothing);
+    });
+
+    testWidgets('tapping other details button reveals brand and product link', (
+      tester,
+    ) async {
+      await tester.pumpWidget(makeWidget());
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text(l10n.otherMaterialDetailsButton));
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('brand_field')), findsOneWidget);
+      expect(find.byKey(const Key('product_link_field')), findsOneWidget);
+    });
+
+    testWidgets('tapping other details button again hides brand and product link', (
+      tester,
+    ) async {
+      await tester.pumpWidget(makeWidget());
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text(l10n.otherMaterialDetailsButton));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text(l10n.otherMaterialDetailsButton));
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('brand_field')), findsNothing);
+      expect(find.byKey(const Key('product_link_field')), findsNothing);
+    });
+  });
+
+  group('MaterialCostFormFields — from cost file mode', () {
+    testWidgets('shows cost file dropdown placeholder', (tester) async {
+      await tester.pumpWidget(makeWidget(fromCostFile: true));
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('cost_file_field')), findsOneWidget);
+    });
+
+    testWidgets('shows material type dropdown placeholder', (tester) async {
+      await tester.pumpWidget(makeWidget(fromCostFile: true));
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('material_type_field')), findsOneWidget);
+    });
+
+    testWidgets('shows quantity dropdown placeholder', (tester) async {
+      await tester.pumpWidget(makeWidget(fromCostFile: true));
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('quantity_field')), findsOneWidget);
+    });
+
+    testWidgets('hides per unit cost field', (tester) async {
+      await tester.pumpWidget(makeWidget(fromCostFile: true));
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('per_unit_cost_field')), findsNothing);
+    });
+
+    testWidgets('hides UOM field', (tester) async {
+      await tester.pumpWidget(makeWidget(fromCostFile: true));
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('uom_field')), findsNothing);
+    });
+
+    testWidgets('reveals brand and product link on button tap', (tester) async {
+      await tester.pumpWidget(makeWidget(fromCostFile: true));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text(l10n.otherMaterialDetailsButton));
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('brand_field')), findsOneWidget);
+      expect(find.byKey(const Key('product_link_field')), findsOneWidget);
+    });
+  });
+
+  group('MaterialCostFormFields — accessibility', () {
+    testWidgets('other details button has semantic label', (tester) async {
+      await tester.pumpWidget(makeWidget());
+      await tester.pumpAndSettle();
+
+      final semantics = tester.getSemantics(
+        find.byKey(const Key('other_material_details_button')),
+      );
+      expect(semantics.label, contains(l10n.otherMaterialDetailsButton));
+    });
+  });
+}


### PR DESCRIPTION
### 1. PR SUMMARY
Introduces `MaterialCostFormFields`, `LabourCostFormFields`, and `EquipmentCostFormFields` — the three static UI layouts for the manual cost item form. Each widget supports both "From cost file" and "Manually" modes, dispatching to the appropriate field set via `fromCostFile: bool`. Wires `CostItemFormScreen._buildFormFields()` to render the correct widget by cost type. Adds l10n strings, widget tests, and a11y tests for all three form fields.

### 2. REVIEW SUMMARY TABLE

| Issue Name | Description | Status | Notes |
|------------|-------------|--------|-------|
| L-size PR | Three new widgets total 566 production lines, exceeding the 200-line ceiling (Rule 5). | Agree – Needs Another Story | Splitting further would require 6+ PRs for a single ticket, violating the >3 split-ticket policy. Each widget is the minimum self-contained unit for this feature. |
| Hardcoded rate label | `_buildCalcMethodCard` renders `'Rate/Day:'` as a hardcoded string instead of an l10n key. | Agree – Fixed | Addressed in PR2 (CA-306-2/extraction-l10n): `CalcMethodCard` derives the label from `calcMethod` via `rateDayLabel`/`rateHourLabel` l10n keys. |
| Missing equipment a11y test | `EquipmentCostFormFields` had no a11y test while material and labour both do. | Agree – Fixed | Added `equipment_cost_form_fields_a11y_test.dart` in this PR's final commit. Checks `unit_price_field` for text contrast in both themes. |

## Test plan
- [ ] `fvm flutter test test/features/estimations/` passes
- [ ] `fvm dart run custom_lint` shows no issues
- [ ] Material form: manually mode shows per-unit cost / qty / UOM fields; from cost file mode shows cost file + material type dropdowns + qty
- [ ] Labour form: manually mode shows calc method card + crew fields; from cost file mode shows cost file + labour type dropdowns + calc card with rate row
- [ ] Equipment form: manually mode shows unit price + qty; from cost file mode shows cost file + equipment type dropdowns + qty
- [ ] Tapping "Other material details" toggles brand and product link fields