### PR TITLE
CA-306 (1/3): extract CalcMethodCard and add l10n for rate labels

### DIFF
--- a/lib/features/estimation/presentation/widgets/calc_method_card.dart
+++ b/lib/features/estimation/presentation/widgets/calc_method_card.dart
@@ -1,0 +1,94 @@
+import 'package:construculator/features/estimation/domain/entities/cost_item_entity.dart';
+import 'package:construculator/features/estimation/presentation/widgets/calc_method_radio_option.dart';
+import 'package:construculator/libraries/extensions/extensions.dart';
+import 'package:flutter/material.dart';
+import 'package:ripplearc_coreui/ripplearc_coreui.dart';
+
+class CalcMethodCard extends StatelessWidget {
+  final LaborCalculationMethodType calcMethod;
+  final bool showRateRow;
+  final ValueChanged<LaborCalculationMethodType> onMethodChanged;
+
+  const CalcMethodCard({
+    super.key,
+    required this.calcMethod,
+    required this.showRateRow,
+    required this.onMethodChanged,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = context.l10n;
+    final colorTheme = context.colorTheme;
+    final textTheme = context.textTheme;
+    return Container(
+      key: const Key('calc_method_card'),
+      decoration: BoxDecoration(
+        color: colorTheme.pageBackground,
+        borderRadius: BorderRadius.circular(8),
+        boxShadow: CoreShadows.small,
+      ),
+      padding: const EdgeInsets.all(CoreSpacing.space3),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            l10n.calcMethodTitle,
+            style: textTheme.bodyMediumMedium.copyWith(
+              color: colorTheme.textHeadline,
+            ),
+          ),
+          const SizedBox(height: CoreSpacing.space3),
+          Wrap(
+            spacing: CoreSpacing.space8,
+            runSpacing: CoreSpacing.space2,
+            children: [
+              CalcMethodRadioOption(
+                key: const Key('per_day_option'),
+                label: l10n.perDayOption,
+                isSelected: calcMethod == LaborCalculationMethodType.perDay,
+                onTap: () => onMethodChanged(LaborCalculationMethodType.perDay),
+              ),
+              CalcMethodRadioOption(
+                key: const Key('per_hours_option'),
+                label: l10n.perHoursOption,
+                isSelected: calcMethod == LaborCalculationMethodType.perHour,
+                onTap: () => onMethodChanged(LaborCalculationMethodType.perHour),
+              ),
+              // TODO: [CA-319] Add Per Unit calculation option
+            ],
+          ),
+          if (showRateRow) ...[
+            const SizedBox(height: CoreSpacing.space3),
+            // TODO: [CA-298] Wire rate value to CostFileDataSource
+            Row(
+              key: const Key('rate_row'),
+              children: [
+                Text(
+                  _rateLabel(context),
+                  style: textTheme.bodySmallRegular.copyWith(
+                    color: colorTheme.textBody,
+                  ),
+                ),
+                const SizedBox(width: CoreSpacing.space1),
+                Text(
+                  '\$0',
+                  style: textTheme.bodySmallMedium.copyWith(
+                    color: colorTheme.textHeadline,
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+
+  String _rateLabel(BuildContext context) => switch (calcMethod) {
+    LaborCalculationMethodType.perDay => context.l10n.rateDayLabel,
+    LaborCalculationMethodType.perHour => context.l10n.rateHourLabel,
+    // TODO: [CA-319] Add Per Unit rate label
+    LaborCalculationMethodType.perUnit => context.l10n.rateDayLabel,
+  };
+}

--- a/lib/features/estimation/presentation/widgets/calc_method_radio_option.dart
+++ b/lib/features/estimation/presentation/widgets/calc_method_radio_option.dart
@@ -1,0 +1,47 @@
+import 'package:construculator/libraries/extensions/extensions.dart';
+import 'package:flutter/material.dart';
+import 'package:ripplearc_coreui/ripplearc_coreui.dart';
+
+class CalcMethodRadioOption extends StatelessWidget {
+  final String label;
+  final bool isSelected;
+  final VoidCallback onTap;
+
+  const CalcMethodRadioOption({
+    super.key,
+    required this.label,
+    required this.isSelected,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final colorTheme = context.colorTheme;
+    final textTheme = context.textTheme;
+    return Semantics(
+      selected: isSelected,
+      button: true,
+      label: label,
+      child: GestureDetector(
+        onTap: onTap,
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            CoreIconWidget(
+              icon: isSelected ? CoreIcons.radioChecked : CoreIcons.radio,
+              color: isSelected ? colorTheme.iconDark : colorTheme.iconGrayMid,
+              size: 24,
+            ),
+            const SizedBox(width: CoreSpacing.space2),
+            Text(
+              label,
+              style: textTheme.bodyMediumRegular.copyWith(
+                color: isSelected ? colorTheme.textHeadline : colorTheme.textBody,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/estimation/presentation/widgets/labour_cost_form_fields.dart
+++ b/lib/features/estimation/presentation/widgets/labour_cost_form_fields.dart
@@ -1,4 +1,5 @@
 import 'package:construculator/features/estimation/domain/entities/cost_item_entity.dart';
+import 'package:construculator/features/estimation/presentation/widgets/calc_method_card.dart';
 import 'package:construculator/libraries/extensions/extensions.dart';
 import 'package:flutter/material.dart';
 import 'package:ripplearc_coreui/ripplearc_coreui.dart';
@@ -76,7 +77,11 @@ class _LabourCostFormFieldsState extends State<LabourCostFormFields> {
         ),
       ),
       const SizedBox(height: CoreSpacing.space5),
-      _buildCalcMethodCard(context, showRateRow: true),
+      CalcMethodCard(
+        calcMethod: _calcMethod,
+        showRateRow: true,
+        onMethodChanged: (method) => setState(() => _calcMethod = method),
+      ),
       const SizedBox(height: CoreSpacing.space5),
       CoreTextField(
         key: const Key('conditional_value_field'),
@@ -104,7 +109,11 @@ class _LabourCostFormFieldsState extends State<LabourCostFormFields> {
         controller: _labourTypeController,
       ),
       const SizedBox(height: CoreSpacing.space5),
-      _buildCalcMethodCard(context, showRateRow: false),
+      CalcMethodCard(
+        calcMethod: _calcMethod,
+        showRateRow: false,
+        onMethodChanged: (method) => setState(() => _calcMethod = method),
+      ),
       const SizedBox(height: CoreSpacing.space5),
       CoreTextField(
         key: const Key('crew_rate_field'),
@@ -140,122 +149,4 @@ class _LabourCostFormFieldsState extends State<LabourCostFormFields> {
     // TODO: [CA-319] Add Per Unit calculation option
     LaborCalculationMethodType.perUnit => context.l10n.noOfDaysLabel,
   };
-
-  Widget _buildCalcMethodCard(BuildContext context, {required bool showRateRow}) {
-    final l10n = context.l10n;
-    final colorTheme = context.colorTheme;
-    final textTheme = context.textTheme;
-    return Container(
-      key: const Key('calc_method_card'),
-      decoration: BoxDecoration(
-        color: colorTheme.pageBackground,
-        borderRadius: BorderRadius.circular(8),
-        boxShadow: CoreShadows.small,
-      ),
-      padding: const EdgeInsets.all(CoreSpacing.space3),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Text(
-            l10n.calcMethodTitle,
-            style: textTheme.bodyMediumMedium.copyWith(
-              color: colorTheme.textHeadline,
-            ),
-          ),
-          const SizedBox(height: CoreSpacing.space3),
-          Wrap(
-            spacing: CoreSpacing.space8,
-            runSpacing: CoreSpacing.space2,
-            children: [
-              _CalcMethodRadioOption(
-                key: const Key('per_day_option'),
-                label: l10n.perDayOption,
-                isSelected: _calcMethod == LaborCalculationMethodType.perDay,
-                onTap: () => setState(
-                  () => _calcMethod = LaborCalculationMethodType.perDay,
-                ),
-              ),
-              _CalcMethodRadioOption(
-                key: const Key('per_hours_option'),
-                label: l10n.perHoursOption,
-                isSelected: _calcMethod == LaborCalculationMethodType.perHour,
-                onTap: () => setState(
-                  () => _calcMethod = LaborCalculationMethodType.perHour,
-                ),
-              ),
-              // TODO: [CA-319] Add Per Unit calculation option
-            ],
-          ),
-          if (showRateRow) ...[
-            const SizedBox(height: CoreSpacing.space3),
-            // TODO: [CA-298] Wire rate label to CostFileDataSource
-            Row(
-              key: const Key('rate_row'),
-              children: [
-                Text(
-                  'Rate/Day:',
-                  style: textTheme.bodySmallRegular.copyWith(
-                    color: colorTheme.textBody,
-                  ),
-                ),
-                const SizedBox(width: CoreSpacing.space1),
-                Text(
-                  '\$0',
-                  style: textTheme.bodySmallMedium.copyWith(
-                    color: colorTheme.textHeadline,
-                  ),
-                ),
-              ],
-            ),
-          ],
-        ],
-      ),
-    );
-  }
-}
-
-class _CalcMethodRadioOption extends StatelessWidget {
-  final String label;
-  final bool isSelected;
-  final VoidCallback onTap;
-
-  const _CalcMethodRadioOption({
-    super.key,
-    required this.label,
-    required this.isSelected,
-    required this.onTap,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    final colorTheme = context.colorTheme;
-    final textTheme = context.textTheme;
-    return Semantics(
-      selected: isSelected,
-      button: true,
-      label: label,
-      child: GestureDetector(
-        onTap: onTap,
-        child: Row(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            CoreIconWidget(
-              icon: isSelected ? CoreIcons.radioChecked : CoreIcons.radio,
-              color: isSelected ? colorTheme.iconDark : colorTheme.iconGrayMid,
-              size: 24,
-            ),
-            const SizedBox(width: CoreSpacing.space2),
-            Text(
-              label,
-              style: textTheme.bodyMediumRegular.copyWith(
-                color: isSelected
-                    ? colorTheme.textHeadline
-                    : colorTheme.textBody,
-              ),
-            ),
-          ],
-        ),
-      ),
-    );
-  }
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1734,6 +1734,14 @@
   "unitPriceLabel": "Unit price*",
   "@unitPriceLabel": {
     "description": "Hint label for the unit price field on the equipment cost form (manually mode)"
+  },
+  "rateDayLabel": "Rate/Day:",
+  "@rateDayLabel": {
+    "description": "Rate label inside the calculation method card when per-day method is selected (from cost file mode)"
+  },
+  "rateHourLabel": "Rate/Hour:",
+  "@rateHourLabel": {
+    "description": "Rate label inside the calculation method card when per-hours method is selected (from cost file mode)"
   }
 }
 

--- a/lib/l10n/generated/app_localizations.dart
+++ b/lib/l10n/generated/app_localizations.dart
@@ -2121,6 +2121,18 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Unit price*'**
   String get unitPriceLabel;
+
+  /// Rate label inside the calculation method card when per-day method is selected (from cost file mode)
+  ///
+  /// In en, this message translates to:
+  /// **'Rate/Day:'**
+  String get rateDayLabel;
+
+  /// Rate label inside the calculation method card when per-hours method is selected (from cost file mode)
+  ///
+  /// In en, this message translates to:
+  /// **'Rate/Hour:'**
+  String get rateHourLabel;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/generated/app_localizations_en.dart
+++ b/lib/l10n/generated/app_localizations_en.dart
@@ -1113,4 +1113,10 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get unitPriceLabel => 'Unit price*';
+
+  @override
+  String get rateDayLabel => 'Rate/Day:';
+
+  @override
+  String get rateHourLabel => 'Rate/Hour:';
 }

--- a/test/features/estimations/widgets/calc_method_card_test.dart
+++ b/test/features/estimations/widgets/calc_method_card_test.dart
@@ -1,0 +1,142 @@
+import 'package:construculator/features/estimation/domain/entities/cost_item_entity.dart';
+import 'package:construculator/features/estimation/presentation/widgets/calc_method_card.dart';
+import 'package:construculator/l10n/generated/app_localizations.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:ripplearc_coreui/ripplearc_coreui.dart';
+
+void main() {
+  late AppLocalizations l10n;
+
+  setUpAll(() {
+    l10n = lookupAppLocalizations(const Locale('en'));
+  });
+
+  Widget makeWidget({
+    LaborCalculationMethodType calcMethod = LaborCalculationMethodType.perDay,
+    bool showRateRow = false,
+    ValueChanged<LaborCalculationMethodType>? onMethodChanged,
+  }) {
+    return MaterialApp(
+      theme: CoreTheme.light(),
+      locale: const Locale('en'),
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: Scaffold(
+        body: CalcMethodCard(
+          calcMethod: calcMethod,
+          showRateRow: showRateRow,
+          onMethodChanged: onMethodChanged ?? (_) {},
+        ),
+      ),
+    );
+  }
+
+  group('CalcMethodCard — options', () {
+    testWidgets('shows per day and per hours options', (tester) async {
+      await tester.pumpWidget(makeWidget());
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('per_day_option')), findsOneWidget);
+      expect(find.byKey(const Key('per_hours_option')), findsOneWidget);
+    });
+
+    testWidgets('per day is selected by default', (tester) async {
+      await tester.pumpWidget(makeWidget());
+      await tester.pumpAndSettle();
+
+      final perDay = tester.getSemantics(find.byKey(const Key('per_day_option')));
+      expect(perDay.hasFlag(SemanticsFlag.isSelected), isTrue);
+    });
+
+    testWidgets('per hours is selected when calcMethod is perHour', (tester) async {
+      await tester.pumpWidget(
+        makeWidget(calcMethod: LaborCalculationMethodType.perHour),
+      );
+      await tester.pumpAndSettle();
+
+      final perHours = tester.getSemantics(
+        find.byKey(const Key('per_hours_option')),
+      );
+      expect(perHours.hasFlag(SemanticsFlag.isSelected), isTrue);
+    });
+
+    testWidgets('calls onMethodChanged with perHour when per hours tapped', (
+      tester,
+    ) async {
+      LaborCalculationMethodType? selected;
+      await tester.pumpWidget(
+        makeWidget(onMethodChanged: (m) => selected = m),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byKey(const Key('per_hours_option')));
+      await tester.pump();
+
+      expect(selected, LaborCalculationMethodType.perHour);
+    });
+
+    testWidgets('calls onMethodChanged with perDay when per day tapped', (
+      tester,
+    ) async {
+      LaborCalculationMethodType? selected;
+      await tester.pumpWidget(
+        makeWidget(
+          calcMethod: LaborCalculationMethodType.perHour,
+          onMethodChanged: (m) => selected = m,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byKey(const Key('per_day_option')));
+      await tester.pump();
+
+      expect(selected, LaborCalculationMethodType.perDay);
+    });
+  });
+
+  group('CalcMethodCard — rate row', () {
+    testWidgets('hides rate row when showRateRow is false', (tester) async {
+      await tester.pumpWidget(makeWidget(showRateRow: false));
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('rate_row')), findsNothing);
+    });
+
+    testWidgets('shows rate row when showRateRow is true', (tester) async {
+      await tester.pumpWidget(makeWidget(showRateRow: true));
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('rate_row')), findsOneWidget);
+    });
+
+    testWidgets('shows Rate/Day label when per day method is selected', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        makeWidget(
+          calcMethod: LaborCalculationMethodType.perDay,
+          showRateRow: true,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text(l10n.rateDayLabel), findsOneWidget);
+    });
+
+    testWidgets('shows Rate/Hour label when per hours method is selected', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        makeWidget(
+          calcMethod: LaborCalculationMethodType.perHour,
+          showRateRow: true,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text(l10n.rateHourLabel), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
### 1. PR SUMMARY
Extracts the inline `_buildCalcMethodCard` and `_CalcMethodRadioOption` from `LabourCostFormFields` into standalone public widgets `CalcMethodCard` and `CalcMethodRadioOption`. Fixes the hardcoded `'Rate/Day:'` string by deriving the label from `calcMethod` via new `rateDayLabel`/`rateHourLabel` l10n keys in `app_en.arb`.

### 2. REVIEW SUMMARY TABLE

| Issue Name | Description | Status | Notes |
|------------|-------------|--------|-------|
| `BorderRadius.circular(8)` | `CalcMethodCard` uses `BorderRadius.circular(8)` instead of a CoreUI constant (Rule 4). | Disagree | No `CoreRadius` or `CoreBorderRadius` constant exists in the CoreUI package. `BorderRadius.circular(8)` is the established pattern throughout estimation widgets — see `estimation_actions_sheet.dart` and `cost_estimation_log_tile.dart`. Aligning with those files is the right call. |

## Test plan
- [ ] `fvm flutter test test/features/estimations/widgets/calc_method_card_test.dart` passes
- [ ] No regressions in `labour_cost_form_fields_test.dart`
- [ ] Labour form in from cost file mode: rate label reads "Rate/Day:" by default; switching to per-hours shows "Rate/Hour:"
- [ ] `fvm dart run custom_lint` shows no issues