### PR TITLE
CA-771 (2/4): feat(project-search): add tag/owner/date filter events, state, and handlers to ProjectSearchBloc

### DIFF
--- a/lib/features/dashboard/dashboard_module.dart
+++ b/lib/features/dashboard/dashboard_module.dart
@@ -2,8 +2,10 @@ import 'package:construculator/app/app_bootstrap.dart';
 import 'package:construculator/features/dashboard/presentation/bloc/dashboard_bloc/dashboard_bloc.dart';
 import 'package:construculator/features/dashboard/presentation/bloc/project_search_bloc/project_search_bloc.dart';
 import 'package:construculator/libraries/auth/auth_library_module.dart';
+import 'package:construculator/libraries/owner/owner_library_module.dart';
 import 'package:construculator/libraries/project/project_library_module.dart';
 import 'package:construculator/libraries/router/router_module.dart';
+import 'package:construculator/libraries/tag/tag_library_module.dart';
 import 'package:flutter_modular/flutter_modular.dart';
 
 class DashboardModule extends Module {
@@ -14,6 +16,8 @@ class DashboardModule extends Module {
   List<Module> get imports => [
     AuthLibraryModule(appBootstrap),
     ProjectLibraryModule(appBootstrap),
+    TagLibraryModule(appBootstrap),
+    OwnerLibraryModule(appBootstrap),
     RouterModule(),
   ];
 
@@ -28,7 +32,12 @@ class DashboardModule extends Module {
       ),
     );
     i.add<ProjectSearchBloc>(
-      () => ProjectSearchBloc(repository: i(), authManager: i()),
+      () => ProjectSearchBloc(
+        repository: i(),
+        authManager: i(),
+        tagRepository: i(),
+        ownerRepository: i(),
+      ),
     );
   }
 }

--- a/lib/features/dashboard/presentation/bloc/project_search_bloc/project_search_bloc.dart
+++ b/lib/features/dashboard/presentation/bloc/project_search_bloc/project_search_bloc.dart
@@ -1,11 +1,15 @@
 import 'dart:async';
 
+import 'package:construculator/libraries/auth/domain/entities/user_profile_entity.dart';
 import 'package:construculator/libraries/auth/domain/types/auth_types.dart';
 import 'package:construculator/libraries/auth/interfaces/auth_manager.dart';
 import 'package:construculator/libraries/errors/failures.dart';
 import 'package:construculator/libraries/logging/app_logger.dart';
+import 'package:construculator/libraries/owner/domain/repositories/owner_repository.dart';
 import 'package:construculator/libraries/project/domain/entities/project_entity.dart';
 import 'package:construculator/libraries/project/domain/repositories/project_search_repository.dart';
+import 'package:construculator/libraries/search_filters/presentation/widgets/date_range_bottom_sheet.dart';
+import 'package:construculator/libraries/tag/domain/repositories/tag_repository.dart';
 import 'package:equatable/equatable.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -26,7 +30,9 @@ EventTransformer<E> _debounce<E>(Duration duration) =>
 /// BLoC for managing project search state on the dashboard.
 ///
 /// Handles debounced query updates and explicit search submissions, plus the
-/// recent-searches and suggestions surfaces shown on the idle state.
+/// recent-searches and suggestions surfaces shown on the idle state, and the
+/// Tags / Owner / Modified-date filter chips. Selected filters are threaded
+/// into [ProjectSearchRepository.searchProjects] on the next search.
 /// Delegates to [ProjectSearchRepository] and maps results to typed states.
 ///
 /// The in-flight suggestions loading flag is tracked as private instance
@@ -38,6 +44,8 @@ EventTransformer<E> _debounce<E>(Duration duration) =>
 class ProjectSearchBloc extends Bloc<ProjectSearchEvent, ProjectSearchState> {
   final ProjectSearchRepository _repository;
   final AuthManager _authManager;
+  final TagRepository _tagRepository;
+  final OwnerRepository _ownerRepository;
   static final _logger = AppLogger().tag('ProjectSearchBloc');
 
   List<String> _cachedRecents = const [];
@@ -50,17 +58,46 @@ class ProjectSearchBloc extends Bloc<ProjectSearchEvent, ProjectSearchState> {
 
   int _suggestionsFetchGeneration = 0;
 
+  Set<String> _selectedTags = const {};
+
+  // Full list of available tag names fetched from TagRepository.
+  List<String> _availableTags = const [];
+
+  // Whether _availableTags has been fetched at least once, so subsequent
+  // sheet openings reuse the cached list instead of refetching.
+  bool _availableTagsFetched = false;
+
+  String _tagSearchQuery = '';
+
+  Set<String> _selectedOwnerIds = const {};
+
+  // Full list of available owners fetched from OwnerRepository.
+  List<UserProfile> _availableOwners = const [];
+
+  // Whether _availableOwners has been fetched at least once, so subsequent
+  // sheet openings reuse the cached list instead of refetching.
+  bool _availableOwnersFetched = false;
+
+  String _ownerSearchQuery = '';
+
+  DateRange? _selectedDateRange;
+
   /// Exposed for testing only — resolves when the last save-after-search
   /// completes, allowing tests to await it instead of using wall-clock waits.
   @visibleForTesting
   Future<void>? lastSaveCompleted;
 
-  /// Creates a [ProjectSearchBloc] with the given [repository] and [authManager].
+  /// Creates a [ProjectSearchBloc] with the given [repository], [authManager],
+  /// [tagRepository], and [ownerRepository].
   ProjectSearchBloc({
     required ProjectSearchRepository repository,
     required AuthManager authManager,
+    required TagRepository tagRepository,
+    required OwnerRepository ownerRepository,
   }) : _repository = repository,
        _authManager = authManager,
+       _tagRepository = tagRepository,
+       _ownerRepository = ownerRepository,
        super(const ProjectSearchInitial()) {
     on<ProjectSearchQueryUpdatedEvent>(
       (event, emit) => _handleQuery(event.query, emit),
@@ -69,6 +106,20 @@ class ProjectSearchBloc extends Bloc<ProjectSearchEvent, ProjectSearchState> {
     on<ProjectSearchPerformedEvent>(_onPerformed);
     on<ProjectSearchHistoryRequestedEvent>(_onHistoryRequested);
     on<ProjectSearchHistoryItemDismissedEvent>(_onHistoryItemDismissed);
+    on<ProjectSearchTagFiltersAppliedEvent>(_onTagFiltersApplied);
+    on<ProjectSearchTagFilterClearedEvent>(_onTagFilterCleared);
+    on<ProjectSearchAvailableTagsRequestedEvent>(_onAvailableTagsRequested);
+    // Intentionally not debounced: tag filtering is in-memory (no network
+    // call), so instant per-keystroke feedback is cheap and preferable.
+    on<ProjectSearchTagSearchQueryUpdatedEvent>(_onTagSearchQueryUpdated);
+    on<ProjectSearchOwnerFiltersAppliedEvent>(_onOwnerFiltersApplied);
+    on<ProjectSearchOwnerFilterClearedEvent>(_onOwnerFilterCleared);
+    on<ProjectSearchAvailableOwnersRequestedEvent>(_onAvailableOwnersRequested);
+    // Intentionally not debounced: owner filtering is in-memory (no network
+    // call), so instant per-keystroke feedback is cheap and preferable.
+    on<ProjectSearchOwnerSearchQueryUpdatedEvent>(_onOwnerSearchQueryUpdated);
+    on<ProjectSearchDateFilterAppliedEvent>(_onDateFilterApplied);
+    on<ProjectSearchDateFilterClearedEvent>(_onDateFilterCleared);
   }
 
   Future<void> _handleQuery(
@@ -98,7 +149,9 @@ class ProjectSearchBloc extends Bloc<ProjectSearchEvent, ProjectSearchState> {
     emit(_initialFromCache());
   }
 
-  Future<void> _fetchAndEmitSuggestions(Emitter<ProjectSearchState> emit) async {
+  Future<void> _fetchAndEmitSuggestions(
+    Emitter<ProjectSearchState> emit,
+  ) async {
     final userId = _authManager.getCurrentCredentials().data?.id;
     if (userId == null || userId.isEmpty) {
       _logger.warning('Suggestions fetch aborted: no authenticated user');
@@ -154,9 +207,10 @@ class ProjectSearchBloc extends Bloc<ProjectSearchEvent, ProjectSearchState> {
     ProjectSearchHistoryRequestedEvent event,
     Emitter<ProjectSearchState> emit,
   ) async {
-    // Reset per-session suggestion state — a fresh page open re-fetches
-    // suggestions lazily on the user's first keystroke, matching Global
-    // Search's GlobalSearchStarted behavior.
+    // Reset per-session suggestion and filter state — a fresh page open
+    // re-fetches suggestions lazily on the user's first keystroke and starts
+    // with no filters applied, matching Global Search's GlobalSearchStarted
+    // behavior.
     _currentQuery = '';
     _cachedSuggestions = const [];
     _suggestionsFetched = false;
@@ -165,6 +219,11 @@ class ProjectSearchBloc extends Bloc<ProjectSearchEvent, ProjectSearchState> {
     // resurrect the pre-reset cache, mark suggestions as fetched, or emit
     // over the isLoadingHistory state emitted below.
     _suggestionsFetchGeneration++;
+    _selectedTags = const {};
+    _tagSearchQuery = '';
+    _selectedOwnerIds = const {};
+    _ownerSearchQuery = '';
+    _selectedDateRange = null;
 
     final userId = _authManager.getCurrentCredentials().data?.id;
     if (userId == null || userId.isEmpty) {
@@ -174,20 +233,20 @@ class ProjectSearchBloc extends Bloc<ProjectSearchEvent, ProjectSearchState> {
     }
 
     emit(
-      ProjectSearchInitial(recentSearches: _cachedRecents, isLoadingHistory: true),
+      ProjectSearchInitial(
+        recentSearches: _cachedRecents,
+        isLoadingHistory: true,
+      ),
     );
 
     final result = await _repository.getRecentProjectSearches(userId: userId);
 
     // On failure, keep the previously cached value so a transient network
     // hiccup does not blank the history surface.
-    _cachedRecents = result.fold<List<String>>(
-      (failure) {
-        _logger.warning('Failed to load recent project searches: $failure');
-        return _cachedRecents;
-      },
-      (terms) => terms,
-    );
+    _cachedRecents = result.fold<List<String>>((failure) {
+      _logger.warning('Failed to load recent project searches: $failure');
+      return _cachedRecents;
+    }, (terms) => terms);
 
     emit(_initialFromCache());
   }
@@ -207,14 +266,11 @@ class ProjectSearchBloc extends Bloc<ProjectSearchEvent, ProjectSearchState> {
       searchTerm: event.searchTerm,
     );
 
-    result.fold(
-      (failure) {
-        _logger.warning(
-          'Failed to delete recent project search "${event.searchTerm}": $failure',
-        );
-      },
-      (_) => _removeDismissedTermAndEmit(event.searchTerm, emit),
-    );
+    result.fold((failure) {
+      _logger.warning(
+        'Failed to delete recent project search "${event.searchTerm}": $failure',
+      );
+    }, (_) => _removeDismissedTermAndEmit(event.searchTerm, emit));
   }
 
   void _removeDismissedTermAndEmit(
@@ -251,6 +307,19 @@ class ProjectSearchBloc extends Bloc<ProjectSearchEvent, ProjectSearchState> {
     final result = await _repository.searchProjects(
       userId: userId,
       query: query,
+      // The repository accepts a single tag; sort for deterministic selection
+      // until the RPC is extended to support multi-tag filtering.
+      filterByTag: _selectedTags.isEmpty
+          ? null
+          : (_selectedTags.toList()..sort()).first,
+      // The repository accepts a single owner; sort for deterministic
+      // selection until the RPC is extended to support multi-owner filtering.
+      filterByOwner: _selectedOwnerIds.isEmpty
+          ? null
+          : (_selectedOwnerIds.toList()..sort()).first,
+      // filter_by_date is a lower bound ("created on or after"); pass the
+      // range start.
+      filterByDate: _selectedDateRange?.start,
     );
 
     result.fold(
@@ -262,13 +331,13 @@ class ProjectSearchBloc extends Bloc<ProjectSearchEvent, ProjectSearchState> {
       },
       (projects) {
         emit(ProjectSearchResultsLoaded(results: projects, query: query));
-        final saveCompleted = _saveSearchToHistory(
+        final saveFuture = _saveSearchToHistory(
           userId: userId,
           query: query,
           hasResults: projects.isNotEmpty,
         );
-        lastSaveCompleted = saveCompleted;
-        unawaited(saveCompleted);
+        lastSaveCompleted = saveFuture;
+        unawaited(saveFuture);
       },
     );
   }
@@ -308,10 +377,163 @@ class ProjectSearchBloc extends Bloc<ProjectSearchEvent, ProjectSearchState> {
     );
   }
 
-  ProjectSearchInitial _initialFromCache() => ProjectSearchInitial(
+  ProjectSearchInitial _initialFromCache({
+    bool availableTagsLoading = false,
+    bool availableOwnersLoading = false,
+  }) => ProjectSearchInitial(
     recentSearches: _cachedRecents,
     suggestions: _filterSuggestions(_currentQuery),
     query: _currentQuery,
     suggestionsLoading: _suggestionsLoading,
+    selectedTags: _selectedTags,
+    availableTags: _filterAvailableTags(),
+    availableTagsLoading: availableTagsLoading,
+    selectedOwnerIds: _selectedOwnerIds,
+    availableOwners: _filterAvailableOwners(),
+    availableOwnersLoading: availableOwnersLoading,
+    selectedDateRange: _selectedDateRange,
   );
+
+  // Returns _availableTags filtered by the current tag search query.
+  List<String> _filterAvailableTags() {
+    if (_tagSearchQuery.isEmpty) return _availableTags;
+    final lower = _tagSearchQuery.toLowerCase();
+    return _availableTags
+        .where((tag) => tag.toLowerCase().contains(lower))
+        .toList();
+  }
+
+  // Returns _availableOwners filtered by the current owner search query,
+  // matching against the owner's full name.
+  List<UserProfile> _filterAvailableOwners() {
+    if (_ownerSearchQuery.isEmpty) return _availableOwners;
+    final lower = _ownerSearchQuery.toLowerCase();
+    return _availableOwners
+        .where((owner) => owner.fullName.toLowerCase().contains(lower))
+        .toList();
+  }
+
+  Future<void> _onAvailableTagsRequested(
+    ProjectSearchAvailableTagsRequestedEvent event,
+    Emitter<ProjectSearchState> emit,
+  ) async {
+    _tagSearchQuery = '';
+    if (_availableTagsFetched) {
+      emit(_initialFromCache());
+      return;
+    }
+
+    emit(_initialFromCache(availableTagsLoading: true));
+
+    final result = await _tagRepository.getTags();
+
+    result.fold(
+      (failure) {
+        _logger.warning('Failed to load project search tags: $failure');
+        emit(ProjectSearchTagsLoadFailure(failure: failure));
+        emit(_initialFromCache());
+      },
+      (tags) {
+        _availableTags = List.unmodifiable(tags.map((tag) => tag.name));
+        _availableTagsFetched = true;
+        emit(_initialFromCache());
+      },
+    );
+  }
+
+  void _onTagSearchQueryUpdated(
+    ProjectSearchTagSearchQueryUpdatedEvent event,
+    Emitter<ProjectSearchState> emit,
+  ) {
+    _tagSearchQuery = event.query.trim();
+    emit(_initialFromCache());
+  }
+
+  void _onTagFiltersApplied(
+    ProjectSearchTagFiltersAppliedEvent event,
+    Emitter<ProjectSearchState> emit,
+  ) {
+    _selectedTags = Set.unmodifiable(event.tags);
+    emit(_initialFromCache());
+  }
+
+  void _onTagFilterCleared(
+    ProjectSearchTagFilterClearedEvent event,
+    Emitter<ProjectSearchState> emit,
+  ) {
+    _selectedTags = Set.unmodifiable(
+      _selectedTags.where((t) => t != event.tag),
+    );
+    emit(_initialFromCache());
+  }
+
+  Future<void> _onAvailableOwnersRequested(
+    ProjectSearchAvailableOwnersRequestedEvent event,
+    Emitter<ProjectSearchState> emit,
+  ) async {
+    _ownerSearchQuery = '';
+    if (_availableOwnersFetched) {
+      emit(_initialFromCache());
+      return;
+    }
+
+    emit(_initialFromCache(availableOwnersLoading: true));
+
+    final result = await _ownerRepository.getOwners();
+
+    result.fold(
+      (failure) {
+        _logger.warning('Failed to load project search owners: $failure');
+        emit(ProjectSearchOwnersLoadFailure(failure: failure));
+        emit(_initialFromCache());
+      },
+      (owners) {
+        _availableOwners = List.unmodifiable(owners);
+        _availableOwnersFetched = true;
+        emit(_initialFromCache());
+      },
+    );
+  }
+
+  void _onOwnerSearchQueryUpdated(
+    ProjectSearchOwnerSearchQueryUpdatedEvent event,
+    Emitter<ProjectSearchState> emit,
+  ) {
+    _ownerSearchQuery = event.query.trim();
+    emit(_initialFromCache());
+  }
+
+  void _onOwnerFiltersApplied(
+    ProjectSearchOwnerFiltersAppliedEvent event,
+    Emitter<ProjectSearchState> emit,
+  ) {
+    _selectedOwnerIds = Set.unmodifiable(event.ownerIds);
+    emit(_initialFromCache());
+  }
+
+  void _onOwnerFilterCleared(
+    ProjectSearchOwnerFilterClearedEvent event,
+    Emitter<ProjectSearchState> emit,
+  ) {
+    _selectedOwnerIds = Set.unmodifiable(
+      _selectedOwnerIds.where((id) => id != event.ownerId),
+    );
+    emit(_initialFromCache());
+  }
+
+  void _onDateFilterApplied(
+    ProjectSearchDateFilterAppliedEvent event,
+    Emitter<ProjectSearchState> emit,
+  ) {
+    _selectedDateRange = event.range;
+    emit(_initialFromCache());
+  }
+
+  void _onDateFilterCleared(
+    ProjectSearchDateFilterClearedEvent event,
+    Emitter<ProjectSearchState> emit,
+  ) {
+    _selectedDateRange = null;
+    emit(_initialFromCache());
+  }
 }

--- a/lib/features/dashboard/presentation/bloc/project_search_bloc/project_search_bloc.dart
+++ b/lib/features/dashboard/presentation/bloc/project_search_bloc/project_search_bloc.dart
@@ -8,7 +8,7 @@ import 'package:construculator/libraries/logging/app_logger.dart';
 import 'package:construculator/libraries/owner/domain/repositories/owner_repository.dart';
 import 'package:construculator/libraries/project/domain/entities/project_entity.dart';
 import 'package:construculator/libraries/project/domain/repositories/project_search_repository.dart';
-import 'package:construculator/libraries/search_filters/presentation/widgets/date_range_bottom_sheet.dart';
+import 'package:construculator/libraries/search_filters/domain/entities/date_range.dart';
 import 'package:construculator/libraries/tag/domain/repositories/tag_repository.dart';
 import 'package:equatable/equatable.dart';
 import 'package:flutter/foundation.dart';

--- a/lib/features/dashboard/presentation/bloc/project_search_bloc/project_search_bloc.dart
+++ b/lib/features/dashboard/presentation/bloc/project_search_bloc/project_search_bloc.dart
@@ -27,12 +27,6 @@ const int _kMaxDisplayedSuggestions = 5;
 EventTransformer<E> _debounce<E>(Duration duration) =>
     (events, mapper) => events.debounceTime(duration).switchMap(mapper);
 
-// Restartable semantics: a re-dispatch cancels the in-flight handler, so
-// rapidly reopening a filter sheet cannot fire two concurrent fetches whose
-// interleaved results would surface a stray failure toast after a success.
-EventTransformer<E> _restartable<E>() =>
-    (events, mapper) => events.switchMap(mapper);
-
 /// BLoC for managing project search state on the dashboard.
 ///
 /// Handles debounced query updates and explicit search submissions, plus the
@@ -41,12 +35,14 @@ EventTransformer<E> _restartable<E>() =>
 /// into [ProjectSearchRepository.searchProjects] on the next search.
 /// Delegates to [ProjectSearchRepository] and maps results to typed states.
 ///
-/// The in-flight suggestions loading flag is tracked as private instance
-/// state rather than a state-builder parameter, so a concurrently-handled
-/// event rebuilding the state cannot stomp it. A fetch-generation counter
-/// lets a superseded fetch (cancelled by the switchMap transformer or
-/// disowned by a history-request reset) bail out on completion instead of
-/// clearing a newer fetch's flag or resurrecting pre-reset data.
+/// The in-flight loading flags (suggestions, tags, owners) are tracked as
+/// private instance state rather than state-builder parameters, so a
+/// concurrently-handled event rebuilding the state cannot stomp them. The
+/// loading flag also gates its own fetch handler, so a request arriving while
+/// a fetch is in flight reuses it instead of starting a duplicate. Per-fetch
+/// generation counters let a superseded fetch (cancelled by the switchMap
+/// transformer or disowned by a history-request reset) bail out on completion
+/// instead of clearing a newer fetch's flag or resurrecting pre-reset data.
 class ProjectSearchBloc extends Bloc<ProjectSearchEvent, ProjectSearchState> {
   final ProjectSearchRepository _repository;
   final AuthManager _authManager;
@@ -73,6 +69,10 @@ class ProjectSearchBloc extends Bloc<ProjectSearchEvent, ProjectSearchState> {
   // sheet openings reuse the cached list instead of refetching.
   bool _availableTagsFetched = false;
 
+  bool _availableTagsLoading = false;
+
+  int _availableTagsFetchGeneration = 0;
+
   String _tagSearchQuery = '';
 
   Set<String> _selectedOwnerIds = const {};
@@ -83,6 +83,10 @@ class ProjectSearchBloc extends Bloc<ProjectSearchEvent, ProjectSearchState> {
   // Whether _availableOwners has been fetched at least once, so subsequent
   // sheet openings reuse the cached list instead of refetching.
   bool _availableOwnersFetched = false;
+
+  bool _availableOwnersLoading = false;
+
+  int _availableOwnersFetchGeneration = 0;
 
   String _ownerSearchQuery = '';
 
@@ -127,19 +131,18 @@ class ProjectSearchBloc extends Bloc<ProjectSearchEvent, ProjectSearchState> {
     on<ProjectSearchHistoryItemDismissedEvent>(_onHistoryItemDismissed);
     on<ProjectSearchTagFiltersAppliedEvent>(_onTagFiltersApplied);
     on<ProjectSearchTagFilterClearedEvent>(_onTagFilterCleared);
-    on<ProjectSearchAvailableTagsRequestedEvent>(
-      _onAvailableTagsRequested,
-      transformer: _restartable(),
-    );
+    // No transformer: the handler's _availableTagsLoading gate collapses a
+    // request arriving mid-fetch into the in-flight one, mirroring
+    // GlobalSearchBloc. A cancelling transformer would instead suppress the
+    // in-flight handler's completion emit, stranding the sheet on a spinner.
+    on<ProjectSearchAvailableTagsRequestedEvent>(_onAvailableTagsRequested);
     // Intentionally not debounced: tag filtering is in-memory (no network
     // call), so instant per-keystroke feedback is cheap and preferable.
     on<ProjectSearchTagSearchQueryUpdatedEvent>(_onTagSearchQueryUpdated);
     on<ProjectSearchOwnerFiltersAppliedEvent>(_onOwnerFiltersApplied);
     on<ProjectSearchOwnerFilterClearedEvent>(_onOwnerFilterCleared);
-    on<ProjectSearchAvailableOwnersRequestedEvent>(
-      _onAvailableOwnersRequested,
-      transformer: _restartable(),
-    );
+    // No transformer — see the tags registration above.
+    on<ProjectSearchAvailableOwnersRequestedEvent>(_onAvailableOwnersRequested);
     // Intentionally not debounced: owner filtering is in-memory (no network
     // call), so instant per-keystroke feedback is cheap and preferable.
     on<ProjectSearchOwnerSearchQueryUpdatedEvent>(_onOwnerSearchQueryUpdated);
@@ -246,8 +249,16 @@ class ProjectSearchBloc extends Bloc<ProjectSearchEvent, ProjectSearchState> {
     _suggestionsFetchGeneration++;
     _selectedTags = const {};
     _tagSearchQuery = '';
+    _availableTags = const [];
+    _availableTagsFetched = false;
+    _availableTagsLoading = false;
+    _availableTagsFetchGeneration++;
     _selectedOwnerIds = const {};
     _ownerSearchQuery = '';
+    _availableOwners = const [];
+    _availableOwnersFetched = false;
+    _availableOwnersLoading = false;
+    _availableOwnersFetchGeneration++;
     _selectedDateRange = null;
 
     final userId = _authManager.getCurrentCredentials().data?.id;
@@ -358,9 +369,10 @@ class ProjectSearchBloc extends Bloc<ProjectSearchEvent, ProjectSearchState> {
       filterByOwner: _selectedOwnerIds.isEmpty
           ? null
           : (_selectedOwnerIds.toList()..sort()).first,
-      // filter_by_date is a lower bound ("created on or after"); pass the
-      // range start.
-      filterByDate: _selectedDateRange?.start,
+      // The RPC's date filter is an inclusive modification-date range;
+      // thread both bounds, mirroring GlobalSearchBloc.
+      filterByDateFrom: _selectedDateRange?.start,
+      filterByDateTo: _selectedDateRange?.end,
     );
 
     result.fold(
@@ -418,24 +430,17 @@ class ProjectSearchBloc extends Bloc<ProjectSearchEvent, ProjectSearchState> {
     );
   }
 
-  // TODO: [CA-797] Track the loading flags as bloc instance fields consulted
-  // here (like _availableTagsFetched) instead of caller-supplied parameters,
-  // so a concurrently-handled event cannot reset an in-flight flag to false.
-  // https://ripplearc.youtrack.cloud/issue/CA-797
-  ProjectSearchInitial _initialFromCache({
-    bool availableTagsLoading = false,
-    bool availableOwnersLoading = false,
-  }) => ProjectSearchInitial(
+  ProjectSearchInitial _initialFromCache() => ProjectSearchInitial(
     recentSearches: _cachedRecents,
     suggestions: _filterSuggestions(_currentQuery),
     query: _currentQuery,
     suggestionsLoading: _suggestionsLoading,
     selectedTags: _selectedTags,
     availableTags: _filterAvailableTags(),
-    availableTagsLoading: availableTagsLoading,
+    availableTagsLoading: _availableTagsLoading,
     selectedOwnerIds: _selectedOwnerIds,
     availableOwners: _filterAvailableOwners(),
-    availableOwnersLoading: availableOwnersLoading,
+    availableOwnersLoading: _availableOwnersLoading,
     selectedDateRange: _selectedDateRange,
   );
 
@@ -463,15 +468,27 @@ class ProjectSearchBloc extends Bloc<ProjectSearchEvent, ProjectSearchState> {
     Emitter<ProjectSearchState> emit,
   ) async {
     _tagSearchQuery = '';
-    if (_availableTagsFetched) {
+    // _availableTagsLoading also gates: a request arriving while a fetch is
+    // in flight must not start a duplicate fetch, whose earlier completion
+    // would clear the loading flag while the later fetch is still running.
+    if (_availableTagsFetched || _availableTagsLoading) {
       emit(_initialFromCache());
       availableTagsHandlerRuns++;
       return;
     }
 
-    emit(_initialFromCache(availableTagsLoading: true));
+    final generation = ++_availableTagsFetchGeneration;
+    _availableTagsLoading = true;
+    emit(_initialFromCache());
 
     final result = await _tagRepository.getTags();
+    // A history-request reset disowned this fetch while it was in flight;
+    // the reset handler owns the loading flag and caches now.
+    if (generation != _availableTagsFetchGeneration) {
+      availableTagsHandlerRuns++;
+      return;
+    }
+    _availableTagsLoading = false;
 
     result.fold(
       (failure) {
@@ -519,15 +536,27 @@ class ProjectSearchBloc extends Bloc<ProjectSearchEvent, ProjectSearchState> {
     Emitter<ProjectSearchState> emit,
   ) async {
     _ownerSearchQuery = '';
-    if (_availableOwnersFetched) {
+    // _availableOwnersLoading also gates: a request arriving while a fetch is
+    // in flight must not start a duplicate fetch, whose earlier completion
+    // would clear the loading flag while the later fetch is still running.
+    if (_availableOwnersFetched || _availableOwnersLoading) {
       emit(_initialFromCache());
       availableOwnersHandlerRuns++;
       return;
     }
 
-    emit(_initialFromCache(availableOwnersLoading: true));
+    final generation = ++_availableOwnersFetchGeneration;
+    _availableOwnersLoading = true;
+    emit(_initialFromCache());
 
     final result = await _ownerRepository.getOwners();
+    // A history-request reset disowned this fetch while it was in flight;
+    // the reset handler owns the loading flag and caches now.
+    if (generation != _availableOwnersFetchGeneration) {
+      availableOwnersHandlerRuns++;
+      return;
+    }
+    _availableOwnersLoading = false;
 
     result.fold(
       (failure) {

--- a/lib/features/dashboard/presentation/bloc/project_search_bloc/project_search_bloc.dart
+++ b/lib/features/dashboard/presentation/bloc/project_search_bloc/project_search_bloc.dart
@@ -27,6 +27,12 @@ const int _kMaxDisplayedSuggestions = 5;
 EventTransformer<E> _debounce<E>(Duration duration) =>
     (events, mapper) => events.debounceTime(duration).switchMap(mapper);
 
+// Restartable semantics: a re-dispatch cancels the in-flight handler, so
+// rapidly reopening a filter sheet cannot fire two concurrent fetches whose
+// interleaved results would surface a stray failure toast after a success.
+EventTransformer<E> _restartable<E>() =>
+    (events, mapper) => events.switchMap(mapper);
+
 /// BLoC for managing project search state on the dashboard.
 ///
 /// Handles debounced query updates and explicit search submissions, plus the
@@ -108,13 +114,19 @@ class ProjectSearchBloc extends Bloc<ProjectSearchEvent, ProjectSearchState> {
     on<ProjectSearchHistoryItemDismissedEvent>(_onHistoryItemDismissed);
     on<ProjectSearchTagFiltersAppliedEvent>(_onTagFiltersApplied);
     on<ProjectSearchTagFilterClearedEvent>(_onTagFilterCleared);
-    on<ProjectSearchAvailableTagsRequestedEvent>(_onAvailableTagsRequested);
+    on<ProjectSearchAvailableTagsRequestedEvent>(
+      _onAvailableTagsRequested,
+      transformer: _restartable(),
+    );
     // Intentionally not debounced: tag filtering is in-memory (no network
     // call), so instant per-keystroke feedback is cheap and preferable.
     on<ProjectSearchTagSearchQueryUpdatedEvent>(_onTagSearchQueryUpdated);
     on<ProjectSearchOwnerFiltersAppliedEvent>(_onOwnerFiltersApplied);
     on<ProjectSearchOwnerFilterClearedEvent>(_onOwnerFilterCleared);
-    on<ProjectSearchAvailableOwnersRequestedEvent>(_onAvailableOwnersRequested);
+    on<ProjectSearchAvailableOwnersRequestedEvent>(
+      _onAvailableOwnersRequested,
+      transformer: _restartable(),
+    );
     // Intentionally not debounced: owner filtering is in-memory (no network
     // call), so instant per-keystroke feedback is cheap and preferable.
     on<ProjectSearchOwnerSearchQueryUpdatedEvent>(_onOwnerSearchQueryUpdated);
@@ -304,6 +316,22 @@ class ProjectSearchBloc extends Bloc<ProjectSearchEvent, ProjectSearchState> {
 
     emit(ProjectSearchLoading(query: query));
 
+    // The RPC accepts a single tag/owner, so a multi-selection is silently
+    // truncated to the alphabetically-first value; log it until the RPC
+    // supports multi-value filters.
+    if (_selectedTags.length > 1) {
+      _logger.warning(
+        'Tag filter truncated: ${_selectedTags.length} tags selected, only '
+        'the alphabetically-first is sent to the RPC',
+      );
+    }
+    if (_selectedOwnerIds.length > 1) {
+      _logger.warning(
+        'Owner filter truncated: ${_selectedOwnerIds.length} owners selected, '
+        'only the alphabetically-first is sent to the RPC',
+      );
+    }
+
     final result = await _repository.searchProjects(
       userId: userId,
       query: query,
@@ -377,6 +405,10 @@ class ProjectSearchBloc extends Bloc<ProjectSearchEvent, ProjectSearchState> {
     );
   }
 
+  // TODO: [CA-797] Track the loading flags as bloc instance fields consulted
+  // here (like _availableTagsFetched) instead of caller-supplied parameters,
+  // so a concurrently-handled event cannot reset an in-flight flag to false.
+  // https://ripplearc.youtrack.cloud/issue/CA-797
   ProjectSearchInitial _initialFromCache({
     bool availableTagsLoading = false,
     bool availableOwnersLoading = false,

--- a/lib/features/dashboard/presentation/bloc/project_search_bloc/project_search_bloc.dart
+++ b/lib/features/dashboard/presentation/bloc/project_search_bloc/project_search_bloc.dart
@@ -93,6 +93,19 @@ class ProjectSearchBloc extends Bloc<ProjectSearchEvent, ProjectSearchState> {
   @visibleForTesting
   Future<void>? lastSaveCompleted;
 
+  /// Exposed for testing only — increments each time the available-tags
+  /// handler finishes (cache hit or fetch). A cache-hit re-emits an
+  /// `Equatable`-equal [ProjectSearchInitial] that `emit` suppresses, so this
+  /// counter gives tests a deterministic completion signal to await instead of
+  /// draining the event queue on a wall clock.
+  @visibleForTesting
+  int availableTagsHandlerRuns = 0;
+
+  /// Exposed for testing only — the owner equivalent of
+  /// [availableTagsHandlerRuns].
+  @visibleForTesting
+  int availableOwnersHandlerRuns = 0;
+
   /// Creates a [ProjectSearchBloc] with the given [repository], [authManager],
   /// [tagRepository], and [ownerRepository].
   ProjectSearchBloc({
@@ -452,6 +465,7 @@ class ProjectSearchBloc extends Bloc<ProjectSearchEvent, ProjectSearchState> {
     _tagSearchQuery = '';
     if (_availableTagsFetched) {
       emit(_initialFromCache());
+      availableTagsHandlerRuns++;
       return;
     }
 
@@ -471,6 +485,7 @@ class ProjectSearchBloc extends Bloc<ProjectSearchEvent, ProjectSearchState> {
         emit(_initialFromCache());
       },
     );
+    availableTagsHandlerRuns++;
   }
 
   void _onTagSearchQueryUpdated(
@@ -506,6 +521,7 @@ class ProjectSearchBloc extends Bloc<ProjectSearchEvent, ProjectSearchState> {
     _ownerSearchQuery = '';
     if (_availableOwnersFetched) {
       emit(_initialFromCache());
+      availableOwnersHandlerRuns++;
       return;
     }
 
@@ -525,6 +541,7 @@ class ProjectSearchBloc extends Bloc<ProjectSearchEvent, ProjectSearchState> {
         emit(_initialFromCache());
       },
     );
+    availableOwnersHandlerRuns++;
   }
 
   void _onOwnerSearchQueryUpdated(

--- a/lib/features/dashboard/presentation/bloc/project_search_bloc/project_search_event.dart
+++ b/lib/features/dashboard/presentation/bloc/project_search_bloc/project_search_event.dart
@@ -57,3 +57,115 @@ class ProjectSearchHistoryItemDismissedEvent extends ProjectSearchEvent {
   @override
   List<Object?> get props => [searchTerm];
 }
+
+/// Dispatched when the user taps Apply in the Tags filter sheet.
+class ProjectSearchTagFiltersAppliedEvent extends ProjectSearchEvent {
+  /// The tags selected in the sheet at the time Apply was tapped.
+  final Set<String> tags;
+
+  /// Creates a [ProjectSearchTagFiltersAppliedEvent] with the given [tags].
+  const ProjectSearchTagFiltersAppliedEvent({required this.tags});
+
+  @override
+  List<Object?> get props => [tags];
+}
+
+/// Dispatched when the user clears a single active tag filter chip.
+class ProjectSearchTagFilterClearedEvent extends ProjectSearchEvent {
+  /// The tag to remove from the active filter set.
+  final String tag;
+
+  /// Creates a [ProjectSearchTagFilterClearedEvent] with the given [tag].
+  const ProjectSearchTagFilterClearedEvent({required this.tag});
+
+  @override
+  List<Object?> get props => [tag];
+}
+
+/// Requests the list of available tags for the Tags filter sheet.
+///
+/// Dispatched when the user opens the Tags filter sheet. The BLoC fetches
+/// tags from `TagRepository` on the first request and serves the cached list
+/// on subsequent openings.
+class ProjectSearchAvailableTagsRequestedEvent extends ProjectSearchEvent {
+  /// Creates a [ProjectSearchAvailableTagsRequestedEvent].
+  const ProjectSearchAvailableTagsRequestedEvent();
+}
+
+/// Dispatched as the user types in the tag search field inside the Tags
+/// filter sheet.
+class ProjectSearchTagSearchQueryUpdatedEvent extends ProjectSearchEvent {
+  /// The current value of the tag search field.
+  final String query;
+
+  /// Creates a [ProjectSearchTagSearchQueryUpdatedEvent] with the given [query].
+  const ProjectSearchTagSearchQueryUpdatedEvent({required this.query});
+
+  @override
+  List<Object?> get props => [query];
+}
+
+/// Dispatched when the user taps Apply in the Owner filter sheet.
+class ProjectSearchOwnerFiltersAppliedEvent extends ProjectSearchEvent {
+  /// The owner ids selected in the sheet at the time Apply was tapped.
+  final Set<String> ownerIds;
+
+  /// Creates a [ProjectSearchOwnerFiltersAppliedEvent] with the given [ownerIds].
+  const ProjectSearchOwnerFiltersAppliedEvent({required this.ownerIds});
+
+  @override
+  List<Object?> get props => [ownerIds];
+}
+
+/// Dispatched when the user clears a single active owner filter chip.
+class ProjectSearchOwnerFilterClearedEvent extends ProjectSearchEvent {
+  /// The owner id to remove from the active filter set.
+  final String ownerId;
+
+  /// Creates a [ProjectSearchOwnerFilterClearedEvent] with the given [ownerId].
+  const ProjectSearchOwnerFilterClearedEvent({required this.ownerId});
+
+  @override
+  List<Object?> get props => [ownerId];
+}
+
+/// Requests the list of available owners for the Owner filter sheet.
+///
+/// Dispatched when the user opens the Owner filter sheet. The BLoC fetches
+/// owners from `OwnerRepository` on the first request and serves the cached
+/// list on subsequent openings.
+class ProjectSearchAvailableOwnersRequestedEvent extends ProjectSearchEvent {
+  /// Creates a [ProjectSearchAvailableOwnersRequestedEvent].
+  const ProjectSearchAvailableOwnersRequestedEvent();
+}
+
+/// Dispatched as the user types in the owner search field inside the Owner
+/// filter sheet.
+class ProjectSearchOwnerSearchQueryUpdatedEvent extends ProjectSearchEvent {
+  /// The current value of the owner search field.
+  final String query;
+
+  /// Creates a [ProjectSearchOwnerSearchQueryUpdatedEvent] with the given [query].
+  const ProjectSearchOwnerSearchQueryUpdatedEvent({required this.query});
+
+  @override
+  List<Object?> get props => [query];
+}
+
+/// Dispatched when the user taps Apply in [DateRangeBottomSheet].
+class ProjectSearchDateFilterAppliedEvent extends ProjectSearchEvent {
+  /// The modification-date range selected by the user.
+  final DateRange range;
+
+  /// Creates a [ProjectSearchDateFilterAppliedEvent] with the given [range].
+  const ProjectSearchDateFilterAppliedEvent({required this.range});
+
+  @override
+  List<Object?> get props => [range];
+}
+
+/// Dispatched when the user clears the active modification-date filter.
+class ProjectSearchDateFilterClearedEvent extends ProjectSearchEvent {
+  /// Creates a [ProjectSearchDateFilterClearedEvent].
+  const ProjectSearchDateFilterClearedEvent();
+}

--- a/lib/features/dashboard/presentation/bloc/project_search_bloc/project_search_state.dart
+++ b/lib/features/dashboard/presentation/bloc/project_search_bloc/project_search_state.dart
@@ -37,14 +37,46 @@ class ProjectSearchInitial extends ProjectSearchState {
   /// flight.
   final bool suggestionsLoading;
 
+  /// Tags currently applied as filters. Empty means no tag filter is active.
+  final Set<String> selectedTags;
+
+  /// Available tag names to display in the Tags filter sheet, already
+  /// filtered by the current tag search query.
+  final List<String> availableTags;
+
+  /// `true` while the available tags fetch is currently in flight.
+  final bool availableTagsLoading;
+
+  /// Owner ids currently applied as filters. Empty means no owner filter is
+  /// active.
+  final Set<String> selectedOwnerIds;
+
+  /// Available owners to display in the Owner filter sheet, already filtered
+  /// by the current owner search query.
+  final List<UserProfile> availableOwners;
+
+  /// `true` while the available owners fetch is currently in flight.
+  final bool availableOwnersLoading;
+
+  /// The modification-date range currently applied as a filter, if any.
+  final DateRange? selectedDateRange;
+
   /// Creates a [ProjectSearchInitial] with the given [recentSearches],
-  /// [suggestions], [isLoadingHistory], [query], and [suggestionsLoading].
+  /// [suggestions], [isLoadingHistory], [query], [suggestionsLoading], and the
+  /// active/available filter fields.
   const ProjectSearchInitial({
     this.recentSearches = const [],
     this.suggestions = const [],
     this.isLoadingHistory = false,
     this.query = '',
     this.suggestionsLoading = false,
+    this.selectedTags = const {},
+    this.availableTags = const [],
+    this.availableTagsLoading = false,
+    this.selectedOwnerIds = const {},
+    this.availableOwners = const [],
+    this.availableOwnersLoading = false,
+    this.selectedDateRange,
   });
 
   @override
@@ -54,6 +86,13 @@ class ProjectSearchInitial extends ProjectSearchState {
     isLoadingHistory,
     query,
     suggestionsLoading,
+    selectedTags,
+    availableTags,
+    availableTagsLoading,
+    selectedOwnerIds,
+    availableOwners,
+    availableOwnersLoading,
+    selectedDateRange,
   ];
 }
 
@@ -81,7 +120,10 @@ class ProjectSearchResultsLoaded extends ProjectSearchState {
   final String query;
 
   /// Creates a [ProjectSearchResultsLoaded] with the given [results] and [query].
-  const ProjectSearchResultsLoaded({required this.results, required this.query});
+  const ProjectSearchResultsLoaded({
+    required this.results,
+    required this.query,
+  });
 
   @override
   List<Object?> get props => [results, query];
@@ -100,4 +142,34 @@ class ProjectSearchFailureState extends ProjectSearchState {
 
   @override
   List<Object?> get props => [failure, query];
+}
+
+/// Emitted when loading the available tags for the filter sheet fails.
+///
+/// Transient: the BLoC re-emits a [ProjectSearchInitial] immediately after so
+/// the idle surface (with its cached filter state) remains interactive.
+class ProjectSearchTagsLoadFailure extends ProjectSearchState {
+  /// The failure describing why the tags fetch failed.
+  final Failure failure;
+
+  /// Creates a [ProjectSearchTagsLoadFailure] with the given [failure].
+  const ProjectSearchTagsLoadFailure({required this.failure});
+
+  @override
+  List<Object?> get props => [failure];
+}
+
+/// Emitted when loading the available owners for the filter sheet fails.
+///
+/// Transient: the BLoC re-emits a [ProjectSearchInitial] immediately after so
+/// the idle surface (with its cached filter state) remains interactive.
+class ProjectSearchOwnersLoadFailure extends ProjectSearchState {
+  /// The failure describing why the owners fetch failed.
+  final Failure failure;
+
+  /// Creates a [ProjectSearchOwnersLoadFailure] with the given [failure].
+  const ProjectSearchOwnersLoadFailure({required this.failure});
+
+  @override
+  List<Object?> get props => [failure];
 }

--- a/lib/libraries/project/data/data_source/interfaces/project_search_data_source.dart
+++ b/lib/libraries/project/data/data_source/interfaces/project_search_data_source.dart
@@ -11,10 +11,15 @@ abstract class ProjectSearchDataSource {
   /// the remote API. [userId] may be used as an early-exit guard; backend user
   /// scoping is implementation-specific and not required to be forwarded as an
   /// explicit parameter.
+  ///
+  /// [filterByDateFrom]/[filterByDateTo] bound the inclusive
+  /// modification-date range filter; either may be omitted for an
+  /// open-ended range.
   Future<List<ProjectDto>> fetchProjectsBySearchQuery({
     required String userId,
     required String query,
-    DateTime? filterByDate,
+    DateTime? filterByDateFrom,
+    DateTime? filterByDateTo,
     String? filterByTag,
     String? filterByOwner,
   });

--- a/lib/libraries/project/data/data_source/remote_project_search_data_source.dart
+++ b/lib/libraries/project/data/data_source/remote_project_search_data_source.dart
@@ -26,7 +26,8 @@ class RemoteProjectSearchDataSource implements ProjectSearchDataSource {
   Future<List<ProjectDto>> fetchProjectsBySearchQuery({
     required String userId,
     required String query,
-    DateTime? filterByDate,
+    DateTime? filterByDateFrom,
+    DateTime? filterByDateTo,
     String? filterByTag,
     String? filterByOwner,
   }) async {
@@ -43,7 +44,8 @@ class RemoteProjectSearchDataSource implements ProjectSearchDataSource {
         params: {
           'query': query,
           'filter_by_tag': filterByTag,
-          'filter_by_date': filterByDate?.toIso8601String(),
+          'filter_by_date_from': filterByDateFrom?.toIso8601String(),
+          'filter_by_date_to': filterByDateTo?.toIso8601String(),
           // The RPC takes an owner-id array; this data source still exposes a
           // single-owner filter, so wrap it. Widening this interface to
           // multiple owners is tracked in CA-771.

--- a/lib/libraries/project/data/repositories/project_search_repository_impl.dart
+++ b/lib/libraries/project/data/repositories/project_search_repository_impl.dart
@@ -87,7 +87,8 @@ class ProjectSearchRepositoryImpl implements ProjectSearchRepository {
   Future<Either<Failure, List<Project>>> searchProjects({
     required String userId,
     required String query,
-    DateTime? filterByDate,
+    DateTime? filterByDateFrom,
+    DateTime? filterByDateTo,
     String? filterByTag,
     String? filterByOwner,
   }) async {
@@ -100,7 +101,8 @@ class ProjectSearchRepositoryImpl implements ProjectSearchRepository {
       final dtos = await _dataSource.fetchProjectsBySearchQuery(
         userId: userId,
         query: query,
-        filterByDate: filterByDate,
+        filterByDateFrom: filterByDateFrom,
+        filterByDateTo: filterByDateTo,
         filterByTag: filterByTag,
         filterByOwner: filterByOwner,
       );

--- a/lib/libraries/project/domain/repositories/project_search_repository.dart
+++ b/lib/libraries/project/domain/repositories/project_search_repository.dart
@@ -10,7 +10,8 @@ abstract class ProjectSearchRepository {
   /// Searches projects accessible to [userId] that match [query].
   ///
   /// Optional filters:
-  /// - [filterByDate]: only projects created on or after this date.
+  /// - [filterByDateFrom]/[filterByDateTo]: inclusive modification-date
+  ///   range; either bound may be omitted for an open-ended range.
   /// - [filterByTag]: only projects tagged with this value.
   /// - [filterByOwner]: only projects owned by this user id.
   ///
@@ -18,7 +19,8 @@ abstract class ProjectSearchRepository {
   Future<Either<Failure, List<Project>>> searchProjects({
     required String userId,
     required String query,
-    DateTime? filterByDate,
+    DateTime? filterByDateFrom,
+    DateTime? filterByDateTo,
     String? filterByTag,
     String? filterByOwner,
   });

--- a/lib/libraries/project/testing/fake_project_search_repository.dart
+++ b/lib/libraries/project/testing/fake_project_search_repository.dart
@@ -70,7 +70,8 @@ class FakeProjectSearchRepository implements ProjectSearchRepository {
   Future<Either<Failure, List<Project>>> searchProjects({
     required String userId,
     required String query,
-    DateTime? filterByDate,
+    DateTime? filterByDateFrom,
+    DateTime? filterByDateTo,
     String? filterByTag,
     String? filterByOwner,
   }) async {
@@ -82,7 +83,8 @@ class FakeProjectSearchRepository implements ProjectSearchRepository {
       'method': 'searchProjects',
       'userId': userId,
       'query': query,
-      'filterByDate': filterByDate,
+      'filterByDateFrom': filterByDateFrom,
+      'filterByDateTo': filterByDateTo,
       'filterByTag': filterByTag,
       'filterByOwner': filterByOwner,
     });

--- a/test/features/dashboard/units/blocs/project_search_bloc_test.dart
+++ b/test/features/dashboard/units/blocs/project_search_bloc_test.dart
@@ -27,6 +27,20 @@ import '../../../../utils/fake_app_bootstrap_factory.dart';
 const String _testUserId = 'user-search-test';
 const String _testUserEmail = 'search@test.com';
 
+// Yields microtasks until [condition] holds, bounded by [maxTurns]. Unlike
+// pumpEventQueue this uses no wall-clock Future.delayed: bloc event dispatch
+// settles within a few microtask turns, so this is a deterministic gate for
+// handlers whose only observable effect is an Equatable-suppressed re-emit.
+Future<void> _untilHandlerRuns(
+  bool Function() condition, {
+  int maxTurns = 100,
+}) async {
+  for (var turn = 0; turn < maxTurns; turn++) {
+    if (condition()) return;
+    await Future<void>.microtask(() {});
+  }
+}
+
 Map<String, dynamic> _fakeProjectData({String? id, String? projectName}) {
   return {
     DatabaseConstants.idColumn: id ?? 'project-1',
@@ -1191,6 +1205,36 @@ void main() {
       );
 
       blocTest<ProjectSearchBloc, ProjectSearchState>(
+        'restartable transformer collapses a rapid double tag request into one fetch',
+        setUp: () => seedTags(['Concrete', 'Steel']),
+        build: () => Modular.get<ProjectSearchBloc>(),
+        act: (bloc) async {
+          // Two requests dispatched before the first fetch resolves. The
+          // restartable() (switchMap) transformer must cancel the stale first
+          // handler so only a single tag catalog read reaches the datasource —
+          // guarding against the duplicate-fetch/stray-failure-toast race. If
+          // the transformer were dropped, both handlers would run and fetch.
+          bloc
+            ..add(const ProjectSearchAvailableTagsRequestedEvent())
+            ..add(const ProjectSearchAvailableTagsRequestedEvent());
+          await bloc.stream.firstWhere(
+            (s) => s is ProjectSearchInitial && !s.availableTagsLoading,
+          );
+        },
+        verify: (_) {
+          final tagReads = fakeSupabase
+              .getMethodCallsFor('selectMatch')
+              .where((call) => call['table'] == DatabaseConstants.tagsTable)
+              .toList();
+          expect(
+            tagReads,
+            hasLength(1),
+            reason: 'restartable() must cancel the stale in-flight tag fetch',
+          );
+        },
+      );
+
+      blocTest<ProjectSearchBloc, ProjectSearchState>(
         'emits ProjectSearchTagsLoadFailure then recovers to initial on fetch error',
         setUp: () {
           fakeSupabase.shouldThrowOnSelectMatch = true;
@@ -1362,6 +1406,40 @@ void main() {
               )
               .toList();
           expect(ownerCalls, hasLength(1));
+        },
+      );
+
+      blocTest<ProjectSearchBloc, ProjectSearchState>(
+        'restartable transformer collapses a rapid double owner request into one fetch',
+        setUp: () => seedOwners([
+          (id: 'owner-1', firstName: 'Ada', lastName: 'Lovelace'),
+          (id: 'owner-2', firstName: 'Alan', lastName: 'Turing'),
+        ]),
+        build: () => Modular.get<ProjectSearchBloc>(),
+        act: (bloc) async {
+          // See the tag equivalent: the restartable() (switchMap) transformer
+          // must cancel the stale first handler so only one owner RPC fires.
+          bloc
+            ..add(const ProjectSearchAvailableOwnersRequestedEvent())
+            ..add(const ProjectSearchAvailableOwnersRequestedEvent());
+          await bloc.stream.firstWhere(
+            (s) => s is ProjectSearchInitial && !s.availableOwnersLoading,
+          );
+        },
+        verify: (_) {
+          final ownerCalls = fakeSupabase
+              .getMethodCallsFor('rpc')
+              .where(
+                (call) =>
+                    call['functionName'] ==
+                    DatabaseConstants.projectOwnersRpcFunction,
+              )
+              .toList();
+          expect(
+            ownerCalls,
+            hasLength(1),
+            reason: 'restartable() must cancel the stale in-flight owner fetch',
+          );
         },
       );
 
@@ -1593,13 +1671,17 @@ void main() {
           await bloc.stream.firstWhere(
             (s) => s is ProjectSearchInitial && !s.isLoadingHistory,
           );
-          // The cached catalog means the second request emits no loading state,
-          // so drain the event queue rather than awaiting a (deduplicated)
-          // state transition.
+          // The cached catalog re-emits an Equatable-equal state that `emit`
+          // suppresses, so there is no state transition to await. Gate on the
+          // handler-run counter — it increments synchronously on the cache-hit
+          // path, giving a deterministic signal instead of a wall-clock wait.
+          final runsBefore = bloc.availableTagsHandlerRuns;
           bloc.add(const ProjectSearchAvailableTagsRequestedEvent());
-          await pumpEventQueue();
+          await _untilHandlerRuns(
+            () => bloc.availableTagsHandlerRuns > runsBefore,
+          );
         },
-        verify: (_) {
+        verify: (bloc) {
           final tagReads = fakeSupabase
               .getMethodCallsFor('selectMatch')
               .where((call) => call['table'] == DatabaseConstants.tagsTable)
@@ -1608,6 +1690,12 @@ void main() {
             tagReads,
             hasLength(1),
             reason: 'the reopened page must serve the cached tag catalog',
+          );
+          expect(
+            bloc.availableTagsHandlerRuns,
+            2,
+            reason:
+                'both requests reached the handler; the second was a cache hit',
           );
         },
       );

--- a/test/features/dashboard/units/blocs/project_search_bloc_test.dart
+++ b/test/features/dashboard/units/blocs/project_search_bloc_test.dart
@@ -7,6 +7,7 @@ import 'package:construculator/features/dashboard/presentation/bloc/project_sear
 import 'package:construculator/libraries/auth/domain/types/auth_types.dart';
 import 'package:construculator/libraries/errors/failures.dart';
 import 'package:construculator/libraries/global_search/domain/search_error_type.dart';
+import 'package:construculator/libraries/search_filters/presentation/widgets/date_range_bottom_sheet.dart';
 import 'package:construculator/libraries/supabase/data/supabase_types.dart';
 import 'package:construculator/libraries/supabase/database_constants.dart';
 import 'package:construculator/libraries/supabase/interfaces/supabase_wrapper.dart';
@@ -85,9 +86,8 @@ void main() {
       blocTest<ProjectSearchBloc, ProjectSearchState>(
         'emits ProjectSearchInitial when query is empty',
         build: () => Modular.get<ProjectSearchBloc>(),
-        act: (bloc) => bloc.add(
-          const ProjectSearchQueryUpdatedEvent(query: ''),
-        ),
+        act: (bloc) =>
+            bloc.add(const ProjectSearchQueryUpdatedEvent(query: '')),
         wait: const Duration(milliseconds: 500),
         expect: () => [const ProjectSearchInitial()],
       );
@@ -140,11 +140,10 @@ void main() {
           isA<ProjectSearchInitial>()
               .having((s) => s.query, 'query', 'foundation')
               .having((s) => s.suggestionsLoading, 'loading', isFalse)
-              .having(
-                (s) => s.suggestions,
-                'suggestions',
-                ['foundation', 'foundation repair'],
-              ),
+              .having((s) => s.suggestions, 'suggestions', [
+                'foundation',
+                'foundation repair',
+              ]),
         ],
       );
 
@@ -186,7 +185,8 @@ void main() {
           );
         },
         build: () => Modular.get<ProjectSearchBloc>(),
-        act: (bloc) => bloc.add(const ProjectSearchQueryUpdatedEvent(query: 'C')),
+        act: (bloc) =>
+            bloc.add(const ProjectSearchQueryUpdatedEvent(query: 'C')),
         wait: const Duration(milliseconds: 310),
         expect: () => [
           isA<ProjectSearchInitial>().having(
@@ -492,8 +492,7 @@ void main() {
       blocTest<ProjectSearchBloc, ProjectSearchState>(
         'emits ProjectSearchInitial when query is empty',
         build: () => Modular.get<ProjectSearchBloc>(),
-        act: (bloc) =>
-            bloc.add(const ProjectSearchPerformedEvent(query: '')),
+        act: (bloc) => bloc.add(const ProjectSearchPerformedEvent(query: '')),
         expect: () => [const ProjectSearchInitial()],
       );
 
@@ -566,9 +565,8 @@ void main() {
           );
         },
         build: () => Modular.get<ProjectSearchBloc>(),
-        act: (bloc) => bloc.add(
-          const ProjectSearchPerformedEvent(query: 'wall'),
-        ),
+        act: (bloc) =>
+            bloc.add(const ProjectSearchPerformedEvent(query: 'wall')),
         expect: () => [
           const ProjectSearchLoading(query: 'wall'),
           isA<ProjectSearchResultsLoaded>()
@@ -586,13 +584,15 @@ void main() {
           );
         },
         build: () => Modular.get<ProjectSearchBloc>(),
-        act: (bloc) => bloc.add(
-          const ProjectSearchPerformedEvent(query: 'nonexistent'),
-        ),
+        act: (bloc) =>
+            bloc.add(const ProjectSearchPerformedEvent(query: 'nonexistent')),
         expect: () => [
           const ProjectSearchLoading(query: 'nonexistent'),
-          isA<ProjectSearchResultsLoaded>()
-              .having((s) => s.results, 'results', isEmpty),
+          isA<ProjectSearchResultsLoaded>().having(
+            (s) => s.results,
+            'results',
+            isEmpty,
+          ),
         ],
       );
 
@@ -604,9 +604,8 @@ void main() {
           fakeSupabase.rpcErrorMessage = 'Network error';
         },
         build: () => Modular.get<ProjectSearchBloc>(),
-        act: (bloc) => bloc.add(
-          const ProjectSearchPerformedEvent(query: 'wall'),
-        ),
+        act: (bloc) =>
+            bloc.add(const ProjectSearchPerformedEvent(query: 'wall')),
         expect: () => [
           const ProjectSearchLoading(query: 'wall'),
           isA<ProjectSearchFailureState>()
@@ -625,9 +624,8 @@ void main() {
           fakeSupabase.setCurrentUser(null);
         },
         build: () => Modular.get<ProjectSearchBloc>(),
-        act: (bloc) => bloc.add(
-          const ProjectSearchPerformedEvent(query: 'wall'),
-        ),
+        act: (bloc) =>
+            bloc.add(const ProjectSearchPerformedEvent(query: 'wall')),
         expect: () => [
           const ProjectSearchFailureState(
             failure: AuthFailure(errorType: AuthErrorType.userNotFound),
@@ -644,13 +642,15 @@ void main() {
           fakeSupabase.rpcErrorMessage = 'Server error';
         },
         build: () => Modular.get<ProjectSearchBloc>(),
-        act: (bloc) => bloc.add(
-          const ProjectSearchPerformedEvent(query: 'wall'),
-        ),
+        act: (bloc) =>
+            bloc.add(const ProjectSearchPerformedEvent(query: 'wall')),
         expect: () => [
           const ProjectSearchLoading(query: 'wall'),
-          isA<ProjectSearchFailureState>()
-              .having((s) => s.failure, 'failure', isA<UnexpectedFailure>()),
+          isA<ProjectSearchFailureState>().having(
+            (s) => s.failure,
+            'failure',
+            isA<UnexpectedFailure>(),
+          ),
         ],
       );
     });
@@ -681,8 +681,7 @@ void main() {
           );
         },
         build: () => Modular.get<ProjectSearchBloc>(),
-        act: (bloc) =>
-            bloc.add(const ProjectSearchHistoryRequestedEvent()),
+        act: (bloc) => bloc.add(const ProjectSearchHistoryRequestedEvent()),
         expect: () => [
           const ProjectSearchInitial(isLoadingHistory: true),
           const ProjectSearchInitial(recentSearches: ['foundation', 'wall']),
@@ -707,8 +706,7 @@ void main() {
           fakeSupabase.setCurrentUser(null);
         },
         build: () => Modular.get<ProjectSearchBloc>(),
-        act: (bloc) =>
-            bloc.add(const ProjectSearchHistoryRequestedEvent()),
+        act: (bloc) => bloc.add(const ProjectSearchHistoryRequestedEvent()),
         expect: () => [const ProjectSearchInitial()],
         verify: (_) {
           expect(fakeSupabase.getMethodCallsFor('selectMatch'), isEmpty);
@@ -820,8 +818,7 @@ void main() {
           // Wait for the non-loading Initial to land so the cached recents
           // are populated before we dispatch the dismissal.
           await bloc.stream.firstWhere(
-            (state) =>
-                state is ProjectSearchInitial && !state.isLoadingHistory,
+            (state) => state is ProjectSearchInitial && !state.isLoadingHistory,
           );
           bloc.add(
             const ProjectSearchHistoryItemDismissedEvent(
@@ -831,16 +828,10 @@ void main() {
         },
         skip: 2,
         expect: () => [
-          const ProjectSearchInitial(
-            recentSearches: ['wall'],
-            suggestions: [],
-          ),
+          const ProjectSearchInitial(recentSearches: ['wall'], suggestions: []),
         ],
         verify: (_) {
-          expect(
-            fakeSupabase.getMethodCallsFor('deleteMatch'),
-            hasLength(1),
-          );
+          expect(fakeSupabase.getMethodCallsFor('deleteMatch'), hasLength(1));
         },
       );
 
@@ -915,8 +906,7 @@ void main() {
         'emits nothing when deleteMatch fails',
         setUp: () {
           fakeSupabase.shouldThrowOnDeleteMatch = true;
-          fakeSupabase.deleteMatchExceptionType =
-              SupabaseExceptionType.timeout;
+          fakeSupabase.deleteMatchExceptionType = SupabaseExceptionType.timeout;
           fakeSupabase.deleteMatchErrorMessage = 'Timeout';
         },
         build: () => Modular.get<ProjectSearchBloc>(),
@@ -962,10 +952,7 @@ void main() {
           expect(upserts, hasLength(1));
           final data = upserts.first['data'] as Map<String, dynamic>;
           expect(data[DatabaseConstants.hasResultsColumn], isTrue);
-          expect(
-            data[DatabaseConstants.searchTermColumn],
-            equals('wall'),
-          );
+          expect(data[DatabaseConstants.searchTermColumn], equals('wall'));
         },
       );
 
@@ -1112,6 +1099,472 @@ void main() {
                 isNot(contains('term-20')),
               ),
         ],
+      );
+    });
+
+    // -------------------------------------------------------------------------
+    // Filters: Tags / Owner / Modified date
+    // -------------------------------------------------------------------------
+
+    void seedTags(List<String> names) {
+      fakeSupabase.addTableData(
+        DatabaseConstants.tagsTable,
+        names
+            .map(
+              (name) => <String, dynamic>{
+                DatabaseConstants.idColumn: 'tag-$name',
+                DatabaseConstants.nameColumn: name,
+              },
+            )
+            .toList(),
+      );
+    }
+
+    void seedOwners(
+      List<({String id, String firstName, String lastName})> owners,
+    ) {
+      fakeSupabase.setRpcResponse(
+        DatabaseConstants.projectOwnersRpcFunction,
+        owners
+            .map(
+              (owner) => <String, dynamic>{
+                DatabaseConstants.idColumn: owner.id,
+                DatabaseConstants.credentialIdColumn: null,
+                DatabaseConstants.firstNameColumn: owner.firstName,
+                DatabaseConstants.lastNameColumn: owner.lastName,
+                DatabaseConstants.professionalRoleColumn: 'Engineer',
+                DatabaseConstants.profilePhotoUrlColumn: null,
+              },
+            )
+            .toList(),
+      );
+    }
+
+    Map<String, dynamic> lastSearchRpcParams() {
+      final calls = fakeSupabase
+          .getMethodCallsFor('rpc')
+          .where(
+            (call) =>
+                call['functionName'] ==
+                DatabaseConstants.globalSearchRpcFunction,
+          )
+          .toList();
+      expect(
+        calls,
+        isNotEmpty,
+        reason: 'expected a global_search RPC call to have been made',
+      );
+      return calls.last['params'] as Map<String, dynamic>;
+    }
+
+    group('Tag filters', () {
+      blocTest<ProjectSearchBloc, ProjectSearchState>(
+        'fetches available tags on first request and caches them',
+        setUp: () => seedTags(['Concrete', 'Steel']),
+        build: () => Modular.get<ProjectSearchBloc>(),
+        act: (bloc) async {
+          bloc.add(const ProjectSearchAvailableTagsRequestedEvent());
+          await bloc.stream.firstWhere(
+            (s) => s is ProjectSearchInitial && !s.availableTagsLoading,
+          );
+          // Second request must serve the cache — no extra table query.
+          bloc.add(const ProjectSearchAvailableTagsRequestedEvent());
+        },
+        wait: const Duration(milliseconds: 100),
+        expect: () => [
+          isA<ProjectSearchInitial>().having(
+            (s) => s.availableTagsLoading,
+            'loading',
+            isTrue,
+          ),
+          isA<ProjectSearchInitial>()
+              .having((s) => s.availableTagsLoading, 'loading', isFalse)
+              .having((s) => s.availableTags, 'tags', ['Concrete', 'Steel']),
+        ],
+        verify: (_) {
+          final tagReads = fakeSupabase
+              .getMethodCallsFor('selectMatch')
+              .where((call) => call['table'] == DatabaseConstants.tagsTable)
+              .toList();
+          expect(tagReads, hasLength(1));
+        },
+      );
+
+      blocTest<ProjectSearchBloc, ProjectSearchState>(
+        'emits ProjectSearchTagsLoadFailure then recovers to initial on fetch error',
+        setUp: () {
+          fakeSupabase.shouldThrowOnSelectMatch = true;
+          fakeSupabase.selectExceptionType = SupabaseExceptionType.timeout;
+          fakeSupabase.selectErrorMessage = 'Timeout';
+        },
+        build: () => Modular.get<ProjectSearchBloc>(),
+        act: (bloc) =>
+            bloc.add(const ProjectSearchAvailableTagsRequestedEvent()),
+        wait: const Duration(milliseconds: 100),
+        expect: () => [
+          isA<ProjectSearchInitial>().having(
+            (s) => s.availableTagsLoading,
+            'loading',
+            isTrue,
+          ),
+          isA<ProjectSearchTagsLoadFailure>(),
+          isA<ProjectSearchInitial>().having(
+            (s) => s.availableTagsLoading,
+            'loading',
+            isFalse,
+          ),
+        ],
+      );
+
+      blocTest<ProjectSearchBloc, ProjectSearchState>(
+        'filters available tags by the tag search query and restores on clear',
+        setUp: () => seedTags(['Concrete', 'Steel', 'Confetti']),
+        build: () => Modular.get<ProjectSearchBloc>(),
+        act: (bloc) async {
+          bloc.add(const ProjectSearchAvailableTagsRequestedEvent());
+          await bloc.stream.firstWhere(
+            (s) => s is ProjectSearchInitial && !s.availableTagsLoading,
+          );
+          bloc.add(const ProjectSearchTagSearchQueryUpdatedEvent(query: 'con'));
+          await bloc.stream.firstWhere(
+            (s) => s is ProjectSearchInitial && s.availableTags.length == 2,
+          );
+          bloc.add(const ProjectSearchTagSearchQueryUpdatedEvent(query: ''));
+        },
+        skip: 2,
+        expect: () => [
+          isA<ProjectSearchInitial>().having(
+            (s) => s.availableTags,
+            'filtered tags (case-insensitive contains)',
+            ['Concrete', 'Confetti'],
+          ),
+          isA<ProjectSearchInitial>().having(
+            (s) => s.availableTags,
+            // The tag data source orders by name, so the unfiltered list is
+            // alphabetical regardless of seed order.
+            'all tags restored on empty query',
+            ['Concrete', 'Confetti', 'Steel'],
+          ),
+        ],
+      );
+
+      blocTest<ProjectSearchBloc, ProjectSearchState>(
+        'applying tag filters exposes them on the initial state',
+        build: () => Modular.get<ProjectSearchBloc>(),
+        act: (bloc) => bloc.add(
+          const ProjectSearchTagFiltersAppliedEvent(
+            tags: {'Concrete', 'Steel'},
+          ),
+        ),
+        expect: () => [
+          isA<ProjectSearchInitial>().having(
+            (s) => s.selectedTags,
+            'selectedTags',
+            {'Concrete', 'Steel'},
+          ),
+        ],
+      );
+
+      blocTest<ProjectSearchBloc, ProjectSearchState>(
+        'clearing a single tag removes only that tag',
+        build: () => Modular.get<ProjectSearchBloc>(),
+        act: (bloc) async {
+          bloc.add(
+            const ProjectSearchTagFiltersAppliedEvent(
+              tags: {'Concrete', 'Steel'},
+            ),
+          );
+          await bloc.stream.firstWhere(
+            (s) => s is ProjectSearchInitial && s.selectedTags.length == 2,
+          );
+          bloc.add(const ProjectSearchTagFilterClearedEvent(tag: 'Concrete'));
+        },
+        skip: 1,
+        expect: () => [
+          isA<ProjectSearchInitial>().having(
+            (s) => s.selectedTags,
+            'selectedTags',
+            {'Steel'},
+          ),
+        ],
+      );
+
+      blocTest<ProjectSearchBloc, ProjectSearchState>(
+        'threads the selected tag into the search RPC',
+        setUp: () {
+          fakeSupabase.setRpcResponse(
+            DatabaseConstants.globalSearchRpcFunction,
+            <String, dynamic>{'projects': <dynamic>[]},
+          );
+        },
+        build: () => Modular.get<ProjectSearchBloc>(),
+        act: (bloc) async {
+          bloc.add(
+            const ProjectSearchTagFiltersAppliedEvent(
+              tags: {'Steel', 'Concrete'},
+            ),
+          );
+          await bloc.stream.firstWhere(
+            (s) => s is ProjectSearchInitial && s.selectedTags.isNotEmpty,
+          );
+          bloc.add(const ProjectSearchPerformedEvent(query: 'wall'));
+          await bloc.stream.firstWhere((s) => s is ProjectSearchResultsLoaded);
+        },
+        verify: (_) {
+          // Selection is sorted for determinism → 'Concrete' wins.
+          expect(lastSearchRpcParams()['filter_by_tag'], 'Concrete');
+        },
+      );
+    });
+
+    group('Owner filters', () {
+      blocTest<ProjectSearchBloc, ProjectSearchState>(
+        'fetches available owners on first request and caches them',
+        setUp: () => seedOwners([
+          (id: 'owner-1', firstName: 'Ada', lastName: 'Lovelace'),
+          (id: 'owner-2', firstName: 'Alan', lastName: 'Turing'),
+        ]),
+        build: () => Modular.get<ProjectSearchBloc>(),
+        act: (bloc) async {
+          bloc.add(const ProjectSearchAvailableOwnersRequestedEvent());
+          await bloc.stream.firstWhere(
+            (s) => s is ProjectSearchInitial && !s.availableOwnersLoading,
+          );
+          bloc.add(const ProjectSearchAvailableOwnersRequestedEvent());
+        },
+        wait: const Duration(milliseconds: 100),
+        expect: () => [
+          isA<ProjectSearchInitial>().having(
+            (s) => s.availableOwnersLoading,
+            'loading',
+            isTrue,
+          ),
+          isA<ProjectSearchInitial>()
+              .having((s) => s.availableOwnersLoading, 'loading', isFalse)
+              .having(
+                (s) => s.availableOwners.map((o) => o.fullName).toList(),
+                'owners',
+                ['Ada Lovelace', 'Alan Turing'],
+              ),
+        ],
+        verify: (_) {
+          final ownerCalls = fakeSupabase
+              .getMethodCallsFor('rpc')
+              .where(
+                (call) =>
+                    call['functionName'] ==
+                    DatabaseConstants.projectOwnersRpcFunction,
+              )
+              .toList();
+          expect(ownerCalls, hasLength(1));
+        },
+      );
+
+      blocTest<ProjectSearchBloc, ProjectSearchState>(
+        'emits ProjectSearchOwnersLoadFailure then recovers to initial on fetch error',
+        setUp: () {
+          fakeSupabase.shouldThrowOnRpc = true;
+          fakeSupabase.rpcExceptionType = SupabaseExceptionType.timeout;
+          fakeSupabase.rpcErrorMessage = 'Timeout';
+        },
+        build: () => Modular.get<ProjectSearchBloc>(),
+        act: (bloc) =>
+            bloc.add(const ProjectSearchAvailableOwnersRequestedEvent()),
+        wait: const Duration(milliseconds: 100),
+        expect: () => [
+          isA<ProjectSearchInitial>().having(
+            (s) => s.availableOwnersLoading,
+            'loading',
+            isTrue,
+          ),
+          isA<ProjectSearchOwnersLoadFailure>(),
+          isA<ProjectSearchInitial>().having(
+            (s) => s.availableOwnersLoading,
+            'loading',
+            isFalse,
+          ),
+        ],
+      );
+
+      blocTest<ProjectSearchBloc, ProjectSearchState>(
+        'filters available owners by full name via the owner search query',
+        setUp: () => seedOwners([
+          (id: 'owner-1', firstName: 'Ada', lastName: 'Lovelace'),
+          (id: 'owner-2', firstName: 'Alan', lastName: 'Turing'),
+        ]),
+        build: () => Modular.get<ProjectSearchBloc>(),
+        act: (bloc) async {
+          bloc.add(const ProjectSearchAvailableOwnersRequestedEvent());
+          await bloc.stream.firstWhere(
+            (s) => s is ProjectSearchInitial && !s.availableOwnersLoading,
+          );
+          bloc.add(
+            const ProjectSearchOwnerSearchQueryUpdatedEvent(query: 'turing'),
+          );
+        },
+        skip: 2,
+        expect: () => [
+          isA<ProjectSearchInitial>().having(
+            (s) => s.availableOwners.map((o) => o.fullName).toList(),
+            'filtered owners (case-insensitive full-name contains)',
+            ['Alan Turing'],
+          ),
+        ],
+      );
+
+      blocTest<ProjectSearchBloc, ProjectSearchState>(
+        'clearing a single owner removes only that owner id',
+        build: () => Modular.get<ProjectSearchBloc>(),
+        act: (bloc) async {
+          bloc.add(
+            const ProjectSearchOwnerFiltersAppliedEvent(
+              ownerIds: {'owner-1', 'owner-2'},
+            ),
+          );
+          await bloc.stream.firstWhere(
+            (s) => s is ProjectSearchInitial && s.selectedOwnerIds.length == 2,
+          );
+          bloc.add(
+            const ProjectSearchOwnerFilterClearedEvent(ownerId: 'owner-1'),
+          );
+        },
+        skip: 1,
+        expect: () => [
+          isA<ProjectSearchInitial>().having(
+            (s) => s.selectedOwnerIds,
+            'selectedOwnerIds',
+            {'owner-2'},
+          ),
+        ],
+      );
+
+      blocTest<ProjectSearchBloc, ProjectSearchState>(
+        'threads the selected owner into the search RPC',
+        setUp: () {
+          fakeSupabase.setRpcResponse(
+            DatabaseConstants.globalSearchRpcFunction,
+            <String, dynamic>{'projects': <dynamic>[]},
+          );
+        },
+        build: () => Modular.get<ProjectSearchBloc>(),
+        act: (bloc) async {
+          bloc.add(
+            const ProjectSearchOwnerFiltersAppliedEvent(
+              ownerIds: {'owner-2', 'owner-1'},
+            ),
+          );
+          await bloc.stream.firstWhere(
+            (s) => s is ProjectSearchInitial && s.selectedOwnerIds.isNotEmpty,
+          );
+          bloc.add(const ProjectSearchPerformedEvent(query: 'wall'));
+          await bloc.stream.firstWhere((s) => s is ProjectSearchResultsLoaded);
+        },
+        verify: (_) {
+          // Selection is sorted for determinism → 'owner-1' wins.
+          expect(lastSearchRpcParams()['filter_by_owner'], 'owner-1');
+        },
+      );
+    });
+
+    group('Modified date filter', () {
+      blocTest<ProjectSearchBloc, ProjectSearchState>(
+        'applying and clearing a date range updates the initial state',
+        build: () => Modular.get<ProjectSearchBloc>(),
+        act: (bloc) async {
+          bloc.add(
+            ProjectSearchDateFilterAppliedEvent(
+              range: DateRange(
+                start: DateTime(2026, 1, 1),
+                end: DateTime(2026, 1, 31),
+              ),
+            ),
+          );
+          await bloc.stream.firstWhere(
+            (s) => s is ProjectSearchInitial && s.selectedDateRange != null,
+          );
+          bloc.add(const ProjectSearchDateFilterClearedEvent());
+        },
+        expect: () => [
+          isA<ProjectSearchInitial>().having(
+            (s) => s.selectedDateRange,
+            'range',
+            DateRange(start: DateTime(2026, 1, 1), end: DateTime(2026, 1, 31)),
+          ),
+          isA<ProjectSearchInitial>().having(
+            (s) => s.selectedDateRange,
+            'range',
+            isNull,
+          ),
+        ],
+      );
+
+      blocTest<ProjectSearchBloc, ProjectSearchState>(
+        'threads the range start into filter_by_date on the search RPC',
+        setUp: () {
+          fakeSupabase.setRpcResponse(
+            DatabaseConstants.globalSearchRpcFunction,
+            <String, dynamic>{'projects': <dynamic>[]},
+          );
+        },
+        build: () => Modular.get<ProjectSearchBloc>(),
+        act: (bloc) async {
+          bloc.add(
+            ProjectSearchDateFilterAppliedEvent(
+              range: DateRange(
+                start: DateTime(2026, 1, 1),
+                end: DateTime(2026, 1, 31),
+              ),
+            ),
+          );
+          await bloc.stream.firstWhere(
+            (s) => s is ProjectSearchInitial && s.selectedDateRange != null,
+          );
+          bloc.add(const ProjectSearchPerformedEvent(query: 'wall'));
+          await bloc.stream.firstWhere((s) => s is ProjectSearchResultsLoaded);
+        },
+        verify: (_) {
+          expect(
+            lastSearchRpcParams()['filter_by_date'],
+            DateTime(2026, 1, 1).toIso8601String(),
+          );
+        },
+      );
+    });
+
+    group('Filter reset on page reopen', () {
+      blocTest<ProjectSearchBloc, ProjectSearchState>(
+        'clears all selected filters when history is requested again',
+        build: () => Modular.get<ProjectSearchBloc>(),
+        act: (bloc) async {
+          bloc.add(
+            const ProjectSearchTagFiltersAppliedEvent(tags: {'Concrete'}),
+          );
+          bloc.add(
+            const ProjectSearchOwnerFiltersAppliedEvent(ownerIds: {'owner-1'}),
+          );
+          bloc.add(
+            ProjectSearchDateFilterAppliedEvent(
+              range: DateRange(
+                start: DateTime(2026, 1, 1),
+                end: DateTime(2026, 1, 5),
+              ),
+            ),
+          );
+          await bloc.stream.firstWhere(
+            (s) => s is ProjectSearchInitial && s.selectedDateRange != null,
+          );
+          // Mirrors GlobalSearchStarted: a fresh page open starts unfiltered.
+          bloc.add(const ProjectSearchHistoryRequestedEvent());
+          await bloc.stream.firstWhere(
+            (s) => s is ProjectSearchInitial && !s.isLoadingHistory,
+          );
+        },
+        verify: (bloc) {
+          final state = bloc.state as ProjectSearchInitial;
+          expect(state.selectedTags, isEmpty);
+          expect(state.selectedOwnerIds, isEmpty);
+          expect(state.selectedDateRange, isNull);
+        },
       );
     });
   });

--- a/test/features/dashboard/units/blocs/project_search_bloc_test.dart
+++ b/test/features/dashboard/units/blocs/project_search_bloc_test.dart
@@ -7,7 +7,7 @@ import 'package:construculator/features/dashboard/presentation/bloc/project_sear
 import 'package:construculator/libraries/auth/domain/types/auth_types.dart';
 import 'package:construculator/libraries/errors/failures.dart';
 import 'package:construculator/libraries/global_search/domain/search_error_type.dart';
-import 'package:construculator/libraries/search_filters/presentation/widgets/date_range_bottom_sheet.dart';
+import 'package:construculator/libraries/search_filters/domain/entities/date_range.dart';
 import 'package:construculator/libraries/supabase/data/supabase_types.dart';
 import 'package:construculator/libraries/supabase/database_constants.dart';
 import 'package:construculator/libraries/supabase/interfaces/supabase_wrapper.dart';

--- a/test/features/dashboard/units/blocs/project_search_bloc_test.dart
+++ b/test/features/dashboard/units/blocs/project_search_bloc_test.dart
@@ -891,7 +891,9 @@ void main() {
               searchTerm: 'foundation',
             ),
           );
-          await pumpEventQueue();
+          await _untilHandlerRuns(
+            () => fakeSupabase.getMethodCallsFor('deleteMatch').isNotEmpty,
+          );
         },
         skip: 4,
         expect: () => <ProjectSearchState>[],

--- a/test/features/dashboard/units/blocs/project_search_bloc_test.dart
+++ b/test/features/dashboard/units/blocs/project_search_bloc_test.dart
@@ -1183,10 +1183,16 @@ void main() {
           await bloc.stream.firstWhere(
             (s) => s is ProjectSearchInitial && !s.availableTagsLoading,
           );
-          // Second request must serve the cache — no extra table query.
+          // Second request must serve the cache — no extra table query. Its
+          // re-emit is Equatable-suppressed, so gate on the handler-run
+          // counter instead of a wall-clock wait: a timer could elapse before
+          // the event is even dequeued, letting a broken cache pass.
+          final runsBefore = bloc.availableTagsHandlerRuns;
           bloc.add(const ProjectSearchAvailableTagsRequestedEvent());
+          await _untilHandlerRuns(
+            () => bloc.availableTagsHandlerRuns > runsBefore,
+          );
         },
-        wait: const Duration(milliseconds: 100),
         expect: () => [
           isA<ProjectSearchInitial>().having(
             (s) => s.availableTagsLoading,
@@ -1207,18 +1213,29 @@ void main() {
       );
 
       blocTest<ProjectSearchBloc, ProjectSearchState>(
-        'restartable transformer collapses a rapid double tag request into one fetch',
-        setUp: () => seedTags(['Concrete', 'Steel']),
+        'does not start a duplicate tags fetch when one is already in flight',
+        setUp: () {
+          seedTags(['Concrete', 'Steel']);
+          fakeSupabase.shouldDelayOperations = true;
+          fakeSupabase.completer = Completer<void>();
+        },
         build: () => Modular.get<ProjectSearchBloc>(),
         act: (bloc) async {
-          // Two requests dispatched before the first fetch resolves. The
-          // restartable() (switchMap) transformer must cancel the stale first
-          // handler so only a single tag catalog read reaches the datasource —
-          // guarding against the duplicate-fetch/stray-failure-toast race. If
-          // the transformer were dropped, both handlers would run and fetch.
-          bloc
-            ..add(const ProjectSearchAvailableTagsRequestedEvent())
-            ..add(const ProjectSearchAvailableTagsRequestedEvent());
+          bloc.add(const ProjectSearchAvailableTagsRequestedEvent());
+          // Wait for the in-flight loading emission, then request tags again
+          // while the first fetch is still parked on the completer — the
+          // second request must reuse the in-flight fetch (loading-flag gate)
+          // instead of starting another, guarding against the
+          // duplicate-fetch/stray-failure-toast race.
+          await bloc.stream.firstWhere(
+            (s) => s is ProjectSearchInitial && s.availableTagsLoading,
+          );
+          final runsBefore = bloc.availableTagsHandlerRuns;
+          bloc.add(const ProjectSearchAvailableTagsRequestedEvent());
+          await _untilHandlerRuns(
+            () => bloc.availableTagsHandlerRuns > runsBefore,
+          );
+          fakeSupabase.completer!.complete();
           await bloc.stream.firstWhere(
             (s) => s is ProjectSearchInitial && !s.availableTagsLoading,
           );
@@ -1231,9 +1248,58 @@ void main() {
           expect(
             tagReads,
             hasLength(1),
-            reason: 'restartable() must cancel the stale in-flight tag fetch',
+            reason: 'the in-flight gate must absorb the duplicate request',
           );
         },
+      );
+
+      blocTest<ProjectSearchBloc, ProjectSearchState>(
+        'keeps availableTagsLoading true when a concurrent handler emits '
+        'while the tags fetch is in flight',
+        setUp: () {
+          seedTags(['Concrete']);
+          fakeSupabase.shouldDelayOperations = true;
+          fakeSupabase.completer = Completer<void>();
+        },
+        build: () => Modular.get<ProjectSearchBloc>(),
+        act: (bloc) async {
+          bloc.add(const ProjectSearchAvailableTagsRequestedEvent());
+          // Wait for the in-flight loading emission, then dispatch an event
+          // whose handler rebuilds the state while the fetch is still
+          // pending — it must not reset the loading flag.
+          await bloc.stream.firstWhere(
+            (s) => s is ProjectSearchInitial && s.availableTagsLoading,
+          );
+          bloc.add(
+            const ProjectSearchOwnerFiltersAppliedEvent(ownerIds: {'owner-1'}),
+          );
+          await bloc.stream.firstWhere(
+            (s) =>
+                s is ProjectSearchInitial &&
+                s.selectedOwnerIds.contains('owner-1'),
+          );
+          fakeSupabase.completer!.complete();
+          await bloc.stream.firstWhere(
+            (s) => s is ProjectSearchInitial && !s.availableTagsLoading,
+          );
+        },
+        expect: () => [
+          isA<ProjectSearchInitial>()
+              .having((s) => s.availableTagsLoading, 'loading', isTrue)
+              .having((s) => s.selectedOwnerIds, 'selectedOwnerIds', isEmpty),
+          isA<ProjectSearchInitial>()
+              .having(
+                (s) => s.availableTagsLoading,
+                'loading survives concurrent emission',
+                isTrue,
+              )
+              .having((s) => s.selectedOwnerIds, 'selectedOwnerIds', {
+                'owner-1',
+              }),
+          isA<ProjectSearchInitial>()
+              .having((s) => s.availableTagsLoading, 'loading', isFalse)
+              .having((s) => s.availableTags, 'tags', ['Concrete']),
+        ],
       );
 
       blocTest<ProjectSearchBloc, ProjectSearchState>(
@@ -1381,9 +1447,14 @@ void main() {
           await bloc.stream.firstWhere(
             (s) => s is ProjectSearchInitial && !s.availableOwnersLoading,
           );
+          // Cache-hit re-emit is Equatable-suppressed — gate on the counter,
+          // not a wall clock (see the tag equivalent above).
+          final runsBefore = bloc.availableOwnersHandlerRuns;
           bloc.add(const ProjectSearchAvailableOwnersRequestedEvent());
+          await _untilHandlerRuns(
+            () => bloc.availableOwnersHandlerRuns > runsBefore,
+          );
         },
-        wait: const Duration(milliseconds: 100),
         expect: () => [
           isA<ProjectSearchInitial>().having(
             (s) => s.availableOwnersLoading,
@@ -1412,18 +1483,29 @@ void main() {
       );
 
       blocTest<ProjectSearchBloc, ProjectSearchState>(
-        'restartable transformer collapses a rapid double owner request into one fetch',
-        setUp: () => seedOwners([
-          (id: 'owner-1', firstName: 'Ada', lastName: 'Lovelace'),
-          (id: 'owner-2', firstName: 'Alan', lastName: 'Turing'),
-        ]),
+        'does not start a duplicate owners fetch when one is already in flight',
+        setUp: () {
+          seedOwners([
+            (id: 'owner-1', firstName: 'Ada', lastName: 'Lovelace'),
+            (id: 'owner-2', firstName: 'Alan', lastName: 'Turing'),
+          ]);
+          fakeSupabase.shouldDelayOperations = true;
+          fakeSupabase.completer = Completer<void>();
+        },
         build: () => Modular.get<ProjectSearchBloc>(),
         act: (bloc) async {
-          // See the tag equivalent: the restartable() (switchMap) transformer
-          // must cancel the stale first handler so only one owner RPC fires.
-          bloc
-            ..add(const ProjectSearchAvailableOwnersRequestedEvent())
-            ..add(const ProjectSearchAvailableOwnersRequestedEvent());
+          // See the tag equivalent: the second request arriving mid-fetch
+          // must be absorbed by the loading-flag gate, not fetch again.
+          bloc.add(const ProjectSearchAvailableOwnersRequestedEvent());
+          await bloc.stream.firstWhere(
+            (s) => s is ProjectSearchInitial && s.availableOwnersLoading,
+          );
+          final runsBefore = bloc.availableOwnersHandlerRuns;
+          bloc.add(const ProjectSearchAvailableOwnersRequestedEvent());
+          await _untilHandlerRuns(
+            () => bloc.availableOwnersHandlerRuns > runsBefore,
+          );
+          fakeSupabase.completer!.complete();
           await bloc.stream.firstWhere(
             (s) => s is ProjectSearchInitial && !s.availableOwnersLoading,
           );
@@ -1440,9 +1522,58 @@ void main() {
           expect(
             ownerCalls,
             hasLength(1),
-            reason: 'restartable() must cancel the stale in-flight owner fetch',
+            reason: 'the in-flight gate must absorb the duplicate request',
           );
         },
+      );
+
+      blocTest<ProjectSearchBloc, ProjectSearchState>(
+        'keeps availableOwnersLoading true when a concurrent handler emits '
+        'while the owners fetch is in flight',
+        setUp: () {
+          seedOwners([
+            (id: 'owner-1', firstName: 'Ada', lastName: 'Lovelace'),
+          ]);
+          fakeSupabase.shouldDelayOperations = true;
+          fakeSupabase.completer = Completer<void>();
+        },
+        build: () => Modular.get<ProjectSearchBloc>(),
+        act: (bloc) async {
+          bloc.add(const ProjectSearchAvailableOwnersRequestedEvent());
+          // See the tag equivalent: a concurrent handler rebuilding the
+          // state must not reset the in-flight owners loading flag.
+          await bloc.stream.firstWhere(
+            (s) => s is ProjectSearchInitial && s.availableOwnersLoading,
+          );
+          bloc.add(
+            const ProjectSearchTagFiltersAppliedEvent(tags: {'Concrete'}),
+          );
+          await bloc.stream.firstWhere(
+            (s) =>
+                s is ProjectSearchInitial &&
+                s.selectedTags.contains('Concrete'),
+          );
+          fakeSupabase.completer!.complete();
+          await bloc.stream.firstWhere(
+            (s) => s is ProjectSearchInitial && !s.availableOwnersLoading,
+          );
+        },
+        expect: () => [
+          isA<ProjectSearchInitial>()
+              .having((s) => s.availableOwnersLoading, 'loading', isTrue)
+              .having((s) => s.selectedTags, 'selectedTags', isEmpty),
+          isA<ProjectSearchInitial>()
+              .having(
+                (s) => s.availableOwnersLoading,
+                'loading survives concurrent emission',
+                isTrue,
+              )
+              .having((s) => s.selectedTags, 'selectedTags', {'Concrete'}),
+          isA<ProjectSearchInitial>()
+              .having((s) => s.availableOwnersLoading, 'loading', isFalse)
+              .having((s) => s.availableOwners.map((o) => o.fullName).toList(),
+                  'owners', ['Ada Lovelace']),
+        ],
       );
 
       blocTest<ProjectSearchBloc, ProjectSearchState>(
@@ -1590,7 +1721,7 @@ void main() {
       );
 
       blocTest<ProjectSearchBloc, ProjectSearchState>(
-        'threads the range start into filter_by_date on the search RPC',
+        'threads both date range bounds into the search RPC',
         setUp: () {
           fakeSupabase.setRpcResponse(
             DatabaseConstants.globalSearchRpcFunction,
@@ -1614,9 +1745,14 @@ void main() {
           await bloc.stream.firstWhere((s) => s is ProjectSearchResultsLoaded);
         },
         verify: (_) {
+          final params = lastSearchRpcParams();
           expect(
-            lastSearchRpcParams()['filter_by_date'],
+            params['filter_by_date_from'],
             DateTime(2026, 1, 1).toIso8601String(),
+          );
+          expect(
+            params['filter_by_date_to'],
+            DateTime(2026, 1, 31).toIso8601String(),
           );
         },
       );
@@ -1659,7 +1795,8 @@ void main() {
       );
 
       blocTest<ProjectSearchBloc, ProjectSearchState>(
-        'keeps the fetched tag catalog across a page reopen — only selections reset',
+        'clears the fetched tag catalog on page reopen — a fresh open '
+        'refetches instead of serving a stale cache',
         setUp: () => seedTags(['Concrete', 'Steel']),
         build: () => Modular.get<ProjectSearchBloc>(),
         act: (bloc) async {
@@ -1667,20 +1804,18 @@ void main() {
           await bloc.stream.firstWhere(
             (s) => s is ProjectSearchInitial && s.availableTags.isNotEmpty,
           );
-          // Reopening the page resets selections but intentionally reuses the
-          // already-fetched catalog (it rarely changes mid-session).
+          // Reopening the page resets catalogs along with selections,
+          // mirroring GlobalSearchStarted — a fresh session refetches.
           bloc.add(const ProjectSearchHistoryRequestedEvent());
           await bloc.stream.firstWhere(
-            (s) => s is ProjectSearchInitial && !s.isLoadingHistory,
+            (s) =>
+                s is ProjectSearchInitial &&
+                !s.isLoadingHistory &&
+                s.availableTags.isEmpty,
           );
-          // The cached catalog re-emits an Equatable-equal state that `emit`
-          // suppresses, so there is no state transition to await. Gate on the
-          // handler-run counter — it increments synchronously on the cache-hit
-          // path, giving a deterministic signal instead of a wall-clock wait.
-          final runsBefore = bloc.availableTagsHandlerRuns;
           bloc.add(const ProjectSearchAvailableTagsRequestedEvent());
-          await _untilHandlerRuns(
-            () => bloc.availableTagsHandlerRuns > runsBefore,
+          await bloc.stream.firstWhere(
+            (s) => s is ProjectSearchInitial && s.availableTags.isNotEmpty,
           );
         },
         verify: (bloc) {
@@ -1690,14 +1825,120 @@ void main() {
               .toList();
           expect(
             tagReads,
-            hasLength(1),
-            reason: 'the reopened page must serve the cached tag catalog',
+            hasLength(2),
+            reason: 'the reopened page must refetch the cleared tag catalog',
           );
+        },
+      );
+
+      blocTest<ProjectSearchBloc, ProjectSearchState>(
+        'a tags fetch surviving a page reopen neither stomps the reset '
+        'loading flag nor resurrects the pre-reset catalog',
+        setUp: () {
+          seedTags(['Concrete', 'Steel']);
+          fakeSupabase.shouldDelayOperations = true;
+          fakeSupabase.completer = Completer<void>();
+        },
+        build: () => Modular.get<ProjectSearchBloc>(),
+        act: (bloc) async {
+          final tagsFetchGate = fakeSupabase.completer!;
+          bloc.add(const ProjectSearchAvailableTagsRequestedEvent());
+          await bloc.stream.firstWhere(
+            (s) => s is ProjectSearchInitial && s.availableTagsLoading,
+          );
+          // Later operations run ungated; only the in-flight tags fetch
+          // stays parked on the gate.
+          fakeSupabase.shouldDelayOperations = false;
+          bloc.add(const ProjectSearchHistoryRequestedEvent());
+          await bloc.stream.firstWhere(
+            (s) =>
+                s is ProjectSearchInitial &&
+                !s.isLoadingHistory &&
+                !s.availableTagsLoading,
+          );
+          // Release the pre-reset fetch; the reset disowned it, so it must
+          // not mark tags as fetched or emit over the reset state.
+          final runsBefore = bloc.availableTagsHandlerRuns;
+          tagsFetchGate.complete();
+          await _untilHandlerRuns(
+            () => bloc.availableTagsHandlerRuns > runsBefore,
+          );
+          bloc.add(const ProjectSearchAvailableTagsRequestedEvent());
+          await bloc.stream.firstWhere(
+            (s) =>
+                s is ProjectSearchInitial &&
+                !s.availableTagsLoading &&
+                s.availableTags.isNotEmpty,
+          );
+        },
+        verify: (bloc) {
+          final tagReads = fakeSupabase
+              .getMethodCallsFor('selectMatch')
+              .where((call) => call['table'] == DatabaseConstants.tagsTable)
+              .toList();
           expect(
-            bloc.availableTagsHandlerRuns,
-            2,
+            tagReads,
+            hasLength(2),
             reason:
-                'both requests reached the handler; the second was a cache hit',
+                'the disowned fetch must not count as fetched — the next '
+                'sheet open starts a fresh fetch',
+          );
+        },
+      );
+
+      blocTest<ProjectSearchBloc, ProjectSearchState>(
+        'an owners fetch surviving a page reopen neither stomps the reset '
+        'loading flag nor resurrects the pre-reset catalog',
+        setUp: () {
+          seedOwners([
+            (id: 'owner-1', firstName: 'Ada', lastName: 'Lovelace'),
+          ]);
+          fakeSupabase.shouldDelayOperations = true;
+          fakeSupabase.completer = Completer<void>();
+        },
+        build: () => Modular.get<ProjectSearchBloc>(),
+        act: (bloc) async {
+          final ownersFetchGate = fakeSupabase.completer!;
+          bloc.add(const ProjectSearchAvailableOwnersRequestedEvent());
+          await bloc.stream.firstWhere(
+            (s) => s is ProjectSearchInitial && s.availableOwnersLoading,
+          );
+          fakeSupabase.shouldDelayOperations = false;
+          bloc.add(const ProjectSearchHistoryRequestedEvent());
+          await bloc.stream.firstWhere(
+            (s) =>
+                s is ProjectSearchInitial &&
+                !s.isLoadingHistory &&
+                !s.availableOwnersLoading,
+          );
+          final runsBefore = bloc.availableOwnersHandlerRuns;
+          ownersFetchGate.complete();
+          await _untilHandlerRuns(
+            () => bloc.availableOwnersHandlerRuns > runsBefore,
+          );
+          bloc.add(const ProjectSearchAvailableOwnersRequestedEvent());
+          await bloc.stream.firstWhere(
+            (s) =>
+                s is ProjectSearchInitial &&
+                !s.availableOwnersLoading &&
+                s.availableOwners.isNotEmpty,
+          );
+        },
+        verify: (bloc) {
+          final ownerCalls = fakeSupabase
+              .getMethodCallsFor('rpc')
+              .where(
+                (call) =>
+                    call['functionName'] ==
+                    DatabaseConstants.projectOwnersRpcFunction,
+              )
+              .toList();
+          expect(
+            ownerCalls,
+            hasLength(2),
+            reason:
+                'the disowned fetch must not count as fetched — the next '
+                'sheet open starts a fresh fetch',
           );
         },
       );

--- a/test/features/dashboard/units/blocs/project_search_bloc_test.dart
+++ b/test/features/dashboard/units/blocs/project_search_bloc_test.dart
@@ -1198,9 +1198,14 @@ void main() {
           fakeSupabase.selectErrorMessage = 'Timeout';
         },
         build: () => Modular.get<ProjectSearchBloc>(),
-        act: (bloc) =>
-            bloc.add(const ProjectSearchAvailableTagsRequestedEvent()),
-        wait: const Duration(milliseconds: 100),
+        act: (bloc) async {
+          bloc.add(const ProjectSearchAvailableTagsRequestedEvent());
+          // Gate on the recovery state landing instead of a wall-clock wait,
+          // so a slow CI runner cannot cut the observation window short.
+          await bloc.stream.firstWhere(
+            (s) => s is ProjectSearchInitial && !s.availableTagsLoading,
+          );
+        },
         expect: () => [
           isA<ProjectSearchInitial>().having(
             (s) => s.availableTagsLoading,
@@ -1368,9 +1373,14 @@ void main() {
           fakeSupabase.rpcErrorMessage = 'Timeout';
         },
         build: () => Modular.get<ProjectSearchBloc>(),
-        act: (bloc) =>
-            bloc.add(const ProjectSearchAvailableOwnersRequestedEvent()),
-        wait: const Duration(milliseconds: 100),
+        act: (bloc) async {
+          bloc.add(const ProjectSearchAvailableOwnersRequestedEvent());
+          // Gate on the recovery state landing instead of a wall-clock wait,
+          // so a slow CI runner cannot cut the observation window short.
+          await bloc.stream.firstWhere(
+            (s) => s is ProjectSearchInitial && !s.availableOwnersLoading,
+          );
+        },
         expect: () => [
           isA<ProjectSearchInitial>().having(
             (s) => s.availableOwnersLoading,
@@ -1460,8 +1470,9 @@ void main() {
           await bloc.stream.firstWhere((s) => s is ProjectSearchResultsLoaded);
         },
         verify: (_) {
-          // Selection is sorted for determinism → 'owner-1' wins.
-          expect(lastSearchRpcParams()['filter_by_owner'], 'owner-1');
+          // The RPC takes an owner-id array; the single-owner selection is
+          // wrapped, and sorted for determinism → 'owner-1' wins.
+          expect(lastSearchRpcParams()['filter_by_owners'], ['owner-1']);
         },
       );
     });
@@ -1564,6 +1575,40 @@ void main() {
           expect(state.selectedTags, isEmpty);
           expect(state.selectedOwnerIds, isEmpty);
           expect(state.selectedDateRange, isNull);
+        },
+      );
+
+      blocTest<ProjectSearchBloc, ProjectSearchState>(
+        'keeps the fetched tag catalog across a page reopen — only selections reset',
+        setUp: () => seedTags(['Concrete', 'Steel']),
+        build: () => Modular.get<ProjectSearchBloc>(),
+        act: (bloc) async {
+          bloc.add(const ProjectSearchAvailableTagsRequestedEvent());
+          await bloc.stream.firstWhere(
+            (s) => s is ProjectSearchInitial && s.availableTags.isNotEmpty,
+          );
+          // Reopening the page resets selections but intentionally reuses the
+          // already-fetched catalog (it rarely changes mid-session).
+          bloc.add(const ProjectSearchHistoryRequestedEvent());
+          await bloc.stream.firstWhere(
+            (s) => s is ProjectSearchInitial && !s.isLoadingHistory,
+          );
+          // The cached catalog means the second request emits no loading state,
+          // so drain the event queue rather than awaiting a (deduplicated)
+          // state transition.
+          bloc.add(const ProjectSearchAvailableTagsRequestedEvent());
+          await pumpEventQueue();
+        },
+        verify: (_) {
+          final tagReads = fakeSupabase
+              .getMethodCallsFor('selectMatch')
+              .where((call) => call['table'] == DatabaseConstants.tagsTable)
+              .toList();
+          expect(
+            tagReads,
+            hasLength(1),
+            reason: 'the reopened page must serve the cached tag catalog',
+          );
         },
       );
     });

--- a/test/libraries/project/units/data/data_source/remote_project_search_data_source_test.dart
+++ b/test/libraries/project/units/data/data_source/remote_project_search_data_source_test.dart
@@ -179,23 +179,37 @@ void main() {
         expect(params['offset'], equals(DatabaseConstants.globalSearchDefaultOffset));
       });
 
-      test('passes filterByDate as ISO8601 string in RPC params', () async {
-        supabaseWrapper.setRpcResponse(
-          DatabaseConstants.globalSearchRpcFunction,
-          {'projects': [], 'estimations': [], 'members': []},
-        );
+      test(
+        'passes both modification-date range bounds as ISO8601 strings in '
+        'RPC params',
+        () async {
+          supabaseWrapper.setRpcResponse(
+            DatabaseConstants.globalSearchRpcFunction,
+            {'projects': [], 'estimations': [], 'members': []},
+          );
 
-        final filterDate = DateTime(2024, 6, 1);
-        await dataSource.fetchProjectsBySearchQuery(
-          userId: 'user-1',
-          query: 'wall',
-          filterByDate: filterDate,
-        );
+          final filterFrom = DateTime(2024, 6, 1);
+          final filterTo = DateTime(2024, 6, 30);
+          await dataSource.fetchProjectsBySearchQuery(
+            userId: 'user-1',
+            query: 'wall',
+            filterByDateFrom: filterFrom,
+            filterByDateTo: filterTo,
+          );
 
-        final params = supabaseWrapper.getMethodCallsFor('rpc').first['params']
-            as Map<String, dynamic>?;
-        expect(params!['filter_by_date'], equals(filterDate.toIso8601String()));
-      });
+          final params =
+              supabaseWrapper.getMethodCallsFor('rpc').first['params']
+                  as Map<String, dynamic>?;
+          expect(
+            params!['filter_by_date_from'],
+            equals(filterFrom.toIso8601String()),
+          );
+          expect(
+            params['filter_by_date_to'],
+            equals(filterTo.toIso8601String()),
+          );
+        },
+      );
 
       test('passes filterByTag and filterByOwner in RPC params', () async {
         supabaseWrapper.setRpcResponse(

--- a/test/libraries/project/units/data/repositories/project_search_repository_impl_test.dart
+++ b/test/libraries/project/units/data/repositories/project_search_repository_impl_test.dart
@@ -204,11 +204,13 @@ void main() {
           {'projects': [], 'estimations': [], 'members': []},
         );
 
-        final filterDate = DateTime(2024, 6, 1);
+        final filterFrom = DateTime(2024, 6, 1);
+        final filterTo = DateTime(2024, 6, 30);
         await repository.searchProjects(
           userId: testUserId,
           query: 'wall',
-          filterByDate: filterDate,
+          filterByDateFrom: filterFrom,
+          filterByDateTo: filterTo,
           filterByTag: 'structural',
           filterByOwner: 'owner-42',
         );
@@ -219,8 +221,12 @@ void main() {
         expect(params, isNotNull);
         expect(params!['query'], equals('wall'));
         expect(
-          params['filter_by_date'],
-          equals(filterDate.toIso8601String()),
+          params['filter_by_date_from'],
+          equals(filterFrom.toIso8601String()),
+        );
+        expect(
+          params['filter_by_date_to'],
+          equals(filterTo.toIso8601String()),
         );
         expect(params['filter_by_tag'], equals('structural'));
         expect(


### PR DESCRIPTION
# PR Review: CA-771b-feat/project-search-filter-bloc → CA-771a-refactor/shared-filter-widgets-to-libraries

## 📝 PR Description

Adds the filter state machine for CA-771 to `ProjectSearchBloc`: tag, owner, and modified-date filter events with handlers that mirror `GlobalSearchBloc`'s shipped pattern. Selected filters are threaded into `ProjectSearchRepository.searchProjects` (`filter_by_tag` / `filter_by_owner` / `filter_by_date` on the existing RPC — previously hardcoded `null`). Available tag/owner lists are fetched lazily on first sheet open and cached; in-sheet search queries filter them in memory. Filters reset on page reopen, mirroring `GlobalSearchStarted`. UI wiring lands in (3/4) and (4/4).

**Type:** Feature ·
**Size:** L (450 production lines — see finding 1) ·
**Rules applied:** Digestible PR, Naming & Abstraction, Self-Documenting Code, Unit Test Behavior, Test Double Pattern, Sentry Logging, Stream Lifecycle

### What changed
- `project_search_event.dart`: 10 new events (`ProjectSearchTagFiltersAppliedEvent`, `…TagFilterClearedEvent`, `…AvailableTagsRequestedEvent`, `…TagSearchQueryUpdatedEvent`, owner equivalents, `…DateFilterAppliedEvent`/`…ClearedEvent`) — suffixed `Event` to match the file's existing convention
- `project_search_state.dart`: `ProjectSearchInitial` gains `selectedTags`/`availableTags`/`availableTagsLoading`, owner equivalents, and `selectedDateRange`; new transient `ProjectSearchTagsLoadFailure`/`ProjectSearchOwnersLoadFailure` states (each immediately followed by a recovered `ProjectSearchInitial`)
- `project_search_bloc.dart`: handlers + caches mirroring `GlobalSearchBloc`; `_executeSearch` passes the selected filters to the RPC (single value, sorted for determinism); pre-existing `unawaited(lastSaveCompleted!)` forced-unwrap replaced with a local variable (custom_lint `forbid_forced_unwrapping`)
- `dashboard_module.dart`: imports `TagLibraryModule`/`OwnerLibraryModule`, injects both repositories into the bloc factory
- `DateRange` is now imported from `libraries/search_filters/domain/entities/date_range.dart` (moved there in CA-771a) instead of the `DateRangeBottomSheet` widget file — the bloc no longer depends on a `presentation/widgets` file for a domain type
- 18 new bloc tests (39 total): apply/clear per filter, available-list fetch success/caching/failure-recovery, in-sheet query filtering, filter reset on reopen, and RPC-param threading assertions

---

## 🔍 Review Summary

> Found 3 issue(s): 0 🔴 critical · 1 🟠 major · 0 🟡 minor · 2 🔵 suggestion — across 2 file(s).

| # | Issue | Severity | Location | Description | Suggested Fix | Status | Notes |
|---|-------|----------|----------|-------------|---------------|--------|-------|
| 1 | PR exceeds M size | 🟠 Major | PR-level | 450 production lines (>200). | Split further. | ❌ Disagree | Already the bloc slice of a 4-way split of CA-771; ~40% is `///` docs + Equatable ceremony on events/states. No further cohesive split exists. |
| 2 | Bloc-layer warning logs duplicate the DataSource boundary | 🔵 Suggestion | `project_search_bloc.dart` | Tag/owner fetch failures are logged `warning()` in the bloc although the DataSource already logs at the boundary (Sentry rule: one layer). | Drop bloc-level warnings in a cleanup. | ❌ Disagree | Matches this bloc's existing pattern (history/suggestions handlers); `warning()` is breadcrumb-only, no Sentry quota. |
| 3 | Single-value owner/tag filter | 🔵 Suggestion | `project_search_bloc.dart` (`_executeSearch`) | Multiple selections send only the first (sorted) value — the `global_search` RPC takes a single `filter_by_owner`/`filter_by_tag`. | Extend the RPC for multi-value (as CA-737 did for global search). | 📋 Future Story | Mirrors GlobalSearchBloc's shipped approach; needs a backend ticket. |

**Status (author fills):** ✅ Addressed · 📋 Future Story (add YouTrack ID) ·
❌ Disagree (justify) · 🔄 In Progress

Notes for reviewers:
- Deliberate divergence: the bloc calls `ProjectSearchRepository` directly (no use case), consistent with the established ProjectSearch/CreateProject pattern (CA-163).
- Ticket wording: CA-771 says "Owner + Modified"; the base branch's TODO said "Tags + Modified". Product decision: all three filters, since the repository already accepts all three params.
- Pre-existing dead code flagged, not touched: `lib/features/dashboard/data/data_source/remote_project_search_data_source.dart` is an orphaned duplicate of the bound `lib/libraries/project/...` datasource.

<!-- Skipped: CoreUI Components / UI-Business Separation / Localization / Widget Test Finders / Accessibility (no presentation-widget code in this slice), Mutation Testing (no mutation configs exist for dashboard blocs incl. the base — candidate follow-up) -->


---

### R4 update (round-4 review, post-#451 merge)

The stack is rebased onto main (which now contains CA-797), and R4 supersedes some of the description above:

- **CA-797 pattern adopted**: `availableTagsLoading`/`availableOwnersLoading` are instance fields with fetch-generation guards; the `// TODO: [CA-797]` is removed. A page reopen now disowns in-flight fetches and **clears** the tag/owner catalogs (parity with `GlobalSearchStarted`), superseding the earlier catalog-kept-across-reopen behavior.
- **`restartable()` transformer removed**: the duplicate-fetch guard is the in-flight loading-flag gate (as in post-CA-797 `GlobalSearchBloc`); a cancelling transformer would suppress the cancelled fetch's completion emit and strand the sheet spinner.
- **Date filter**: the stale single `filter_by_date` ("created on or after") RPC param is replaced by the RPC's documented `filter_by_date_from`/`filter_by_date_to` inclusive modification-date range across `ProjectSearchRepository`/`DataSource`; both `DateRange` bounds are threaded. The tag/owner single-value truncation (finding 3) remains a future story; the date filter no longer truncates.
- **Tests**: cache-hit tests gate on the handler-run counters (no `wait:` barriers anywhere); per-field regression tests added for the in-flight gate, flag-stomp survival, reopen-clears-catalog, and disowned-fetch refetch.
