### PR TITLE
CA-771 (3/4): feat(project-search): add Tags and Owner filter bottom sheets

### DIFF
--- a/lib/features/dashboard/presentation/widgets/project_search_owner_filter_sheet.dart
+++ b/lib/features/dashboard/presentation/widgets/project_search_owner_filter_sheet.dart
@@ -1,0 +1,193 @@
+import 'package:construculator/features/dashboard/presentation/bloc/project_search_bloc/project_search_bloc.dart';
+import 'package:construculator/l10n/generated/app_localizations.dart';
+import 'package:construculator/libraries/extensions/extensions.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:ripplearc_coreui/ripplearc_coreui.dart';
+
+/// A modal bottom sheet for selecting owner filters on the project search
+/// screen.
+///
+/// The available owners and search filtering are owned by [ProjectSearchBloc]:
+/// the sheet dispatches [ProjectSearchOwnerSearchQueryUpdatedEvent] as the user
+/// types and renders [ProjectSearchInitial.availableOwners]. Owner selection
+/// is kept local (by owner id) until the user taps Apply, at which point the
+/// sheet dispatches [ProjectSearchOwnerFiltersAppliedEvent] and pops itself.
+/// Tapping Clear all deselects all owners without dismissing the sheet.
+class ProjectSearchOwnerFilterSheet extends StatefulWidget {
+  /// The owner ids already selected when the sheet opens.
+  final Set<String> initialSelectedOwnerIds;
+
+  /// Creates a [ProjectSearchOwnerFilterSheet].
+  const ProjectSearchOwnerFilterSheet({
+    super.key,
+    required this.initialSelectedOwnerIds,
+  });
+
+  @override
+  State<ProjectSearchOwnerFilterSheet> createState() =>
+      _ProjectSearchOwnerFilterSheetState();
+}
+
+class _ProjectSearchOwnerFilterSheetState
+    extends State<ProjectSearchOwnerFilterSheet> {
+  late Set<String> _localSelected;
+
+  @override
+  void initState() {
+    super.initState();
+    _localSelected = Set.of(widget.initialSelectedOwnerIds);
+  }
+
+  void _onApply(BuildContext context) {
+    BlocProvider.of<ProjectSearchBloc>(context).add(
+      ProjectSearchOwnerFiltersAppliedEvent(
+        ownerIds: Set.unmodifiable(_localSelected),
+      ),
+    );
+    Navigator.of(context).pop();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final typography = context.textTheme;
+    final l10n = context.l10n;
+
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        _buildTitle(typography, l10n),
+        _buildSearchField(context, l10n),
+        _buildOwnerList(typography, l10n),
+        _buildActionButtons(context, l10n),
+      ],
+    );
+  }
+
+  Widget _buildTitle(AppTypographyExtension typography, AppLocalizations l10n) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(
+        horizontal: CoreSpacing.space4,
+        vertical: CoreSpacing.space3,
+      ),
+      child: Text(
+        l10n.projectSearchOwnerSheetTitle,
+        style: typography.bodyLargeSemiBold,
+      ),
+    );
+  }
+
+  Widget _buildSearchField(BuildContext context, AppLocalizations l10n) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(
+        horizontal: CoreSpacing.space4,
+        vertical: CoreSpacing.space2,
+      ),
+      child: CoreTextField(
+        hintText: l10n.projectSearchOwnerSheetSearchHint,
+        onChanged: (value) => BlocProvider.of<ProjectSearchBloc>(
+          context,
+        ).add(ProjectSearchOwnerSearchQueryUpdatedEvent(query: value)),
+        prefix: const CoreIconWidget(
+          icon: CoreIcons.search,
+          size: CoreSpacing.space5,
+        ),
+      ),
+    );
+  }
+
+  Widget _buildOwnerList(
+    AppTypographyExtension typography,
+    AppLocalizations l10n,
+  ) {
+    return ConstrainedBox(
+      constraints: const BoxConstraints(maxHeight: 300),
+      child: BlocBuilder<ProjectSearchBloc, ProjectSearchState>(
+        buildWhen: (prev, curr) => curr is ProjectSearchInitial,
+        builder: (context, state) {
+          if (state is! ProjectSearchInitial) {
+            return const SizedBox.shrink();
+          }
+          if (state.availableOwnersLoading) {
+            return const Padding(
+              padding: EdgeInsets.all(CoreSpacing.space6),
+              child: Center(
+                child: CoreLoadingIndicator(
+                  key: Key('project_search_owner_filter_loading_indicator'),
+                ),
+              ),
+            );
+          }
+          final owners = state.availableOwners;
+          if (owners.isEmpty) {
+            return Padding(
+              padding: const EdgeInsets.all(CoreSpacing.space6),
+              child: Center(
+                child: Text(
+                  l10n.projectSearchOwnerSheetEmpty,
+                  key: const Key('project_search_owner_filter_empty_label'),
+                  style: typography.bodyMediumRegular,
+                ),
+              ),
+            );
+          }
+          return ListView.builder(
+            shrinkWrap: true,
+            itemCount: owners.length,
+            itemBuilder: (_, index) {
+              final owner = owners[index];
+              final isSelected = _localSelected.contains(owner.id);
+              return CheckboxListTile(
+                key: Key('project_search_owner_filter_item_${owner.id}'),
+                value: isSelected,
+                title: Text(owner.fullName, style: typography.bodyLargeRegular),
+                // Ignore the nullable bool parameter; use the pre-captured
+                // isSelected to avoid null-unwrapping and keep the toggle readable.
+                onChanged: (_) => setState(() {
+                  if (isSelected) {
+                    _localSelected = Set.of(_localSelected)..remove(owner.id);
+                  } else {
+                    _localSelected = Set.of(_localSelected)..add(owner.id);
+                  }
+                }),
+                controlAffinity: ListTileControlAffinity.leading,
+              );
+            },
+          );
+        },
+      ),
+    );
+  }
+
+  Widget _buildActionButtons(BuildContext context, AppLocalizations l10n) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(
+        CoreSpacing.space4,
+        CoreSpacing.space3,
+        CoreSpacing.space4,
+        CoreSpacing.space4,
+      ),
+      child: Row(
+        children: [
+          Expanded(
+            child: CoreButton(
+              key: const Key('project_search_owner_filter_clear_all_button'),
+              label: l10n.projectSearchOwnerSheetClearAll,
+              variant: CoreButtonVariant.secondary,
+              onPressed: () => setState(() => _localSelected = {}),
+            ),
+          ),
+          const SizedBox(width: CoreSpacing.space3),
+          Expanded(
+            child: CoreButton(
+              key: const Key('project_search_owner_filter_apply_button'),
+              label: l10n.projectSearchOwnerSheetApply,
+              onPressed: () => _onApply(context),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/dashboard/presentation/widgets/project_search_owner_filter_sheet.dart
+++ b/lib/features/dashboard/presentation/widgets/project_search_owner_filter_sheet.dart
@@ -1,20 +1,20 @@
 import 'package:construculator/features/dashboard/presentation/bloc/project_search_bloc/project_search_bloc.dart';
-import 'package:construculator/l10n/generated/app_localizations.dart';
 import 'package:construculator/libraries/extensions/extensions.dart';
+import 'package:construculator/libraries/search_filters/presentation/widgets/multi_select_filter_sheet.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:ripplearc_coreui/ripplearc_coreui.dart';
 
 /// A modal bottom sheet for selecting owner filters on the project search
 /// screen.
 ///
-/// The available owners and search filtering are owned by [ProjectSearchBloc]:
-/// the sheet dispatches [ProjectSearchOwnerSearchQueryUpdatedEvent] as the user
-/// types and renders [ProjectSearchInitial.availableOwners]. Owner selection
-/// is kept local (by owner id) until the user taps Apply, at which point the
-/// sheet dispatches [ProjectSearchOwnerFiltersAppliedEvent] and pops itself.
-/// Tapping Clear all deselects all owners without dismissing the sheet.
-class ProjectSearchOwnerFilterSheet extends StatefulWidget {
+/// A thin wrapper around the shared [MultiSelectFilterSheet]: the available
+/// owners and search filtering are owned by [ProjectSearchBloc]. The sheet
+/// dispatches [ProjectSearchOwnerSearchQueryUpdatedEvent] as the user types
+/// and renders [ProjectSearchInitial.availableOwners]. Owner selection is kept
+/// local (by owner id) until the user taps Apply, at which point the sheet
+/// dispatches [ProjectSearchOwnerFiltersAppliedEvent] and pops itself. Tapping
+/// Clear all deselects all owners without dismissing the sheet.
+class ProjectSearchOwnerFilterSheet extends StatelessWidget {
   /// The owner ids already selected when the sheet opens.
   final Set<String> initialSelectedOwnerIds;
 
@@ -25,169 +25,51 @@ class ProjectSearchOwnerFilterSheet extends StatefulWidget {
   });
 
   @override
-  State<ProjectSearchOwnerFilterSheet> createState() =>
-      _ProjectSearchOwnerFilterSheetState();
-}
-
-class _ProjectSearchOwnerFilterSheetState
-    extends State<ProjectSearchOwnerFilterSheet> {
-  late Set<String> _localSelected;
-
-  @override
-  void initState() {
-    super.initState();
-    _localSelected = Set.of(widget.initialSelectedOwnerIds);
-  }
-
-  void _onApply(BuildContext context) {
-    BlocProvider.of<ProjectSearchBloc>(context).add(
-      ProjectSearchOwnerFiltersAppliedEvent(
-        ownerIds: Set.unmodifiable(_localSelected),
-      ),
-    );
-    Navigator.of(context).pop();
-  }
-
-  @override
   Widget build(BuildContext context) {
-    final typography = context.textTheme;
     final l10n = context.l10n;
 
-    return Column(
-      mainAxisSize: MainAxisSize.min,
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        _buildTitle(typography, l10n),
-        _buildSearchField(context, l10n),
-        _buildOwnerList(typography, l10n),
-        _buildActionButtons(context, l10n),
-      ],
-    );
-  }
-
-  Widget _buildTitle(AppTypographyExtension typography, AppLocalizations l10n) {
-    return Padding(
-      padding: const EdgeInsets.symmetric(
-        horizontal: CoreSpacing.space4,
-        vertical: CoreSpacing.space3,
-      ),
-      child: Text(
-        l10n.projectSearchOwnerSheetTitle,
-        style: typography.bodyLargeSemiBold,
-      ),
-    );
-  }
-
-  Widget _buildSearchField(BuildContext context, AppLocalizations l10n) {
-    return Padding(
-      padding: const EdgeInsets.symmetric(
-        horizontal: CoreSpacing.space4,
-        vertical: CoreSpacing.space2,
-      ),
-      child: CoreTextField(
-        hintText: l10n.projectSearchOwnerSheetSearchHint,
-        onChanged: (value) => BlocProvider.of<ProjectSearchBloc>(
-          context,
-        ).add(ProjectSearchOwnerSearchQueryUpdatedEvent(query: value)),
-        prefix: const CoreIconWidget(
-          icon: CoreIcons.search,
-          size: CoreSpacing.space5,
-        ),
-      ),
-    );
-  }
-
-  Widget _buildOwnerList(
-    AppTypographyExtension typography,
-    AppLocalizations l10n,
-  ) {
-    return ConstrainedBox(
-      constraints: const BoxConstraints(maxHeight: 300),
-      child: BlocBuilder<ProjectSearchBloc, ProjectSearchState>(
-        buildWhen: (prev, curr) => curr is ProjectSearchInitial,
-        builder: (context, state) {
-          if (state is! ProjectSearchInitial) {
-            return const SizedBox.shrink();
-          }
-          if (state.availableOwnersLoading) {
-            return const Padding(
-              padding: EdgeInsets.all(CoreSpacing.space6),
-              child: Center(
-                child: CoreLoadingIndicator(
-                  key: Key('project_search_owner_filter_loading_indicator'),
-                ),
-              ),
-            );
-          }
-          final owners = state.availableOwners;
-          if (owners.isEmpty) {
-            return Padding(
-              padding: const EdgeInsets.all(CoreSpacing.space6),
-              child: Center(
-                child: Text(
-                  l10n.projectSearchOwnerSheetEmpty,
-                  key: const Key('project_search_owner_filter_empty_label'),
-                  style: typography.bodyMediumRegular,
-                ),
-              ),
-            );
-          }
-          return ListView.builder(
-            shrinkWrap: true,
-            itemCount: owners.length,
-            itemBuilder: (_, index) {
-              final owner = owners[index];
-              final isSelected = _localSelected.contains(owner.id);
-              return CheckboxListTile(
-                key: Key('project_search_owner_filter_item_${owner.id}'),
-                value: isSelected,
-                title: Text(owner.fullName, style: typography.bodyLargeRegular),
-                // Ignore the nullable bool parameter; use the pre-captured
-                // isSelected to avoid null-unwrapping and keep the toggle readable.
-                onChanged: (_) => setState(() {
-                  if (isSelected) {
-                    _localSelected = Set.of(_localSelected)..remove(owner.id);
-                  } else {
-                    _localSelected = Set.of(_localSelected)..add(owner.id);
-                  }
-                }),
-                controlAffinity: ListTileControlAffinity.leading,
-              );
-            },
-          );
-        },
-      ),
-    );
-  }
-
-  Widget _buildActionButtons(BuildContext context, AppLocalizations l10n) {
-    return Padding(
-      padding: const EdgeInsets.fromLTRB(
-        CoreSpacing.space4,
-        CoreSpacing.space3,
-        CoreSpacing.space4,
-        CoreSpacing.space4,
-      ),
-      child: Row(
-        children: [
-          Expanded(
-            child: CoreButton(
-              key: const Key('project_search_owner_filter_clear_all_button'),
-              label: l10n.projectSearchOwnerSheetClearAll,
-              variant: CoreButtonVariant.secondary,
-              onPressed: () => setState(() => _localSelected = {}),
-            ),
+    return BlocBuilder<ProjectSearchBloc, ProjectSearchState>(
+      buildWhen: (prev, curr) => curr is ProjectSearchInitial,
+      builder: (context, state) {
+        return MultiSelectFilterSheet(
+          title: l10n.projectSearchOwnerSheetTitle,
+          searchHint: l10n.projectSearchOwnerSheetSearchHint,
+          emptyLabel: l10n.projectSearchOwnerSheetEmpty,
+          clearAllLabel: l10n.projectSearchOwnerSheetClearAll,
+          applyLabel: l10n.projectSearchOwnerSheetApply,
+          initialSelectedIds: initialSelectedOwnerIds,
+          listData: state is ProjectSearchInitial
+              ? MultiSelectFilterListData(
+                  isLoading: state.availableOwnersLoading,
+                  items: [
+                    for (final owner in state.availableOwners)
+                      MultiSelectFilterItem(
+                        id: owner.id,
+                        label: owner.fullName,
+                      ),
+                  ],
+                )
+              : null,
+          onSearchQueryChanged: (query) => BlocProvider.of<ProjectSearchBloc>(
+            context,
+          ).add(ProjectSearchOwnerSearchQueryUpdatedEvent(query: query)),
+          onApply: (ownerIds) => BlocProvider.of<ProjectSearchBloc>(
+            context,
+          ).add(ProjectSearchOwnerFiltersAppliedEvent(ownerIds: ownerIds)),
+          loadingIndicatorKey: const Key(
+            'project_search_owner_filter_loading_indicator',
           ),
-          const SizedBox(width: CoreSpacing.space3),
-          Expanded(
-            child: CoreButton(
-              key: const Key('project_search_owner_filter_apply_button'),
-              label: l10n.projectSearchOwnerSheetApply,
-              onPressed: () => _onApply(context),
-            ),
+          emptyLabelKey: const Key('project_search_owner_filter_empty_label'),
+          itemKeyOf: (ownerId) =>
+              Key('project_search_owner_filter_item_$ownerId'),
+          clearAllButtonKey: const Key(
+            'project_search_owner_filter_clear_all_button',
           ),
-        ],
-      ),
+          applyButtonKey: const Key(
+            'project_search_owner_filter_apply_button',
+          ),
+        );
+      },
     );
   }
 }

--- a/lib/features/dashboard/presentation/widgets/project_search_tags_filter_sheet.dart
+++ b/lib/features/dashboard/presentation/widgets/project_search_tags_filter_sheet.dart
@@ -1,0 +1,192 @@
+import 'package:construculator/features/dashboard/presentation/bloc/project_search_bloc/project_search_bloc.dart';
+import 'package:construculator/l10n/generated/app_localizations.dart';
+import 'package:construculator/libraries/extensions/extensions.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:ripplearc_coreui/ripplearc_coreui.dart';
+
+/// A modal bottom sheet for selecting tag filters on the project search screen.
+///
+/// The available tags and search filtering are owned by [ProjectSearchBloc]:
+/// the sheet dispatches [ProjectSearchTagSearchQueryUpdatedEvent] as the user types
+/// and renders [ProjectSearchInitial.availableTags]. Tag selection is kept
+/// local until the user taps Apply, at which point the sheet dispatches
+/// [ProjectSearchTagFiltersAppliedEvent] and pops itself. Tapping Clear all
+/// deselects all tags without dismissing the sheet.
+class ProjectSearchTagsFilterSheet extends StatefulWidget {
+  /// The tags already selected when the sheet opens.
+  final Set<String> initialSelectedTags;
+
+  /// Creates a [ProjectSearchTagsFilterSheet].
+  const ProjectSearchTagsFilterSheet({
+    super.key,
+    required this.initialSelectedTags,
+  });
+
+  @override
+  State<ProjectSearchTagsFilterSheet> createState() =>
+      _ProjectSearchTagsFilterSheetState();
+}
+
+class _ProjectSearchTagsFilterSheetState
+    extends State<ProjectSearchTagsFilterSheet> {
+  late Set<String> _localSelected;
+
+  @override
+  void initState() {
+    super.initState();
+    _localSelected = Set.of(widget.initialSelectedTags);
+  }
+
+  void _onApply(BuildContext context) {
+    BlocProvider.of<ProjectSearchBloc>(context).add(
+      ProjectSearchTagFiltersAppliedEvent(
+        tags: Set.unmodifiable(_localSelected),
+      ),
+    );
+    Navigator.of(context).pop();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final typography = context.textTheme;
+    final l10n = context.l10n;
+
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        _buildTitle(typography, l10n),
+        _buildSearchField(context, l10n),
+        _buildTagList(typography, l10n),
+        _buildActionButtons(context, l10n),
+      ],
+    );
+  }
+
+  Widget _buildTitle(AppTypographyExtension typography, AppLocalizations l10n) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(
+        horizontal: CoreSpacing.space4,
+        vertical: CoreSpacing.space3,
+      ),
+      child: Text(
+        l10n.projectSearchTagsSheetTitle,
+        style: typography.bodyLargeSemiBold,
+      ),
+    );
+  }
+
+  Widget _buildSearchField(BuildContext context, AppLocalizations l10n) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(
+        horizontal: CoreSpacing.space4,
+        vertical: CoreSpacing.space2,
+      ),
+      child: CoreTextField(
+        hintText: l10n.projectSearchTagsSheetSearchHint,
+        onChanged: (value) => BlocProvider.of<ProjectSearchBloc>(
+          context,
+        ).add(ProjectSearchTagSearchQueryUpdatedEvent(query: value)),
+        prefix: const CoreIconWidget(
+          icon: CoreIcons.search,
+          size: CoreSpacing.space5,
+        ),
+      ),
+    );
+  }
+
+  Widget _buildTagList(
+    AppTypographyExtension typography,
+    AppLocalizations l10n,
+  ) {
+    return ConstrainedBox(
+      constraints: const BoxConstraints(maxHeight: 300),
+      child: BlocBuilder<ProjectSearchBloc, ProjectSearchState>(
+        buildWhen: (prev, curr) => curr is ProjectSearchInitial,
+        builder: (context, state) {
+          if (state is! ProjectSearchInitial) {
+            return const SizedBox.shrink();
+          }
+          if (state.availableTagsLoading) {
+            return const Padding(
+              padding: EdgeInsets.all(CoreSpacing.space6),
+              child: Center(
+                child: CoreLoadingIndicator(
+                  key: Key('project_search_tags_filter_loading_indicator'),
+                ),
+              ),
+            );
+          }
+          final tags = state.availableTags;
+          if (tags.isEmpty) {
+            return Padding(
+              padding: const EdgeInsets.all(CoreSpacing.space6),
+              child: Center(
+                child: Text(
+                  l10n.projectSearchTagsSheetEmpty,
+                  key: const Key('project_search_tags_filter_empty_label'),
+                  style: typography.bodyMediumRegular,
+                ),
+              ),
+            );
+          }
+          return ListView.builder(
+            shrinkWrap: true,
+            itemCount: tags.length,
+            itemBuilder: (_, index) {
+              final tag = tags[index];
+              final isSelected = _localSelected.contains(tag);
+              return CheckboxListTile(
+                key: Key('project_search_tag_filter_item_$tag'),
+                value: isSelected,
+                title: Text(tag, style: typography.bodyLargeRegular),
+                // Ignore the nullable bool parameter; use the pre-captured
+                // isSelected to avoid null-unwrapping and keep the toggle readable.
+                onChanged: (_) => setState(() {
+                  if (isSelected) {
+                    _localSelected = Set.of(_localSelected)..remove(tag);
+                  } else {
+                    _localSelected = Set.of(_localSelected)..add(tag);
+                  }
+                }),
+                controlAffinity: ListTileControlAffinity.leading,
+              );
+            },
+          );
+        },
+      ),
+    );
+  }
+
+  Widget _buildActionButtons(BuildContext context, AppLocalizations l10n) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(
+        CoreSpacing.space4,
+        CoreSpacing.space3,
+        CoreSpacing.space4,
+        CoreSpacing.space4,
+      ),
+      child: Row(
+        children: [
+          Expanded(
+            child: CoreButton(
+              key: const Key('project_search_tags_filter_clear_all_button'),
+              label: l10n.projectSearchTagsSheetClearAll,
+              variant: CoreButtonVariant.secondary,
+              onPressed: () => setState(() => _localSelected = {}),
+            ),
+          ),
+          const SizedBox(width: CoreSpacing.space3),
+          Expanded(
+            child: CoreButton(
+              key: const Key('project_search_tags_filter_apply_button'),
+              label: l10n.projectSearchTagsSheetApply,
+              onPressed: () => _onApply(context),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/dashboard/presentation/widgets/project_search_tags_filter_sheet.dart
+++ b/lib/features/dashboard/presentation/widgets/project_search_tags_filter_sheet.dart
@@ -1,19 +1,19 @@
 import 'package:construculator/features/dashboard/presentation/bloc/project_search_bloc/project_search_bloc.dart';
-import 'package:construculator/l10n/generated/app_localizations.dart';
 import 'package:construculator/libraries/extensions/extensions.dart';
+import 'package:construculator/libraries/search_filters/presentation/widgets/multi_select_filter_sheet.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:ripplearc_coreui/ripplearc_coreui.dart';
 
 /// A modal bottom sheet for selecting tag filters on the project search screen.
 ///
-/// The available tags and search filtering are owned by [ProjectSearchBloc]:
-/// the sheet dispatches [ProjectSearchTagSearchQueryUpdatedEvent] as the user types
-/// and renders [ProjectSearchInitial.availableTags]. Tag selection is kept
-/// local until the user taps Apply, at which point the sheet dispatches
+/// A thin wrapper around the shared [MultiSelectFilterSheet]: the available
+/// tags and search filtering are owned by [ProjectSearchBloc]. The sheet
+/// dispatches [ProjectSearchTagSearchQueryUpdatedEvent] as the user types and
+/// renders [ProjectSearchInitial.availableTags]. Tag selection is kept local
+/// until the user taps Apply, at which point the sheet dispatches
 /// [ProjectSearchTagFiltersAppliedEvent] and pops itself. Tapping Clear all
 /// deselects all tags without dismissing the sheet.
-class ProjectSearchTagsFilterSheet extends StatefulWidget {
+class ProjectSearchTagsFilterSheet extends StatelessWidget {
   /// The tags already selected when the sheet opens.
   final Set<String> initialSelectedTags;
 
@@ -24,169 +24,45 @@ class ProjectSearchTagsFilterSheet extends StatefulWidget {
   });
 
   @override
-  State<ProjectSearchTagsFilterSheet> createState() =>
-      _ProjectSearchTagsFilterSheetState();
-}
-
-class _ProjectSearchTagsFilterSheetState
-    extends State<ProjectSearchTagsFilterSheet> {
-  late Set<String> _localSelected;
-
-  @override
-  void initState() {
-    super.initState();
-    _localSelected = Set.of(widget.initialSelectedTags);
-  }
-
-  void _onApply(BuildContext context) {
-    BlocProvider.of<ProjectSearchBloc>(context).add(
-      ProjectSearchTagFiltersAppliedEvent(
-        tags: Set.unmodifiable(_localSelected),
-      ),
-    );
-    Navigator.of(context).pop();
-  }
-
-  @override
   Widget build(BuildContext context) {
-    final typography = context.textTheme;
     final l10n = context.l10n;
 
-    return Column(
-      mainAxisSize: MainAxisSize.min,
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        _buildTitle(typography, l10n),
-        _buildSearchField(context, l10n),
-        _buildTagList(typography, l10n),
-        _buildActionButtons(context, l10n),
-      ],
-    );
-  }
-
-  Widget _buildTitle(AppTypographyExtension typography, AppLocalizations l10n) {
-    return Padding(
-      padding: const EdgeInsets.symmetric(
-        horizontal: CoreSpacing.space4,
-        vertical: CoreSpacing.space3,
-      ),
-      child: Text(
-        l10n.projectSearchTagsSheetTitle,
-        style: typography.bodyLargeSemiBold,
-      ),
-    );
-  }
-
-  Widget _buildSearchField(BuildContext context, AppLocalizations l10n) {
-    return Padding(
-      padding: const EdgeInsets.symmetric(
-        horizontal: CoreSpacing.space4,
-        vertical: CoreSpacing.space2,
-      ),
-      child: CoreTextField(
-        hintText: l10n.projectSearchTagsSheetSearchHint,
-        onChanged: (value) => BlocProvider.of<ProjectSearchBloc>(
-          context,
-        ).add(ProjectSearchTagSearchQueryUpdatedEvent(query: value)),
-        prefix: const CoreIconWidget(
-          icon: CoreIcons.search,
-          size: CoreSpacing.space5,
-        ),
-      ),
-    );
-  }
-
-  Widget _buildTagList(
-    AppTypographyExtension typography,
-    AppLocalizations l10n,
-  ) {
-    return ConstrainedBox(
-      constraints: const BoxConstraints(maxHeight: 300),
-      child: BlocBuilder<ProjectSearchBloc, ProjectSearchState>(
-        buildWhen: (prev, curr) => curr is ProjectSearchInitial,
-        builder: (context, state) {
-          if (state is! ProjectSearchInitial) {
-            return const SizedBox.shrink();
-          }
-          if (state.availableTagsLoading) {
-            return const Padding(
-              padding: EdgeInsets.all(CoreSpacing.space6),
-              child: Center(
-                child: CoreLoadingIndicator(
-                  key: Key('project_search_tags_filter_loading_indicator'),
-                ),
-              ),
-            );
-          }
-          final tags = state.availableTags;
-          if (tags.isEmpty) {
-            return Padding(
-              padding: const EdgeInsets.all(CoreSpacing.space6),
-              child: Center(
-                child: Text(
-                  l10n.projectSearchTagsSheetEmpty,
-                  key: const Key('project_search_tags_filter_empty_label'),
-                  style: typography.bodyMediumRegular,
-                ),
-              ),
-            );
-          }
-          return ListView.builder(
-            shrinkWrap: true,
-            itemCount: tags.length,
-            itemBuilder: (_, index) {
-              final tag = tags[index];
-              final isSelected = _localSelected.contains(tag);
-              return CheckboxListTile(
-                key: Key('project_search_tag_filter_item_$tag'),
-                value: isSelected,
-                title: Text(tag, style: typography.bodyLargeRegular),
-                // Ignore the nullable bool parameter; use the pre-captured
-                // isSelected to avoid null-unwrapping and keep the toggle readable.
-                onChanged: (_) => setState(() {
-                  if (isSelected) {
-                    _localSelected = Set.of(_localSelected)..remove(tag);
-                  } else {
-                    _localSelected = Set.of(_localSelected)..add(tag);
-                  }
-                }),
-                controlAffinity: ListTileControlAffinity.leading,
-              );
-            },
-          );
-        },
-      ),
-    );
-  }
-
-  Widget _buildActionButtons(BuildContext context, AppLocalizations l10n) {
-    return Padding(
-      padding: const EdgeInsets.fromLTRB(
-        CoreSpacing.space4,
-        CoreSpacing.space3,
-        CoreSpacing.space4,
-        CoreSpacing.space4,
-      ),
-      child: Row(
-        children: [
-          Expanded(
-            child: CoreButton(
-              key: const Key('project_search_tags_filter_clear_all_button'),
-              label: l10n.projectSearchTagsSheetClearAll,
-              variant: CoreButtonVariant.secondary,
-              onPressed: () => setState(() => _localSelected = {}),
-            ),
+    return BlocBuilder<ProjectSearchBloc, ProjectSearchState>(
+      buildWhen: (prev, curr) => curr is ProjectSearchInitial,
+      builder: (context, state) {
+        return MultiSelectFilterSheet(
+          title: l10n.projectSearchTagsSheetTitle,
+          searchHint: l10n.projectSearchTagsSheetSearchHint,
+          emptyLabel: l10n.projectSearchTagsSheetEmpty,
+          clearAllLabel: l10n.projectSearchTagsSheetClearAll,
+          applyLabel: l10n.projectSearchTagsSheetApply,
+          initialSelectedIds: initialSelectedTags,
+          listData: state is ProjectSearchInitial
+              ? MultiSelectFilterListData(
+                  isLoading: state.availableTagsLoading,
+                  items: [
+                    for (final tag in state.availableTags)
+                      MultiSelectFilterItem(id: tag, label: tag),
+                  ],
+                )
+              : null,
+          onSearchQueryChanged: (query) => BlocProvider.of<ProjectSearchBloc>(
+            context,
+          ).add(ProjectSearchTagSearchQueryUpdatedEvent(query: query)),
+          onApply: (tags) => BlocProvider.of<ProjectSearchBloc>(
+            context,
+          ).add(ProjectSearchTagFiltersAppliedEvent(tags: tags)),
+          loadingIndicatorKey: const Key(
+            'project_search_tags_filter_loading_indicator',
           ),
-          const SizedBox(width: CoreSpacing.space3),
-          Expanded(
-            child: CoreButton(
-              key: const Key('project_search_tags_filter_apply_button'),
-              label: l10n.projectSearchTagsSheetApply,
-              onPressed: () => _onApply(context),
-            ),
+          emptyLabelKey: const Key('project_search_tags_filter_empty_label'),
+          itemKeyOf: (tag) => Key('project_search_tag_filter_item_$tag'),
+          clearAllButtonKey: const Key(
+            'project_search_tags_filter_clear_all_button',
           ),
-        ],
-      ),
+          applyButtonKey: const Key('project_search_tags_filter_apply_button'),
+        );
+      },
     );
   }
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1638,6 +1638,56 @@
     "description": "Accessibility label for the Modified date filter chip on the project search screen",
     "context": "N/A"
   },
+  "projectSearchTagsSheetTitle": "Tags",
+  "@projectSearchTagsSheetTitle": {
+    "description": "Title of the Tags filter bottom sheet on the project search screen",
+    "context": "N/A"
+  },
+  "projectSearchTagsSheetSearchHint": "Search by tag name",
+  "@projectSearchTagsSheetSearchHint": {
+    "description": "Hint text for the tag search field inside the Tags filter sheet on the project search screen",
+    "context": "N/A"
+  },
+  "projectSearchTagsSheetClearAll": "Clear all",
+  "@projectSearchTagsSheetClearAll": {
+    "description": "Label for the button that deselects all tags in the Tags filter sheet on the project search screen",
+    "context": "N/A"
+  },
+  "projectSearchTagsSheetApply": "Apply",
+  "@projectSearchTagsSheetApply": {
+    "description": "Label for the button that applies the selected tag filters on the project search screen",
+    "context": "N/A"
+  },
+  "projectSearchTagsSheetEmpty": "No tags found.",
+  "@projectSearchTagsSheetEmpty": {
+    "description": "Message shown when no tags match the search query in the Tags filter sheet on the project search screen",
+    "context": "N/A"
+  },
+  "projectSearchOwnerSheetTitle": "Owner",
+  "@projectSearchOwnerSheetTitle": {
+    "description": "Title of the Owner filter bottom sheet on the project search screen",
+    "context": "N/A"
+  },
+  "projectSearchOwnerSheetSearchHint": "Search by owner name",
+  "@projectSearchOwnerSheetSearchHint": {
+    "description": "Hint text for the owner search field inside the Owner filter sheet on the project search screen",
+    "context": "N/A"
+  },
+  "projectSearchOwnerSheetClearAll": "Clear all",
+  "@projectSearchOwnerSheetClearAll": {
+    "description": "Label for the button that deselects all owners in the Owner filter sheet on the project search screen",
+    "context": "N/A"
+  },
+  "projectSearchOwnerSheetApply": "Apply",
+  "@projectSearchOwnerSheetApply": {
+    "description": "Label for the button that applies the selected owner filters on the project search screen",
+    "context": "N/A"
+  },
+  "projectSearchOwnerSheetEmpty": "No owners found.",
+  "@projectSearchOwnerSheetEmpty": {
+    "description": "Message shown when no owners match the search query in the Owner filter sheet on the project search screen",
+    "context": "N/A"
+  },
   "globalSearchClearDateFilterSemanticLabel": "Clear modification date filter",
   "@globalSearchClearDateFilterSemanticLabel": {
     "description": "Accessibility label for the × button that removes the active modification-date filter",
@@ -1955,4 +2005,3 @@
     "context": "Dashboard projects sheet"
   }
 }
-

--- a/lib/l10n/generated/app_localizations.dart
+++ b/lib/l10n/generated/app_localizations.dart
@@ -1942,6 +1942,66 @@ abstract class AppLocalizations {
   /// **'Filter by modification date'**
   String get projectSearchFilterModifiedSemanticLabel;
 
+  /// Title of the Tags filter bottom sheet on the project search screen
+  ///
+  /// In en, this message translates to:
+  /// **'Tags'**
+  String get projectSearchTagsSheetTitle;
+
+  /// Hint text for the tag search field inside the Tags filter sheet on the project search screen
+  ///
+  /// In en, this message translates to:
+  /// **'Search by tag name'**
+  String get projectSearchTagsSheetSearchHint;
+
+  /// Label for the button that deselects all tags in the Tags filter sheet on the project search screen
+  ///
+  /// In en, this message translates to:
+  /// **'Clear all'**
+  String get projectSearchTagsSheetClearAll;
+
+  /// Label for the button that applies the selected tag filters on the project search screen
+  ///
+  /// In en, this message translates to:
+  /// **'Apply'**
+  String get projectSearchTagsSheetApply;
+
+  /// Message shown when no tags match the search query in the Tags filter sheet on the project search screen
+  ///
+  /// In en, this message translates to:
+  /// **'No tags found.'**
+  String get projectSearchTagsSheetEmpty;
+
+  /// Title of the Owner filter bottom sheet on the project search screen
+  ///
+  /// In en, this message translates to:
+  /// **'Owner'**
+  String get projectSearchOwnerSheetTitle;
+
+  /// Hint text for the owner search field inside the Owner filter sheet on the project search screen
+  ///
+  /// In en, this message translates to:
+  /// **'Search by owner name'**
+  String get projectSearchOwnerSheetSearchHint;
+
+  /// Label for the button that deselects all owners in the Owner filter sheet on the project search screen
+  ///
+  /// In en, this message translates to:
+  /// **'Clear all'**
+  String get projectSearchOwnerSheetClearAll;
+
+  /// Label for the button that applies the selected owner filters on the project search screen
+  ///
+  /// In en, this message translates to:
+  /// **'Apply'**
+  String get projectSearchOwnerSheetApply;
+
+  /// Message shown when no owners match the search query in the Owner filter sheet on the project search screen
+  ///
+  /// In en, this message translates to:
+  /// **'No owners found.'**
+  String get projectSearchOwnerSheetEmpty;
+
   /// Accessibility label for the × button that removes the active modification-date filter
   ///
   /// In en, this message translates to:

--- a/lib/l10n/generated/app_localizations_en.dart
+++ b/lib/l10n/generated/app_localizations_en.dart
@@ -1031,6 +1031,36 @@ class AppLocalizationsEn extends AppLocalizations {
       'Filter by modification date';
 
   @override
+  String get projectSearchTagsSheetTitle => 'Tags';
+
+  @override
+  String get projectSearchTagsSheetSearchHint => 'Search by tag name';
+
+  @override
+  String get projectSearchTagsSheetClearAll => 'Clear all';
+
+  @override
+  String get projectSearchTagsSheetApply => 'Apply';
+
+  @override
+  String get projectSearchTagsSheetEmpty => 'No tags found.';
+
+  @override
+  String get projectSearchOwnerSheetTitle => 'Owner';
+
+  @override
+  String get projectSearchOwnerSheetSearchHint => 'Search by owner name';
+
+  @override
+  String get projectSearchOwnerSheetClearAll => 'Clear all';
+
+  @override
+  String get projectSearchOwnerSheetApply => 'Apply';
+
+  @override
+  String get projectSearchOwnerSheetEmpty => 'No owners found.';
+
+  @override
   String get globalSearchClearDateFilterSemanticLabel =>
       'Clear modification date filter';
 

--- a/test/features/dashboard/widgets/project_search_owner_filter_sheet_test.dart
+++ b/test/features/dashboard/widgets/project_search_owner_filter_sheet_test.dart
@@ -1,0 +1,252 @@
+import 'package:construculator/app/app_bootstrap.dart';
+import 'package:construculator/features/dashboard/dashboard_module.dart';
+import 'package:construculator/features/dashboard/presentation/bloc/project_search_bloc/project_search_bloc.dart';
+import 'package:construculator/features/dashboard/presentation/widgets/project_search_owner_filter_sheet.dart';
+import 'package:construculator/l10n/generated/app_localizations.dart';
+import 'package:construculator/libraries/supabase/database_constants.dart';
+import 'package:construculator/libraries/supabase/interfaces/supabase_wrapper.dart';
+import 'package:construculator/libraries/supabase/testing/fake_supabase_user.dart';
+import 'package:construculator/libraries/supabase/testing/fake_supabase_wrapper.dart';
+import 'package:construculator/libraries/time/testing/fake_clock_impl.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_modular/flutter_modular.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:ripplearc_coreui/ripplearc_coreui.dart';
+
+import '../../../utils/fake_app_bootstrap_factory.dart';
+import '../../../utils/screenshot/font_loader.dart';
+
+class _OwnerFilterSheetTestModule extends Module {
+  final AppBootstrap appBootstrap;
+
+  _OwnerFilterSheetTestModule(this.appBootstrap);
+
+  @override
+  List<Module> get imports => [DashboardModule(appBootstrap)];
+}
+
+typedef _Owner = ({String id, String firstName, String lastName});
+
+void main() {
+  late FakeSupabaseWrapper fakeSupabase;
+  late ProjectSearchBloc bloc;
+  BuildContext? buildContext;
+
+  const defaultOwners = <_Owner>[
+    (id: 'owner-ada', firstName: 'Ada', lastName: 'Lovelace'),
+    (id: 'owner-alan', firstName: 'Alan', lastName: 'Turing'),
+    (id: 'owner-grace', firstName: 'Grace', lastName: 'Hopper'),
+  ];
+
+  setUp(() {
+    final bootstrap = FakeAppBootstrapFactory.create(
+      supabaseWrapper: FakeSupabaseWrapper(clock: FakeClockImpl()),
+    );
+    Modular.init(_OwnerFilterSheetTestModule(bootstrap));
+    fakeSupabase = Modular.get<SupabaseWrapper>() as FakeSupabaseWrapper;
+    fakeSupabase.setCurrentUser(
+      FakeUser(
+        id: 'user-1',
+        email: 'user@test.com',
+        createdAt: DateTime(2024).toIso8601String(),
+      ),
+    );
+  });
+
+  tearDown(() {
+    bloc.close();
+    fakeSupabase.reset();
+    Modular.destroy();
+  });
+
+  AppLocalizations l10n() => AppLocalizations.of(buildContext!)!;
+
+  void seedOwners(List<_Owner> owners) {
+    fakeSupabase.setRpcResponse(
+      DatabaseConstants.projectOwnersRpcFunction,
+      owners
+          .map(
+            (owner) => <String, dynamic>{
+              DatabaseConstants.idColumn: owner.id,
+              DatabaseConstants.credentialIdColumn: null,
+              DatabaseConstants.firstNameColumn: owner.firstName,
+              DatabaseConstants.lastNameColumn: owner.lastName,
+              DatabaseConstants.professionalRoleColumn: 'Engineer',
+              DatabaseConstants.profilePhotoUrlColumn: null,
+            },
+          )
+          .toList(),
+    );
+  }
+
+  /// Pumps a host page whose button opens [ProjectSearchOwnerFilterSheet] via
+  /// [CoreQuickSheet], mirroring how the production page presents the sheet.
+  Future<void> pumpAndOpenSheet(
+    WidgetTester tester, {
+    List<_Owner> owners = defaultOwners,
+    Set<String> initialSelectedOwnerIds = const {},
+  }) async {
+    // Create the bloc inside the test zone: a bloc created in setUp lives
+    // outside the fake-async zone and its awaits never resume under pump.
+    bloc = Modular.get<ProjectSearchBloc>();
+    seedOwners(owners);
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: createTestTheme(),
+        locale: const Locale('en'),
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Builder(
+          builder: (context) {
+            buildContext = context;
+            return Scaffold(
+              body: Center(
+                child: CoreFilterChip(
+                  key: const Key('open_sheet_button'),
+                  label: 'open',
+                  onTap: () {
+                    bloc.add(
+                      const ProjectSearchAvailableOwnersRequestedEvent(),
+                    );
+                    CoreQuickSheet.show(
+                      context: context,
+                      child: BlocProvider.value(
+                        value: bloc,
+                        child: ProjectSearchOwnerFilterSheet(
+                          initialSelectedOwnerIds: initialSelectedOwnerIds,
+                        ),
+                      ),
+                    );
+                  },
+                ),
+              ),
+            );
+          },
+        ),
+      ),
+    );
+    await tester.tap(find.byKey(const Key('open_sheet_button')));
+    await tester.pumpAndSettle();
+  }
+
+  bool isOwnerChecked(WidgetTester tester, String ownerId) {
+    final tile = tester.widget<CheckboxListTile>(
+      find.byKey(Key('project_search_owner_filter_item_$ownerId')),
+    );
+    return tile.value == true;
+  }
+
+  group('User on ProjectSearchOwnerFilterSheet', () {
+    testWidgets('sees the sheet title and owners listed by full name', (
+      tester,
+    ) async {
+      await pumpAndOpenSheet(tester);
+
+      expect(find.byType(ProjectSearchOwnerFilterSheet), findsOneWidget);
+      expect(
+        find.descendant(
+          of: find.byType(ProjectSearchOwnerFilterSheet),
+          matching: find.text(l10n().projectSearchOwnerSheetTitle),
+        ),
+        findsOneWidget,
+      );
+      expect(find.text('Ada Lovelace'), findsOneWidget);
+      expect(find.text('Alan Turing'), findsOneWidget);
+    });
+
+    testWidgets('sees the empty label when no owners are available', (
+      tester,
+    ) async {
+      await pumpAndOpenSheet(tester, owners: const []);
+
+      expect(
+        find.byKey(const Key('project_search_owner_filter_empty_label')),
+        findsOneWidget,
+      );
+      expect(find.byType(CheckboxListTile), findsNothing);
+    });
+
+    testWidgets('filters the owner list by full name', (tester) async {
+      await pumpAndOpenSheet(tester);
+
+      await tester.enterText(
+        find.descendant(
+          of: find.byType(ProjectSearchOwnerFilterSheet),
+          matching: find.byType(TextFormField),
+        ),
+        'Ada',
+      );
+      await tester.pump();
+
+      expect(
+        find.byKey(const Key('project_search_owner_filter_item_owner-ada')),
+        findsOneWidget,
+      );
+      expect(
+        find.byKey(const Key('project_search_owner_filter_item_owner-alan')),
+        findsNothing,
+      );
+    });
+
+    testWidgets('toggles an owner checkbox on tap', (tester) async {
+      await pumpAndOpenSheet(tester);
+
+      expect(isOwnerChecked(tester, 'owner-ada'), isFalse);
+
+      await tester.tap(
+        find.byKey(const Key('project_search_owner_filter_item_owner-ada')),
+      );
+      await tester.pump();
+      expect(isOwnerChecked(tester, 'owner-ada'), isTrue);
+    });
+
+    testWidgets('pre-checks the initially selected owners', (tester) async {
+      await pumpAndOpenSheet(tester, initialSelectedOwnerIds: {'owner-alan'});
+
+      expect(isOwnerChecked(tester, 'owner-alan'), isTrue);
+      expect(isOwnerChecked(tester, 'owner-ada'), isFalse);
+    });
+
+    testWidgets(
+      'Apply dispatches the selection to the bloc and closes the sheet',
+      (tester) async {
+        await pumpAndOpenSheet(tester);
+
+        await tester.tap(
+          find.byKey(const Key('project_search_owner_filter_item_owner-ada')),
+        );
+        await tester.pump();
+        await tester.tap(
+          find.byKey(const Key('project_search_owner_filter_apply_button')),
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.byType(ProjectSearchOwnerFilterSheet), findsNothing);
+        final state = bloc.state;
+        expect(state, isA<ProjectSearchInitial>());
+        expect((state as ProjectSearchInitial).selectedOwnerIds, {'owner-ada'});
+      },
+    );
+
+    testWidgets('Clear all deselects every owner without closing the sheet', (
+      tester,
+    ) async {
+      await pumpAndOpenSheet(tester);
+
+      await tester.tap(
+        find.byKey(const Key('project_search_owner_filter_item_owner-ada')),
+      );
+      await tester.pump();
+      expect(isOwnerChecked(tester, 'owner-ada'), isTrue);
+
+      await tester.tap(
+        find.byKey(const Key('project_search_owner_filter_clear_all_button')),
+      );
+      await tester.pump();
+
+      expect(find.byType(ProjectSearchOwnerFilterSheet), findsOneWidget);
+      expect(isOwnerChecked(tester, 'owner-ada'), isFalse);
+    });
+  });
+}

--- a/test/features/dashboard/widgets/project_search_tags_filter_sheet_test.dart
+++ b/test/features/dashboard/widgets/project_search_tags_filter_sheet_test.dart
@@ -1,0 +1,252 @@
+import 'package:construculator/app/app_bootstrap.dart';
+import 'package:construculator/features/dashboard/dashboard_module.dart';
+import 'package:construculator/features/dashboard/presentation/bloc/project_search_bloc/project_search_bloc.dart';
+import 'package:construculator/features/dashboard/presentation/widgets/project_search_tags_filter_sheet.dart';
+import 'package:construculator/l10n/generated/app_localizations.dart';
+import 'package:construculator/libraries/supabase/database_constants.dart';
+import 'package:construculator/libraries/supabase/interfaces/supabase_wrapper.dart';
+import 'package:construculator/libraries/supabase/testing/fake_supabase_user.dart';
+import 'package:construculator/libraries/supabase/testing/fake_supabase_wrapper.dart';
+import 'package:construculator/libraries/time/testing/fake_clock_impl.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_modular/flutter_modular.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:ripplearc_coreui/ripplearc_coreui.dart';
+
+import '../../../utils/fake_app_bootstrap_factory.dart';
+import '../../../utils/screenshot/font_loader.dart';
+
+class _TagsFilterSheetTestModule extends Module {
+  final AppBootstrap appBootstrap;
+
+  _TagsFilterSheetTestModule(this.appBootstrap);
+
+  @override
+  List<Module> get imports => [DashboardModule(appBootstrap)];
+}
+
+void main() {
+  late FakeSupabaseWrapper fakeSupabase;
+  late ProjectSearchBloc bloc;
+  BuildContext? buildContext;
+
+  setUp(() {
+    final bootstrap = FakeAppBootstrapFactory.create(
+      supabaseWrapper: FakeSupabaseWrapper(clock: FakeClockImpl()),
+    );
+    Modular.init(_TagsFilterSheetTestModule(bootstrap));
+    fakeSupabase = Modular.get<SupabaseWrapper>() as FakeSupabaseWrapper;
+    fakeSupabase.setCurrentUser(
+      FakeUser(
+        id: 'user-1',
+        email: 'user@test.com',
+        createdAt: DateTime(2024).toIso8601String(),
+      ),
+    );
+  });
+
+  tearDown(() {
+    bloc.close();
+    fakeSupabase.reset();
+    Modular.destroy();
+  });
+
+  AppLocalizations l10n() => AppLocalizations.of(buildContext!)!;
+
+  void seedTags(List<String> names) {
+    fakeSupabase.addTableData(
+      DatabaseConstants.tagsTable,
+      names
+          .map(
+            (name) => <String, dynamic>{
+              DatabaseConstants.idColumn: 'tag-$name',
+              DatabaseConstants.nameColumn: name,
+            },
+          )
+          .toList(),
+    );
+  }
+
+  /// Pumps a host page whose button opens [ProjectSearchTagsFilterSheet] via
+  /// [CoreQuickSheet], mirroring how the production page presents the sheet.
+  Future<void> pumpAndOpenSheet(
+    WidgetTester tester, {
+    List<String> tags = const ['Roofing', 'Carpeting', 'Flooring', 'Wall'],
+    Set<String> initialSelectedTags = const {},
+  }) async {
+    // Create the bloc inside the test zone: a bloc created in setUp lives
+    // outside the fake-async zone and its awaits never resume under pump.
+    bloc = Modular.get<ProjectSearchBloc>();
+    seedTags(tags);
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: createTestTheme(),
+        locale: const Locale('en'),
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Builder(
+          builder: (context) {
+            buildContext = context;
+            return Scaffold(
+              body: Center(
+                child: CoreFilterChip(
+                  key: const Key('open_sheet_button'),
+                  label: 'open',
+                  onTap: () {
+                    bloc.add(const ProjectSearchAvailableTagsRequestedEvent());
+                    CoreQuickSheet.show(
+                      context: context,
+                      child: BlocProvider.value(
+                        value: bloc,
+                        child: ProjectSearchTagsFilterSheet(
+                          initialSelectedTags: initialSelectedTags,
+                        ),
+                      ),
+                    );
+                  },
+                ),
+              ),
+            );
+          },
+        ),
+      ),
+    );
+    await tester.tap(find.byKey(const Key('open_sheet_button')));
+    await tester.pumpAndSettle();
+  }
+
+  bool isTagChecked(WidgetTester tester, String tag) {
+    final tile = tester.widget<CheckboxListTile>(
+      find.byKey(Key('project_search_tag_filter_item_$tag')),
+    );
+    return tile.value == true;
+  }
+
+  group('User on ProjectSearchTagsFilterSheet', () {
+    testWidgets('sees the sheet title and the available tag list', (
+      tester,
+    ) async {
+      await pumpAndOpenSheet(tester);
+
+      expect(find.byType(ProjectSearchTagsFilterSheet), findsOneWidget);
+      expect(
+        find.descendant(
+          of: find.byType(ProjectSearchTagsFilterSheet),
+          matching: find.text(l10n().projectSearchTagsSheetTitle),
+        ),
+        findsOneWidget,
+      );
+      expect(
+        find.byKey(const Key('project_search_tag_filter_item_Roofing')),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('sees the empty label when no tags are available', (
+      tester,
+    ) async {
+      await pumpAndOpenSheet(tester, tags: const []);
+
+      expect(
+        find.byKey(const Key('project_search_tags_filter_empty_label')),
+        findsOneWidget,
+      );
+      expect(find.byType(CheckboxListTile), findsNothing);
+    });
+
+    testWidgets('filters the tag list when typing a search query', (
+      tester,
+    ) async {
+      await pumpAndOpenSheet(tester);
+
+      await tester.enterText(
+        find.descendant(
+          of: find.byType(ProjectSearchTagsFilterSheet),
+          matching: find.byType(TextFormField),
+        ),
+        'Roof',
+      );
+      await tester.pump();
+
+      expect(
+        find.byKey(const Key('project_search_tag_filter_item_Roofing')),
+        findsOneWidget,
+      );
+      expect(
+        find.byKey(const Key('project_search_tag_filter_item_Wall')),
+        findsNothing,
+      );
+    });
+
+    testWidgets('toggles a tag checkbox on tap', (tester) async {
+      await pumpAndOpenSheet(tester);
+
+      expect(isTagChecked(tester, 'Roofing'), isFalse);
+
+      await tester.tap(
+        find.byKey(const Key('project_search_tag_filter_item_Roofing')),
+      );
+      await tester.pump();
+      expect(isTagChecked(tester, 'Roofing'), isTrue);
+
+      await tester.tap(
+        find.byKey(const Key('project_search_tag_filter_item_Roofing')),
+      );
+      await tester.pump();
+      expect(isTagChecked(tester, 'Roofing'), isFalse);
+    });
+
+    testWidgets('pre-checks the initially selected tags', (tester) async {
+      await pumpAndOpenSheet(tester, initialSelectedTags: {'Wall'});
+
+      expect(isTagChecked(tester, 'Wall'), isTrue);
+      expect(isTagChecked(tester, 'Roofing'), isFalse);
+    });
+
+    testWidgets(
+      'Apply dispatches the selection to the bloc and closes the sheet',
+      (tester) async {
+        await pumpAndOpenSheet(tester);
+
+        await tester.tap(
+          find.byKey(const Key('project_search_tag_filter_item_Roofing')),
+        );
+        await tester.pump();
+        await tester.tap(
+          find.byKey(const Key('project_search_tags_filter_apply_button')),
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.byType(ProjectSearchTagsFilterSheet), findsNothing);
+        final state = bloc.state;
+        expect(state, isA<ProjectSearchInitial>());
+        expect((state as ProjectSearchInitial).selectedTags, {'Roofing'});
+      },
+    );
+
+    testWidgets('Clear all deselects every tag without closing the sheet', (
+      tester,
+    ) async {
+      await pumpAndOpenSheet(tester);
+
+      await tester.tap(
+        find.byKey(const Key('project_search_tag_filter_item_Roofing')),
+      );
+      await tester.pump();
+      await tester.tap(
+        find.byKey(const Key('project_search_tag_filter_item_Wall')),
+      );
+      await tester.pump();
+
+      await tester.tap(
+        find.byKey(const Key('project_search_tags_filter_clear_all_button')),
+      );
+      await tester.pump();
+
+      expect(find.byType(ProjectSearchTagsFilterSheet), findsOneWidget);
+      expect(isTagChecked(tester, 'Roofing'), isFalse);
+      expect(isTagChecked(tester, 'Wall'), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
# PR Review: CA-771c-feat/project-search-filter-sheets → CA-771b-feat/project-search-filter-bloc

## 📝 PR Description

Adds the two filter bottom sheets for CA-771: `ProjectSearchTagsFilterSheet` and the new `ProjectSearchOwnerFilterSheet` (no owner sheet existed anywhere — the ticket's "reuse Owner filter sheet UI" was aspirational; `GlobalSearchBloc` has owner events/state but never rendered a sheet). Both are thin stateless wrappers over the shared `MultiSelectFilterSheet` from `libraries/search_filters` (extracted in CA-771a from the global-search Tags sheet): each wrapper binds `ProjectSearchBloc` state/events and supplies its own l10n strings and widget keys, while the shared sheet owns the layout, local selection until Apply, in-sheet search field, and loading/empty/list states. The page chips that open these sheets land in (4/4).

**Type:** Feature ·
**Size:** S (≈185 production lines after the dedup rewrite; was 385 as hand-built sheets) ·
**Rules applied:** Digestible PR, Naming & Abstraction, CoreUI Components, UI/Business Separation, Self-Documenting Code, Localization, Widget Test Finders, Test Double Pattern, Accessibility

### What changed
- `project_search_tags_filter_sheet.dart` / `project_search_owner_filter_sheet.dart` under the dashboard feature (matching how CA-689/690 keep project-search widgets feature-local)
- Both sheets rewritten (follow-up dedup commit) as stateless wrappers over the shared `MultiSelectFilterSheet` — `BlocBuilder` + event dispatch + keys/strings only; no duplicated layout/list/button code with `GlobalSearchTagsFilterSheet`. All widget keys and behavior preserved (the 14 existing widget tests pass unchanged)
- Owners render by `UserProfile.fullName`, select by `id`
- 10 sheet-scoped l10n keys (`projectSearchTagsSheet*`, `projectSearchOwnerSheet*`)
- 14 standalone widget tests hosting each sheet via `CoreQuickSheet` + `BlocProvider.value` (production-faithful): render, empty label, in-sheet search filtering, toggle, pre-check of initial selection, Apply-dispatches-and-closes, Clear-all-keeps-sheet-open

---

## 🔍 Review Summary

> Found 1 issue(s): 0 🔴 critical · 1 🟠 major · 0 🟡 minor · 0 🔵 suggestion — across 2 file(s).

| # | Issue | Severity | Location | Description | Suggested Fix | Status | Notes |
|---|-------|----------|----------|-------------|---------------|--------|-------|
| 1 | Sheets duplicated `GlobalSearchTagsFilterSheet` near-verbatim | 🟠 Major | `project_search_tags_filter_sheet.dart`, `project_search_owner_filter_sheet.dart` | The tags sheet was a ~95% copy of the global-search sheet (only bloc/event/state names and keys differed); the owner sheet shared the same scaffold. Cross-feature imports are forbidden, so reuse must go through `libraries/`. | Extract a shared multi-select sheet into `libraries/search_filters` and wrap it per feature. | ✅ Addressed | Fixed by the shared `MultiSelectFilterSheet` extraction in CA-771a + the wrapper rewrite commit in this PR. |

**Status (author fills):** ✅ Addressed · 📋 Future Story (add YouTrack ID) ·
❌ Disagree (justify) · 🔄 In Progress

Notes for reviewers:
- `CheckboxListTile` follows the shipped `GlobalSearchTagsFilterSheet` precedent (no CoreUI checkbox-list component exists); it now lives once, inside the shared `MultiSelectFilterSheet`.
- Test-harness note: the sheets' blocs must be created **inside** the `testWidgets` zone (not `setUp`) — a bloc created outside the fake-async zone never resumes its awaits under `pump`, leaving the sheet stuck on the loading indicator. The harness documents this.

<!-- Skipped: Stream Lifecycle (no stream-owning code), Unit Test Behavior (bloc-level tests live in 2/4), Mutation Testing (no logic-heavy code — sheets are presentation), Sentry Logging (no AppLogger usage) -->
