### PR TITLE
CA-309: wire item type field to enable save button across all three tabs

### DIFF
--- a/lib/features/estimation/presentation/pages/cost_item_form_screen.dart
+++ b/lib/features/estimation/presentation/pages/cost_item_form_screen.dart
@@ -27,6 +27,7 @@ class CostItemFormScreen extends StatefulWidget {
 class _CostItemFormScreenState extends State<CostItemFormScreen> {
   bool _fromCostFile = false;
   double _total = 0;
+  bool _canSave = false;
 
   @override
   Widget build(BuildContext context) {
@@ -138,15 +139,19 @@ class _CostItemFormScreenState extends State<CostItemFormScreen> {
 
   Widget _buildFormFields() {
     void onTotalChanged(double total) => setState(() => _total = total);
+    void onSaveEnabledChanged(bool enabled) =>
+        setState(() => _canSave = enabled);
     return switch (widget.type) {
       CostItemType.material => MaterialCostFormFields(fromCostFile: _fromCostFile),
       CostItemType.labor => LabourCostFormFields(
           fromCostFile: _fromCostFile,
           onTotalChanged: onTotalChanged,
+          onSaveEnabledChanged: onSaveEnabledChanged,
         ),
       CostItemType.equipment => EquipmentCostFormFields(
           fromCostFile: _fromCostFile,
           onTotalChanged: onTotalChanged,
+          onSaveEnabledChanged: onSaveEnabledChanged,
         ),
     };
   }
@@ -198,7 +203,7 @@ class _CostItemFormScreenState extends State<CostItemFormScreen> {
             CoreButton(
               key: const Key('add_to_cost_button'),
               label: l10n.addToCostButton,
-              isDisabled: true,
+              isDisabled: !_canSave,
               fullWidth: false,
               onPressed: () {},
             ),

--- a/lib/features/estimation/presentation/pages/cost_item_form_screen.dart
+++ b/lib/features/estimation/presentation/pages/cost_item_form_screen.dart
@@ -142,7 +142,11 @@ class _CostItemFormScreenState extends State<CostItemFormScreen> {
     void onSaveEnabledChanged(bool enabled) =>
         setState(() => _canSave = enabled);
     return switch (widget.type) {
-      CostItemType.material => MaterialCostFormFields(fromCostFile: _fromCostFile),
+      CostItemType.material => MaterialCostFormFields(
+          fromCostFile: _fromCostFile,
+          onTotalChanged: onTotalChanged,
+          onSaveEnabledChanged: onSaveEnabledChanged,
+        ),
       CostItemType.labor => LabourCostFormFields(
           fromCostFile: _fromCostFile,
           onTotalChanged: onTotalChanged,

--- a/lib/features/estimation/presentation/widgets/equipment_cost_form_fields.dart
+++ b/lib/features/estimation/presentation/widgets/equipment_cost_form_fields.dart
@@ -41,6 +41,7 @@ class _EquipmentCostFormFieldsState extends State<EquipmentCostFormFields> {
       WidgetsBinding.instance.addPostFrameCallback((_) {
         if (!mounted) return;
         _notifyTotal();
+        _notifySaveEnabled();
       });
     }
   }
@@ -53,10 +54,15 @@ class _EquipmentCostFormFieldsState extends State<EquipmentCostFormFields> {
     super.dispose();
   }
 
-  void _notifySaveEnabled() =>
-      widget.onSaveEnabledChanged?.call(
-        _equipmentNameController.text.trim().isNotEmpty,
-      );
+  void _notifySaveEnabled() {
+    if (widget.fromCostFile) {
+      widget.onSaveEnabledChanged?.call(false);
+      return;
+    }
+    widget.onSaveEnabledChanged?.call(
+      _equipmentNameController.text.trim().isNotEmpty,
+    );
+  }
 
   // TODO: [CA-355] Move total calculation into BLoC when submission is wired
   void _notifyTotal() {

--- a/lib/features/estimation/presentation/widgets/equipment_cost_form_fields.dart
+++ b/lib/features/estimation/presentation/widgets/equipment_cost_form_fields.dart
@@ -7,11 +7,13 @@ class EquipmentCostFormFields extends StatefulWidget {
   /// When true, renders fields for selecting from a cost file; otherwise renders manual-entry fields.
   final bool fromCostFile;
   final ValueChanged<double>? onTotalChanged;
+  final ValueChanged<bool>? onSaveEnabledChanged;
 
   const EquipmentCostFormFields({
     super.key,
     required this.fromCostFile,
     this.onTotalChanged,
+    this.onSaveEnabledChanged,
   });
 
   @override
@@ -27,6 +29,7 @@ class _EquipmentCostFormFieldsState extends State<EquipmentCostFormFields> {
   @override
   void initState() {
     super.initState();
+    _equipmentNameController.addListener(_notifySaveEnabled);
     _unitPriceController.addListener(_notifyTotal);
     _quantityController.addListener(_notifyTotal);
   }
@@ -49,6 +52,11 @@ class _EquipmentCostFormFieldsState extends State<EquipmentCostFormFields> {
     _quantityController.dispose();
     super.dispose();
   }
+
+  void _notifySaveEnabled() =>
+      widget.onSaveEnabledChanged?.call(
+        _equipmentNameController.text.trim().isNotEmpty,
+      );
 
   // TODO: [CA-355] Move total calculation into BLoC when submission is wired
   void _notifyTotal() {

--- a/lib/features/estimation/presentation/widgets/equipment_cost_form_fields.dart
+++ b/lib/features/estimation/presentation/widgets/equipment_cost_form_fields.dart
@@ -54,6 +54,7 @@ class _EquipmentCostFormFieldsState extends State<EquipmentCostFormFields> {
     super.dispose();
   }
 
+  // TODO: [CA-800] Fold into shared mixin/base alongside _notifyTotal
   void _notifySaveEnabled() {
     if (widget.fromCostFile) {
       widget.onSaveEnabledChanged?.call(false);

--- a/lib/features/estimation/presentation/widgets/equipment_cost_form_fields.dart
+++ b/lib/features/estimation/presentation/widgets/equipment_cost_form_fields.dart
@@ -54,7 +54,7 @@ class _EquipmentCostFormFieldsState extends State<EquipmentCostFormFields> {
     super.dispose();
   }
 
-  // TODO: [CA-800] Fold into shared mixin/base alongside _notifyTotal
+  // TODO: [CA-800] Fold into shared mixin/base alongside _notifyTotal https://ripplearc.youtrack.cloud/issue/CA-800
   void _notifySaveEnabled() {
     if (widget.fromCostFile) {
       widget.onSaveEnabledChanged?.call(false);

--- a/lib/features/estimation/presentation/widgets/labour_cost_form_fields.dart
+++ b/lib/features/estimation/presentation/widgets/labour_cost_form_fields.dart
@@ -59,7 +59,7 @@ class _LabourCostFormFieldsState extends State<LabourCostFormFields> {
     super.dispose();
   }
 
-  // TODO: [CA-800] Fold into shared mixin/base alongside _notifyTotal
+  // TODO: [CA-800] Fold into shared mixin/base alongside _notifyTotal https://ripplearc.youtrack.cloud/issue/CA-800
   void _notifySaveEnabled() {
     if (widget.fromCostFile) {
       widget.onSaveEnabledChanged?.call(false);

--- a/lib/features/estimation/presentation/widgets/labour_cost_form_fields.dart
+++ b/lib/features/estimation/presentation/widgets/labour_cost_form_fields.dart
@@ -45,6 +45,7 @@ class _LabourCostFormFieldsState extends State<LabourCostFormFields> {
       WidgetsBinding.instance.addPostFrameCallback((_) {
         if (!mounted) return;
         _notifyTotal();
+        _notifySaveEnabled();
       });
     }
   }
@@ -58,10 +59,15 @@ class _LabourCostFormFieldsState extends State<LabourCostFormFields> {
     super.dispose();
   }
 
-  void _notifySaveEnabled() =>
-      widget.onSaveEnabledChanged?.call(
-        _labourTypeController.text.trim().isNotEmpty,
-      );
+  void _notifySaveEnabled() {
+    if (widget.fromCostFile) {
+      widget.onSaveEnabledChanged?.call(false);
+      return;
+    }
+    widget.onSaveEnabledChanged?.call(
+      _labourTypeController.text.trim().isNotEmpty,
+    );
+  }
 
   // TODO: [CA-355] Move total calculation into BLoC when submission is wired
   void _notifyTotal() {

--- a/lib/features/estimation/presentation/widgets/labour_cost_form_fields.dart
+++ b/lib/features/estimation/presentation/widgets/labour_cost_form_fields.dart
@@ -9,11 +9,13 @@ class LabourCostFormFields extends StatefulWidget {
   /// When true, renders fields for selecting from a cost file; otherwise renders manual-entry fields.
   final bool fromCostFile;
   final ValueChanged<double>? onTotalChanged;
+  final ValueChanged<bool>? onSaveEnabledChanged;
 
   const LabourCostFormFields({
     super.key,
     required this.fromCostFile,
     this.onTotalChanged,
+    this.onSaveEnabledChanged,
   });
 
   @override
@@ -30,6 +32,7 @@ class _LabourCostFormFieldsState extends State<LabourCostFormFields> {
   @override
   void initState() {
     super.initState();
+    _labourTypeController.addListener(_notifySaveEnabled);
     _crewRateController.addListener(_notifyTotal);
     _conditionalValueController.addListener(_notifyTotal);
     _crewSizeController.addListener(_notifyTotal);
@@ -54,6 +57,11 @@ class _LabourCostFormFieldsState extends State<LabourCostFormFields> {
     _crewSizeController.dispose();
     super.dispose();
   }
+
+  void _notifySaveEnabled() =>
+      widget.onSaveEnabledChanged?.call(
+        _labourTypeController.text.trim().isNotEmpty,
+      );
 
   // TODO: [CA-355] Move total calculation into BLoC when submission is wired
   void _notifyTotal() {

--- a/lib/features/estimation/presentation/widgets/labour_cost_form_fields.dart
+++ b/lib/features/estimation/presentation/widgets/labour_cost_form_fields.dart
@@ -59,6 +59,7 @@ class _LabourCostFormFieldsState extends State<LabourCostFormFields> {
     super.dispose();
   }
 
+  // TODO: [CA-800] Fold into shared mixin/base alongside _notifyTotal
   void _notifySaveEnabled() {
     if (widget.fromCostFile) {
       widget.onSaveEnabledChanged?.call(false);

--- a/lib/features/estimation/presentation/widgets/material_cost_form_fields.dart
+++ b/lib/features/estimation/presentation/widgets/material_cost_form_fields.dart
@@ -56,6 +56,7 @@ class _MaterialCostFormFieldsState extends State<MaterialCostFormFields> {
     super.dispose();
   }
 
+  // TODO: [CA-800] Fold into shared mixin/base alongside _notifyTotal
   void _notifySaveEnabled() {
     if (widget.fromCostFile) {
       widget.onSaveEnabledChanged?.call(false);

--- a/lib/features/estimation/presentation/widgets/material_cost_form_fields.dart
+++ b/lib/features/estimation/presentation/widgets/material_cost_form_fields.dart
@@ -42,6 +42,7 @@ class _MaterialCostFormFieldsState extends State<MaterialCostFormFields> {
       WidgetsBinding.instance.addPostFrameCallback((_) {
         if (!mounted) return;
         _notifyTotal();
+        _notifySaveEnabled();
       });
     }
   }
@@ -55,10 +56,15 @@ class _MaterialCostFormFieldsState extends State<MaterialCostFormFields> {
     super.dispose();
   }
 
-  void _notifySaveEnabled() =>
-      widget.onSaveEnabledChanged?.call(
-        _materialTypeController.text.trim().isNotEmpty,
-      );
+  void _notifySaveEnabled() {
+    if (widget.fromCostFile) {
+      widget.onSaveEnabledChanged?.call(false);
+      return;
+    }
+    widget.onSaveEnabledChanged?.call(
+      _materialTypeController.text.trim().isNotEmpty,
+    );
+  }
 
   // TODO: [CA-355] Move total calculation into BLoC when submission is wired
   void _notifyTotal() {

--- a/lib/features/estimation/presentation/widgets/material_cost_form_fields.dart
+++ b/lib/features/estimation/presentation/widgets/material_cost_form_fields.dart
@@ -56,7 +56,7 @@ class _MaterialCostFormFieldsState extends State<MaterialCostFormFields> {
     super.dispose();
   }
 
-  // TODO: [CA-800] Fold into shared mixin/base alongside _notifyTotal
+  // TODO: [CA-800] Fold into shared mixin/base alongside _notifyTotal https://ripplearc.youtrack.cloud/issue/CA-800
   void _notifySaveEnabled() {
     if (widget.fromCostFile) {
       widget.onSaveEnabledChanged?.call(false);

--- a/lib/features/estimation/presentation/widgets/material_cost_form_fields.dart
+++ b/lib/features/estimation/presentation/widgets/material_cost_form_fields.dart
@@ -7,11 +7,13 @@ class MaterialCostFormFields extends StatefulWidget {
   /// When true, renders fields for selecting from a cost file; otherwise renders manual-entry fields.
   final bool fromCostFile;
   final ValueChanged<double>? onTotalChanged;
+  final ValueChanged<bool>? onSaveEnabledChanged;
 
   const MaterialCostFormFields({
     super.key,
     required this.fromCostFile,
     this.onTotalChanged,
+    this.onSaveEnabledChanged,
   });
 
   @override
@@ -28,6 +30,7 @@ class _MaterialCostFormFieldsState extends State<MaterialCostFormFields> {
   @override
   void initState() {
     super.initState();
+    _materialTypeController.addListener(_notifySaveEnabled);
     _perUnitCostController.addListener(_notifyTotal);
     _quantityController.addListener(_notifyTotal);
   }
@@ -51,6 +54,11 @@ class _MaterialCostFormFieldsState extends State<MaterialCostFormFields> {
     _productLinkController.dispose();
     super.dispose();
   }
+
+  void _notifySaveEnabled() =>
+      widget.onSaveEnabledChanged?.call(
+        _materialTypeController.text.trim().isNotEmpty,
+      );
 
   // TODO: [CA-355] Move total calculation into BLoC when submission is wired
   void _notifyTotal() {

--- a/test/features/estimations/widgets/equipment_cost_form_fields_test.dart
+++ b/test/features/estimations/widgets/equipment_cost_form_fields_test.dart
@@ -12,6 +12,7 @@ void main() {
   Widget makeWidget({
     bool fromCostFile = false,
     ValueChanged<double>? onTotalChanged,
+    ValueChanged<bool>? onSaveEnabledChanged,
   }) {
     return MaterialApp(
       theme: CoreTheme.light(),
@@ -22,6 +23,7 @@ void main() {
         body: EquipmentCostFormFields(
           fromCostFile: fromCostFile,
           onTotalChanged: onTotalChanged,
+          onSaveEnabledChanged: onSaveEnabledChanged,
         ),
       ),
     );
@@ -98,6 +100,77 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.byKey(const Key('unit_price_field')), findsNothing);
+    });
+  });
+
+  group('EquipmentCostFormFields — save enabled', () {
+    testWidgets('calls onSaveEnabledChanged(false) initially', (tester) async {
+      bool? captured;
+      await tester.pumpWidget(
+        makeWidget(onSaveEnabledChanged: (v) => captured = v),
+      );
+      await tester.pumpAndSettle();
+
+      expect(captured, isNull);
+    });
+
+    testWidgets(
+        'calls onSaveEnabledChanged(true) when equipment name has text', (
+      tester,
+    ) async {
+      bool? captured;
+      await tester.pumpWidget(
+        makeWidget(onSaveEnabledChanged: (v) => captured = v),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.enterText(
+        find.byKey(const Key('equipment_name_field')),
+        'Backhoe',
+      );
+      await tester.pump();
+
+      expect(captured, isTrue);
+    });
+
+    testWidgets(
+        'calls onSaveEnabledChanged(false) when equipment name is cleared', (
+      tester,
+    ) async {
+      bool? captured;
+      await tester.pumpWidget(
+        makeWidget(onSaveEnabledChanged: (v) => captured = v),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.enterText(
+        find.byKey(const Key('equipment_name_field')),
+        'Backhoe',
+      );
+      await tester.pump();
+      await tester.enterText(
+        find.byKey(const Key('equipment_name_field')),
+        '',
+      );
+      await tester.pump();
+
+      expect(captured, isFalse);
+    });
+
+    testWidgets(
+        'does not call onSaveEnabledChanged in from cost file mode', (
+      tester,
+    ) async {
+      bool? captured;
+      await tester.pumpWidget(
+        makeWidget(
+          fromCostFile: true,
+          onSaveEnabledChanged: (v) => captured = v,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(captured, isNull);
     });
   });
 

--- a/test/features/estimations/widgets/equipment_cost_form_fields_test.dart
+++ b/test/features/estimations/widgets/equipment_cost_form_fields_test.dart
@@ -172,6 +172,31 @@ void main() {
 
       expect(captured, isNull);
     });
+
+    testWidgets(
+        'calls onSaveEnabledChanged(false) when switching to from cost file mode after typing', (
+      tester,
+    ) async {
+      bool? captured;
+      await tester.pumpWidget(
+        makeWidget(onSaveEnabledChanged: (v) => captured = v),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.enterText(
+        find.byKey(const Key('equipment_name_field')),
+        'Backhoe',
+      );
+      await tester.pump();
+      expect(captured, isTrue);
+
+      await tester.pumpWidget(
+        makeWidget(fromCostFile: true, onSaveEnabledChanged: (v) => captured = v),
+      );
+      await tester.pump();
+
+      expect(captured, isFalse);
+    });
   });
 
   group('EquipmentCostFormFields — real-time total', () {

--- a/test/features/estimations/widgets/labour_cost_form_fields_test.dart
+++ b/test/features/estimations/widgets/labour_cost_form_fields_test.dart
@@ -220,6 +220,31 @@ void main() {
 
       expect(captured, isNull);
     });
+
+    testWidgets(
+        'calls onSaveEnabledChanged(false) when switching to from cost file mode after typing', (
+      tester,
+    ) async {
+      bool? captured;
+      await tester.pumpWidget(
+        makeWidget(onSaveEnabledChanged: (v) => captured = v),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.enterText(
+        find.byKey(const Key('labour_type_field')),
+        'Mason',
+      );
+      await tester.pump();
+      expect(captured, isTrue);
+
+      await tester.pumpWidget(
+        makeWidget(fromCostFile: true, onSaveEnabledChanged: (v) => captured = v),
+      );
+      await tester.pump();
+
+      expect(captured, isFalse);
+    });
   });
 
   group('LabourCostFormFields — real-time total', () {

--- a/test/features/estimations/widgets/labour_cost_form_fields_test.dart
+++ b/test/features/estimations/widgets/labour_cost_form_fields_test.dart
@@ -15,6 +15,7 @@ void main() {
   Widget makeWidget({
     bool fromCostFile = false,
     ValueChanged<double>? onTotalChanged,
+    ValueChanged<bool>? onSaveEnabledChanged,
   }) {
     return MaterialApp(
       theme: CoreTheme.light(),
@@ -25,6 +26,7 @@ void main() {
         body: LabourCostFormFields(
           fromCostFile: fromCostFile,
           onTotalChanged: onTotalChanged,
+          onSaveEnabledChanged: onSaveEnabledChanged,
         ),
       ),
     );
@@ -150,6 +152,73 @@ void main() {
       final perDay = tester.getSemantics(find.byKey(const Key('per_day_option')));
       expect(perHours.hasFlag(SemanticsFlag.isSelected), isTrue);
       expect(perDay.hasFlag(SemanticsFlag.isSelected), isFalse);
+    });
+  });
+
+  group('LabourCostFormFields — save enabled', () {
+    testWidgets('calls onSaveEnabledChanged(false) initially', (tester) async {
+      bool? captured;
+      await tester.pumpWidget(
+        makeWidget(onSaveEnabledChanged: (v) => captured = v),
+      );
+      await tester.pumpAndSettle();
+
+      expect(captured, isNull);
+    });
+
+    testWidgets('calls onSaveEnabledChanged(true) when labour type has text', (
+      tester,
+    ) async {
+      bool? captured;
+      await tester.pumpWidget(
+        makeWidget(onSaveEnabledChanged: (v) => captured = v),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.enterText(
+        find.byKey(const Key('labour_type_field')),
+        'Mason',
+      );
+      await tester.pump();
+
+      expect(captured, isTrue);
+    });
+
+    testWidgets(
+        'calls onSaveEnabledChanged(false) when labour type is cleared', (
+      tester,
+    ) async {
+      bool? captured;
+      await tester.pumpWidget(
+        makeWidget(onSaveEnabledChanged: (v) => captured = v),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.enterText(
+        find.byKey(const Key('labour_type_field')),
+        'Mason',
+      );
+      await tester.pump();
+      await tester.enterText(find.byKey(const Key('labour_type_field')), '');
+      await tester.pump();
+
+      expect(captured, isFalse);
+    });
+
+    testWidgets(
+        'does not call onSaveEnabledChanged in from cost file mode', (
+      tester,
+    ) async {
+      bool? captured;
+      await tester.pumpWidget(
+        makeWidget(
+          fromCostFile: true,
+          onSaveEnabledChanged: (v) => captured = v,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(captured, isNull);
     });
   });
 

--- a/test/features/estimations/widgets/material_cost_form_fields_test.dart
+++ b/test/features/estimations/widgets/material_cost_form_fields_test.dart
@@ -321,6 +321,31 @@ void main() {
 
       expect(captured, isNull);
     });
+
+    testWidgets(
+        'calls onSaveEnabledChanged(false) when switching to from cost file mode after typing', (
+      tester,
+    ) async {
+      bool? captured;
+      await tester.pumpWidget(
+        makeWidget(onSaveEnabledChanged: (v) => captured = v),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.enterText(
+        find.byKey(const Key('material_type_field')),
+        'Lap Sealant',
+      );
+      await tester.pump();
+      expect(captured, isTrue);
+
+      await tester.pumpWidget(
+        makeWidget(fromCostFile: true, onSaveEnabledChanged: (v) => captured = v),
+      );
+      await tester.pump();
+
+      expect(captured, isFalse);
+    });
   });
 
   group('MaterialCostFormFields — accessibility', () {

--- a/test/features/estimations/widgets/material_cost_form_fields_test.dart
+++ b/test/features/estimations/widgets/material_cost_form_fields_test.dart
@@ -14,6 +14,7 @@ void main() {
   Widget makeWidget({
     bool fromCostFile = false,
     ValueChanged<double>? onTotalChanged,
+    ValueChanged<bool>? onSaveEnabledChanged,
   }) {
     return MaterialApp(
       theme: CoreTheme.light(),
@@ -24,6 +25,7 @@ void main() {
         body: MaterialCostFormFields(
           fromCostFile: fromCostFile,
           onTotalChanged: onTotalChanged,
+          onSaveEnabledChanged: onSaveEnabledChanged,
         ),
       ),
     );
@@ -251,6 +253,73 @@ void main() {
       await tester.pump();
 
       expect(capturedTotal, 0.0);
+    });
+  });
+
+  group('MaterialCostFormFields — save enabled', () {
+    testWidgets('calls onSaveEnabledChanged(false) initially', (tester) async {
+      bool? captured;
+      await tester.pumpWidget(
+        makeWidget(onSaveEnabledChanged: (v) => captured = v),
+      );
+      await tester.pumpAndSettle();
+
+      expect(captured, isNull);
+    });
+
+    testWidgets('calls onSaveEnabledChanged(true) when material type has text', (
+      tester,
+    ) async {
+      bool? captured;
+      await tester.pumpWidget(
+        makeWidget(onSaveEnabledChanged: (v) => captured = v),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.enterText(
+        find.byKey(const Key('material_type_field')),
+        'Lap Sealant',
+      );
+      await tester.pump();
+
+      expect(captured, isTrue);
+    });
+
+    testWidgets(
+        'calls onSaveEnabledChanged(false) when material type is cleared', (
+      tester,
+    ) async {
+      bool? captured;
+      await tester.pumpWidget(
+        makeWidget(onSaveEnabledChanged: (v) => captured = v),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.enterText(
+        find.byKey(const Key('material_type_field')),
+        'Lap Sealant',
+      );
+      await tester.pump();
+      await tester.enterText(find.byKey(const Key('material_type_field')), '');
+      await tester.pump();
+
+      expect(captured, isFalse);
+    });
+
+    testWidgets(
+        'does not call onSaveEnabledChanged in from cost file mode', (
+      tester,
+    ) async {
+      bool? captured;
+      await tester.pumpWidget(
+        makeWidget(
+          fromCostFile: true,
+          onSaveEnabledChanged: (v) => captured = v,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(captured, isNull);
     });
   });
 

--- a/test/features/estimations/widgets/pages/cost_item_form_screen_test.dart
+++ b/test/features/estimations/widgets/pages/cost_item_form_screen_test.dart
@@ -219,6 +219,29 @@ void main() {
       expect(semantics.hasFlag(SemanticsFlag.isEnabled), isTrue);
     });
 
+    testWidgets(
+        'add to cost button disables after typing then switching to from cost file mode', (
+      tester,
+    ) async {
+      setUpAuthenticatedUser();
+      await pumpAppAtRoute(tester, materialRoute);
+
+      await tester.enterText(
+        find.byKey(const Key('material_type_field')),
+        'Lap Sealant',
+      );
+      await tester.pump();
+
+      await tester.tap(find.byKey(const Key('from_cost_file_pill')));
+      await tester.pump();
+      await tester.pump();
+
+      final semantics = tester.getSemantics(
+        find.byKey(const Key('add_to_cost_button')),
+      );
+      expect(semantics.hasFlag(SemanticsFlag.isEnabled), isFalse);
+    });
+
     testWidgets('displays total label', (tester) async {
       setUpAuthenticatedUser();
       await pumpAppAtRoute(tester, makeApp(), materialRoute);

--- a/test/features/estimations/widgets/pages/cost_item_form_screen_test.dart
+++ b/test/features/estimations/widgets/pages/cost_item_form_screen_test.dart
@@ -205,7 +205,7 @@ void main() {
       tester,
     ) async {
       setUpAuthenticatedUser();
-      await pumpAppAtRoute(tester, materialRoute);
+      await pumpAppAtRoute(tester, makeApp(), materialRoute);
 
       await tester.enterText(
         find.byKey(const Key('material_type_field')),
@@ -224,7 +224,7 @@ void main() {
       tester,
     ) async {
       setUpAuthenticatedUser();
-      await pumpAppAtRoute(tester, materialRoute);
+      await pumpAppAtRoute(tester, makeApp(), materialRoute);
 
       await tester.enterText(
         find.byKey(const Key('material_type_field')),

--- a/test/features/estimations/widgets/pages/cost_item_form_screen_test.dart
+++ b/test/features/estimations/widgets/pages/cost_item_form_screen_test.dart
@@ -181,14 +181,17 @@ void main() {
       expect(semantics.hasFlag(SemanticsFlag.isSelected), isTrue);
     });
 
-    testWidgets('displays add to cost button disabled', (tester) async {
+    testWidgets('add to cost button is present and disabled initially', (
+      tester,
+    ) async {
       setUpAuthenticatedUser();
       await pumpAppAtRoute(tester, makeApp(), materialRoute);
 
-      final button = tester.widget<CoreButton>(
+      expect(find.byKey(const Key('add_to_cost_button')), findsOneWidget);
+      final semantics = tester.getSemantics(
         find.byKey(const Key('add_to_cost_button')),
       );
-      expect(button.isDisabled, isTrue);
+      expect(semantics.hasFlag(SemanticsFlag.isEnabled), isFalse);
     });
 
     testWidgets('displays edit title button', (tester) async {
@@ -196,6 +199,24 @@ void main() {
       await pumpAppAtRoute(tester, makeApp(), materialRoute);
 
       expect(find.byKey(const Key('edit_title_button')), findsOneWidget);
+    });
+
+    testWidgets('add to cost button enables after entering material type', (
+      tester,
+    ) async {
+      setUpAuthenticatedUser();
+      await pumpAppAtRoute(tester, materialRoute);
+
+      await tester.enterText(
+        find.byKey(const Key('material_type_field')),
+        'Lap Sealant',
+      );
+      await tester.pump();
+
+      final semantics = tester.getSemantics(
+        find.byKey(const Key('add_to_cost_button')),
+      );
+      expect(semantics.hasFlag(SemanticsFlag.isEnabled), isTrue);
     });
 
     testWidgets('displays total label', (tester) async {


### PR DESCRIPTION
### 1. PR SUMMARY
Adds an `onSaveEnabledChanged(bool)` callback to `MaterialCostFormFields`, `LabourCostFormFields`, and `EquipmentCostFormFields`, driven by their existing item-type text controllers (`_materialTypeController`, `_labourTypeController`, `_equipmentNameController`). `CostItemFormScreen` consumes the callback to toggle `isDisabled` on the "Add to cost" button, replacing the previous always-disabled hardcode. Follows the same `onTotalChanged` callback pattern already established in these widgets.

### 2. REVIEW SUMMARY TABLE
No issues found.

## Test plan
- [ ] All 2658 tests pass (`fvm flutter test`)
- [ ] `fvm dart run custom_lint` reports no issues
- [ ] "Add to cost" button is disabled on initial render (item type field empty)
- [ ] "Add to cost" button enables after typing in the material/labour/equipment name field
- [ ] "Add to cost" button disables again if the field is cleared
- [ ] Button state is independent per form type (material vs labour vs equipment)