### PR TITLE
CA-310 (1/3): add CostItemRepository interface, impl, and module binding

### DIFF
--- a/lib/features/estimation/data/repositories/cost_item_repository_impl.dart
+++ b/lib/features/estimation/data/repositories/cost_item_repository_impl.dart
@@ -1,0 +1,64 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:construculator/features/estimation/data/data_source/interfaces/cost_item_data_source.dart';
+import 'package:construculator/features/estimation/data/models/cost_item_dto.dart';
+import 'package:construculator/features/estimation/domain/entities/cost_item_entity.dart';
+import 'package:construculator/features/estimation/domain/repositories/cost_item_repository.dart';
+import 'package:construculator/libraries/either/either.dart';
+import 'package:construculator/libraries/errors/failures.dart';
+import 'package:construculator/libraries/estimation/domain/estimation_error_type.dart';
+import 'package:construculator/libraries/logging/app_logger.dart';
+
+class CostItemRepositoryImpl implements CostItemRepository {
+  CostItemRepositoryImpl({required this.dataSource});
+
+  final CostItemDataSource dataSource;
+  static final _logger = AppLogger().tag('CostItemRepositoryImpl');
+
+  @override
+  Future<Either<Failure, CostItem>> createCostItem(CostItem item) async {
+    try {
+      final dto = CostItemDto.fromEntity(item);
+      final created = await dataSource.createCostItem(dto);
+      return Right(created.toEntity());
+    } catch (e) {
+      return _handleError(e, 'creating cost item');
+    }
+  }
+
+  Left<Failure, CostItem> _handleError(Object error, String operation) {
+    if (error is TimeoutException) {
+      _logger.error(
+        'Timeout error $operation: message=${error.message}, duration=${error.duration}',
+      );
+      return const Left(
+        EstimationFailure(errorType: EstimationErrorType.timeoutError),
+      );
+    } else if (error is SocketException) {
+      _logger.warning(
+        'Connection error $operation: message=${error.message}',
+      );
+      return const Left(
+        EstimationFailure(errorType: EstimationErrorType.connectionError),
+      );
+    } else if (error is FormatException) {
+      _logger.error(
+        'Parsing error $operation: message=${error.message}',
+      );
+      return const Left(
+        EstimationFailure(errorType: EstimationErrorType.parsingError),
+      );
+    } else if (error is TypeError) {
+      _logger.error('Parsing error $operation: ${error.toString()}');
+      return const Left(
+        EstimationFailure(errorType: EstimationErrorType.parsingError),
+      );
+    } else {
+      _logger.error('Unexpected error $operation: $error');
+      return const Left(
+        EstimationFailure(errorType: EstimationErrorType.unexpectedError),
+      );
+    }
+  }
+}

--- a/lib/features/estimation/domain/repositories/cost_item_repository.dart
+++ b/lib/features/estimation/domain/repositories/cost_item_repository.dart
@@ -1,0 +1,9 @@
+import 'package:construculator/features/estimation/domain/entities/cost_item_entity.dart';
+import 'package:construculator/libraries/either/interfaces/either.dart';
+import 'package:construculator/libraries/errors/failures.dart';
+
+/// Repository interface for cost item data operations.
+abstract class CostItemRepository {
+  /// Creates a new cost item and returns the persisted entity.
+  Future<Either<Failure, CostItem>> createCostItem(CostItem item);
+}

--- a/lib/features/estimation/estimation_module.dart
+++ b/lib/features/estimation/estimation_module.dart
@@ -4,7 +4,9 @@ import 'package:construculator/features/estimation/data/data_source/interfaces/c
 import 'package:construculator/features/estimation/data/data_source/remote_cost_estimation_log_data_source.dart';
 import 'package:construculator/features/estimation/data/data_source/remote_cost_item_data_source.dart';
 import 'package:construculator/features/estimation/data/repositories/cost_estimation_log_repository_impl.dart';
+import 'package:construculator/features/estimation/data/repositories/cost_item_repository_impl.dart';
 import 'package:construculator/features/estimation/domain/repositories/cost_estimation_log_repository.dart';
+import 'package:construculator/features/estimation/domain/repositories/cost_item_repository.dart';
 import 'package:construculator/features/estimation/domain/usecases/add_cost_estimation_usecase.dart';
 import 'package:construculator/features/estimation/presentation/bloc/add_cost_estimation_bloc/add_cost_estimation_bloc.dart';
 import 'package:construculator/features/estimation/presentation/bloc/change_lock_status_bloc/change_lock_status_bloc.dart';
@@ -92,6 +94,10 @@ class EstimationModule extends Module {
     i.addLazySingleton<CostEstimationLogRepository>(
       () => CostEstimationLogRepositoryImpl(dataSource: i.get()),
       config: BindConfig(onDispose: (repository) => repository.dispose()),
+    );
+
+    i.addLazySingleton<CostItemRepository>(
+      () => CostItemRepositoryImpl(dataSource: i.get()),
     );
 
     i.addLazySingleton<AddCostEstimationUseCase>(

--- a/lib/features/estimation/estimation_module.dart
+++ b/lib/features/estimation/estimation_module.dart
@@ -13,6 +13,9 @@ import 'package:construculator/features/estimation/presentation/bloc/change_lock
 import 'package:construculator/features/estimation/presentation/bloc/cost_estimation_list_bloc/cost_estimation_list_bloc.dart';
 import 'package:construculator/features/estimation/presentation/bloc/cost_estimation_log_bloc/cost_estimation_log_bloc.dart';
 import 'package:construculator/features/estimation/presentation/bloc/delete_cost_estimation_bloc/delete_cost_estimation_bloc.dart';
+import 'package:construculator/features/estimation/presentation/bloc/equipment_cost_form_bloc/equipment_cost_form_bloc.dart';
+import 'package:construculator/features/estimation/presentation/bloc/labour_cost_form_bloc/labour_cost_form_bloc.dart';
+import 'package:construculator/features/estimation/presentation/bloc/material_cost_form_bloc/material_cost_form_bloc.dart';
 import 'package:construculator/features/estimation/presentation/bloc/rename_estimation_bloc/rename_estimation_bloc.dart';
 import 'package:construculator/features/estimation/presentation/pages/cost_estimation_landing_page.dart';
 import 'package:construculator/libraries/auth/auth_library_module.dart';
@@ -139,6 +142,15 @@ class EstimationModule extends Module {
     );
     i.add<CostEstimationLogBloc>(
       () => CostEstimationLogBloc(repository: i.get()),
+    );
+    i.add<MaterialCostFormBloc>(
+      () => MaterialCostFormBloc(repository: i.get()),
+    );
+    i.add<LabourCostFormBloc>(
+      () => LabourCostFormBloc(repository: i.get()),
+    );
+    i.add<EquipmentCostFormBloc>(
+      () => EquipmentCostFormBloc(repository: i.get()),
     );
     i.addSingleton<EstimationTileProvider>(
       () => const EstimationTileProviderImpl(),

--- a/lib/features/estimation/estimation_routes_module.dart
+++ b/lib/features/estimation/estimation_routes_module.dart
@@ -1,6 +1,9 @@
 import 'package:construculator/app/app_bootstrap.dart';
 import 'package:construculator/features/estimation/domain/entities/cost_item_entity.dart';
 import 'package:construculator/features/estimation/estimation_module.dart';
+import 'package:construculator/features/estimation/presentation/bloc/equipment_cost_form_bloc/equipment_cost_form_bloc.dart';
+import 'package:construculator/features/estimation/presentation/bloc/labour_cost_form_bloc/labour_cost_form_bloc.dart';
+import 'package:construculator/features/estimation/presentation/bloc/material_cost_form_bloc/material_cost_form_bloc.dart';
 import 'package:construculator/features/estimation/presentation/pages/cost_estimation_details_page.dart';
 import 'package:construculator/features/estimation/presentation/pages/cost_item_form_screen.dart';
 import 'package:construculator/libraries/auth/auth_library_module.dart';
@@ -8,6 +11,7 @@ import 'package:construculator/libraries/auth/interfaces/auth_manager.dart';
 import 'package:construculator/libraries/router/guards/auth_guard.dart';
 import 'package:construculator/libraries/router/interfaces/app_router.dart';
 import 'package:construculator/libraries/router/routes/estimation_routes.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_modular/flutter_modular.dart';
 
 /// Modular module owning Tier-1 (full-screen) routes for the Estimation feature.
@@ -49,30 +53,39 @@ class EstimationRoutesModule extends Module {
     r.child(
       addMaterialCostRoute,
       guards: [AuthGuard(() => Modular.get<AuthManager>())],
-      child: (context) => CostItemFormScreen(
-        type: CostItemType.material,
-        estimationId: Modular.args.params['estimationId'] ?? '',
-        router: Modular.get<AppRouter>(),
+      child: (context) => BlocProvider<MaterialCostFormBloc>(
+        create: (_) => Modular.get<MaterialCostFormBloc>(),
+        child: CostItemFormScreen(
+          type: CostItemType.material,
+          estimationId: Modular.args.params['estimationId'] ?? '',
+          router: Modular.get<AppRouter>(),
+        ),
       ),
     );
 
     r.child(
       addLabourCostRoute,
       guards: [AuthGuard(() => Modular.get<AuthManager>())],
-      child: (context) => CostItemFormScreen(
-        type: CostItemType.labor,
-        estimationId: Modular.args.params['estimationId'] ?? '',
-        router: Modular.get<AppRouter>(),
+      child: (context) => BlocProvider<LabourCostFormBloc>(
+        create: (_) => Modular.get<LabourCostFormBloc>(),
+        child: CostItemFormScreen(
+          type: CostItemType.labor,
+          estimationId: Modular.args.params['estimationId'] ?? '',
+          router: Modular.get<AppRouter>(),
+        ),
       ),
     );
 
     r.child(
       addEquipmentCostRoute,
       guards: [AuthGuard(() => Modular.get<AuthManager>())],
-      child: (context) => CostItemFormScreen(
-        type: CostItemType.equipment,
-        estimationId: Modular.args.params['estimationId'] ?? '',
-        router: Modular.get<AppRouter>(),
+      child: (context) => BlocProvider<EquipmentCostFormBloc>(
+        create: (_) => Modular.get<EquipmentCostFormBloc>(),
+        child: CostItemFormScreen(
+          type: CostItemType.equipment,
+          estimationId: Modular.args.params['estimationId'] ?? '',
+          router: Modular.get<AppRouter>(),
+        ),
       ),
     );
   }

--- a/lib/features/estimation/presentation/bloc/equipment_cost_form_bloc/equipment_cost_form_bloc.dart
+++ b/lib/features/estimation/presentation/bloc/equipment_cost_form_bloc/equipment_cost_form_bloc.dart
@@ -1,0 +1,71 @@
+import 'package:construculator/features/estimation/domain/entities/cost_item_entity.dart';
+import 'package:construculator/features/estimation/domain/repositories/cost_item_repository.dart';
+import 'package:construculator/libraries/errors/failures.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+part 'equipment_cost_form_event.dart';
+part 'equipment_cost_form_state.dart';
+
+class EquipmentCostFormBloc
+    extends Bloc<EquipmentCostFormEvent, EquipmentCostFormState> {
+  EquipmentCostFormBloc({required CostItemRepository repository})
+    : _repository = repository,
+      super(const EquipmentCostFormInitial()) {
+    on<EquipmentCostItemTypeChanged>(_onItemTypeChanged);
+    on<EquipmentCostFormSubmitted>(_onSubmitted);
+  }
+
+  final CostItemRepository _repository;
+
+  void _onItemTypeChanged(
+    EquipmentCostItemTypeChanged event,
+    Emitter<EquipmentCostFormState> emit,
+  ) {
+    final current = state is EquipmentCostFormEditing
+        ? state as EquipmentCostFormEditing
+        : const EquipmentCostFormEditing();
+    emit(
+      current.copyWith(
+        equipmentName: event.value,
+        itemTypeError: event.value.trim().isEmpty ? 'itemTypeRequired' : null,
+      ),
+    );
+  }
+
+  Future<void> _onSubmitted(
+    EquipmentCostFormSubmitted event,
+    Emitter<EquipmentCostFormState> emit,
+  ) async {
+    final editing = state is EquipmentCostFormEditing
+        ? state as EquipmentCostFormEditing
+        : const EquipmentCostFormEditing();
+
+    if (!editing.isItemTypeValid) {
+      emit(editing.copyWith(itemTypeError: 'itemTypeRequired'));
+      return;
+    }
+
+    emit(const EquipmentCostFormSubmitting());
+
+    final now = DateTime.now();
+    final item = EquipmentCostItem(
+      id: '',
+      estimateId: event.estimateId,
+      itemName: editing.equipmentName,
+      calculation: const {},
+      itemTotalCost: 0,
+      createdAt: now,
+      updatedAt: now,
+      currency: 'USD',
+      unitPrice: const Money(amount: 0),
+      quantity: const Quantity(value: 0, unit: Unit.pieces),
+    );
+
+    final result = await _repository.createCostItem(item);
+
+    result.fold(
+      (failure) => emit(EquipmentCostFormFailure(failure: failure)),
+      (created) => emit(EquipmentCostFormSuccess(item: created)),
+    );
+  }
+}

--- a/lib/features/estimation/presentation/bloc/equipment_cost_form_bloc/equipment_cost_form_event.dart
+++ b/lib/features/estimation/presentation/bloc/equipment_cost_form_bloc/equipment_cost_form_event.dart
@@ -1,0 +1,18 @@
+part of 'equipment_cost_form_bloc.dart';
+
+sealed class EquipmentCostFormEvent {
+  const EquipmentCostFormEvent();
+}
+
+class EquipmentCostItemTypeChanged extends EquipmentCostFormEvent {
+  const EquipmentCostItemTypeChanged(this.value);
+
+  final String value;
+}
+
+class EquipmentCostFormSubmitted extends EquipmentCostFormEvent {
+  const EquipmentCostFormSubmitted({required this.estimateId});
+
+  final String estimateId;
+  // TODO (CA-355): add other field values (unitPrice, quantity, etc.)
+}

--- a/lib/features/estimation/presentation/bloc/equipment_cost_form_bloc/equipment_cost_form_state.dart
+++ b/lib/features/estimation/presentation/bloc/equipment_cost_form_bloc/equipment_cost_form_state.dart
@@ -1,0 +1,52 @@
+part of 'equipment_cost_form_bloc.dart';
+
+sealed class EquipmentCostFormState {
+  const EquipmentCostFormState();
+}
+
+class EquipmentCostFormInitial extends EquipmentCostFormState {
+  const EquipmentCostFormInitial();
+}
+
+class EquipmentCostFormEditing extends EquipmentCostFormState {
+  const EquipmentCostFormEditing({this.equipmentName = '', this.itemTypeError});
+
+  final String equipmentName;
+  final String? itemTypeError;
+
+  bool get isItemTypeValid => equipmentName.trim().isNotEmpty;
+
+  EquipmentCostFormEditing copyWith({
+    String? equipmentName,
+    Object? itemTypeError = _keep,
+  }) {
+    return EquipmentCostFormEditing(
+      equipmentName: equipmentName ?? this.equipmentName,
+      itemTypeError: itemTypeError == _keep
+          ? this.itemTypeError
+          : itemTypeError as String?,
+    );
+  }
+}
+
+class EquipmentCostFormSubmitting extends EquipmentCostFormState {
+  const EquipmentCostFormSubmitting();
+}
+
+class EquipmentCostFormSuccess extends EquipmentCostFormState {
+  const EquipmentCostFormSuccess({required this.item});
+
+  final CostItem item;
+}
+
+class EquipmentCostFormFailure extends EquipmentCostFormState {
+  const EquipmentCostFormFailure({
+    required this.failure,
+    this.equipmentName = '',
+  });
+
+  final Failure failure;
+  final String equipmentName;
+}
+
+const Object _keep = Object();

--- a/lib/features/estimation/presentation/bloc/labour_cost_form_bloc/labour_cost_form_bloc.dart
+++ b/lib/features/estimation/presentation/bloc/labour_cost_form_bloc/labour_cost_form_bloc.dart
@@ -1,0 +1,71 @@
+import 'package:construculator/features/estimation/domain/entities/cost_item_entity.dart';
+import 'package:construculator/features/estimation/domain/repositories/cost_item_repository.dart';
+import 'package:construculator/libraries/errors/failures.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+part 'labour_cost_form_event.dart';
+part 'labour_cost_form_state.dart';
+
+class LabourCostFormBloc
+    extends Bloc<LabourCostFormEvent, LabourCostFormState> {
+  LabourCostFormBloc({required CostItemRepository repository})
+    : _repository = repository,
+      super(const LabourCostFormInitial()) {
+    on<LabourCostItemTypeChanged>(_onItemTypeChanged);
+    on<LabourCostFormSubmitted>(_onSubmitted);
+  }
+
+  final CostItemRepository _repository;
+
+  void _onItemTypeChanged(
+    LabourCostItemTypeChanged event,
+    Emitter<LabourCostFormState> emit,
+  ) {
+    final current = state is LabourCostFormEditing
+        ? state as LabourCostFormEditing
+        : const LabourCostFormEditing();
+    emit(
+      current.copyWith(
+        labourType: event.value,
+        itemTypeError: event.value.trim().isEmpty ? 'itemTypeRequired' : null,
+      ),
+    );
+  }
+
+  Future<void> _onSubmitted(
+    LabourCostFormSubmitted event,
+    Emitter<LabourCostFormState> emit,
+  ) async {
+    final editing = state is LabourCostFormEditing
+        ? state as LabourCostFormEditing
+        : const LabourCostFormEditing();
+
+    if (!editing.isItemTypeValid) {
+      emit(editing.copyWith(itemTypeError: 'itemTypeRequired'));
+      return;
+    }
+
+    emit(const LabourCostFormSubmitting());
+
+    final now = DateTime.now();
+    final item = LaborCostItem(
+      id: '',
+      estimateId: event.estimateId,
+      itemName: editing.labourType,
+      calculation: const {},
+      itemTotalCost: 0,
+      createdAt: now,
+      updatedAt: now,
+      currency: 'USD',
+      laborCalcMethod: LaborCalculationMethodType.perDay,
+      laborValue: const LaborValue(),
+    );
+
+    final result = await _repository.createCostItem(item);
+
+    result.fold(
+      (failure) => emit(LabourCostFormFailure(failure: failure)),
+      (created) => emit(LabourCostFormSuccess(item: created)),
+    );
+  }
+}

--- a/lib/features/estimation/presentation/bloc/labour_cost_form_bloc/labour_cost_form_event.dart
+++ b/lib/features/estimation/presentation/bloc/labour_cost_form_bloc/labour_cost_form_event.dart
@@ -1,0 +1,18 @@
+part of 'labour_cost_form_bloc.dart';
+
+sealed class LabourCostFormEvent {
+  const LabourCostFormEvent();
+}
+
+class LabourCostItemTypeChanged extends LabourCostFormEvent {
+  const LabourCostItemTypeChanged(this.value);
+
+  final String value;
+}
+
+class LabourCostFormSubmitted extends LabourCostFormEvent {
+  const LabourCostFormSubmitted({required this.estimateId});
+
+  final String estimateId;
+  // TODO (CA-355): add other field values (crewRate, laborValue, etc.)
+}

--- a/lib/features/estimation/presentation/bloc/labour_cost_form_bloc/labour_cost_form_state.dart
+++ b/lib/features/estimation/presentation/bloc/labour_cost_form_bloc/labour_cost_form_state.dart
@@ -1,0 +1,49 @@
+part of 'labour_cost_form_bloc.dart';
+
+sealed class LabourCostFormState {
+  const LabourCostFormState();
+}
+
+class LabourCostFormInitial extends LabourCostFormState {
+  const LabourCostFormInitial();
+}
+
+class LabourCostFormEditing extends LabourCostFormState {
+  const LabourCostFormEditing({this.labourType = '', this.itemTypeError});
+
+  final String labourType;
+  final String? itemTypeError;
+
+  bool get isItemTypeValid => labourType.trim().isNotEmpty;
+
+  LabourCostFormEditing copyWith({
+    String? labourType,
+    Object? itemTypeError = _keep,
+  }) {
+    return LabourCostFormEditing(
+      labourType: labourType ?? this.labourType,
+      itemTypeError: itemTypeError == _keep
+          ? this.itemTypeError
+          : itemTypeError as String?,
+    );
+  }
+}
+
+class LabourCostFormSubmitting extends LabourCostFormState {
+  const LabourCostFormSubmitting();
+}
+
+class LabourCostFormSuccess extends LabourCostFormState {
+  const LabourCostFormSuccess({required this.item});
+
+  final CostItem item;
+}
+
+class LabourCostFormFailure extends LabourCostFormState {
+  const LabourCostFormFailure({required this.failure, this.labourType = ''});
+
+  final Failure failure;
+  final String labourType;
+}
+
+const Object _keep = Object();

--- a/lib/features/estimation/presentation/bloc/material_cost_form_bloc/material_cost_form_bloc.dart
+++ b/lib/features/estimation/presentation/bloc/material_cost_form_bloc/material_cost_form_bloc.dart
@@ -1,0 +1,73 @@
+import 'package:construculator/features/estimation/domain/entities/cost_item_entity.dart';
+import 'package:construculator/features/estimation/domain/repositories/cost_item_repository.dart';
+import 'package:construculator/libraries/errors/failures.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+part 'material_cost_form_event.dart';
+part 'material_cost_form_state.dart';
+
+class MaterialCostFormBloc
+    extends Bloc<MaterialCostFormEvent, MaterialCostFormState> {
+  MaterialCostFormBloc({required CostItemRepository repository})
+    : _repository = repository,
+      super(const MaterialCostFormInitial()) {
+    on<MaterialCostItemTypeChanged>(_onItemTypeChanged);
+    on<MaterialCostFormSubmitted>(_onSubmitted);
+  }
+
+  final CostItemRepository _repository;
+
+  void _onItemTypeChanged(
+    MaterialCostItemTypeChanged event,
+    Emitter<MaterialCostFormState> emit,
+  ) {
+    final current = state is MaterialCostFormEditing
+        ? state as MaterialCostFormEditing
+        : const MaterialCostFormEditing();
+    emit(
+      current.copyWith(
+        materialType: event.value,
+        itemTypeError: event.value.trim().isEmpty ? 'itemTypeRequired' : null,
+      ),
+    );
+  }
+
+  Future<void> _onSubmitted(
+    MaterialCostFormSubmitted event,
+    Emitter<MaterialCostFormState> emit,
+  ) async {
+    final editing = state is MaterialCostFormEditing
+        ? state as MaterialCostFormEditing
+        : const MaterialCostFormEditing();
+
+    if (!editing.isItemTypeValid) {
+      emit(editing.copyWith(itemTypeError: 'itemTypeRequired'));
+      return;
+    }
+
+    emit(const MaterialCostFormSubmitting());
+
+    final now = DateTime.now();
+    final item = MaterialCostItem(
+      id: '',
+      estimateId: event.estimateId,
+      itemName: editing.materialType,
+      calculation: const {},
+      itemTotalCost: 0,
+      createdAt: now,
+      updatedAt: now,
+      currency: 'USD',
+      unitPrice: const Money(amount: 0),
+      quantity: const Quantity(value: 0, unit: Unit.pieces),
+    );
+
+    final result = await _repository.createCostItem(item);
+
+    result.fold(
+      (failure) => emit(
+        MaterialCostFormFailure(failure: failure),
+      ),
+      (created) => emit(MaterialCostFormSuccess(item: created)),
+    );
+  }
+}

--- a/lib/features/estimation/presentation/bloc/material_cost_form_bloc/material_cost_form_event.dart
+++ b/lib/features/estimation/presentation/bloc/material_cost_form_bloc/material_cost_form_event.dart
@@ -1,0 +1,18 @@
+part of 'material_cost_form_bloc.dart';
+
+sealed class MaterialCostFormEvent {
+  const MaterialCostFormEvent();
+}
+
+class MaterialCostItemTypeChanged extends MaterialCostFormEvent {
+  const MaterialCostItemTypeChanged(this.value);
+
+  final String value;
+}
+
+class MaterialCostFormSubmitted extends MaterialCostFormEvent {
+  const MaterialCostFormSubmitted({required this.estimateId});
+
+  final String estimateId;
+  // TODO (CA-355): add other field values (unitPrice, quantity, etc.)
+}

--- a/lib/features/estimation/presentation/bloc/material_cost_form_bloc/material_cost_form_state.dart
+++ b/lib/features/estimation/presentation/bloc/material_cost_form_bloc/material_cost_form_state.dart
@@ -1,0 +1,50 @@
+part of 'material_cost_form_bloc.dart';
+
+sealed class MaterialCostFormState {
+  const MaterialCostFormState();
+}
+
+class MaterialCostFormInitial extends MaterialCostFormState {
+  const MaterialCostFormInitial();
+}
+
+class MaterialCostFormEditing extends MaterialCostFormState {
+  const MaterialCostFormEditing({this.materialType = '', this.itemTypeError});
+
+  final String materialType;
+  final String? itemTypeError;
+
+  bool get isItemTypeValid => materialType.trim().isNotEmpty;
+
+  MaterialCostFormEditing copyWith({
+    String? materialType,
+    Object? itemTypeError = _keep,
+  }) {
+    return MaterialCostFormEditing(
+      materialType: materialType ?? this.materialType,
+      itemTypeError: itemTypeError == _keep
+          ? this.itemTypeError
+          : itemTypeError as String?,
+    );
+  }
+}
+
+class MaterialCostFormSubmitting extends MaterialCostFormState {
+  const MaterialCostFormSubmitting();
+}
+
+class MaterialCostFormSuccess extends MaterialCostFormState {
+  const MaterialCostFormSuccess({required this.item});
+
+  final CostItem item;
+}
+
+class MaterialCostFormFailure extends MaterialCostFormState {
+  const MaterialCostFormFailure({required this.failure, this.materialType = ''});
+
+  final Failure failure;
+  final String materialType;
+}
+
+// Sentinel to distinguish "not provided" from null in copyWith.
+const Object _keep = Object();

--- a/lib/features/estimation/presentation/widgets/equipment_cost_form_fields.dart
+++ b/lib/features/estimation/presentation/widgets/equipment_cost_form_fields.dart
@@ -1,5 +1,7 @@
+import 'package:construculator/features/estimation/presentation/bloc/equipment_cost_form_bloc/equipment_cost_form_bloc.dart';
 import 'package:construculator/libraries/extensions/extensions.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:ripplearc_coreui/ripplearc_coreui.dart';
 
 class EquipmentCostFormFields extends StatefulWidget {
@@ -48,10 +50,13 @@ class _EquipmentCostFormFieldsState extends State<EquipmentCostFormFields> {
     super.dispose();
   }
 
-  void _notifySaveEnabled() =>
-      widget.onSaveEnabledChanged?.call(
-        _equipmentNameController.text.trim().isNotEmpty,
-      );
+  void _notifySaveEnabled() {
+    final value = _equipmentNameController.text;
+    widget.onSaveEnabledChanged?.call(value.trim().isNotEmpty);
+    context
+        .read<EquipmentCostFormBloc>()
+        .add(EquipmentCostItemTypeChanged(value));
+  }
 
   // TODO: [CA-355] Move total calculation into BLoC when submission is wired
   void _notifyTotal() {
@@ -126,10 +131,24 @@ class _EquipmentCostFormFieldsState extends State<EquipmentCostFormFields> {
     final l10n = context.l10n;
     final colorTheme = context.colorTheme;
     return [
-      CoreTextField(
-        key: const Key('equipment_name_field'),
-        hintText: l10n.equipmentNameLabel,
-        controller: _equipmentNameController,
+      BlocConsumer<EquipmentCostFormBloc, EquipmentCostFormState>(
+        listenWhen: (_, state) => state is EquipmentCostFormFailure,
+        listener: (_, state) {
+          if (state is EquipmentCostFormFailure) {
+            _equipmentNameController.text = state.equipmentName;
+          }
+        },
+        builder: (_, state) {
+          final error =
+              state is EquipmentCostFormEditing ? state.itemTypeError : null;
+          return CoreTextField(
+            key: const Key('equipment_name_field'),
+            hintText: l10n.equipmentNameLabel,
+            controller: _equipmentNameController,
+            errorTextList:
+                error != null ? [l10n.equipmentNameRequiredError] : null,
+          );
+        },
       ),
       const SizedBox(height: CoreSpacing.space5),
       CoreTextField(

--- a/lib/features/estimation/presentation/widgets/equipment_cost_form_fields.dart
+++ b/lib/features/estimation/presentation/widgets/equipment_cost_form_fields.dart
@@ -58,7 +58,7 @@ class _EquipmentCostFormFieldsState extends State<EquipmentCostFormFields> {
         .add(EquipmentCostItemTypeChanged(value));
   }
 
-  // TODO: [CA-355] Move total calculation into BLoC when submission is wired
+  // TODO: [CA-353] Move total calculation into BLoC when submission is wired
   void _notifyTotal() {
     if (widget.fromCostFile) {
       widget.onTotalChanged?.call(0);

--- a/lib/features/estimation/presentation/widgets/labour_cost_form_fields.dart
+++ b/lib/features/estimation/presentation/widgets/labour_cost_form_fields.dart
@@ -61,7 +61,7 @@ class _LabourCostFormFieldsState extends State<LabourCostFormFields> {
     context.read<LabourCostFormBloc>().add(LabourCostItemTypeChanged(value));
   }
 
-  // TODO: [CA-355] Move total calculation into BLoC when submission is wired
+  // TODO: [CA-353] Move total calculation into BLoC when submission is wired
   void _notifyTotal() {
     if (widget.fromCostFile) {
       widget.onTotalChanged?.call(0);

--- a/lib/features/estimation/presentation/widgets/labour_cost_form_fields.dart
+++ b/lib/features/estimation/presentation/widgets/labour_cost_form_fields.dart
@@ -1,7 +1,9 @@
 import 'package:construculator/features/estimation/domain/entities/cost_item_entity.dart';
+import 'package:construculator/features/estimation/presentation/bloc/labour_cost_form_bloc/labour_cost_form_bloc.dart';
 import 'package:construculator/features/estimation/presentation/widgets/calc_method_card.dart';
 import 'package:construculator/libraries/extensions/extensions.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:ripplearc_coreui/ripplearc_coreui.dart';
 
 class LabourCostFormFields extends StatefulWidget {
@@ -53,10 +55,11 @@ class _LabourCostFormFieldsState extends State<LabourCostFormFields> {
     super.dispose();
   }
 
-  void _notifySaveEnabled() =>
-      widget.onSaveEnabledChanged?.call(
-        _labourTypeController.text.trim().isNotEmpty,
-      );
+  void _notifySaveEnabled() {
+    final value = _labourTypeController.text;
+    widget.onSaveEnabledChanged?.call(value.trim().isNotEmpty);
+    context.read<LabourCostFormBloc>().add(LabourCostItemTypeChanged(value));
+  }
 
   // TODO: [CA-355] Move total calculation into BLoC when submission is wired
   void _notifyTotal() {
@@ -144,10 +147,24 @@ class _LabourCostFormFieldsState extends State<LabourCostFormFields> {
     final l10n = context.l10n;
     final colorTheme = context.colorTheme;
     return [
-      CoreTextField(
-        key: const Key('labour_type_field'),
-        hintText: l10n.labourTypeLabel,
-        controller: _labourTypeController,
+      BlocConsumer<LabourCostFormBloc, LabourCostFormState>(
+        listenWhen: (_, state) => state is LabourCostFormFailure,
+        listener: (_, state) {
+          if (state is LabourCostFormFailure) {
+            _labourTypeController.text = state.labourType;
+          }
+        },
+        builder: (_, state) {
+          final error =
+              state is LabourCostFormEditing ? state.itemTypeError : null;
+          return CoreTextField(
+            key: const Key('labour_type_field'),
+            hintText: l10n.labourTypeLabel,
+            controller: _labourTypeController,
+            errorTextList:
+                error != null ? [l10n.labourTypeRequiredError] : null,
+          );
+        },
       ),
       const SizedBox(height: CoreSpacing.space5),
       CalcMethodCard(

--- a/lib/features/estimation/presentation/widgets/material_cost_form_fields.dart
+++ b/lib/features/estimation/presentation/widgets/material_cost_form_fields.dart
@@ -1,5 +1,7 @@
+import 'package:construculator/features/estimation/presentation/bloc/material_cost_form_bloc/material_cost_form_bloc.dart';
 import 'package:construculator/libraries/extensions/extensions.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:ripplearc_coreui/ripplearc_coreui.dart';
 
 class MaterialCostFormFields extends StatefulWidget {
@@ -50,10 +52,11 @@ class _MaterialCostFormFieldsState extends State<MaterialCostFormFields> {
     super.dispose();
   }
 
-  void _notifySaveEnabled() =>
-      widget.onSaveEnabledChanged?.call(
-        _materialTypeController.text.trim().isNotEmpty,
-      );
+  void _notifySaveEnabled() {
+    final value = _materialTypeController.text;
+    widget.onSaveEnabledChanged?.call(value.trim().isNotEmpty);
+    context.read<MaterialCostFormBloc>().add(MaterialCostItemTypeChanged(value));
+  }
 
   // TODO: [CA-355] Move total calculation into BLoC when submission is wired
   void _notifyTotal() {
@@ -129,10 +132,24 @@ class _MaterialCostFormFieldsState extends State<MaterialCostFormFields> {
     final l10n = context.l10n;
     final colorTheme = context.colorTheme;
     return [
-      CoreTextField(
-        key: const Key('material_type_field'),
-        hintText: l10n.materialTypeLabel,
-        controller: _materialTypeController,
+      BlocConsumer<MaterialCostFormBloc, MaterialCostFormState>(
+        listenWhen: (_, state) => state is MaterialCostFormFailure,
+        listener: (_, state) {
+          if (state is MaterialCostFormFailure) {
+            _materialTypeController.text = state.materialType;
+          }
+        },
+        builder: (_, state) {
+          final error =
+              state is MaterialCostFormEditing ? state.itemTypeError : null;
+          return CoreTextField(
+            key: const Key('material_type_field'),
+            hintText: l10n.materialTypeLabel,
+            controller: _materialTypeController,
+            errorTextList:
+                error != null ? [l10n.materialTypeRequiredError] : null,
+          );
+        },
       ),
       const SizedBox(height: CoreSpacing.space5),
       CoreTextField(

--- a/lib/features/estimation/presentation/widgets/material_cost_form_fields.dart
+++ b/lib/features/estimation/presentation/widgets/material_cost_form_fields.dart
@@ -58,7 +58,7 @@ class _MaterialCostFormFieldsState extends State<MaterialCostFormFields> {
     context.read<MaterialCostFormBloc>().add(MaterialCostItemTypeChanged(value));
   }
 
-  // TODO: [CA-355] Move total calculation into BLoC when submission is wired
+  // TODO: [CA-353] Move total calculation into BLoC when submission is wired
   void _notifyTotal() {
     if (widget.fromCostFile) {
       widget.onTotalChanged?.call(0);

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1752,6 +1752,18 @@
   "rateHourLabel": "Rate/Hour:",
   "@rateHourLabel": {
     "description": "Rate label inside the calculation method card when per-hours method is selected (from cost file mode)"
+  },
+  "materialTypeRequiredError": "Material type is required",
+  "@materialTypeRequiredError": {
+    "description": "Validation error shown below the material type field when it is submitted empty"
+  },
+  "labourTypeRequiredError": "Labour type is required",
+  "@labourTypeRequiredError": {
+    "description": "Validation error shown below the labour type field when it is submitted empty"
+  },
+  "equipmentNameRequiredError": "Equipment name is required",
+  "@equipmentNameRequiredError": {
+    "description": "Validation error shown below the equipment name field when it is submitted empty"
   }
 }
 

--- a/lib/l10n/generated/app_localizations.dart
+++ b/lib/l10n/generated/app_localizations.dart
@@ -2145,6 +2145,24 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Rate/Hour:'**
   String get rateHourLabel;
+
+  /// Validation error shown below the material type field when it is submitted empty
+  ///
+  /// In en, this message translates to:
+  /// **'Material type is required'**
+  String get materialTypeRequiredError;
+
+  /// Validation error shown below the labour type field when it is submitted empty
+  ///
+  /// In en, this message translates to:
+  /// **'Labour type is required'**
+  String get labourTypeRequiredError;
+
+  /// Validation error shown below the equipment name field when it is submitted empty
+  ///
+  /// In en, this message translates to:
+  /// **'Equipment name is required'**
+  String get equipmentNameRequiredError;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/generated/app_localizations_en.dart
+++ b/lib/l10n/generated/app_localizations_en.dart
@@ -1125,4 +1125,13 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get rateHourLabel => 'Rate/Hour:';
+
+  @override
+  String get materialTypeRequiredError => 'Material type is required';
+
+  @override
+  String get labourTypeRequiredError => 'Labour type is required';
+
+  @override
+  String get equipmentNameRequiredError => 'Equipment name is required';
 }

--- a/test/features/estimations/screenshots/cost_item_form_screen_screenshot_test.dart
+++ b/test/features/estimations/screenshots/cost_item_form_screen_screenshot_test.dart
@@ -1,17 +1,41 @@
 import 'package:construculator/features/estimation/domain/entities/cost_item_entity.dart';
+import 'package:construculator/features/estimation/estimation_module.dart';
+import 'package:construculator/features/estimation/presentation/bloc/equipment_cost_form_bloc/equipment_cost_form_bloc.dart';
+import 'package:construculator/features/estimation/presentation/bloc/labour_cost_form_bloc/labour_cost_form_bloc.dart';
+import 'package:construculator/features/estimation/presentation/bloc/material_cost_form_bloc/material_cost_form_bloc.dart';
 import 'package:construculator/features/estimation/presentation/pages/cost_item_form_screen.dart';
 import 'package:construculator/l10n/generated/app_localizations.dart';
 import 'package:construculator/libraries/router/testing/fake_router.dart';
+import 'package:construculator/libraries/supabase/testing/fake_supabase_wrapper.dart';
+import 'package:construculator/libraries/time/testing/fake_clock_impl.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_modular/flutter_modular.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import '../../../utils/fake_app_bootstrap_factory.dart';
 import '../../../utils/screenshot/font_loader.dart';
 
 void main() {
   const size = Size(390, 844);
   TestWidgetsFlutterBinding.ensureInitialized();
 
+  late FakeSupabaseWrapper fakeSupabase;
+
+  setUpAll(() {
+    fakeSupabase = FakeSupabaseWrapper(clock: FakeClockImpl());
+    final bootstrap = FakeAppBootstrapFactory.create(
+      supabaseWrapper: fakeSupabase,
+    );
+    Modular.init(EstimationModule(bootstrap));
+  });
+
+  tearDownAll(() {
+    Modular.dispose();
+  });
+
   setUp(() async {
+    fakeSupabase.reset();
     await loadAppFontsAll();
   });
 
@@ -26,10 +50,23 @@ void main() {
         locale: const Locale('en'),
         localizationsDelegates: AppLocalizations.localizationsDelegates,
         supportedLocales: AppLocalizations.supportedLocales,
-        home: CostItemFormScreen(
-          type: type,
-          estimationId: 'test-estimation-id',
-          router: FakeAppRouter(),
+        home: MultiBlocProvider(
+          providers: [
+            BlocProvider<MaterialCostFormBloc>(
+              create: (_) => Modular.get<MaterialCostFormBloc>(),
+            ),
+            BlocProvider<LabourCostFormBloc>(
+              create: (_) => Modular.get<LabourCostFormBloc>(),
+            ),
+            BlocProvider<EquipmentCostFormBloc>(
+              create: (_) => Modular.get<EquipmentCostFormBloc>(),
+            ),
+          ],
+          child: CostItemFormScreen(
+            type: type,
+            estimationId: 'test-estimation-id',
+            router: FakeAppRouter(),
+          ),
         ),
       ),
     );

--- a/test/features/estimations/screenshots/equipment_cost_form_fields_screenshot_test.dart
+++ b/test/features/estimations/screenshots/equipment_cost_form_fields_screenshot_test.dart
@@ -1,15 +1,37 @@
+import 'package:construculator/features/estimation/estimation_module.dart';
+import 'package:construculator/features/estimation/presentation/bloc/equipment_cost_form_bloc/equipment_cost_form_bloc.dart';
 import 'package:construculator/features/estimation/presentation/widgets/equipment_cost_form_fields.dart';
 import 'package:construculator/l10n/generated/app_localizations.dart';
+import 'package:construculator/libraries/supabase/testing/fake_supabase_wrapper.dart';
+import 'package:construculator/libraries/time/testing/fake_clock_impl.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_modular/flutter_modular.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import '../../../utils/fake_app_bootstrap_factory.dart';
 import '../../../utils/screenshot/font_loader.dart';
 
 void main() {
   const size = Size(390.0, 600.0);
   TestWidgetsFlutterBinding.ensureInitialized();
 
+  late FakeSupabaseWrapper fakeSupabase;
+
+  setUpAll(() {
+    fakeSupabase = FakeSupabaseWrapper(clock: FakeClockImpl());
+    final bootstrap = FakeAppBootstrapFactory.create(
+      supabaseWrapper: fakeSupabase,
+    );
+    Modular.init(EstimationModule(bootstrap));
+  });
+
+  tearDownAll(() {
+    Modular.dispose();
+  });
+
   setUp(() async {
+    fakeSupabase.reset();
     await loadAppFontsAll();
   });
 
@@ -25,7 +47,10 @@ void main() {
         localizationsDelegates: AppLocalizations.localizationsDelegates,
         supportedLocales: AppLocalizations.supportedLocales,
         home: Scaffold(
-          body: EquipmentCostFormFields(fromCostFile: fromCostFile),
+          body: BlocProvider<EquipmentCostFormBloc>(
+            create: (_) => Modular.get<EquipmentCostFormBloc>(),
+            child: EquipmentCostFormFields(fromCostFile: fromCostFile),
+          ),
         ),
       ),
     );

--- a/test/features/estimations/screenshots/labour_cost_form_fields_screenshot_test.dart
+++ b/test/features/estimations/screenshots/labour_cost_form_fields_screenshot_test.dart
@@ -1,15 +1,37 @@
+import 'package:construculator/features/estimation/estimation_module.dart';
+import 'package:construculator/features/estimation/presentation/bloc/labour_cost_form_bloc/labour_cost_form_bloc.dart';
 import 'package:construculator/features/estimation/presentation/widgets/labour_cost_form_fields.dart';
 import 'package:construculator/l10n/generated/app_localizations.dart';
+import 'package:construculator/libraries/supabase/testing/fake_supabase_wrapper.dart';
+import 'package:construculator/libraries/time/testing/fake_clock_impl.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_modular/flutter_modular.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import '../../../utils/fake_app_bootstrap_factory.dart';
 import '../../../utils/screenshot/font_loader.dart';
 
 void main() {
   const size = Size(390.0, 600.0);
   TestWidgetsFlutterBinding.ensureInitialized();
 
+  late FakeSupabaseWrapper fakeSupabase;
+
+  setUpAll(() {
+    fakeSupabase = FakeSupabaseWrapper(clock: FakeClockImpl());
+    final bootstrap = FakeAppBootstrapFactory.create(
+      supabaseWrapper: fakeSupabase,
+    );
+    Modular.init(EstimationModule(bootstrap));
+  });
+
+  tearDownAll(() {
+    Modular.dispose();
+  });
+
   setUp(() async {
+    fakeSupabase.reset();
     await loadAppFontsAll();
   });
 
@@ -25,7 +47,10 @@ void main() {
         localizationsDelegates: AppLocalizations.localizationsDelegates,
         supportedLocales: AppLocalizations.supportedLocales,
         home: Scaffold(
-          body: LabourCostFormFields(fromCostFile: fromCostFile),
+          body: BlocProvider<LabourCostFormBloc>(
+            create: (_) => Modular.get<LabourCostFormBloc>(),
+            child: LabourCostFormFields(fromCostFile: fromCostFile),
+          ),
         ),
       ),
     );

--- a/test/features/estimations/screenshots/material_cost_form_fields_screenshot_test.dart
+++ b/test/features/estimations/screenshots/material_cost_form_fields_screenshot_test.dart
@@ -1,15 +1,37 @@
+import 'package:construculator/features/estimation/estimation_module.dart';
+import 'package:construculator/features/estimation/presentation/bloc/material_cost_form_bloc/material_cost_form_bloc.dart';
 import 'package:construculator/features/estimation/presentation/widgets/material_cost_form_fields.dart';
 import 'package:construculator/l10n/generated/app_localizations.dart';
+import 'package:construculator/libraries/supabase/testing/fake_supabase_wrapper.dart';
+import 'package:construculator/libraries/time/testing/fake_clock_impl.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_modular/flutter_modular.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import '../../../utils/fake_app_bootstrap_factory.dart';
 import '../../../utils/screenshot/font_loader.dart';
 
 void main() {
   const size = Size(390.0, 600.0);
   TestWidgetsFlutterBinding.ensureInitialized();
 
+  late FakeSupabaseWrapper fakeSupabase;
+
+  setUpAll(() {
+    fakeSupabase = FakeSupabaseWrapper(clock: FakeClockImpl());
+    final bootstrap = FakeAppBootstrapFactory.create(
+      supabaseWrapper: fakeSupabase,
+    );
+    Modular.init(EstimationModule(bootstrap));
+  });
+
+  tearDownAll(() {
+    Modular.dispose();
+  });
+
   setUp(() async {
+    fakeSupabase.reset();
     await loadAppFontsAll();
   });
 
@@ -25,7 +47,10 @@ void main() {
         localizationsDelegates: AppLocalizations.localizationsDelegates,
         supportedLocales: AppLocalizations.supportedLocales,
         home: Scaffold(
-          body: MaterialCostFormFields(fromCostFile: fromCostFile),
+          body: BlocProvider<MaterialCostFormBloc>(
+            create: (_) => Modular.get<MaterialCostFormBloc>(),
+            child: MaterialCostFormFields(fromCostFile: fromCostFile),
+          ),
         ),
       ),
     );

--- a/test/features/estimations/units/blocs/equipment_cost_form_bloc_test.dart
+++ b/test/features/estimations/units/blocs/equipment_cost_form_bloc_test.dart
@@ -1,0 +1,135 @@
+import 'package:bloc_test/bloc_test.dart';
+import 'package:construculator/features/estimation/domain/entities/cost_item_entity.dart';
+import 'package:construculator/features/estimation/estimation_module.dart';
+import 'package:construculator/features/estimation/presentation/bloc/equipment_cost_form_bloc/equipment_cost_form_bloc.dart';
+import 'package:construculator/libraries/supabase/data/supabase_types.dart';
+import 'package:construculator/libraries/supabase/interfaces/supabase_wrapper.dart';
+import 'package:construculator/libraries/supabase/testing/fake_supabase_wrapper.dart';
+import 'package:construculator/libraries/time/testing/fake_clock_impl.dart';
+import 'package:flutter_modular/flutter_modular.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../../../../utils/fake_app_bootstrap_factory.dart';
+
+void main() {
+  group('EquipmentCostFormBloc', () {
+    late EquipmentCostFormBloc bloc;
+    late FakeSupabaseWrapper fakeSupabaseWrapper;
+
+    const testEstimateId = 'test-estimate-123';
+    const testEquipmentName = 'Excavator';
+
+    setUpAll(() {
+      final bootstrap = FakeAppBootstrapFactory.create(
+        supabaseWrapper: FakeSupabaseWrapper(clock: FakeClockImpl()),
+      );
+      Modular.init(EstimationModule(bootstrap));
+      fakeSupabaseWrapper =
+          Modular.get<SupabaseWrapper>() as FakeSupabaseWrapper;
+    });
+
+    tearDownAll(() {
+      Modular.dispose();
+    });
+
+    setUp(() {
+      fakeSupabaseWrapper.reset();
+      bloc = Modular.get<EquipmentCostFormBloc>();
+    });
+
+    test('initial state is EquipmentCostFormInitial', () {
+      expect(bloc.state, isA<EquipmentCostFormInitial>());
+    });
+
+    group('EquipmentCostItemTypeChanged', () {
+      blocTest<EquipmentCostFormBloc, EquipmentCostFormState>(
+        'emits Editing with itemTypeError when value is empty',
+        build: () => bloc,
+        act: (bloc) => bloc.add(const EquipmentCostItemTypeChanged('')),
+        expect: () => [
+          isA<EquipmentCostFormEditing>()
+              .having((s) => s.itemTypeError, 'itemTypeError', isNotNull)
+              .having((s) => s.isItemTypeValid, 'isItemTypeValid', false),
+        ],
+      );
+
+      blocTest<EquipmentCostFormBloc, EquipmentCostFormState>(
+        'emits Editing with no error when value is non-empty',
+        build: () => bloc,
+        act: (bloc) =>
+            bloc.add(const EquipmentCostItemTypeChanged(testEquipmentName)),
+        expect: () => [
+          isA<EquipmentCostFormEditing>()
+              .having(
+                (s) => s.equipmentName,
+                'equipmentName',
+                testEquipmentName,
+              )
+              .having((s) => s.itemTypeError, 'itemTypeError', isNull)
+              .having((s) => s.isItemTypeValid, 'isItemTypeValid', true),
+        ],
+      );
+    });
+
+    group('EquipmentCostFormSubmitted', () {
+      blocTest<EquipmentCostFormBloc, EquipmentCostFormState>(
+        'emits Editing with error when submitted with empty equipment name',
+        build: () => bloc,
+        act: (bloc) => bloc.add(
+          const EquipmentCostFormSubmitted(estimateId: testEstimateId),
+        ),
+        expect: () => [
+          isA<EquipmentCostFormEditing>().having(
+            (s) => s.itemTypeError,
+            'itemTypeError',
+            isNotNull,
+          ),
+        ],
+      );
+
+      blocTest<EquipmentCostFormBloc, EquipmentCostFormState>(
+        'emits [Submitting, Success] when submitted with valid equipment name',
+        build: () => bloc,
+        act: (bloc) {
+          bloc.add(const EquipmentCostItemTypeChanged(testEquipmentName));
+          bloc.add(
+            const EquipmentCostFormSubmitted(estimateId: testEstimateId),
+          );
+        },
+        expect: () => [
+          isA<EquipmentCostFormEditing>(),
+          isA<EquipmentCostFormSubmitting>(),
+          isA<EquipmentCostFormSuccess>().having(
+            (s) => (s.item as EquipmentCostItem).itemName,
+            'itemName',
+            testEquipmentName,
+          ),
+        ],
+      );
+
+      blocTest<EquipmentCostFormBloc, EquipmentCostFormState>(
+        'emits [Submitting, Failure] with empty equipmentName when data source throws socket error',
+        build: () {
+          fakeSupabaseWrapper.shouldThrowOnInsert = true;
+          fakeSupabaseWrapper.insertExceptionType = SupabaseExceptionType.socket;
+          return bloc;
+        },
+        act: (bloc) {
+          bloc.add(const EquipmentCostItemTypeChanged(testEquipmentName));
+          bloc.add(
+            const EquipmentCostFormSubmitted(estimateId: testEstimateId),
+          );
+        },
+        expect: () => [
+          isA<EquipmentCostFormEditing>(),
+          isA<EquipmentCostFormSubmitting>(),
+          isA<EquipmentCostFormFailure>().having(
+            (s) => s.equipmentName,
+            'equipmentName',
+            '',
+          ),
+        ],
+      );
+    });
+  });
+}

--- a/test/features/estimations/units/blocs/labour_cost_form_bloc_test.dart
+++ b/test/features/estimations/units/blocs/labour_cost_form_bloc_test.dart
@@ -1,0 +1,131 @@
+import 'package:bloc_test/bloc_test.dart';
+import 'package:construculator/features/estimation/domain/entities/cost_item_entity.dart';
+import 'package:construculator/features/estimation/estimation_module.dart';
+import 'package:construculator/features/estimation/presentation/bloc/labour_cost_form_bloc/labour_cost_form_bloc.dart';
+import 'package:construculator/libraries/supabase/data/supabase_types.dart';
+import 'package:construculator/libraries/supabase/interfaces/supabase_wrapper.dart';
+import 'package:construculator/libraries/supabase/testing/fake_supabase_wrapper.dart';
+import 'package:construculator/libraries/time/testing/fake_clock_impl.dart';
+import 'package:flutter_modular/flutter_modular.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../../../../utils/fake_app_bootstrap_factory.dart';
+
+void main() {
+  group('LabourCostFormBloc', () {
+    late LabourCostFormBloc bloc;
+    late FakeSupabaseWrapper fakeSupabaseWrapper;
+
+    const testEstimateId = 'test-estimate-123';
+    const testLabourType = 'Bricklayer';
+
+    setUpAll(() {
+      final bootstrap = FakeAppBootstrapFactory.create(
+        supabaseWrapper: FakeSupabaseWrapper(clock: FakeClockImpl()),
+      );
+      Modular.init(EstimationModule(bootstrap));
+      fakeSupabaseWrapper =
+          Modular.get<SupabaseWrapper>() as FakeSupabaseWrapper;
+    });
+
+    tearDownAll(() {
+      Modular.dispose();
+    });
+
+    setUp(() {
+      fakeSupabaseWrapper.reset();
+      bloc = Modular.get<LabourCostFormBloc>();
+    });
+
+    test('initial state is LabourCostFormInitial', () {
+      expect(bloc.state, isA<LabourCostFormInitial>());
+    });
+
+    group('LabourCostItemTypeChanged', () {
+      blocTest<LabourCostFormBloc, LabourCostFormState>(
+        'emits Editing with itemTypeError when value is empty',
+        build: () => bloc,
+        act: (bloc) => bloc.add(const LabourCostItemTypeChanged('')),
+        expect: () => [
+          isA<LabourCostFormEditing>()
+              .having((s) => s.itemTypeError, 'itemTypeError', isNotNull)
+              .having((s) => s.isItemTypeValid, 'isItemTypeValid', false),
+        ],
+      );
+
+      blocTest<LabourCostFormBloc, LabourCostFormState>(
+        'emits Editing with no error when value is non-empty',
+        build: () => bloc,
+        act: (bloc) =>
+            bloc.add(const LabourCostItemTypeChanged(testLabourType)),
+        expect: () => [
+          isA<LabourCostFormEditing>()
+              .having((s) => s.labourType, 'labourType', testLabourType)
+              .having((s) => s.itemTypeError, 'itemTypeError', isNull)
+              .having((s) => s.isItemTypeValid, 'isItemTypeValid', true),
+        ],
+      );
+    });
+
+    group('LabourCostFormSubmitted', () {
+      blocTest<LabourCostFormBloc, LabourCostFormState>(
+        'emits Editing with error when submitted with empty labour type',
+        build: () => bloc,
+        act: (bloc) => bloc.add(
+          const LabourCostFormSubmitted(estimateId: testEstimateId),
+        ),
+        expect: () => [
+          isA<LabourCostFormEditing>().having(
+            (s) => s.itemTypeError,
+            'itemTypeError',
+            isNotNull,
+          ),
+        ],
+      );
+
+      blocTest<LabourCostFormBloc, LabourCostFormState>(
+        'emits [Submitting, Success] when submitted with valid labour type',
+        build: () => bloc,
+        act: (bloc) {
+          bloc.add(const LabourCostItemTypeChanged(testLabourType));
+          bloc.add(
+            const LabourCostFormSubmitted(estimateId: testEstimateId),
+          );
+        },
+        expect: () => [
+          isA<LabourCostFormEditing>(),
+          isA<LabourCostFormSubmitting>(),
+          isA<LabourCostFormSuccess>().having(
+            (s) => (s.item as LaborCostItem).itemName,
+            'itemName',
+            testLabourType,
+          ),
+        ],
+      );
+
+      blocTest<LabourCostFormBloc, LabourCostFormState>(
+        'emits [Submitting, Failure] with empty labourType when data source throws socket error',
+        build: () {
+          fakeSupabaseWrapper.shouldThrowOnInsert = true;
+          fakeSupabaseWrapper.insertExceptionType = SupabaseExceptionType.socket;
+          return bloc;
+        },
+        act: (bloc) {
+          bloc.add(const LabourCostItemTypeChanged(testLabourType));
+          bloc.add(
+            const LabourCostFormSubmitted(estimateId: testEstimateId),
+          );
+        },
+        expect: () => [
+          isA<LabourCostFormEditing>(),
+          isA<LabourCostFormSubmitting>(),
+          isA<LabourCostFormFailure>().having(
+            (s) => s.labourType,
+            'labourType',
+            '',
+          ),
+        ],
+      );
+    });
+  });
+}

--- a/test/features/estimations/units/blocs/material_cost_form_bloc_test.dart
+++ b/test/features/estimations/units/blocs/material_cost_form_bloc_test.dart
@@ -1,0 +1,131 @@
+import 'package:bloc_test/bloc_test.dart';
+import 'package:construculator/features/estimation/domain/entities/cost_item_entity.dart';
+import 'package:construculator/features/estimation/estimation_module.dart';
+import 'package:construculator/features/estimation/presentation/bloc/material_cost_form_bloc/material_cost_form_bloc.dart';
+import 'package:construculator/libraries/supabase/data/supabase_types.dart';
+import 'package:construculator/libraries/supabase/interfaces/supabase_wrapper.dart';
+import 'package:construculator/libraries/supabase/testing/fake_supabase_wrapper.dart';
+import 'package:construculator/libraries/time/testing/fake_clock_impl.dart';
+import 'package:flutter_modular/flutter_modular.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../../../../utils/fake_app_bootstrap_factory.dart';
+
+void main() {
+  group('MaterialCostFormBloc', () {
+    late MaterialCostFormBloc bloc;
+    late FakeSupabaseWrapper fakeSupabaseWrapper;
+
+    const testEstimateId = 'test-estimate-123';
+    const testMaterialType = 'Concrete';
+
+    setUpAll(() {
+      final bootstrap = FakeAppBootstrapFactory.create(
+        supabaseWrapper: FakeSupabaseWrapper(clock: FakeClockImpl()),
+      );
+      Modular.init(EstimationModule(bootstrap));
+      fakeSupabaseWrapper =
+          Modular.get<SupabaseWrapper>() as FakeSupabaseWrapper;
+    });
+
+    tearDownAll(() {
+      Modular.dispose();
+    });
+
+    setUp(() {
+      fakeSupabaseWrapper.reset();
+      bloc = Modular.get<MaterialCostFormBloc>();
+    });
+
+    test('initial state is MaterialCostFormInitial', () {
+      expect(bloc.state, isA<MaterialCostFormInitial>());
+    });
+
+    group('MaterialCostItemTypeChanged', () {
+      blocTest<MaterialCostFormBloc, MaterialCostFormState>(
+        'emits Editing with itemTypeError when value is empty',
+        build: () => bloc,
+        act: (bloc) => bloc.add(const MaterialCostItemTypeChanged('')),
+        expect: () => [
+          isA<MaterialCostFormEditing>()
+              .having((s) => s.itemTypeError, 'itemTypeError', isNotNull)
+              .having((s) => s.isItemTypeValid, 'isItemTypeValid', false),
+        ],
+      );
+
+      blocTest<MaterialCostFormBloc, MaterialCostFormState>(
+        'emits Editing with no error when value is non-empty',
+        build: () => bloc,
+        act: (bloc) =>
+            bloc.add(const MaterialCostItemTypeChanged(testMaterialType)),
+        expect: () => [
+          isA<MaterialCostFormEditing>()
+              .having((s) => s.materialType, 'materialType', testMaterialType)
+              .having((s) => s.itemTypeError, 'itemTypeError', isNull)
+              .having((s) => s.isItemTypeValid, 'isItemTypeValid', true),
+        ],
+      );
+    });
+
+    group('MaterialCostFormSubmitted', () {
+      blocTest<MaterialCostFormBloc, MaterialCostFormState>(
+        'emits Editing with error when submitted with empty material type',
+        build: () => bloc,
+        act: (bloc) => bloc.add(
+          const MaterialCostFormSubmitted(estimateId: testEstimateId),
+        ),
+        expect: () => [
+          isA<MaterialCostFormEditing>().having(
+            (s) => s.itemTypeError,
+            'itemTypeError',
+            isNotNull,
+          ),
+        ],
+      );
+
+      blocTest<MaterialCostFormBloc, MaterialCostFormState>(
+        'emits [Submitting, Success] when submitted with valid material type',
+        build: () => bloc,
+        act: (bloc) {
+          bloc.add(const MaterialCostItemTypeChanged(testMaterialType));
+          bloc.add(
+            const MaterialCostFormSubmitted(estimateId: testEstimateId),
+          );
+        },
+        expect: () => [
+          isA<MaterialCostFormEditing>(),
+          isA<MaterialCostFormSubmitting>(),
+          isA<MaterialCostFormSuccess>().having(
+            (s) => (s.item as MaterialCostItem).itemName,
+            'itemName',
+            testMaterialType,
+          ),
+        ],
+      );
+
+      blocTest<MaterialCostFormBloc, MaterialCostFormState>(
+        'emits [Submitting, Failure] with empty materialType when data source throws socket error',
+        build: () {
+          fakeSupabaseWrapper.shouldThrowOnInsert = true;
+          fakeSupabaseWrapper.insertExceptionType = SupabaseExceptionType.socket;
+          return bloc;
+        },
+        act: (bloc) {
+          bloc.add(const MaterialCostItemTypeChanged(testMaterialType));
+          bloc.add(
+            const MaterialCostFormSubmitted(estimateId: testEstimateId),
+          );
+        },
+        expect: () => [
+          isA<MaterialCostFormEditing>(),
+          isA<MaterialCostFormSubmitting>(),
+          isA<MaterialCostFormFailure>().having(
+            (s) => s.materialType,
+            'materialType',
+            '',
+          ),
+        ],
+      );
+    });
+  });
+}

--- a/test/features/estimations/widgets/accessibility/equipment_cost_form_fields_a11y_test.dart
+++ b/test/features/estimations/widgets/accessibility/equipment_cost_form_fields_a11y_test.dart
@@ -1,12 +1,31 @@
+import 'package:construculator/features/estimation/estimation_module.dart';
+import 'package:construculator/features/estimation/presentation/bloc/equipment_cost_form_bloc/equipment_cost_form_bloc.dart';
 import 'package:construculator/features/estimation/presentation/widgets/equipment_cost_form_fields.dart';
 import 'package:construculator/l10n/generated/app_localizations.dart';
+import 'package:construculator/libraries/supabase/testing/fake_supabase_wrapper.dart';
+import 'package:construculator/libraries/time/testing/fake_clock_impl.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_modular/flutter_modular.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:ripplearc_coreui/ripplearc_coreui.dart';
 
 import '../../../../utils/a11y/a11y_guidelines.dart';
+import '../../../../utils/fake_app_bootstrap_factory.dart';
 
 void main() {
+  setUpAll(() {
+    final fakeSupabase = FakeSupabaseWrapper(clock: FakeClockImpl());
+    final bootstrap = FakeAppBootstrapFactory.create(
+      supabaseWrapper: fakeSupabase,
+    );
+    Modular.init(EstimationModule(bootstrap));
+  });
+
+  tearDownAll(() {
+    Modular.dispose();
+  });
+
   Widget makeWidget(ThemeData theme, {bool fromCostFile = false}) {
     return MaterialApp(
       theme: theme,
@@ -14,7 +33,10 @@ void main() {
       localizationsDelegates: AppLocalizations.localizationsDelegates,
       supportedLocales: AppLocalizations.supportedLocales,
       home: Scaffold(
-        body: EquipmentCostFormFields(fromCostFile: fromCostFile),
+        body: BlocProvider<EquipmentCostFormBloc>(
+          create: (_) => Modular.get<EquipmentCostFormBloc>(),
+          child: EquipmentCostFormFields(fromCostFile: fromCostFile),
+        ),
       ),
     );
   }

--- a/test/features/estimations/widgets/accessibility/labour_cost_form_fields_a11y_test.dart
+++ b/test/features/estimations/widgets/accessibility/labour_cost_form_fields_a11y_test.dart
@@ -1,12 +1,31 @@
+import 'package:construculator/features/estimation/estimation_module.dart';
+import 'package:construculator/features/estimation/presentation/bloc/labour_cost_form_bloc/labour_cost_form_bloc.dart';
 import 'package:construculator/features/estimation/presentation/widgets/labour_cost_form_fields.dart';
 import 'package:construculator/l10n/generated/app_localizations.dart';
+import 'package:construculator/libraries/supabase/testing/fake_supabase_wrapper.dart';
+import 'package:construculator/libraries/time/testing/fake_clock_impl.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_modular/flutter_modular.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:ripplearc_coreui/ripplearc_coreui.dart';
 
 import '../../../../utils/a11y/a11y_guidelines.dart';
+import '../../../../utils/fake_app_bootstrap_factory.dart';
 
 void main() {
+  setUpAll(() {
+    final fakeSupabase = FakeSupabaseWrapper(clock: FakeClockImpl());
+    final bootstrap = FakeAppBootstrapFactory.create(
+      supabaseWrapper: fakeSupabase,
+    );
+    Modular.init(EstimationModule(bootstrap));
+  });
+
+  tearDownAll(() {
+    Modular.dispose();
+  });
+
   Widget makeWidget(ThemeData theme, {bool fromCostFile = false}) {
     return MaterialApp(
       theme: theme,
@@ -14,7 +33,10 @@ void main() {
       localizationsDelegates: AppLocalizations.localizationsDelegates,
       supportedLocales: AppLocalizations.supportedLocales,
       home: Scaffold(
-        body: LabourCostFormFields(fromCostFile: fromCostFile),
+        body: BlocProvider<LabourCostFormBloc>(
+          create: (_) => Modular.get<LabourCostFormBloc>(),
+          child: LabourCostFormFields(fromCostFile: fromCostFile),
+        ),
       ),
     );
   }

--- a/test/features/estimations/widgets/accessibility/material_cost_form_fields_a11y_test.dart
+++ b/test/features/estimations/widgets/accessibility/material_cost_form_fields_a11y_test.dart
@@ -1,12 +1,31 @@
+import 'package:construculator/features/estimation/estimation_module.dart';
+import 'package:construculator/features/estimation/presentation/bloc/material_cost_form_bloc/material_cost_form_bloc.dart';
 import 'package:construculator/features/estimation/presentation/widgets/material_cost_form_fields.dart';
 import 'package:construculator/l10n/generated/app_localizations.dart';
+import 'package:construculator/libraries/supabase/testing/fake_supabase_wrapper.dart';
+import 'package:construculator/libraries/time/testing/fake_clock_impl.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_modular/flutter_modular.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:ripplearc_coreui/ripplearc_coreui.dart';
 
 import '../../../../utils/a11y/a11y_guidelines.dart';
+import '../../../../utils/fake_app_bootstrap_factory.dart';
 
 void main() {
+  setUpAll(() {
+    final fakeSupabase = FakeSupabaseWrapper(clock: FakeClockImpl());
+    final bootstrap = FakeAppBootstrapFactory.create(
+      supabaseWrapper: fakeSupabase,
+    );
+    Modular.init(EstimationModule(bootstrap));
+  });
+
+  tearDownAll(() {
+    Modular.dispose();
+  });
+
   Widget makeWidget(ThemeData theme, {bool fromCostFile = false}) {
     return MaterialApp(
       theme: theme,
@@ -14,7 +33,10 @@ void main() {
       localizationsDelegates: AppLocalizations.localizationsDelegates,
       supportedLocales: AppLocalizations.supportedLocales,
       home: Scaffold(
-        body: MaterialCostFormFields(fromCostFile: fromCostFile),
+        body: BlocProvider<MaterialCostFormBloc>(
+          create: (_) => Modular.get<MaterialCostFormBloc>(),
+          child: MaterialCostFormFields(fromCostFile: fromCostFile),
+        ),
       ),
     );
   }

--- a/test/features/estimations/widgets/equipment_cost_form_fields_test.dart
+++ b/test/features/estimations/widgets/equipment_cost_form_fields_test.dart
@@ -1,12 +1,35 @@
+import 'package:construculator/features/estimation/estimation_module.dart';
+import 'package:construculator/features/estimation/presentation/bloc/equipment_cost_form_bloc/equipment_cost_form_bloc.dart';
 import 'package:construculator/features/estimation/presentation/widgets/equipment_cost_form_fields.dart';
 import 'package:construculator/l10n/generated/app_localizations.dart';
+import 'package:construculator/libraries/supabase/testing/fake_supabase_wrapper.dart';
+import 'package:construculator/libraries/time/testing/fake_clock_impl.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_modular/flutter_modular.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:ripplearc_coreui/ripplearc_coreui.dart';
 
+import '../../../utils/fake_app_bootstrap_factory.dart';
+
 void main() {
+  late FakeSupabaseWrapper fakeSupabase;
+
   setUpAll(() {
     lookupAppLocalizations(const Locale('en'));
+    fakeSupabase = FakeSupabaseWrapper(clock: FakeClockImpl());
+    final bootstrap = FakeAppBootstrapFactory.create(
+      supabaseWrapper: fakeSupabase,
+    );
+    Modular.init(EstimationModule(bootstrap));
+  });
+
+  tearDownAll(() {
+    Modular.dispose();
+  });
+
+  setUp(() {
+    fakeSupabase.reset();
   });
 
   Widget makeWidget({
@@ -20,10 +43,13 @@ void main() {
       localizationsDelegates: AppLocalizations.localizationsDelegates,
       supportedLocales: AppLocalizations.supportedLocales,
       home: Scaffold(
-        body: EquipmentCostFormFields(
-          fromCostFile: fromCostFile,
-          onTotalChanged: onTotalChanged,
-          onSaveEnabledChanged: onSaveEnabledChanged,
+        body: BlocProvider<EquipmentCostFormBloc>(
+          create: (_) => Modular.get<EquipmentCostFormBloc>(),
+          child: EquipmentCostFormFields(
+            fromCostFile: fromCostFile,
+            onTotalChanged: onTotalChanged,
+            onSaveEnabledChanged: onSaveEnabledChanged,
+          ),
         ),
       ),
     );

--- a/test/features/estimations/widgets/labour_cost_form_fields_test.dart
+++ b/test/features/estimations/widgets/labour_cost_form_fields_test.dart
@@ -1,15 +1,37 @@
+import 'package:construculator/features/estimation/estimation_module.dart';
+import 'package:construculator/features/estimation/presentation/bloc/labour_cost_form_bloc/labour_cost_form_bloc.dart';
 import 'package:construculator/features/estimation/presentation/widgets/labour_cost_form_fields.dart';
 import 'package:construculator/l10n/generated/app_localizations.dart';
+import 'package:construculator/libraries/supabase/testing/fake_supabase_wrapper.dart';
+import 'package:construculator/libraries/time/testing/fake_clock_impl.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/semantics.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_modular/flutter_modular.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:ripplearc_coreui/ripplearc_coreui.dart';
 
+import '../../../utils/fake_app_bootstrap_factory.dart';
+
 void main() {
   late AppLocalizations l10n;
+  late FakeSupabaseWrapper fakeSupabase;
 
   setUpAll(() {
     l10n = lookupAppLocalizations(const Locale('en'));
+    fakeSupabase = FakeSupabaseWrapper(clock: FakeClockImpl());
+    final bootstrap = FakeAppBootstrapFactory.create(
+      supabaseWrapper: fakeSupabase,
+    );
+    Modular.init(EstimationModule(bootstrap));
+  });
+
+  tearDownAll(() {
+    Modular.dispose();
+  });
+
+  setUp(() {
+    fakeSupabase.reset();
   });
 
   Widget makeWidget({
@@ -23,10 +45,13 @@ void main() {
       localizationsDelegates: AppLocalizations.localizationsDelegates,
       supportedLocales: AppLocalizations.supportedLocales,
       home: Scaffold(
-        body: LabourCostFormFields(
-          fromCostFile: fromCostFile,
-          onTotalChanged: onTotalChanged,
-          onSaveEnabledChanged: onSaveEnabledChanged,
+        body: BlocProvider<LabourCostFormBloc>(
+          create: (_) => Modular.get<LabourCostFormBloc>(),
+          child: LabourCostFormFields(
+            fromCostFile: fromCostFile,
+            onTotalChanged: onTotalChanged,
+            onSaveEnabledChanged: onSaveEnabledChanged,
+          ),
         ),
       ),
     );

--- a/test/features/estimations/widgets/material_cost_form_fields_test.dart
+++ b/test/features/estimations/widgets/material_cost_form_fields_test.dart
@@ -1,14 +1,36 @@
+import 'package:construculator/features/estimation/estimation_module.dart';
+import 'package:construculator/features/estimation/presentation/bloc/material_cost_form_bloc/material_cost_form_bloc.dart';
 import 'package:construculator/features/estimation/presentation/widgets/material_cost_form_fields.dart';
 import 'package:construculator/l10n/generated/app_localizations.dart';
+import 'package:construculator/libraries/supabase/testing/fake_supabase_wrapper.dart';
+import 'package:construculator/libraries/time/testing/fake_clock_impl.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_modular/flutter_modular.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:ripplearc_coreui/ripplearc_coreui.dart';
 
+import '../../../utils/fake_app_bootstrap_factory.dart';
+
 void main() {
   late AppLocalizations l10n;
+  late FakeSupabaseWrapper fakeSupabase;
 
   setUpAll(() {
     l10n = lookupAppLocalizations(const Locale('en'));
+    fakeSupabase = FakeSupabaseWrapper(clock: FakeClockImpl());
+    final bootstrap = FakeAppBootstrapFactory.create(
+      supabaseWrapper: fakeSupabase,
+    );
+    Modular.init(EstimationModule(bootstrap));
+  });
+
+  tearDownAll(() {
+    Modular.dispose();
+  });
+
+  setUp(() {
+    fakeSupabase.reset();
   });
 
   Widget makeWidget({
@@ -22,10 +44,13 @@ void main() {
       localizationsDelegates: AppLocalizations.localizationsDelegates,
       supportedLocales: AppLocalizations.supportedLocales,
       home: Scaffold(
-        body: MaterialCostFormFields(
-          fromCostFile: fromCostFile,
-          onTotalChanged: onTotalChanged,
-          onSaveEnabledChanged: onSaveEnabledChanged,
+        body: BlocProvider<MaterialCostFormBloc>(
+          create: (_) => Modular.get<MaterialCostFormBloc>(),
+          child: MaterialCostFormFields(
+            fromCostFile: fromCostFile,
+            onTotalChanged: onTotalChanged,
+            onSaveEnabledChanged: onSaveEnabledChanged,
+          ),
         ),
       ),
     );


### PR DESCRIPTION
### 1. PR SUMMARY

Adds the `CostItemRepository` domain interface and its `CostItemRepositoryImpl` data layer implementation, then binds both in `EstimationModule`. The impl delegates to `CostItemDataSource`, maps DTOs to/from entities, and converts exceptions to typed `EstimationFailure`s using the same `_handleError` pattern as `CostEstimationLogRepositoryImpl`.

### 2. REVIEW SUMMARY TABLE

No issues found.

## Test plan
- [ ] `fvm flutter test --exclude-tags golden` — all passing (repository is covered by BLoC integration tests in PR 3/3 which exercises the full stack via `FakeSupabaseWrapper`)
- [ ] `fvm dart run custom_lint` — no issues