### PR TITLE
CA-311 (3/3): extract UomSelectorSheet into own file following codebase pattern

### DIFF
--- a/lib/features/estimation/presentation/widgets/unit_of_measurement_field.dart
+++ b/lib/features/estimation/presentation/widgets/unit_of_measurement_field.dart
@@ -1,10 +1,8 @@
 import 'package:construculator/features/estimation/domain/entities/cost_item_entity.dart';
-import 'package:construculator/l10n/generated/app_localizations.dart';
+import 'package:construculator/features/estimation/presentation/widgets/uom_selector_sheet.dart';
 import 'package:construculator/libraries/extensions/extensions.dart';
 import 'package:flutter/material.dart';
 import 'package:ripplearc_coreui/ripplearc_coreui.dart';
-
-enum _UomMode { fromList, manually }
 
 /// A tappable selector field that opens a custom bottom sheet for choosing
 /// a [Unit] of measurement.
@@ -55,7 +53,7 @@ class _UnitOfMeasurementFieldState extends State<UnitOfMeasurementField> {
 
   void _syncController() {
     final unit = widget.selectedUnit;
-    final text = unit != null ? _resolveUnitName(context, unit) : '';
+    final text = unit != null ? uomUnitName(context, unit) : '';
     if (_controller.text != text) {
       _controller.text = text;
     }
@@ -88,246 +86,13 @@ class _UnitOfMeasurementFieldState extends State<UnitOfMeasurementField> {
     );
   }
 
-  void _openSheet(BuildContext context) {
-    CoreQuickSheet.show(
+  Future<void> _openSheet(BuildContext context) async {
+    final unit = await UomSelectorSheet.show(
       context: context,
-      useSafeArea: true,
-      child: _UomSelectorSheet(
-        selectedUnit: widget.selectedUnit,
-        onUnitSelected: (unit) {
-          Navigator.of(context).pop();
-          widget.onUnitSelected(unit);
-        },
-      ),
+      selectedUnit: widget.selectedUnit,
     );
-  }
-}
-
-String _resolveUnitName(BuildContext context, Unit unit) {
-  final l10n = context.l10n;
-  return switch (unit) {
-    Unit.pieces => l10n.unitPieces,
-    Unit.meters => l10n.unitMeters,
-    Unit.squareMeters => l10n.unitSquareMeters,
-    Unit.cubicMeters => l10n.unitCubicMeters,
-    Unit.kilograms => l10n.unitKilograms,
-    Unit.tons => l10n.unitTons,
-    Unit.liters => l10n.unitLiters,
-    Unit.hours => l10n.unitHours,
-    Unit.days => l10n.unitDays,
-    Unit.boxes => l10n.unitBoxes,
-    Unit.bags => l10n.unitBags,
-    Unit.rolls => l10n.unitRolls,
-    Unit.sheets => l10n.unitSheets,
-  };
-}
-
-const _unitsByCategory = [
-  [Unit.meters],                              // Length
-  [Unit.squareMeters, Unit.sheets],           // Area
-  [Unit.cubicMeters, Unit.liters, Unit.bags], // Volume
-  [Unit.kilograms, Unit.tons],               // Weight
-  [Unit.pieces, Unit.boxes, Unit.rolls],     // Count
-  [Unit.hours, Unit.days],                   // Time
-];
-
-class _UomSelectorSheet extends StatefulWidget {
-  final Unit? selectedUnit;
-  final ValueChanged<Unit?> onUnitSelected;
-
-  const _UomSelectorSheet({
-    required this.onUnitSelected,
-    this.selectedUnit,
-  });
-
-  @override
-  State<_UomSelectorSheet> createState() => _UomSelectorSheetState();
-}
-
-class _UomSelectorSheetState extends State<_UomSelectorSheet> {
-  _UomMode _mode = _UomMode.fromList;
-  int _tabIndex = 0;
-
-  @override
-  Widget build(BuildContext context) {
-    final l10n = context.l10n;
-    final typography = Theme.of(context).coreTypography;
-
-    return Column(
-      mainAxisSize: MainAxisSize.min,
-      crossAxisAlignment: CrossAxisAlignment.stretch,
-      children: [
-        Container(
-          padding: const EdgeInsets.fromLTRB(
-            CoreSpacing.space4,
-            CoreSpacing.space3,
-            CoreSpacing.space4,
-            CoreSpacing.space3,
-          ),
-          decoration: BoxDecoration(
-            color: Theme.of(context).coreColors.pageBackground,
-            boxShadow: CoreShadows.small,
-          ),
-          child: Text(
-            l10n.uomSheetTitle,
-            style: typography.headlineMediumSemiBold,
-          ),
-        ),
-        const SizedBox(height: CoreSpacing.space4),
-        Padding(
-          padding: const EdgeInsets.symmetric(horizontal: CoreSpacing.space4),
-          child: _buildModeCard(l10n),
-        ),
-        const SizedBox(height: CoreSpacing.space2),
-        if (_mode == _UomMode.fromList) ...[
-          Padding(
-            padding: const EdgeInsets.symmetric(horizontal: CoreSpacing.space4),
-            child: CoreTabs(
-              tabs: [
-                l10n.uomCategoryLength,
-                l10n.uomCategoryArea,
-                l10n.uomCategoryVolume,
-                l10n.uomCategoryWeight,
-                l10n.uomCategoryCount,
-                l10n.uomCategoryTime,
-              ],
-              selectedIndex: _tabIndex,
-              onChanged: (i) => setState(() => _tabIndex = i),
-            ),
-          ),
-          const SizedBox(height: CoreSpacing.space2),
-          Padding(
-            padding: const EdgeInsets.symmetric(horizontal: CoreSpacing.space4),
-            child: _buildUnitList(),
-          ),
-        ] else ...[
-          Padding(
-            padding: const EdgeInsets.symmetric(horizontal: CoreSpacing.space4),
-            child: CoreTextField(hintText: l10n.uomManualInputHint),
-          ),
-        ],
-        const SizedBox(height: CoreSpacing.space6),
-        Padding(
-          padding: const EdgeInsets.symmetric(horizontal: CoreSpacing.space4),
-          child: CoreButton(
-            label: l10n.addUomButton,
-            isDisabled: true,
-          ),
-        ),
-        const SizedBox(height: CoreSpacing.space4),
-      ],
-    );
-  }
-
-  Widget _buildUnitList() {
-    final typography = Theme.of(context).coreTypography;
-    final colors = Theme.of(context).coreColors;
-    final units = _unitsByCategory[_tabIndex];
-
-    return Column(
-      mainAxisSize: MainAxisSize.min,
-      crossAxisAlignment: CrossAxisAlignment.stretch,
-      children: [
-        for (final unit in units)
-          InkWell(
-            borderRadius: BorderRadius.circular(8),
-            onTap: () {
-              Navigator.of(context).pop();
-              widget.onUnitSelected(unit);
-            },
-            child: Padding(
-              padding: const EdgeInsets.all(CoreSpacing.space3),
-              child: Text(
-                _resolveUnitName(context, unit),
-                style: typography.bodyMediumRegular.copyWith(
-                  color: colors.textHeadline,
-                ),
-              ),
-            ),
-          ),
-      ],
-    );
-  }
-
-  Widget _buildModeCard(AppLocalizations l10n) {
-    final typography = Theme.of(context).coreTypography;
-    final colors = Theme.of(context).coreColors;
-
-    return Container(
-      padding: const EdgeInsets.all(CoreSpacing.space3),
-      decoration: BoxDecoration(
-        color: colors.pageBackground,
-        borderRadius: BorderRadius.circular(8),
-        boxShadow: CoreShadows.small,
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Text(
-            l10n.uomAddModeQuestion,
-            style: typography.bodyMediumRegular.copyWith(
-              color: colors.textHeadline,
-            ),
-          ),
-          const SizedBox(height: CoreSpacing.space3),
-          Row(
-            children: [
-              Flexible(
-                child: _buildRadioOption(
-                  label: l10n.uomFromListOption,
-                  value: _UomMode.fromList,
-                ),
-              ),
-              const SizedBox(width: CoreSpacing.space8),
-              Flexible(
-                child: _buildRadioOption(
-                  label: l10n.uomManuallyOption,
-                  value: _UomMode.manually,
-                ),
-              ),
-            ],
-          ),
-        ],
-      ),
-    );
-  }
-
-  Widget _buildRadioOption({
-    required String label,
-    required _UomMode value,
-  }) {
-    final typography = Theme.of(context).coreTypography;
-    final colors = Theme.of(context).coreColors;
-    final isSelected = _mode == value;
-
-    return GestureDetector(
-      onTap: () => setState(() => _mode = value),
-      child: Row(
-        children: [
-          SizedBox(
-            width: 24,
-            height: 24,
-            child: Radio<_UomMode>(
-              value: value,
-              groupValue: _mode,
-              onChanged: (v) {
-                if (v != null) setState(() => _mode = v);
-              },
-              activeColor: colors.outlineFocus,
-              materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
-            ),
-          ),
-          const SizedBox(width: CoreSpacing.space2),
-          Flexible(
-            child: Text(
-              label,
-              style: typography.bodyMediumRegular.copyWith(
-                color: isSelected ? colors.textHeadline : colors.textBody,
-              ),
-            ),
-          ),
-        ],
-      ),
-    );
+    if (unit != null) {
+      widget.onUnitSelected(unit);
+    }
   }
 }

--- a/lib/features/estimation/presentation/widgets/uom_selector_sheet.dart
+++ b/lib/features/estimation/presentation/widgets/uom_selector_sheet.dart
@@ -1,0 +1,240 @@
+import 'package:construculator/features/estimation/domain/entities/cost_item_entity.dart';
+import 'package:construculator/l10n/generated/app_localizations.dart';
+import 'package:construculator/libraries/extensions/extensions.dart';
+import 'package:flutter/material.dart';
+import 'package:ripplearc_coreui/ripplearc_coreui.dart';
+
+enum _UomMode { fromList, manually }
+
+const _unitsByCategory = [
+  [Unit.meters],
+  [Unit.squareMeters, Unit.sheets],
+  [Unit.cubicMeters, Unit.liters, Unit.bags],
+  [Unit.kilograms, Unit.tons],
+  [Unit.pieces, Unit.boxes, Unit.rolls],
+  [Unit.hours, Unit.days],
+];
+
+String uomUnitName(BuildContext context, Unit unit) {
+  final l10n = context.l10n;
+  return switch (unit) {
+    Unit.pieces => l10n.unitPieces,
+    Unit.meters => l10n.unitMeters,
+    Unit.squareMeters => l10n.unitSquareMeters,
+    Unit.cubicMeters => l10n.unitCubicMeters,
+    Unit.kilograms => l10n.unitKilograms,
+    Unit.tons => l10n.unitTons,
+    Unit.liters => l10n.unitLiters,
+    Unit.hours => l10n.unitHours,
+    Unit.days => l10n.unitDays,
+    Unit.boxes => l10n.unitBoxes,
+    Unit.bags => l10n.unitBags,
+    Unit.rolls => l10n.unitRolls,
+    Unit.sheets => l10n.unitSheets,
+  };
+}
+
+class UomSelectorSheet extends StatefulWidget {
+  final Unit? selectedUnit;
+
+  const UomSelectorSheet({super.key, this.selectedUnit});
+
+  static Future<Unit?> show({
+    required BuildContext context,
+    Unit? selectedUnit,
+  }) {
+    return CoreQuickSheet.show<Unit?>(
+      context: context,
+      useSafeArea: true,
+      child: UomSelectorSheet(selectedUnit: selectedUnit),
+    );
+  }
+
+  @override
+  State<UomSelectorSheet> createState() => _UomSelectorSheetState();
+}
+
+class _UomSelectorSheetState extends State<UomSelectorSheet> {
+  _UomMode _mode = _UomMode.fromList;
+  int _tabIndex = 0;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = context.l10n;
+    final typography = Theme.of(context).coreTypography;
+
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Container(
+          padding: const EdgeInsets.fromLTRB(
+            CoreSpacing.space4,
+            CoreSpacing.space3,
+            CoreSpacing.space4,
+            CoreSpacing.space3,
+          ),
+          decoration: BoxDecoration(
+            color: Theme.of(context).coreColors.pageBackground,
+            boxShadow: CoreShadows.small,
+          ),
+          child: Text(
+            l10n.uomSheetTitle,
+            style: typography.headlineMediumSemiBold,
+          ),
+        ),
+        const SizedBox(height: CoreSpacing.space4),
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: CoreSpacing.space4),
+          child: _buildModeCard(l10n),
+        ),
+        const SizedBox(height: CoreSpacing.space2),
+        if (_mode == _UomMode.fromList) ...[
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: CoreSpacing.space4),
+            child: CoreTabs(
+              tabs: [
+                l10n.uomCategoryLength,
+                l10n.uomCategoryArea,
+                l10n.uomCategoryVolume,
+                l10n.uomCategoryWeight,
+                l10n.uomCategoryCount,
+                l10n.uomCategoryTime,
+              ],
+              selectedIndex: _tabIndex,
+              onChanged: (i) => setState(() => _tabIndex = i),
+            ),
+          ),
+          const SizedBox(height: CoreSpacing.space2),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: CoreSpacing.space4),
+            child: _buildUnitList(),
+          ),
+        ] else ...[
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: CoreSpacing.space4),
+            child: CoreTextField(hintText: l10n.uomManualInputHint),
+          ),
+        ],
+        const SizedBox(height: CoreSpacing.space6),
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: CoreSpacing.space4),
+          child: CoreButton(
+            label: l10n.addUomButton,
+            isDisabled: true,
+          ),
+        ),
+        const SizedBox(height: CoreSpacing.space4),
+      ],
+    );
+  }
+
+  Widget _buildUnitList() {
+    final typography = Theme.of(context).coreTypography;
+    final colors = Theme.of(context).coreColors;
+    final units = _unitsByCategory[_tabIndex];
+
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        for (final unit in units)
+          InkWell(
+            borderRadius: BorderRadius.circular(8),
+            onTap: () => Navigator.of(context).pop(unit),
+            child: Padding(
+              padding: const EdgeInsets.all(CoreSpacing.space3),
+              child: Text(
+                uomUnitName(context, unit),
+                style: typography.bodyMediumRegular.copyWith(
+                  color: colors.textHeadline,
+                ),
+              ),
+            ),
+          ),
+      ],
+    );
+  }
+
+  Widget _buildModeCard(AppLocalizations l10n) {
+    final typography = Theme.of(context).coreTypography;
+    final colors = Theme.of(context).coreColors;
+
+    return Container(
+      padding: const EdgeInsets.all(CoreSpacing.space3),
+      decoration: BoxDecoration(
+        color: colors.pageBackground,
+        borderRadius: BorderRadius.circular(8),
+        boxShadow: CoreShadows.small,
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            l10n.uomAddModeQuestion,
+            style: typography.bodyMediumRegular.copyWith(
+              color: colors.textHeadline,
+            ),
+          ),
+          const SizedBox(height: CoreSpacing.space3),
+          Row(
+            children: [
+              Flexible(
+                child: _buildRadioOption(
+                  label: l10n.uomFromListOption,
+                  value: _UomMode.fromList,
+                ),
+              ),
+              const SizedBox(width: CoreSpacing.space8),
+              Flexible(
+                child: _buildRadioOption(
+                  label: l10n.uomManuallyOption,
+                  value: _UomMode.manually,
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildRadioOption({
+    required String label,
+    required _UomMode value,
+  }) {
+    final typography = Theme.of(context).coreTypography;
+    final colors = Theme.of(context).coreColors;
+    final isSelected = _mode == value;
+
+    return GestureDetector(
+      onTap: () => setState(() => _mode = value),
+      child: Row(
+        children: [
+          SizedBox(
+            width: 24,
+            height: 24,
+            child: Radio<_UomMode>(
+              value: value,
+              groupValue: _mode,
+              onChanged: (v) {
+                if (v != null) setState(() => _mode = v);
+              },
+              activeColor: colors.outlineFocus,
+              materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+            ),
+          ),
+          const SizedBox(width: CoreSpacing.space2),
+          Flexible(
+            child: Text(
+              label,
+              style: typography.bodyMediumRegular.copyWith(
+                color: isSelected ? colors.textHeadline : colors.textBody,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/test/features/estimations/widgets/material_cost_form_fields_test.dart
+++ b/test/features/estimations/widgets/material_cost_form_fields_test.dart
@@ -1,3 +1,4 @@
+import 'package:construculator/features/estimation/domain/entities/cost_item_entity.dart';
 import 'package:construculator/features/estimation/estimation_module.dart';
 import 'package:construculator/features/estimation/presentation/bloc/material_cost_form_bloc/material_cost_form_bloc.dart';
 import 'package:construculator/features/estimation/presentation/widgets/material_cost_form_fields.dart';


### PR DESCRIPTION
## Summary
- Extracts `UomSelectorSheet` from `unit_of_measurement_field.dart` into its own `uom_selector_sheet.dart`, following the `DateFilterChip`/`DateRangeBottomSheet` convention already in the codebase
- Adds a `static Future<Unit?> show()` factory on `UomSelectorSheet`, replacing the ad-hoc `CoreQuickSheet.show()` call inside the field
- Exposes `uomUnitName()` as a public top-level function so both the field and sheet share one source of truth for unit display names
- Fixes `dynamic` l10n param → `AppLocalizations` in `_buildModeCard`
- Fixes double-pop by switching `_openSheet` to async `await UomSelectorSheet.show()` returning `Future<Unit?>`
- Adds missing `cost_item_entity.dart` import to `material_cost_form_fields_test.dart`

## Test plan
- [ ] `fvm flutter test test/features/estimations/widgets/`
- [ ] `fvm dart run custom_lint` clean

## Review Summary

No issues found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)