### PR TITLE
CA-310 (1/3): add CostItemRepository interface, impl, and module binding

### DIFF
--- a/lib/features/estimation/data/repositories/cost_item_repository_impl.dart
+++ b/lib/features/estimation/data/repositories/cost_item_repository_impl.dart
@@ -1,0 +1,64 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:construculator/features/estimation/data/data_source/interfaces/cost_item_data_source.dart';
+import 'package:construculator/features/estimation/data/models/cost_item_dto.dart';
+import 'package:construculator/features/estimation/domain/entities/cost_item_entity.dart';
+import 'package:construculator/features/estimation/domain/repositories/cost_item_repository.dart';
+import 'package:construculator/libraries/either/either.dart';
+import 'package:construculator/libraries/errors/failures.dart';
+import 'package:construculator/libraries/estimation/domain/estimation_error_type.dart';
+import 'package:construculator/libraries/logging/app_logger.dart';
+
+class CostItemRepositoryImpl implements CostItemRepository {
+  CostItemRepositoryImpl({required this.dataSource});
+
+  final CostItemDataSource dataSource;
+  static final _logger = AppLogger().tag('CostItemRepositoryImpl');
+
+  @override
+  Future<Either<Failure, CostItem>> createCostItem(CostItem item) async {
+    try {
+      final dto = CostItemDto.fromEntity(item);
+      final created = await dataSource.createCostItem(dto);
+      return Right(created.toEntity());
+    } catch (e) {
+      return _handleError(e, 'creating cost item');
+    }
+  }
+
+  Left<Failure, CostItem> _handleError(Object error, String operation) {
+    if (error is TimeoutException) {
+      _logger.error(
+        'Timeout error $operation: message=${error.message}, duration=${error.duration}',
+      );
+      return const Left(
+        EstimationFailure(errorType: EstimationErrorType.timeoutError),
+      );
+    } else if (error is SocketException) {
+      _logger.warning(
+        'Connection error $operation: message=${error.message}',
+      );
+      return const Left(
+        EstimationFailure(errorType: EstimationErrorType.connectionError),
+      );
+    } else if (error is FormatException) {
+      _logger.error(
+        'Parsing error $operation: message=${error.message}',
+      );
+      return const Left(
+        EstimationFailure(errorType: EstimationErrorType.parsingError),
+      );
+    } else if (error is TypeError) {
+      _logger.error('Parsing error $operation: ${error.toString()}');
+      return const Left(
+        EstimationFailure(errorType: EstimationErrorType.parsingError),
+      );
+    } else {
+      _logger.error('Unexpected error $operation: $error');
+      return const Left(
+        EstimationFailure(errorType: EstimationErrorType.unexpectedError),
+      );
+    }
+  }
+}

--- a/lib/features/estimation/domain/repositories/cost_item_repository.dart
+++ b/lib/features/estimation/domain/repositories/cost_item_repository.dart
@@ -1,0 +1,9 @@
+import 'package:construculator/features/estimation/domain/entities/cost_item_entity.dart';
+import 'package:construculator/libraries/either/interfaces/either.dart';
+import 'package:construculator/libraries/errors/failures.dart';
+
+/// Repository interface for cost item data operations.
+abstract class CostItemRepository {
+  /// Creates a new cost item and returns the persisted entity.
+  Future<Either<Failure, CostItem>> createCostItem(CostItem item);
+}

--- a/lib/features/estimation/estimation_module.dart
+++ b/lib/features/estimation/estimation_module.dart
@@ -4,7 +4,9 @@ import 'package:construculator/features/estimation/data/data_source/interfaces/c
 import 'package:construculator/features/estimation/data/data_source/remote_cost_estimation_log_data_source.dart';
 import 'package:construculator/features/estimation/data/data_source/remote_cost_item_data_source.dart';
 import 'package:construculator/features/estimation/data/repositories/cost_estimation_log_repository_impl.dart';
+import 'package:construculator/features/estimation/data/repositories/cost_item_repository_impl.dart';
 import 'package:construculator/features/estimation/domain/repositories/cost_estimation_log_repository.dart';
+import 'package:construculator/features/estimation/domain/repositories/cost_item_repository.dart';
 import 'package:construculator/features/estimation/domain/usecases/add_cost_estimation_usecase.dart';
 import 'package:construculator/features/estimation/presentation/bloc/add_cost_estimation_bloc/add_cost_estimation_bloc.dart';
 import 'package:construculator/features/estimation/presentation/bloc/change_lock_status_bloc/change_lock_status_bloc.dart';
@@ -92,6 +94,10 @@ class EstimationModule extends Module {
     i.addLazySingleton<CostEstimationLogRepository>(
       () => CostEstimationLogRepositoryImpl(dataSource: i.get()),
       config: BindConfig(onDispose: (repository) => repository.dispose()),
+    );
+
+    i.addLazySingleton<CostItemRepository>(
+      () => CostItemRepositoryImpl(dataSource: i.get()),
     );
 
     i.addLazySingleton<AddCostEstimationUseCase>(


### PR DESCRIPTION
### 1. PR SUMMARY

Adds the `CostItemRepository` interface and its Supabase-backed implementation, then registers both in the estimation Modular module so downstream BLoCs can inject it.

### 2. REVIEW SUMMARY TABLE

No issues found.

## Test plan
- [ ] `fvm flutter test` passes
- [ ] `fvm dart run custom_lint` clean