### PR TITLE
CA-315: add widget tests for per-hour calc method visibility and non-labour hiding

### DIFF
--- a/test/features/estimations/widgets/equipment_cost_form_fields_test.dart
+++ b/test/features/estimations/widgets/equipment_cost_form_fields_test.dart
@@ -94,6 +94,13 @@ void main() {
 
       expect(find.byKey(const Key('equipment_type_field')), findsNothing);
     });
+
+    testWidgets('hides calc method card', (tester) async {
+      await tester.pumpWidget(makeWidget());
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('calc_method_card')), findsNothing);
+    });
   });
 
   group('EquipmentCostFormFields — from cost file mode', () {

--- a/test/features/estimations/widgets/labour_cost_form_fields_test.dart
+++ b/test/features/estimations/widgets/labour_cost_form_fields_test.dart
@@ -139,6 +139,27 @@ void main() {
 
       expect(find.byKey(const Key('rate_row')), findsNothing);
     });
+
+    testWidgets('shows calc method card', (tester) async {
+      await tester.pumpWidget(makeWidget(fromCostFile: true));
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('calc_method_card')), findsOneWidget);
+    });
+
+    testWidgets('shows conditional value field', (tester) async {
+      await tester.pumpWidget(makeWidget(fromCostFile: true));
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('conditional_value_field')), findsOneWidget);
+    });
+
+    testWidgets('shows crew size field', (tester) async {
+      await tester.pumpWidget(makeWidget(fromCostFile: true));
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('crew_size_field')), findsOneWidget);
+    });
   });
 
   group('LabourCostFormFields — calc method switching', () {
@@ -176,6 +197,31 @@ void main() {
       final perDay = tester.getSemantics(find.byKey(const Key('per_day_option')));
       expect(perHours.flagsCollection.isSelected.toBoolOrNull(), isTrue);
       expect(perDay.flagsCollection.isSelected.toBoolOrNull(), isFalse);
+    });
+
+    testWidgets('shows crew size field when per hours is selected', (
+      tester,
+    ) async {
+      await tester.pumpWidget(makeWidget());
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byKey(const Key('per_hours_option')));
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('crew_size_field')), findsOneWidget);
+    });
+
+    testWidgets(
+        'tapping per hours in from cost file mode changes conditional field label',
+        (tester) async {
+      await tester.pumpWidget(makeWidget(fromCostFile: true));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byKey(const Key('per_hours_option')));
+      await tester.pumpAndSettle();
+
+      expect(find.text(l10n.noOfHoursLabel), findsOneWidget);
+      expect(find.text(l10n.noOfDaysLabel), findsNothing);
     });
   });
 

--- a/test/features/estimations/widgets/material_cost_form_fields_test.dart
+++ b/test/features/estimations/widgets/material_cost_form_fields_test.dart
@@ -109,6 +109,13 @@ void main() {
       expect(find.byKey(const Key('cost_file_field')), findsNothing);
     });
 
+    testWidgets('hides calc method card', (tester) async {
+      await tester.pumpWidget(makeWidget());
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('calc_method_card')), findsNothing);
+    });
+
     testWidgets('brand and product link hidden by default', (tester) async {
       await tester.pumpWidget(makeWidget());
       await tester.pumpAndSettle();


### PR DESCRIPTION
### 1. PR SUMMARY
Adds widget tests that verify the three CA-315 requirements: (1) the `CalcMethodCard` is present and the per-hour radio option correctly changes the conditional field label and keeps crew size visible; (2) the calc method section is absent in `MaterialCostFormFields` and `EquipmentCostFormFields`; (3) both from-cost-file and manually modes in the labour form expose the conditional value and crew size fields.

No production code changes — the Per Hour UI was already implemented in CA-306.

### 2. REVIEW SUMMARY TABLE
No issues found.

## Test plan
- [ ] `fvm flutter test test/features/estimations/widgets/labour_cost_form_fields_test.dart` — all pass
- [ ] `fvm flutter test test/features/estimations/widgets/material_cost_form_fields_test.dart` — all pass
- [ ] `fvm flutter test test/features/estimations/widgets/equipment_cost_form_fields_test.dart` — all pass
- [ ] `fvm dart run custom_lint` — no issues