### PR TITLE
CA-316: add per hour calculation logic to LabourCostFormBloc

### DIFF
--- a/lib/features/estimation/presentation/bloc/labour_cost_form_bloc/labour_cost_form_bloc.dart
+++ b/lib/features/estimation/presentation/bloc/labour_cost_form_bloc/labour_cost_form_bloc.dart
@@ -1,3 +1,4 @@
+import 'package:construculator/features/estimation/domain/entities/cost_item_entity.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
 part 'labour_cost_form_event.dart';
@@ -8,6 +9,10 @@ class LabourCostFormBloc
     extends Bloc<LabourCostFormEvent, LabourCostFormState> {
   LabourCostFormBloc() : super(const LabourCostFormInitial()) {
     on<LabourCostItemTypeChanged>(_onItemTypeChanged);
+    on<LabourCostCalculationMethodChanged>(_onCalculationMethodChanged);
+    on<LabourCostLaborValueUpdated>(_onLaborValueUpdated);
+    on<LabourCostCrewSizeUpdated>(_onCrewSizeUpdated);
+    on<LabourCostHourlyRateUpdated>(_onHourlyRateUpdated);
     // TODO(CA-294): register LabourCostFormSubmitted and wire to CostItemRepository.createCostItem
   }
 
@@ -22,6 +27,68 @@ class LabourCostFormBloc
       current.copyWith(
         labourType: event.value,
         itemTypeError: event.value.trim().isEmpty ? 'itemTypeRequired' : null,
+      ),
+    );
+  }
+
+  void _onCalculationMethodChanged(
+    LabourCostCalculationMethodChanged event,
+    Emitter<LabourCostFormState> emit,
+  ) {
+    final current = state is LabourCostFormEditing
+        ? state as LabourCostFormEditing
+        : const LabourCostFormEditing();
+    emit(current.copyWith(calculationMethod: event.calculationMethod));
+  }
+
+  void _onLaborValueUpdated(
+    LabourCostLaborValueUpdated event,
+    Emitter<LabourCostFormState> emit,
+  ) {
+    final current = state is LabourCostFormEditing
+        ? state as LabourCostFormEditing
+        : const LabourCostFormEditing();
+    emit(current.copyWith(laborValue: event.laborValue));
+  }
+
+  void _onCrewSizeUpdated(
+    LabourCostCrewSizeUpdated event,
+    Emitter<LabourCostFormState> emit,
+  ) {
+    final current = state is LabourCostFormEditing
+        ? state as LabourCostFormEditing
+        : const LabourCostFormEditing();
+    final crewSize = event.crewSize;
+    final isPositive = crewSize != null && crewSize > 0;
+    emit(
+      current.copyWith(
+        crewSize: isPositive ? crewSize : null,
+        crewSizeError: crewSize == null
+            ? 'crewSizeRequiredError'
+            : isPositive
+                ? null
+                : 'crewSizeInvalidError',
+      ),
+    );
+  }
+
+  void _onHourlyRateUpdated(
+    LabourCostHourlyRateUpdated event,
+    Emitter<LabourCostFormState> emit,
+  ) {
+    final current = state is LabourCostFormEditing
+        ? state as LabourCostFormEditing
+        : const LabourCostFormEditing();
+    final parsed = double.tryParse(event.value);
+    final isPositive = parsed != null && parsed > 0;
+    emit(
+      current.copyWith(
+        hourlyRate: isPositive ? parsed : null,
+        hourlyRateError: event.value.trim().isEmpty
+            ? 'hourlyRateRequiredError'
+            : isPositive
+                ? null
+                : 'hourlyRateInvalidError',
       ),
     );
   }

--- a/lib/features/estimation/presentation/bloc/labour_cost_form_bloc/labour_cost_form_event.dart
+++ b/lib/features/estimation/presentation/bloc/labour_cost_form_bloc/labour_cost_form_event.dart
@@ -13,4 +13,28 @@ class LabourCostItemTypeChanged extends LabourCostFormEvent {
   final String value;
 }
 
+class LabourCostCalculationMethodChanged extends LabourCostFormEvent {
+  const LabourCostCalculationMethodChanged(this.calculationMethod);
+
+  final LaborCalculationMethodType? calculationMethod;
+}
+
+class LabourCostLaborValueUpdated extends LabourCostFormEvent {
+  const LabourCostLaborValueUpdated(this.laborValue);
+
+  final LaborValue? laborValue;
+}
+
+class LabourCostCrewSizeUpdated extends LabourCostFormEvent {
+  const LabourCostCrewSizeUpdated(this.crewSize);
+
+  final double? crewSize;
+}
+
+class LabourCostHourlyRateUpdated extends LabourCostFormEvent {
+  const LabourCostHourlyRateUpdated(this.value);
+
+  final String value;
+}
+
 // TODO(CA-294): add LabourCostFormSubmitted event with estimateId and other field values

--- a/lib/features/estimation/presentation/bloc/labour_cost_form_bloc/labour_cost_form_state.dart
+++ b/lib/features/estimation/presentation/bloc/labour_cost_form_bloc/labour_cost_form_state.dart
@@ -12,27 +12,69 @@ class LabourCostFormInitial extends LabourCostFormState {
 
 /// State while the user is filling in the labour cost form.
 class LabourCostFormEditing extends LabourCostFormState {
-  const LabourCostFormEditing({this.labourType = '', this.itemTypeError});
+  const LabourCostFormEditing({
+    this.labourType = '',
+    this.itemTypeError,
+    this.calculationMethod,
+    this.laborValue,
+    this.crewSize,
+    this.crewSizeError,
+    this.hourlyRate,
+    this.hourlyRateError,
+  });
 
   /// The labour type value entered by the user.
   final String labourType;
 
   /// Validation error key for the item type field, or null when valid.
   final String? itemTypeError;
+  final LaborCalculationMethodType? calculationMethod;
+  final LaborValue? laborValue;
+  final double? crewSize;
+  final String? crewSizeError;
+  final double? hourlyRate;
+  final String? hourlyRateError;
 
   /// Whether the item type field contains a non-empty value.
   bool get isItemTypeValid => labourType.trim().isNotEmpty;
+  bool get isHourlyRateValid => (hourlyRate ?? 0) > 0;
+  bool get isCrewSizeValid => (crewSize ?? 0) > 0;
+
+  double get perHourTotal {
+    if (calculationMethod != LaborCalculationMethodType.perHour) return 0;
+    return (hourlyRate ?? 0) * (laborValue?.laborHours ?? 0) * (crewSize ?? 0);
+  }
 
   /// Returns a copy of this state with the given fields replaced.
   LabourCostFormEditing copyWith({
     String? labourType,
     Object? itemTypeError = _keep,
+    Object? calculationMethod = _keep,
+    Object? laborValue = _keep,
+    Object? crewSize = _keep,
+    Object? crewSizeError = _keep,
+    Object? hourlyRate = _keep,
+    Object? hourlyRateError = _keep,
   }) {
     return LabourCostFormEditing(
       labourType: labourType ?? this.labourType,
       itemTypeError: itemTypeError == _keep
           ? this.itemTypeError
           : itemTypeError as String?,
+      calculationMethod: calculationMethod == _keep
+          ? this.calculationMethod
+          : calculationMethod as LaborCalculationMethodType?,
+      laborValue:
+          laborValue == _keep ? this.laborValue : laborValue as LaborValue?,
+      crewSize: crewSize == _keep ? this.crewSize : crewSize as double?,
+      crewSizeError: crewSizeError == _keep
+          ? this.crewSizeError
+          : crewSizeError as String?,
+      hourlyRate:
+          hourlyRate == _keep ? this.hourlyRate : hourlyRate as double?,
+      hourlyRateError: hourlyRateError == _keep
+          ? this.hourlyRateError
+          : hourlyRateError as String?,
     );
   }
 }

--- a/test/features/estimations/units/blocs/labour_cost_form_bloc_test.dart
+++ b/test/features/estimations/units/blocs/labour_cost_form_bloc_test.dart
@@ -1,4 +1,5 @@
 import 'package:bloc_test/bloc_test.dart';
+import 'package:construculator/features/estimation/domain/entities/cost_item_entity.dart';
 import 'package:construculator/features/estimation/estimation_module.dart';
 import 'package:construculator/features/estimation/presentation/bloc/labour_cost_form_bloc/labour_cost_form_bloc.dart';
 import 'package:construculator/libraries/supabase/testing/fake_supabase_wrapper.dart';
@@ -63,5 +64,292 @@ void main() {
     });
 
     // TODO(CA-294): add submit event tests covering happy path, validation guard, and server errors
+
+    group('LabourCostCalculationMethodChanged', () {
+      blocTest<LabourCostFormBloc, LabourCostFormState>(
+        'emits Editing with calculationMethod set to perHour',
+        build: () => bloc,
+        act: (bloc) => bloc.add(
+          const LabourCostCalculationMethodChanged(
+            LaborCalculationMethodType.perHour,
+          ),
+        ),
+        expect: () => [
+          isA<LabourCostFormEditing>().having(
+            (s) => s.calculationMethod,
+            'calculationMethod',
+            LaborCalculationMethodType.perHour,
+          ),
+        ],
+      );
+
+      blocTest<LabourCostFormBloc, LabourCostFormState>(
+        'emits Editing with null calculationMethod when null is passed',
+        build: () => bloc,
+        act: (bloc) =>
+            bloc.add(const LabourCostCalculationMethodChanged(null)),
+        expect: () => [
+          isA<LabourCostFormEditing>().having(
+            (s) => s.calculationMethod,
+            'calculationMethod',
+            isNull,
+          ),
+        ],
+      );
+
+      blocTest<LabourCostFormBloc, LabourCostFormState>(
+        'preserves labourType when calculationMethod changes',
+        build: () => bloc,
+        act: (bloc) => bloc
+          ..add(const LabourCostItemTypeChanged(testLabourType))
+          ..add(
+            const LabourCostCalculationMethodChanged(
+              LaborCalculationMethodType.perHour,
+            ),
+          ),
+        expect: () => [
+          isA<LabourCostFormEditing>().having(
+            (s) => s.labourType,
+            'labourType',
+            testLabourType,
+          ),
+          isA<LabourCostFormEditing>()
+              .having((s) => s.labourType, 'labourType', testLabourType)
+              .having(
+                (s) => s.calculationMethod,
+                'calculationMethod',
+                LaborCalculationMethodType.perHour,
+              ),
+        ],
+      );
+    });
+
+    group('LabourCostLaborValueUpdated', () {
+      blocTest<LabourCostFormBloc, LabourCostFormState>(
+        'emits Editing with laborValue containing laborHours',
+        build: () => bloc,
+        act: (bloc) => bloc.add(
+          const LabourCostLaborValueUpdated(LaborValue(laborHours: 8.0)),
+        ),
+        expect: () => [
+          isA<LabourCostFormEditing>().having(
+            (s) => s.laborValue?.laborHours,
+            'laborValue.laborHours',
+            8.0,
+          ),
+        ],
+      );
+
+      blocTest<LabourCostFormBloc, LabourCostFormState>(
+        'emits Editing with null laborValue when null is passed',
+        build: () => bloc,
+        act: (bloc) => bloc.add(const LabourCostLaborValueUpdated(null)),
+        expect: () => [
+          isA<LabourCostFormEditing>().having(
+            (s) => s.laborValue,
+            'laborValue',
+            isNull,
+          ),
+        ],
+      );
+    });
+
+    group('LabourCostCrewSizeUpdated', () {
+      blocTest<LabourCostFormBloc, LabourCostFormState>(
+        'emits crewSizeError when crewSize is null',
+        build: () => bloc,
+        act: (bloc) => bloc.add(const LabourCostCrewSizeUpdated(null)),
+        expect: () => [
+          isA<LabourCostFormEditing>()
+              .having((s) => s.crewSizeError, 'crewSizeError', isNotNull)
+              .having((s) => s.isCrewSizeValid, 'isCrewSizeValid', false),
+        ],
+      );
+
+      blocTest<LabourCostFormBloc, LabourCostFormState>(
+        'emits crewSizeError when crewSize is zero',
+        build: () => bloc,
+        act: (bloc) => bloc.add(const LabourCostCrewSizeUpdated(0)),
+        expect: () => [
+          isA<LabourCostFormEditing>()
+              .having((s) => s.crewSizeError, 'crewSizeError', isNotNull)
+              .having((s) => s.isCrewSizeValid, 'isCrewSizeValid', false),
+        ],
+      );
+
+      blocTest<LabourCostFormBloc, LabourCostFormState>(
+        'emits crewSizeError when crewSize is negative',
+        build: () => bloc,
+        act: (bloc) => bloc.add(const LabourCostCrewSizeUpdated(-2)),
+        expect: () => [
+          isA<LabourCostFormEditing>()
+              .having((s) => s.crewSizeError, 'crewSizeError', isNotNull)
+              .having((s) => s.isCrewSizeValid, 'isCrewSizeValid', false),
+        ],
+      );
+
+      blocTest<LabourCostFormBloc, LabourCostFormState>(
+        'emits no error and sets crewSize when value is positive',
+        build: () => bloc,
+        act: (bloc) => bloc.add(const LabourCostCrewSizeUpdated(2.0)),
+        expect: () => [
+          isA<LabourCostFormEditing>()
+              .having((s) => s.crewSize, 'crewSize', 2.0)
+              .having((s) => s.crewSizeError, 'crewSizeError', isNull)
+              .having((s) => s.isCrewSizeValid, 'isCrewSizeValid', true),
+        ],
+      );
+    });
+
+    group('LabourCostHourlyRateUpdated', () {
+      blocTest<LabourCostFormBloc, LabourCostFormState>(
+        'emits hourlyRateError when value is empty',
+        build: () => bloc,
+        act: (bloc) => bloc.add(const LabourCostHourlyRateUpdated('')),
+        expect: () => [
+          isA<LabourCostFormEditing>()
+              .having((s) => s.hourlyRateError, 'hourlyRateError', isNotNull)
+              .having((s) => s.isHourlyRateValid, 'isHourlyRateValid', false),
+        ],
+      );
+
+      blocTest<LabourCostFormBloc, LabourCostFormState>(
+        'emits hourlyRateError when value is zero',
+        build: () => bloc,
+        act: (bloc) => bloc.add(const LabourCostHourlyRateUpdated('0')),
+        expect: () => [
+          isA<LabourCostFormEditing>()
+              .having((s) => s.hourlyRateError, 'hourlyRateError', isNotNull)
+              .having((s) => s.isHourlyRateValid, 'isHourlyRateValid', false),
+        ],
+      );
+
+      blocTest<LabourCostFormBloc, LabourCostFormState>(
+        'emits hourlyRateError when value is negative',
+        build: () => bloc,
+        act: (bloc) => bloc.add(const LabourCostHourlyRateUpdated('-10')),
+        expect: () => [
+          isA<LabourCostFormEditing>()
+              .having((s) => s.hourlyRateError, 'hourlyRateError', isNotNull)
+              .having((s) => s.isHourlyRateValid, 'isHourlyRateValid', false),
+        ],
+      );
+
+      blocTest<LabourCostFormBloc, LabourCostFormState>(
+        'emits hourlyRateError when value is not a number',
+        build: () => bloc,
+        act: (bloc) => bloc.add(const LabourCostHourlyRateUpdated('abc')),
+        expect: () => [
+          isA<LabourCostFormEditing>()
+              .having((s) => s.hourlyRateError, 'hourlyRateError', isNotNull)
+              .having((s) => s.isHourlyRateValid, 'isHourlyRateValid', false),
+        ],
+      );
+
+      blocTest<LabourCostFormBloc, LabourCostFormState>(
+        'emits no error and sets hourlyRate when value is positive',
+        build: () => bloc,
+        act: (bloc) => bloc.add(const LabourCostHourlyRateUpdated('100')),
+        expect: () => [
+          isA<LabourCostFormEditing>()
+              .having((s) => s.hourlyRate, 'hourlyRate', 100.0)
+              .having((s) => s.hourlyRateError, 'hourlyRateError', isNull)
+              .having((s) => s.isHourlyRateValid, 'isHourlyRateValid', true),
+        ],
+      );
+
+      blocTest<LabourCostFormBloc, LabourCostFormState>(
+        'preserves labourType when hourly rate changes',
+        build: () => bloc,
+        act: (bloc) => bloc
+          ..add(const LabourCostItemTypeChanged(testLabourType))
+          ..add(const LabourCostHourlyRateUpdated('50')),
+        expect: () => [
+          isA<LabourCostFormEditing>().having(
+            (s) => s.labourType,
+            'labourType',
+            testLabourType,
+          ),
+          isA<LabourCostFormEditing>()
+              .having((s) => s.labourType, 'labourType', testLabourType)
+              .having((s) => s.hourlyRate, 'hourlyRate', 50.0)
+              .having((s) => s.hourlyRateError, 'hourlyRateError', isNull),
+        ],
+      );
+    });
+
+    group('perHourTotal', () {
+      blocTest<LabourCostFormBloc, LabourCostFormState>(
+        'returns correct total: hourlyRate × laborHours × crewSize',
+        build: () => bloc,
+        act: (bloc) => bloc
+          ..add(
+            const LabourCostCalculationMethodChanged(
+              LaborCalculationMethodType.perHour,
+            ),
+          )
+          ..add(const LabourCostHourlyRateUpdated('100'))
+          ..add(
+            const LabourCostLaborValueUpdated(LaborValue(laborHours: 8.0)),
+          )
+          ..add(const LabourCostCrewSizeUpdated(2.0)),
+        expect: () => [
+          isA<LabourCostFormEditing>(),
+          isA<LabourCostFormEditing>(),
+          isA<LabourCostFormEditing>(),
+          isA<LabourCostFormEditing>().having(
+            (s) => s.perHourTotal,
+            'perHourTotal',
+            1600.0,
+          ),
+        ],
+      );
+
+      blocTest<LabourCostFormBloc, LabourCostFormState>(
+        'perHourTotal is 0 when calculationMethod is perDay',
+        build: () => bloc,
+        act: (bloc) => bloc
+          ..add(
+            const LabourCostCalculationMethodChanged(
+              LaborCalculationMethodType.perDay,
+            ),
+          )
+          ..add(const LabourCostHourlyRateUpdated('100'))
+          ..add(
+            const LabourCostLaborValueUpdated(LaborValue(laborHours: 8.0)),
+          )
+          ..add(const LabourCostCrewSizeUpdated(2.0)),
+        expect: () => [
+          isA<LabourCostFormEditing>(),
+          isA<LabourCostFormEditing>(),
+          isA<LabourCostFormEditing>(),
+          isA<LabourCostFormEditing>().having(
+            (s) => s.perHourTotal,
+            'perHourTotal',
+            0.0,
+          ),
+        ],
+      );
+
+      blocTest<LabourCostFormBloc, LabourCostFormState>(
+        'perHourTotal is 0 when calculationMethod is null',
+        build: () => bloc,
+        act: (bloc) => bloc
+          ..add(const LabourCostHourlyRateUpdated('100'))
+          ..add(
+            const LabourCostLaborValueUpdated(LaborValue(laborHours: 8.0)),
+          )
+          ..add(const LabourCostCrewSizeUpdated(2.0)),
+        expect: () => [
+          isA<LabourCostFormEditing>(),
+          isA<LabourCostFormEditing>(),
+          isA<LabourCostFormEditing>().having(
+            (s) => s.perHourTotal,
+            'perHourTotal',
+            0.0,
+          ),
+        ],
+      );
+    });
   });
 }


### PR DESCRIPTION
### 1. PR SUMMARY

Adds per-hour calculation logic to `LabourCostFormBloc`. Introduces four new events (`LabourCostCalculationMethodChanged`, `LabourCostLaborValueUpdated`, `LabourCostCrewSizeUpdated`, `LabourCostHourlyRateUpdated`) with handlers that store their values in `LabourCostFormEditing` state and expose a `perHourTotal` getter (`hourlyRate × laborHours × crewSize`). No UI changes; the widget wiring will follow with the submission ticket (CA-294). 21 unit tests cover each event's validation and the total calculation across method types.

### 2. REVIEW SUMMARY TABLE

No issues found.

## Test plan
- [ ] `fvm flutter test test/features/estimations/units/blocs/labour_cost_form_bloc_test.dart` — all 21 tests pass
- [ ] `fvm dart run custom_lint` — no issues
- [ ] `fvm flutter test` — no new failures (4 pre-existing failures in tag/app-shell tests unchanged)