### PR TITLE
CA-317: add per-day calc option widget tests

### DIFF
--- a/test/features/estimations/widgets/labour_cost_form_fields_test.dart
+++ b/test/features/estimations/widgets/labour_cost_form_fields_test.dart
@@ -223,6 +223,68 @@ void main() {
       expect(find.text(l10n.noOfHoursLabel), findsOneWidget);
       expect(find.text(l10n.noOfDaysLabel), findsNothing);
     });
+
+    testWidgets(
+        'tapping per day after switching to per hours restores "No. of days" label',
+        (tester) async {
+      await tester.pumpWidget(makeWidget());
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byKey(const Key('per_hours_option')));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const Key('per_day_option')));
+      await tester.pumpAndSettle();
+
+      expect(find.text(l10n.noOfDaysLabel), findsOneWidget);
+      expect(find.text(l10n.noOfHoursLabel), findsNothing);
+    });
+
+    testWidgets('per day option is re-selected after switching from per hours',
+        (tester) async {
+      await tester.pumpWidget(makeWidget());
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byKey(const Key('per_hours_option')));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const Key('per_day_option')));
+      await tester.pumpAndSettle();
+
+      final perDay =
+          tester.getSemantics(find.byKey(const Key('per_day_option')));
+      final perHours =
+          tester.getSemantics(find.byKey(const Key('per_hours_option')));
+      expect(perDay.hasFlag(SemanticsFlag.isSelected), isTrue);
+      expect(perHours.hasFlag(SemanticsFlag.isSelected), isFalse);
+    });
+
+    testWidgets(
+        'shows crew size field when per day is re-selected after per hours',
+        (tester) async {
+      await tester.pumpWidget(makeWidget());
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byKey(const Key('per_hours_option')));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const Key('per_day_option')));
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('crew_size_field')), findsOneWidget);
+    });
+
+    testWidgets(
+        'tapping per day in from cost file mode after per hours restores "No. of days" label',
+        (tester) async {
+      await tester.pumpWidget(makeWidget(fromCostFile: true));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byKey(const Key('per_hours_option')));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const Key('per_day_option')));
+      await tester.pumpAndSettle();
+
+      expect(find.text(l10n.noOfDaysLabel), findsOneWidget);
+      expect(find.text(l10n.noOfHoursLabel), findsNothing);
+    });
   });
 
   group('LabourCostFormFields — save enabled', () {


### PR DESCRIPTION
### 1. PR SUMMARY
The per-day calculation option UI was already fully implemented as part of CA-315 (the `CalcMethodCard` already renders the Per Day radio option and `_calcMethod` defaults to `perDay`). This PR adds the missing widget tests that verify the round-trip selection behaviour: switching from Per Day → Per Hours → Per Day correctly restores the "No. of days" label, re-selects the Per Day radio semantically, and keeps the crew size field visible. Tests cover both manually and from-cost-file modes.

### 2. REVIEW SUMMARY TABLE
No issues found.

## Test plan
- [ ] All 31 widget tests in `labour_cost_form_fields_test.dart` pass (`fvm flutter test`)
- [ ] `fvm dart run custom_lint` reports no issues
- [ ] Per Day option is selected by default in the UI
- [ ] Switching to Per Hours and back to Per Day restores "No. of days" label
- [ ] Crew size field remains visible throughout method switching