### PR TITLE
CA-614: fix(auth): strip credentialId from UserProfile domain entity

### DIFF
--- a/lib/libraries/auth/data/models/user_profile_dto.dart
+++ b/lib/libraries/auth/data/models/user_profile_dto.dart
@@ -12,6 +12,10 @@ class UserProfileDto extends Equatable {
   final String id;
 
   /// The credential ID associated with the user.
+  ///
+  /// Populated only from the database view via [fromJson]; never mapped to
+  /// the domain entity — it is an internal Supabase Auth identifier that
+  /// stays in the data layer.
   final String? credentialId;
 
   /// User's first name.
@@ -68,10 +72,13 @@ class UserProfileDto extends Equatable {
   };
 
   /// Converts this DTO to a domain [UserProfile] entity.
+  ///
+  /// [credentialId] is intentionally not mapped: it is an internal Supabase
+  /// Auth identifier (used in RLS/JWT) with no domain meaning and must not
+  /// surface outside the auth library's data layer.
   UserProfile toDomain() {
     return UserProfile(
       id: id,
-      credentialId: credentialId,
       firstName: firstName,
       lastName: lastName,
       professionalRole: professionalRole,
@@ -80,10 +87,12 @@ class UserProfileDto extends Equatable {
   }
 
   /// Creates a [UserProfileDto] from a domain [UserProfile] entity.
+  ///
+  /// [credentialId] is always `null` here since the domain entity does not
+  /// carry it; only [fromJson] can populate it from the database view.
   factory UserProfileDto.fromDomain(UserProfile userProfile) {
     return UserProfileDto(
       id: userProfile.id,
-      credentialId: userProfile.credentialId,
       firstName: userProfile.firstName,
       lastName: userProfile.lastName,
       professionalRole: userProfile.professionalRole,

--- a/lib/libraries/auth/domain/entities/user_profile_entity.dart
+++ b/lib/libraries/auth/domain/entities/user_profile_entity.dart
@@ -15,12 +15,6 @@ class UserProfile extends Equatable {
   /// Unique identifier for the user
   final String id;
 
-  // TODO: [CA-614] credentialId is an internal Supabase Auth identifier (used in
-  // RLS/JWT) with no domain meaning. Strip from UserProfile and UserProfileDto.toDomain()
-  // once all 31 consumers are audited. Do not read or surface this field outside the
-  // auth library. https://ripplearc.youtrack.cloud/issue/CA-614
-  final String? credentialId;
-
   /// User's first name
   final String firstName;
 
@@ -35,7 +29,6 @@ class UserProfile extends Equatable {
 
   const UserProfile({
     required this.id,
-    this.credentialId,
     required this.firstName,
     required this.lastName,
     required this.professionalRole,
@@ -55,7 +48,6 @@ class UserProfile extends Equatable {
   /// Creates a copy of this UserProfile with the given fields replaced
   UserProfile copyWith({
     String? id,
-    String? credentialId,
     String? firstName,
     String? lastName,
     String? professionalRole,
@@ -63,7 +55,6 @@ class UserProfile extends Equatable {
   }) {
     return UserProfile(
       id: id ?? this.id,
-      credentialId: credentialId ?? this.credentialId,
       firstName: firstName ?? this.firstName,
       lastName: lastName ?? this.lastName,
       professionalRole: professionalRole ?? this.professionalRole,
@@ -74,7 +65,6 @@ class UserProfile extends Equatable {
   @override
   List<Object?> get props => [
     id,
-    credentialId,
     firstName,
     lastName,
     professionalRole,

--- a/test/features/estimations/screenshots/cost_estimation_log_tile_screenshot_test.dart
+++ b/test/features/estimations/screenshots/cost_estimation_log_tile_screenshot_test.dart
@@ -49,7 +49,6 @@ void main() {
     }) {
       return UserProfile(
         id: 'user-123',
-        credentialId: 'cred-123',
         firstName: firstName,
         lastName: lastName,
         professionalRole: 'Project Manager',

--- a/test/features/estimations/units/blocs/cost_estimation_log_bloc_test.dart
+++ b/test/features/estimations/units/blocs/cost_estimation_log_bloc_test.dart
@@ -77,7 +77,6 @@ void main() {
     }) {
       const defaultUser = UserProfile(
         id: 'user-default',
-        credentialId: 'cred-default',
         firstName: 'John',
         lastName: 'Doe',
         professionalRole: 'Engineer',

--- a/test/features/estimations/units/data/models/cost_estimation_log_dto_test.dart
+++ b/test/features/estimations/units/data/models/cost_estimation_log_dto_test.dart
@@ -44,13 +44,23 @@ void main() {
       'logged_at': '2025-02-25T14:30:00.000Z',
     };
 
+    // fromDomain cannot restore credential_id since UserProfile does not
+    // carry it; expectations for entity-sourced DTOs use this user JSON.
+    final fromDomainUserJson = {
+      'id': 'user-123',
+      'credential_id': null,
+      'first_name': 'John',
+      'last_name': 'Doe',
+      'professional_role': 'Project Manager',
+      'profile_photo_url': 'https://example.com/photo.jpg',
+    };
+
     final testEntity = CostEstimationLog(
       id: 'log-123',
       estimateId: 'estimate-456',
       activity: CostEstimationActivityType.costEstimationRenamed,
       user: const UserProfile(
         id: 'user-123',
-        credentialId: 'cred-456',
         firstName: 'John',
         lastName: 'Doe',
         professionalRole: 'Project Manager',
@@ -194,7 +204,6 @@ void main() {
           firstName: 'John',
           lastName: 'Doe',
           professionalRole: 'Project Manager',
-          credentialId: 'cred-456',
           profilePhotoUrl: 'https://example.com/photo.jpg',
         );
         expect(entity.user, expectedUser);
@@ -217,9 +226,21 @@ void main() {
 
     group('fromDomain', () {
       test('converts domain entity to DTO', () {
+        final expectedDto = CostEstimationLogDto(
+          id: 'log-123',
+          estimateId: 'estimate-456',
+          activity: 'cost_estimation_renamed',
+          user: fromDomainUserJson,
+          activityDetails: const {
+            'oldName': 'Old Estimation',
+            'newName': 'New Estimation',
+          },
+          loggedAt: '2025-02-25T14:30:00.000Z',
+        );
+
         final dto = CostEstimationLogDto.fromDomain(testEntity);
 
-        expect(dto, testDto);
+        expect(dto, expectedDto);
       });
 
       test('converts activity enum to string', () {
@@ -236,7 +257,7 @@ void main() {
           id: 'log-999',
           estimateId: 'estimate-123',
           activity: 'task_assigned',
-          user: testDto.user,
+          user: fromDomainUserJson,
           activityDetails: const {},
           loggedAt: DateTime(2025, 2, 25).toIso8601String(),
         );
@@ -250,15 +271,7 @@ void main() {
         final dto = CostEstimationLogDto.fromDomain(testEntity);
 
         expect(dto.user, isA<Map<String, dynamic>>());
-        final expectedUserJson = {
-          'id': 'user-123',
-          'credential_id': 'cred-456',
-          'first_name': 'John',
-          'last_name': 'Doe',
-          'professional_role': 'Project Manager',
-          'profile_photo_url': 'https://example.com/photo.jpg',
-        };
-        expect(dto.user, expectedUserJson);
+        expect(dto.user, fromDomainUserJson);
       });
     });
 
@@ -274,7 +287,9 @@ void main() {
         final dto = CostEstimationLogDto.fromDomain(testEntity);
         final json = dto.toJson();
 
-        expect(json, testJson);
+        final expectedJson = Map<String, dynamic>.from(testJson)
+          ..['user'] = fromDomainUserJson;
+        expect(json, expectedJson);
       });
 
       test('JSON -> DTO -> JSON produces identical result', () {

--- a/test/features/estimations/units/domain/entities/cost_estimation_log_entity_test.dart
+++ b/test/features/estimations/units/domain/entities/cost_estimation_log_entity_test.dart
@@ -9,7 +9,6 @@ void main() {
 
     const testUser = UserProfile(
       id: 'user-123',
-      credentialId: 'cred-456',
       firstName: 'John',
       lastName: 'Doe',
       professionalRole: 'Project Manager',

--- a/test/features/estimations/widgets/accessibility/cost_estimation_log_tile_a11y_test.dart
+++ b/test/features/estimations/widgets/accessibility/cost_estimation_log_tile_a11y_test.dart
@@ -20,7 +20,6 @@ void main() {
         activity: CostEstimationActivityType.costEstimationCreated,
         user: UserProfile(
           id: 'user-123',
-          credentialId: 'cred-123',
           firstName: 'John',
           lastName: 'Doe',
           professionalRole: 'Project Manager',
@@ -192,7 +191,6 @@ void main() {
       final log = testLog.copyWith(
         user: UserProfile(
           id: 'user-123',
-          credentialId: 'cred-123',
           firstName: 'Christopher',
           lastName: 'Montgomery-Wellington',
           professionalRole: 'Project Manager',

--- a/test/features/estimations/widgets/widgets/cost_estimation_log_tile_test.dart
+++ b/test/features/estimations/widgets/widgets/cost_estimation_log_tile_test.dart
@@ -17,7 +17,6 @@ void main() {
     setUp(() {
       testUser = UserProfile(
         id: 'user-123',
-        credentialId: 'cred-123',
         firstName: 'John',
         lastName: 'Doe',
         professionalRole: 'Project Manager',

--- a/test/features/estimations/widgets/widgets/cost_estimation_logs_list_test.dart
+++ b/test/features/estimations/widgets/widgets/cost_estimation_logs_list_test.dart
@@ -100,7 +100,6 @@ void main() {
       activity: activity,
       user: UserProfile(
         id: 'user-default',
-        credentialId: 'cred-default',
         firstName: firstName,
         lastName: 'Doe',
         professionalRole: 'Engineer',

--- a/test/libraries/auth/units/data/models/user_profile_dto_test.dart
+++ b/test/libraries/auth/units/data/models/user_profile_dto_test.dart
@@ -24,7 +24,6 @@ void main() {
 
     const testEntity = UserProfile(
       id: 'user-123',
-      credentialId: 'cred-456',
       firstName: 'John',
       lastName: 'Doe',
       professionalRole: 'Project Manager',
@@ -132,10 +131,18 @@ void main() {
     });
 
     group('fromDomain', () {
-      test('converts domain entity to DTO', () {
+      test('converts domain entity to DTO without credentialId', () {
+        const expectedDto = UserProfileDto(
+          id: 'user-123',
+          firstName: 'John',
+          lastName: 'Doe',
+          professionalRole: 'Project Manager',
+          profilePhotoUrl: 'https://example.com/photo.jpg',
+        );
+
         final dto = UserProfileDto.fromDomain(testEntity);
 
-        expect(dto, testDto);
+        expect(dto, expectedDto);
       });
 
       test('preserves null optional fields', () {
@@ -171,7 +178,9 @@ void main() {
         final dto = UserProfileDto.fromDomain(testEntity);
         final json = dto.toJson();
 
-        expect(json, testJson);
+        final expectedJson = Map<String, dynamic>.from(testJson)
+          ..['credential_id'] = null;
+        expect(json, expectedJson);
       });
 
       test('JSON -> DTO -> JSON produces identical result', () {

--- a/test/libraries/auth/units/domain/entities/user_profile_entity_test.dart
+++ b/test/libraries/auth/units/domain/entities/user_profile_entity_test.dart
@@ -5,7 +5,6 @@ void main() {
   group('UserProfile', () {
     const testUserProfile = UserProfile(
       id: 'user-123',
-      credentialId: 'cred-456',
       firstName: 'John',
       lastName: 'Doe',
       professionalRole: 'Project Manager',
@@ -21,7 +20,6 @@ void main() {
           professionalRole: 'Engineer',
         );
 
-        expect(userProfile.credentialId, isNull);
         expect(userProfile.profilePhotoUrl, isNull);
       });
     });
@@ -86,7 +84,6 @@ void main() {
       test('returns new instance with updated fields', () {
         const expected = UserProfile(
           id: 'user-123',
-          credentialId: 'cred-456',
           firstName: 'Jane',
           lastName: 'Doe',
           professionalRole: 'Senior Project Manager',
@@ -110,7 +107,6 @@ void main() {
       test('can update all fields at once', () {
         const expected = UserProfile(
           id: 'new-id',
-          credentialId: 'new-cred',
           firstName: 'Jane',
           lastName: 'Smith',
           professionalRole: 'Engineer',
@@ -119,7 +115,6 @@ void main() {
 
         final updated = testUserProfile.copyWith(
           id: 'new-id',
-          credentialId: 'new-cred',
           firstName: 'Jane',
           lastName: 'Smith',
           professionalRole: 'Engineer',
@@ -134,7 +129,6 @@ void main() {
       test('two instances with same values are equal', () {
         const userProfile1 = UserProfile(
           id: 'user-123',
-          credentialId: 'cred-456',
           firstName: 'John',
           lastName: 'Doe',
           professionalRole: 'Project Manager',
@@ -143,7 +137,6 @@ void main() {
 
         const userProfile2 = UserProfile(
           id: 'user-123',
-          credentialId: 'cred-456',
           firstName: 'John',
           lastName: 'Doe',
           professionalRole: 'Project Manager',
@@ -174,18 +167,18 @@ void main() {
       test('instances with different optional field values are not equal', () {
         const userProfile1 = UserProfile(
           id: 'user-123',
-          credentialId: 'cred-456',
           firstName: 'John',
           lastName: 'Doe',
           professionalRole: 'Project Manager',
+          profilePhotoUrl: 'https://example.com/photo.jpg',
         );
 
         const userProfile2 = UserProfile(
           id: 'user-123',
-          credentialId: 'cred-789',
           firstName: 'John',
           lastName: 'Doe',
           professionalRole: 'Project Manager',
+          profilePhotoUrl: 'https://example.com/other-photo.jpg',
         );
 
         expect(userProfile1, isNot(equals(userProfile2)));


### PR DESCRIPTION
# PR Review: CA-614-fix/strip-credential-id-from-user-profile → main

## 📝 PR Description

Removes `credentialId` from the `UserProfile` domain entity and from `UserProfileDto.toDomain()`. The field is an internal Supabase Auth identifier used for RLS/JWT with no domain meaning, so it must not surface outside the auth library's data layer. The DTO keeps the field so `fromJson` can still read the `user_profiles` view; `fromDomain` now always produces a `null` credentialId, and both mapping asymmetries are documented on the methods. The `User` model's `credentialId` (auth/RLS plumbing) is intentionally untouched — it is out of this ticket's scope.

**Type:** Bugfix ·
**Size:** XS (23 production lines) ·
**Rules applied:** Digestible PR, Naming & Abstraction, Self-Documenting Code, Test Double Pattern, Unit Test Behavior

### What changed
- `lib/libraries/auth/domain/entities/user_profile_entity.dart` — `credentialId` removed from field, constructor, `copyWith`, and `props`; the CA-614 TODO is resolved and deleted
- `lib/libraries/auth/data/models/user_profile_dto.dart` — `toDomain()` and `fromDomain()` no longer map `credentialId`; doc comments explain why the mapping is asymmetric
- 9 test files updated: entity/DTO mapping tests assert the new asymmetry (`Entity → DTO → JSON` yields `credential_id: null`); estimation log tests drop the constructor argument; an Equatable test that differed only by `credentialId` now differs by `profilePhotoUrl` so it still asserts inequality

---

## 🔍 Review Summary

> Found 1 issue(s): 0 🔴 critical · 0 🟠 major · 0 🟡 minor · 1 🔵 suggestion — across 1 file(s).

| # | Issue | Severity | Location | Description | Suggested Fix | Status | Notes |
|---|-------|----------|----------|-------------|---------------|--------|-------|
| 1 | DTO field doc could state its data-layer-only scope | 🔵 Suggestion | `lib/libraries/auth/data/models/user_profile_dto.dart:15` | The `credentialId` field doc still reads "The credential ID associated with the user" — it no longer reaches the domain, which the field doc doesn't say (only the method docs do). | Extend the field doc: "Populated only from the database view; never mapped to the domain entity." | ✅ Addressed | Field doc extended in-branch |

**Status (author fills):** ✅ Addressed · 📋 Future Story (add YouTrack ID) ·
❌ Disagree (justify) · 🔄 In Progress

<!-- Skipped: CoreUI Components (no presentation files changed), UI / Business Separation (no presentation files changed), Stream Lifecycle (no stream-owning code changed), Widget Test Finders (no widget-finder changes), Localization (no presentation files changed), Mutation Testing (no logic-heavy code changed), Accessibility (no user-facing UI changed), Sentry Logging (no AppLogger usage changed) -->
