### PR TITLE
CA-797: refactor(search): track loading flags as bloc instance state in GlobalSearchBloc and ProjectSearchBloc

### DIFF
--- a/lib/features/dashboard/presentation/bloc/project_search_bloc/project_search_bloc.dart
+++ b/lib/features/dashboard/presentation/bloc/project_search_bloc/project_search_bloc.dart
@@ -39,6 +39,16 @@ class ProjectSearchBloc extends Bloc<ProjectSearchEvent, ProjectSearchState> {
 
   bool _suggestionsFetched = false;
 
+  // Whether a suggestions fetch is in flight. Tracked as instance state (not
+  // an _initialFromCache parameter) so a concurrently-handled event emitting
+  // _initialFromCache() cannot reset an in-flight loading flag prematurely.
+  bool _suggestionsLoading = false;
+
+  // Monotonic id of the latest suggestions fetch. A superseded fetch (e.g.
+  // cancelled by the switchMap transformer when a newer query arrives) must
+  // not clear _suggestionsLoading on completion — the newest fetch owns it.
+  int _suggestionsFetchGeneration = 0;
+
   /// Exposed for testing only — resolves when the last save-after-search
   /// completes, allowing tests to await it instead of using wall-clock waits.
   @visibleForTesting
@@ -67,7 +77,12 @@ class ProjectSearchBloc extends Bloc<ProjectSearchEvent, ProjectSearchState> {
     _currentQuery = query;
 
     if (query.isEmpty) {
-      // Clearing the field restores the history surface rather than blanking it.
+      // Clearing the field restores the history surface rather than blanking
+      // it. It also cancels any same-pipeline suggestions fetch via the
+      // switchMap transformer, so that handler can no longer emit its
+      // completion — reset the flag here so this emission doesn't report a
+      // loading fetch that will never complete visibly.
+      _suggestionsLoading = false;
       emit(_initialFromCache());
       return;
     }
@@ -90,11 +105,15 @@ class ProjectSearchBloc extends Bloc<ProjectSearchEvent, ProjectSearchState> {
       return;
     }
 
-    emit(_initialFromCache(suggestionsLoading: true));
+    final generation = ++_suggestionsFetchGeneration;
+    _suggestionsLoading = true;
+    emit(_initialFromCache());
 
     final result = await _repository.getProjectSearchSuggestions(
       userId: userId,
     );
+    if (generation != _suggestionsFetchGeneration) return;
+    _suggestionsLoading = false;
     result.fold(
       (failure) => _logger.warning(
         'Failed to load project search suggestions: $failure',
@@ -140,6 +159,11 @@ class ProjectSearchBloc extends Bloc<ProjectSearchEvent, ProjectSearchState> {
     _currentQuery = '';
     _cachedSuggestions = const [];
     _suggestionsFetched = false;
+    _suggestionsLoading = false;
+    // Disown any in-flight suggestions fetch: its completion must not
+    // resurrect the pre-reset cache, mark suggestions as fetched, or emit
+    // over the isLoadingHistory state emitted below.
+    _suggestionsFetchGeneration++;
 
     final userId = _authManager.getCurrentCredentials().data?.id;
     if (userId == null || userId.isEmpty) {
@@ -283,11 +307,12 @@ class ProjectSearchBloc extends Bloc<ProjectSearchEvent, ProjectSearchState> {
     );
   }
 
-  ProjectSearchInitial _initialFromCache({bool suggestionsLoading = false}) =>
-      ProjectSearchInitial(
-        recentSearches: _cachedRecents,
-        suggestions: _filterSuggestions(_currentQuery),
-        query: _currentQuery,
-        suggestionsLoading: suggestionsLoading,
-      );
+  // Reads the in-flight loading flag from instance state so no handler can
+  // stomp another handler's in-flight flag.
+  ProjectSearchInitial _initialFromCache() => ProjectSearchInitial(
+    recentSearches: _cachedRecents,
+    suggestions: _filterSuggestions(_currentQuery),
+    query: _currentQuery,
+    suggestionsLoading: _suggestionsLoading,
+  );
 }

--- a/lib/features/dashboard/presentation/bloc/project_search_bloc/project_search_bloc.dart
+++ b/lib/features/dashboard/presentation/bloc/project_search_bloc/project_search_bloc.dart
@@ -28,6 +28,13 @@ EventTransformer<E> _debounce<E>(Duration duration) =>
 /// Handles debounced query updates and explicit search submissions, plus the
 /// recent-searches and suggestions surfaces shown on the idle state.
 /// Delegates to [ProjectSearchRepository] and maps results to typed states.
+///
+/// The in-flight suggestions loading flag is tracked as private instance
+/// state rather than a state-builder parameter, so a concurrently-handled
+/// event rebuilding the state cannot stomp it. A fetch-generation counter
+/// lets a superseded fetch (cancelled by the switchMap transformer or
+/// disowned by a history-request reset) bail out on completion instead of
+/// clearing a newer fetch's flag or resurrecting pre-reset data.
 class ProjectSearchBloc extends Bloc<ProjectSearchEvent, ProjectSearchState> {
   final ProjectSearchRepository _repository;
   final AuthManager _authManager;
@@ -39,14 +46,8 @@ class ProjectSearchBloc extends Bloc<ProjectSearchEvent, ProjectSearchState> {
 
   bool _suggestionsFetched = false;
 
-  // Whether a suggestions fetch is in flight. Tracked as instance state (not
-  // an _initialFromCache parameter) so a concurrently-handled event emitting
-  // _initialFromCache() cannot reset an in-flight loading flag prematurely.
   bool _suggestionsLoading = false;
 
-  // Monotonic id of the latest suggestions fetch. A superseded fetch (e.g.
-  // cancelled by the switchMap transformer when a newer query arrives) must
-  // not clear _suggestionsLoading on completion — the newest fetch owns it.
   int _suggestionsFetchGeneration = 0;
 
   /// Exposed for testing only — resolves when the last save-after-search
@@ -307,8 +308,6 @@ class ProjectSearchBloc extends Bloc<ProjectSearchEvent, ProjectSearchState> {
     );
   }
 
-  // Reads the in-flight loading flag from instance state so no handler can
-  // stomp another handler's in-flight flag.
   ProjectSearchInitial _initialFromCache() => ProjectSearchInitial(
     recentSearches: _cachedRecents,
     suggestions: _filterSuggestions(_currentQuery),

--- a/lib/features/global_search/presentation/bloc/global_search_bloc/global_search_bloc.dart
+++ b/lib/features/global_search/presentation/bloc/global_search_bloc/global_search_bloc.dart
@@ -41,6 +41,16 @@ class GlobalSearchBloc extends Bloc<GlobalSearchEvent, GlobalSearchState> {
 
   bool _suggestionsFetched = false;
 
+  // Whether a suggestions fetch is in flight. Tracked as instance state (not
+  // a _readyState parameter) so a concurrently-handled event emitting
+  // _readyState() cannot reset an in-flight loading flag prematurely.
+  bool _suggestionsLoading = false;
+
+  // Monotonic id of the latest suggestions fetch. A superseded fetch (e.g.
+  // cancelled by the switchMap transformer when a newer query arrives) must
+  // not clear _suggestionsLoading on completion — the newest fetch owns it.
+  int _suggestionsFetchGeneration = 0;
+
   String _currentQuery = '';
 
   Set<String> _selectedTags = const {};
@@ -52,6 +62,10 @@ class GlobalSearchBloc extends Bloc<GlobalSearchEvent, GlobalSearchState> {
   // sheet openings reuse the cached list instead of refetching.
   bool _availableTagsFetched = false;
 
+  // Whether the available-tags fetch is in flight; instance state for the
+  // same stomp-protection reason as _suggestionsLoading.
+  bool _availableTagsLoading = false;
+
   String _tagSearchQuery = '';
 
   Set<String> _selectedOwnerIds = const {};
@@ -62,6 +76,10 @@ class GlobalSearchBloc extends Bloc<GlobalSearchEvent, GlobalSearchState> {
   // Whether _availableOwners has been fetched at least once, so subsequent
   // sheet openings reuse the cached list instead of refetching.
   bool _availableOwnersFetched = false;
+
+  // Whether the available-owners fetch is in flight; instance state for the
+  // same stomp-protection reason as _suggestionsLoading.
+  bool _availableOwnersLoading = false;
 
   String _ownerSearchQuery = '';
 
@@ -120,23 +138,20 @@ class GlobalSearchBloc extends Bloc<GlobalSearchEvent, GlobalSearchState> {
         .toList();
   }
 
-  // Builds a GlobalSearchReady from the current internal fields.
-  GlobalSearchReady _readyState({
-    bool suggestionsLoading = false,
-    bool availableTagsLoading = false,
-    bool availableOwnersLoading = false,
-  }) {
+  // Builds a GlobalSearchReady from the current internal fields, including
+  // the in-flight loading flags tracked as instance state.
+  GlobalSearchReady _readyState() {
     return GlobalSearchReady(
       recentSearches: _recentSearches,
       query: _currentQuery,
       suggestions: _filterSuggestions(_currentQuery),
-      suggestionsLoading: suggestionsLoading,
+      suggestionsLoading: _suggestionsLoading,
       selectedTags: _selectedTags,
       availableTags: _filterAvailableTags(),
-      availableTagsLoading: availableTagsLoading,
+      availableTagsLoading: _availableTagsLoading,
       selectedOwnerIds: _selectedOwnerIds,
       availableOwners: _filterAvailableOwners(),
-      availableOwnersLoading: availableOwnersLoading,
+      availableOwnersLoading: _availableOwnersLoading,
       selectedDateRange: _selectedDateRange,
     );
   }
@@ -146,14 +161,19 @@ class GlobalSearchBloc extends Bloc<GlobalSearchEvent, GlobalSearchState> {
     Emitter<GlobalSearchState> emit,
   ) async {
     _tagSearchQuery = '';
-    if (_availableTagsFetched) {
+    // _availableTagsLoading also gates: a request arriving while a fetch is
+    // in flight must not start a duplicate fetch, whose earlier completion
+    // would clear the loading flag while the later fetch is still running.
+    if (_availableTagsFetched || _availableTagsLoading) {
       emit(_readyState());
       return;
     }
 
-    emit(_readyState(availableTagsLoading: true));
+    _availableTagsLoading = true;
+    emit(_readyState());
 
     final result = await _tagRepository.getTags();
+    _availableTagsLoading = false;
 
     result.fold(
       (failure) {
@@ -187,11 +207,17 @@ class GlobalSearchBloc extends Bloc<GlobalSearchEvent, GlobalSearchState> {
       _recentSearches = recentSearches;
       _rawSuggestions = const [];
       _suggestionsFetched = false;
+      _suggestionsLoading = false;
+      // Disown any in-flight suggestions fetch: its completion must not
+      // resurrect the pre-reset cache or mark suggestions as fetched.
+      _suggestionsFetchGeneration++;
       _currentQuery = '';
       _selectedTags = const {};
       _tagSearchQuery = '';
+      _availableTagsLoading = false;
       _selectedOwnerIds = const {};
       _ownerSearchQuery = '';
+      _availableOwnersLoading = false;
       _selectedDateRange = null;
       emit(_readyState());
     });
@@ -205,6 +231,11 @@ class GlobalSearchBloc extends Bloc<GlobalSearchEvent, GlobalSearchState> {
     _currentQuery = trimmedQuery;
 
     if (trimmedQuery.isEmpty) {
+      // Clearing the query cancels any same-pipeline suggestions fetch via
+      // the switchMap transformer, so that handler can no longer emit its
+      // completion. Reset the flag here so this emission doesn't report a
+      // loading fetch that will never complete visibly.
+      _suggestionsLoading = false;
       emit(_readyState());
       return;
     }
@@ -312,9 +343,13 @@ class GlobalSearchBloc extends Bloc<GlobalSearchEvent, GlobalSearchState> {
   Future<void> _fetchAndEmitSuggestions(
     Emitter<GlobalSearchState> emit,
   ) async {
-    emit(_readyState(suggestionsLoading: true));
+    final generation = ++_suggestionsFetchGeneration;
+    _suggestionsLoading = true;
+    emit(_readyState());
 
     final result = await _repository.getSearchSuggestions();
+    if (generation != _suggestionsFetchGeneration) return;
+    _suggestionsLoading = false;
 
     result.fold(
       (failure) {
@@ -361,14 +396,19 @@ class GlobalSearchBloc extends Bloc<GlobalSearchEvent, GlobalSearchState> {
     Emitter<GlobalSearchState> emit,
   ) async {
     _ownerSearchQuery = '';
-    if (_availableOwnersFetched) {
+    // _availableOwnersLoading also gates: a request arriving while a fetch is
+    // in flight must not start a duplicate fetch, whose earlier completion
+    // would clear the loading flag while the later fetch is still running.
+    if (_availableOwnersFetched || _availableOwnersLoading) {
       emit(_readyState());
       return;
     }
 
-    emit(_readyState(availableOwnersLoading: true));
+    _availableOwnersLoading = true;
+    emit(_readyState());
 
     final result = await _ownerRepository.getOwners();
+    _availableOwnersLoading = false;
 
     result.fold(
       (failure) {

--- a/lib/features/global_search/presentation/bloc/global_search_bloc/global_search_bloc.dart
+++ b/lib/features/global_search/presentation/bloc/global_search_bloc/global_search_bloc.dart
@@ -28,7 +28,15 @@ const int _kMaxDisplayedSuggestions = 5;
 EventTransformer<E> _debounce<E>(Duration duration) =>
     (events, mapper) => events.debounceTime(duration).switchMap(mapper);
 
-/// Bloc for managing global search state across projects, estimations, and members
+/// Bloc for managing global search state across projects, estimations, and members.
+///
+/// In-flight loading flags are tracked as private instance state rather than
+/// state-builder parameters, so a concurrently-handled event rebuilding the
+/// state cannot stomp another handler's in-flight flag. Each fetch records a
+/// generation counter; a superseded fetch (cancelled by the switchMap
+/// transformer, deduplicated while in flight, or disowned by a
+/// [GlobalSearchStarted] reset) bails out on completion so it can neither
+/// clear a newer fetch's flag nor resurrect pre-reset data.
 class GlobalSearchBloc extends Bloc<GlobalSearchEvent, GlobalSearchState> {
   static final _logger = AppLogger().tag('GlobalSearchBloc');
   final GlobalSearchRepository _repository;
@@ -41,14 +49,8 @@ class GlobalSearchBloc extends Bloc<GlobalSearchEvent, GlobalSearchState> {
 
   bool _suggestionsFetched = false;
 
-  // Whether a suggestions fetch is in flight. Tracked as instance state (not
-  // a _readyState parameter) so a concurrently-handled event emitting
-  // _readyState() cannot reset an in-flight loading flag prematurely.
   bool _suggestionsLoading = false;
 
-  // Monotonic id of the latest suggestions fetch. A superseded fetch (e.g.
-  // cancelled by the switchMap transformer when a newer query arrives) must
-  // not clear _suggestionsLoading on completion — the newest fetch owns it.
   int _suggestionsFetchGeneration = 0;
 
   String _currentQuery = '';
@@ -62,9 +64,9 @@ class GlobalSearchBloc extends Bloc<GlobalSearchEvent, GlobalSearchState> {
   // sheet openings reuse the cached list instead of refetching.
   bool _availableTagsFetched = false;
 
-  // Whether the available-tags fetch is in flight; instance state for the
-  // same stomp-protection reason as _suggestionsLoading.
   bool _availableTagsLoading = false;
+
+  int _availableTagsFetchGeneration = 0;
 
   String _tagSearchQuery = '';
 
@@ -77,9 +79,9 @@ class GlobalSearchBloc extends Bloc<GlobalSearchEvent, GlobalSearchState> {
   // sheet openings reuse the cached list instead of refetching.
   bool _availableOwnersFetched = false;
 
-  // Whether the available-owners fetch is in flight; instance state for the
-  // same stomp-protection reason as _suggestionsLoading.
   bool _availableOwnersLoading = false;
+
+  int _availableOwnersFetchGeneration = 0;
 
   String _ownerSearchQuery = '';
 
@@ -138,8 +140,7 @@ class GlobalSearchBloc extends Bloc<GlobalSearchEvent, GlobalSearchState> {
         .toList();
   }
 
-  // Builds a GlobalSearchReady from the current internal fields, including
-  // the in-flight loading flags tracked as instance state.
+  // Builds a GlobalSearchReady from the current internal fields.
   GlobalSearchReady _readyState() {
     return GlobalSearchReady(
       recentSearches: _recentSearches,
@@ -169,10 +170,14 @@ class GlobalSearchBloc extends Bloc<GlobalSearchEvent, GlobalSearchState> {
       return;
     }
 
+    final generation = ++_availableTagsFetchGeneration;
     _availableTagsLoading = true;
     emit(_readyState());
 
     final result = await _tagRepository.getTags();
+    // A GlobalSearchStarted reset disowned this fetch while it was in
+    // flight; the reset handler owns the loading flag now.
+    if (generation != _availableTagsFetchGeneration) return;
     _availableTagsLoading = false;
 
     result.fold(
@@ -208,16 +213,21 @@ class GlobalSearchBloc extends Bloc<GlobalSearchEvent, GlobalSearchState> {
       _rawSuggestions = const [];
       _suggestionsFetched = false;
       _suggestionsLoading = false;
-      // Disown any in-flight suggestions fetch: its completion must not
-      // resurrect the pre-reset cache or mark suggestions as fetched.
+      // Disown any in-flight fetch: its completion must not resurrect the
+      // pre-reset cache, mark data as fetched, or touch a loading flag the
+      // reset now owns.
       _suggestionsFetchGeneration++;
       _currentQuery = '';
       _selectedTags = const {};
       _tagSearchQuery = '';
+      _availableTagsFetched = false;
       _availableTagsLoading = false;
+      _availableTagsFetchGeneration++;
       _selectedOwnerIds = const {};
       _ownerSearchQuery = '';
+      _availableOwnersFetched = false;
       _availableOwnersLoading = false;
+      _availableOwnersFetchGeneration++;
       _selectedDateRange = null;
       emit(_readyState());
     });
@@ -404,10 +414,14 @@ class GlobalSearchBloc extends Bloc<GlobalSearchEvent, GlobalSearchState> {
       return;
     }
 
+    final generation = ++_availableOwnersFetchGeneration;
     _availableOwnersLoading = true;
     emit(_readyState());
 
     final result = await _ownerRepository.getOwners();
+    // A GlobalSearchStarted reset disowned this fetch while it was in
+    // flight; the reset handler owns the loading flag now.
+    if (generation != _availableOwnersFetchGeneration) return;
     _availableOwnersLoading = false;
 
     result.fold(

--- a/lib/features/global_search/presentation/bloc/global_search_bloc/global_search_bloc.dart
+++ b/lib/features/global_search/presentation/bloc/global_search_bloc/global_search_bloc.dart
@@ -220,11 +220,13 @@ class GlobalSearchBloc extends Bloc<GlobalSearchEvent, GlobalSearchState> {
       _currentQuery = '';
       _selectedTags = const {};
       _tagSearchQuery = '';
+      _availableTags = const [];
       _availableTagsFetched = false;
       _availableTagsLoading = false;
       _availableTagsFetchGeneration++;
       _selectedOwnerIds = const {};
       _ownerSearchQuery = '';
+      _availableOwners = const [];
       _availableOwnersFetched = false;
       _availableOwnersLoading = false;
       _availableOwnersFetchGeneration++;

--- a/test/features/dashboard/units/blocs/project_search_bloc_test.dart
+++ b/test/features/dashboard/units/blocs/project_search_bloc_test.dart
@@ -226,8 +226,10 @@ void main() {
           );
           bloc.add(const ProjectSearchPerformedEvent(query: '   '));
           fakeSupabase.completer!.complete();
+          await bloc.stream.firstWhere(
+            (s) => s is ProjectSearchInitial && !s.suggestionsLoading,
+          );
         },
-        wait: const Duration(milliseconds: 500),
         expect: () => [
           isA<ProjectSearchInitial>()
               .having((s) => s.query, 'query', 'foundation')
@@ -267,9 +269,10 @@ void main() {
           await bloc.stream.firstWhere(
             (s) => s is ProjectSearchInitial && s.query.isEmpty,
           );
+          // Release the cancelled fetch; its generation-guarded continuation
+          // runs to completion during bloc.close() without emitting.
           fakeSupabase.completer!.complete();
         },
-        wait: const Duration(milliseconds: 700),
         expect: () => [
           isA<ProjectSearchInitial>()
               .having((s) => s.query, 'query', 'foundation')
@@ -310,15 +313,16 @@ void main() {
           await bloc.stream.firstWhere(
             (s) => s is ProjectSearchInitial && s.query == 'found',
           );
-          // Release the superseded first fetch; its continuation must return
-          // without touching the newer fetch's loading flag.
+          // Release the superseded fetch, then the newer one. The stale
+          // continuation resumes first (completed first, identical async
+          // path), so it runs its generation check while the newer fetch is
+          // still in flight — it must not touch the newer fetch's flag.
           firstFetchGate.complete();
-          for (var i = 0; i < 10; i++) {
-            await Future<void>.value();
-          }
           secondFetchGate.complete();
+          await bloc.stream.firstWhere(
+            (s) => s is ProjectSearchInitial && !s.suggestionsLoading,
+          );
         },
-        wait: const Duration(milliseconds: 700),
         expect: () => [
           isA<ProjectSearchInitial>()
               .having((s) => s.query, 'query', 'fo')
@@ -363,14 +367,18 @@ void main() {
                 s.query.isEmpty,
           );
           // Release the pre-reset fetch; the reset disowned it, so it must
-          // not resurrect the cache or mark suggestions as fetched.
+          // not resurrect the cache or mark suggestions as fetched. Its
+          // pure-microtask continuation drains before the debounce timer
+          // delivers the next keystroke, so no pump loop is needed.
           suggestionsFetchGate.complete();
-          for (var i = 0; i < 10; i++) {
-            await Future<void>.value();
-          }
           bloc.add(const ProjectSearchQueryUpdatedEvent(query: 'found'));
+          await bloc.stream.firstWhere(
+            (s) =>
+                s is ProjectSearchInitial &&
+                s.query == 'found' &&
+                !s.suggestionsLoading,
+          );
         },
-        wait: const Duration(milliseconds: 700),
         expect: () => [
           isA<ProjectSearchInitial>()
               .having((s) => s.query, 'query', 'fo')

--- a/test/features/dashboard/units/blocs/project_search_bloc_test.dart
+++ b/test/features/dashboard/units/blocs/project_search_bloc_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:bloc_test/bloc_test.dart';
 import 'package:construculator/app/app_bootstrap.dart';
 import 'package:construculator/features/dashboard/dashboard_module.dart';
@@ -197,6 +199,201 @@ void main() {
             'suggestions capped at 5',
             ['C1', 'C2', 'C3', 'C4', 'C5'],
           ),
+        ],
+      );
+
+      blocTest<ProjectSearchBloc, ProjectSearchState>(
+        'keeps suggestionsLoading true when a concurrent handler emits '
+        'while the suggestions fetch is in flight',
+        setUp: () {
+          fakeSupabase.setRpcResponse(
+            DatabaseConstants.projectSearchSuggestionsRpcFunction,
+            ['foundation'],
+          );
+          fakeSupabase.shouldDelayOperations = true;
+          fakeSupabase.completer = Completer<void>();
+        },
+        build: () => Modular.get<ProjectSearchBloc>(),
+        act: (bloc) async {
+          bloc.add(const ProjectSearchQueryUpdatedEvent(query: 'foundation'));
+          // Wait for the in-flight loading emission, then dispatch an event
+          // whose handler emits _initialFromCache() while the fetch is still
+          // pending. It must not reset the loading flag — with the flag held
+          // as instance state, the emission is identical to the current state
+          // and is deduplicated instead of stomping the spinner.
+          await bloc.stream.firstWhere(
+            (s) => s is ProjectSearchInitial && s.suggestionsLoading,
+          );
+          bloc.add(const ProjectSearchPerformedEvent(query: '   '));
+          fakeSupabase.completer!.complete();
+        },
+        wait: const Duration(milliseconds: 500),
+        expect: () => [
+          isA<ProjectSearchInitial>()
+              .having((s) => s.query, 'query', 'foundation')
+              .having((s) => s.suggestionsLoading, 'loading', isTrue),
+          isA<ProjectSearchInitial>()
+              .having(
+                (s) => s.suggestionsLoading,
+                'loading cleared only after fetch completes',
+                isFalse,
+              )
+              .having((s) => s.suggestions, 'suggestions', ['foundation']),
+        ],
+      );
+
+      blocTest<ProjectSearchBloc, ProjectSearchState>(
+        'clears suggestionsLoading when clearing the query cancels the '
+        'in-flight fetch',
+        setUp: () {
+          fakeSupabase.setRpcResponse(
+            DatabaseConstants.projectSearchSuggestionsRpcFunction,
+            ['foundation'],
+          );
+          fakeSupabase.shouldDelayOperations = true;
+          fakeSupabase.completer = Completer<void>();
+        },
+        build: () => Modular.get<ProjectSearchBloc>(),
+        act: (bloc) async {
+          bloc.add(const ProjectSearchQueryUpdatedEvent(query: 'foundation'));
+          // Wait for the fetch to be in flight, then clear the query — the
+          // switchMap transformer cancels the fetch handler, so its
+          // completion can never emit. The empty-query emission must not
+          // report a loading fetch.
+          await bloc.stream.firstWhere(
+            (s) => s is ProjectSearchInitial && s.suggestionsLoading,
+          );
+          bloc.add(const ProjectSearchQueryUpdatedEvent(query: ''));
+          await bloc.stream.firstWhere(
+            (s) => s is ProjectSearchInitial && s.query.isEmpty,
+          );
+          fakeSupabase.completer!.complete();
+        },
+        wait: const Duration(milliseconds: 700),
+        expect: () => [
+          isA<ProjectSearchInitial>()
+              .having((s) => s.query, 'query', 'foundation')
+              .having((s) => s.suggestionsLoading, 'loading', isTrue),
+          isA<ProjectSearchInitial>()
+              .having((s) => s.query, 'query', isEmpty)
+              .having(
+                (s) => s.suggestionsLoading,
+                'loading reset with the cancelled fetch',
+                isFalse,
+              ),
+        ],
+      );
+
+      blocTest<ProjectSearchBloc, ProjectSearchState>(
+        'stale cancelled fetch does not clear the loading flag owned by a '
+        'newer fetch',
+        setUp: () {
+          fakeSupabase.setRpcResponse(
+            DatabaseConstants.projectSearchSuggestionsRpcFunction,
+            ['foundation'],
+          );
+          fakeSupabase.shouldDelayOperations = true;
+          fakeSupabase.completer = Completer<void>();
+        },
+        build: () => Modular.get<ProjectSearchBloc>(),
+        act: (bloc) async {
+          final firstFetchGate = fakeSupabase.completer!;
+          bloc.add(const ProjectSearchQueryUpdatedEvent(query: 'fo'));
+          await bloc.stream.firstWhere(
+            (s) => s is ProjectSearchInitial && s.suggestionsLoading,
+          );
+          // The second fetch awaits its own gate so the first one can be
+          // released while the second is still in flight.
+          final secondFetchGate = Completer<void>();
+          fakeSupabase.completer = secondFetchGate;
+          bloc.add(const ProjectSearchQueryUpdatedEvent(query: 'found'));
+          await bloc.stream.firstWhere(
+            (s) => s is ProjectSearchInitial && s.query == 'found',
+          );
+          // Release the superseded first fetch; its continuation must return
+          // without touching the newer fetch's loading flag.
+          firstFetchGate.complete();
+          for (var i = 0; i < 10; i++) {
+            await Future<void>.value();
+          }
+          secondFetchGate.complete();
+        },
+        wait: const Duration(milliseconds: 700),
+        expect: () => [
+          isA<ProjectSearchInitial>()
+              .having((s) => s.query, 'query', 'fo')
+              .having((s) => s.suggestionsLoading, 'loading', isTrue),
+          isA<ProjectSearchInitial>()
+              .having((s) => s.query, 'query', 'found')
+              .having((s) => s.suggestionsLoading, 'loading', isTrue),
+          isA<ProjectSearchInitial>()
+              .having((s) => s.query, 'query', 'found')
+              .having((s) => s.suggestionsLoading, 'loading', isFalse)
+              .having((s) => s.suggestions, 'suggestions', ['foundation']),
+        ],
+      );
+
+      blocTest<ProjectSearchBloc, ProjectSearchState>(
+        'a fetch surviving a history-request reset does not mark suggestions '
+        'as fetched — the next keystroke refetches',
+        setUp: () {
+          fakeSupabase.setRpcResponse(
+            DatabaseConstants.projectSearchSuggestionsRpcFunction,
+            ['foundation'],
+          );
+          fakeSupabase.shouldDelayOperations = true;
+          fakeSupabase.completer = Completer<void>();
+        },
+        build: () => Modular.get<ProjectSearchBloc>(),
+        act: (bloc) async {
+          final suggestionsFetchGate = fakeSupabase.completer!;
+          bloc.add(const ProjectSearchQueryUpdatedEvent(query: 'fo'));
+          await bloc.stream.firstWhere(
+            (s) => s is ProjectSearchInitial && s.suggestionsLoading,
+          );
+          // Later operations run ungated; only the in-flight suggestions
+          // fetch stays parked on the gate.
+          fakeSupabase.shouldDelayOperations = false;
+          bloc.add(const ProjectSearchHistoryRequestedEvent());
+          await bloc.stream.firstWhere(
+            (s) =>
+                s is ProjectSearchInitial &&
+                !s.isLoadingHistory &&
+                !s.suggestionsLoading &&
+                s.query.isEmpty,
+          );
+          // Release the pre-reset fetch; the reset disowned it, so it must
+          // not resurrect the cache or mark suggestions as fetched.
+          suggestionsFetchGate.complete();
+          for (var i = 0; i < 10; i++) {
+            await Future<void>.value();
+          }
+          bloc.add(const ProjectSearchQueryUpdatedEvent(query: 'found'));
+        },
+        wait: const Duration(milliseconds: 700),
+        expect: () => [
+          isA<ProjectSearchInitial>()
+              .having((s) => s.query, 'query', 'fo')
+              .having((s) => s.suggestionsLoading, 'loading', isTrue),
+          isA<ProjectSearchInitial>().having(
+            (s) => s.isLoadingHistory,
+            'isLoadingHistory',
+            isTrue,
+          ),
+          isA<ProjectSearchInitial>()
+              .having((s) => s.query, 'query after reset', isEmpty)
+              .having((s) => s.isLoadingHistory, 'isLoadingHistory', isFalse),
+          isA<ProjectSearchInitial>()
+              .having((s) => s.query, 'query', 'found')
+              .having(
+                (s) => s.suggestionsLoading,
+                'post-reset keystroke starts a fresh fetch',
+                isTrue,
+              ),
+          isA<ProjectSearchInitial>()
+              .having((s) => s.query, 'query', 'found')
+              .having((s) => s.suggestionsLoading, 'loading', isFalse)
+              .having((s) => s.suggestions, 'suggestions', ['foundation']),
         ],
       );
 

--- a/test/features/global_search/units/blocs/global_search_bloc_test.dart
+++ b/test/features/global_search/units/blocs/global_search_bloc_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:bloc_test/bloc_test.dart';
 import 'package:construculator/features/global_search/domain/entities/search_scope_entity.dart';
 import 'package:construculator/features/global_search/global_search_module.dart';
@@ -762,6 +764,191 @@ void main() {
       );
 
       blocTest<GlobalSearchBloc, GlobalSearchState>(
+        'clears suggestionsLoading when clearing the query cancels the '
+        'in-flight fetch',
+        setUp: () {
+          fakeSupabase.setCurrentUser(
+            FakeUser(
+              id: _testUserId,
+              email: _testUserEmail,
+              createdAt: fakeClock.now().toIso8601String(),
+            ),
+          );
+          fakeSupabase.setRpcResponse(
+            DatabaseConstants.searchSuggestionsRpcFunction,
+            ['foundation'],
+          );
+          fakeSupabase.shouldDelayOperations = true;
+          fakeSupabase.completer = Completer<void>();
+        },
+        build: () => Modular.get<GlobalSearchBloc>(),
+        act: (bloc) async {
+          bloc.add(const GlobalSearchQueryUpdated(query: 'foundation'));
+          // Wait for the fetch to be in flight, then clear the query — the
+          // switchMap transformer cancels the fetch handler, so its
+          // completion can never emit. The empty-query emission must not
+          // report a loading fetch.
+          await bloc.stream.firstWhere(
+            (state) => state is GlobalSearchReady && state.suggestionsLoading,
+          );
+          bloc.add(const GlobalSearchQueryUpdated(query: ''));
+          await bloc.stream.firstWhere(
+            (state) => state is GlobalSearchReady && state.query.isEmpty,
+          );
+          fakeSupabase.completer!.complete();
+        },
+        wait: const Duration(milliseconds: 700),
+        expect: () => [
+          isA<GlobalSearchReady>()
+              .having((s) => s.query, 'query', 'foundation')
+              .having((s) => s.suggestionsLoading, 'loading', isTrue),
+          isA<GlobalSearchReady>()
+              .having((s) => s.query, 'query', isEmpty)
+              .having(
+                (s) => s.suggestionsLoading,
+                'loading reset with the cancelled fetch',
+                isFalse,
+              ),
+        ],
+      );
+
+      blocTest<GlobalSearchBloc, GlobalSearchState>(
+        'stale cancelled fetch does not clear the loading flag owned by a '
+        'newer fetch',
+        setUp: () {
+          fakeSupabase.setCurrentUser(
+            FakeUser(
+              id: _testUserId,
+              email: _testUserEmail,
+              createdAt: fakeClock.now().toIso8601String(),
+            ),
+          );
+          fakeSupabase.setRpcResponse(
+            DatabaseConstants.searchSuggestionsRpcFunction,
+            ['foundation'],
+          );
+          fakeSupabase.shouldDelayOperations = true;
+          fakeSupabase.completer = Completer<void>();
+        },
+        build: () => Modular.get<GlobalSearchBloc>(),
+        act: (bloc) async {
+          final firstFetchGate = fakeSupabase.completer!;
+          bloc.add(const GlobalSearchQueryUpdated(query: 'fo'));
+          await bloc.stream.firstWhere(
+            (state) => state is GlobalSearchReady && state.suggestionsLoading,
+          );
+          // The second fetch awaits its own gate so the first one can be
+          // released while the second is still in flight.
+          final secondFetchGate = Completer<void>();
+          fakeSupabase.completer = secondFetchGate;
+          bloc.add(const GlobalSearchQueryUpdated(query: 'found'));
+          await bloc.stream.firstWhere(
+            (state) => state is GlobalSearchReady && state.query == 'found',
+          );
+          // Release the superseded first fetch and let its continuation run
+          // through the repository chain; it must not touch the flag.
+          firstFetchGate.complete();
+          for (var i = 0; i < 10; i++) {
+            await Future<void>.value();
+          }
+          // A concurrently-handled event emitting now must still see the
+          // newer fetch's loading flag.
+          bloc.add(
+            const GlobalSearchOwnerFiltersApplied(ownerIds: {'owner-1'}),
+          );
+          await bloc.stream.firstWhere(
+            (state) =>
+                state is GlobalSearchReady &&
+                state.selectedOwnerIds.contains('owner-1'),
+          );
+          secondFetchGate.complete();
+        },
+        wait: const Duration(milliseconds: 700),
+        expect: () => [
+          isA<GlobalSearchReady>()
+              .having((s) => s.query, 'query', 'fo')
+              .having((s) => s.suggestionsLoading, 'loading', isTrue),
+          isA<GlobalSearchReady>()
+              .having((s) => s.query, 'query', 'found')
+              .having((s) => s.suggestionsLoading, 'loading', isTrue),
+          isA<GlobalSearchReady>()
+              .having((s) => s.selectedOwnerIds, 'selectedOwnerIds', {
+                'owner-1',
+              })
+              .having(
+                (s) => s.suggestionsLoading,
+                'loading survives the stale fetch completing',
+                isTrue,
+              ),
+          isA<GlobalSearchReady>()
+              .having((s) => s.suggestionsLoading, 'loading', isFalse)
+              .having((s) => s.suggestions, 'suggestions', ['foundation']),
+        ],
+      );
+
+      blocTest<GlobalSearchBloc, GlobalSearchState>(
+        'a fetch surviving a GlobalSearchStarted reset does not mark '
+        'suggestions as fetched — the next keystroke refetches',
+        setUp: () {
+          fakeSupabase.setCurrentUser(
+            FakeUser(
+              id: _testUserId,
+              email: _testUserEmail,
+              createdAt: fakeClock.now().toIso8601String(),
+            ),
+          );
+          fakeSupabase.setRpcResponse(
+            DatabaseConstants.searchSuggestionsRpcFunction,
+            ['foundation'],
+          );
+          fakeSupabase.shouldDelayOperations = true;
+          fakeSupabase.completer = Completer<void>();
+        },
+        build: () => Modular.get<GlobalSearchBloc>(),
+        act: (bloc) async {
+          final suggestionsFetchGate = fakeSupabase.completer!;
+          bloc.add(const GlobalSearchQueryUpdated(query: 'fo'));
+          await bloc.stream.firstWhere(
+            (state) => state is GlobalSearchReady && state.suggestionsLoading,
+          );
+          // Later operations run ungated; only the in-flight suggestions
+          // fetch stays parked on the gate.
+          fakeSupabase.shouldDelayOperations = false;
+          bloc.add(const GlobalSearchStarted());
+          await bloc.stream.firstWhere(
+            (state) => state is GlobalSearchReady && !state.suggestionsLoading,
+          );
+          // Release the pre-reset fetch; the reset disowned it, so it must
+          // not resurrect the cache or mark suggestions as fetched.
+          suggestionsFetchGate.complete();
+          for (var i = 0; i < 10; i++) {
+            await Future<void>.value();
+          }
+          bloc.add(const GlobalSearchQueryUpdated(query: 'found'));
+        },
+        wait: const Duration(milliseconds: 700),
+        expect: () => [
+          isA<GlobalSearchReady>()
+              .having((s) => s.query, 'query', 'fo')
+              .having((s) => s.suggestionsLoading, 'loading', isTrue),
+          isA<GlobalSearchReady>()
+              .having((s) => s.query, 'query after reset', isEmpty)
+              .having((s) => s.suggestionsLoading, 'loading', isFalse),
+          isA<GlobalSearchReady>()
+              .having((s) => s.query, 'query', 'found')
+              .having(
+                (s) => s.suggestionsLoading,
+                'post-reset keystroke starts a fresh fetch',
+                isTrue,
+              ),
+          isA<GlobalSearchReady>()
+              .having((s) => s.query, 'query', 'found')
+              .having((s) => s.suggestionsLoading, 'loading', isFalse)
+              .having((s) => s.suggestions, 'suggestions', ['foundation']),
+        ],
+      );
+
+      blocTest<GlobalSearchBloc, GlobalSearchState>(
         'skips the suggestions fetch when query is whitespace-only',
         setUp: () {
           fakeSupabase.setCurrentUser(
@@ -1311,6 +1498,99 @@ void main() {
           ),
         ],
       );
+
+      blocTest<GlobalSearchBloc, GlobalSearchState>(
+        'keeps availableTagsLoading true when a concurrent handler emits '
+        'while the tags fetch is in flight',
+        setUp: () {
+          seedTags(['Roofing']);
+          fakeSupabase.shouldDelayOperations = true;
+          fakeSupabase.completer = Completer<void>();
+        },
+        build: () => Modular.get<GlobalSearchBloc>(),
+        act: (bloc) async {
+          bloc.add(const GlobalSearchAvailableTagsRequested());
+          // Wait for the in-flight loading emission, then dispatch an event
+          // whose handler emits _readyState() while the fetch is still
+          // pending — it must not reset the loading flag.
+          await bloc.stream.firstWhere(
+            (state) => state is GlobalSearchReady && state.availableTagsLoading,
+          );
+          bloc.add(
+            const GlobalSearchOwnerFiltersApplied(ownerIds: {'owner-1'}),
+          );
+          fakeSupabase.completer!.complete();
+        },
+        expect: () => [
+          isA<GlobalSearchReady>()
+              .having(
+                (s) => s.availableTagsLoading,
+                'availableTagsLoading',
+                isTrue,
+              )
+              .having((s) => s.selectedOwnerIds, 'selectedOwnerIds', isEmpty),
+          isA<GlobalSearchReady>()
+              .having(
+                (s) => s.availableTagsLoading,
+                'availableTagsLoading survives concurrent emission',
+                isTrue,
+              )
+              .having((s) => s.selectedOwnerIds, 'selectedOwnerIds', {
+                'owner-1',
+              }),
+          isA<GlobalSearchReady>()
+              .having(
+                (s) => s.availableTagsLoading,
+                'availableTagsLoading',
+                isFalse,
+              )
+              .having((s) => s.availableTags, 'availableTags', ['Roofing']),
+        ],
+      );
+
+      blocTest<GlobalSearchBloc, GlobalSearchState>(
+        'does not start a duplicate tags fetch when one is already in flight',
+        setUp: () {
+          seedTags(['Roofing']);
+          fakeSupabase.shouldDelayOperations = true;
+          fakeSupabase.completer = Completer<void>();
+        },
+        build: () => Modular.get<GlobalSearchBloc>(),
+        act: (bloc) async {
+          bloc.add(const GlobalSearchAvailableTagsRequested());
+          // Wait for the in-flight loading emission, then request tags again
+          // — the second request must reuse the in-flight fetch instead of
+          // starting another, whose earlier completion would clear the
+          // loading flag while the later fetch is still running.
+          await bloc.stream.firstWhere(
+            (state) => state is GlobalSearchReady && state.availableTagsLoading,
+          );
+          bloc.add(const GlobalSearchAvailableTagsRequested());
+          fakeSupabase.completer!.complete();
+        },
+        expect: () => [
+          isA<GlobalSearchReady>().having(
+            (s) => s.availableTagsLoading,
+            'availableTagsLoading',
+            isTrue,
+          ),
+          isA<GlobalSearchReady>()
+              .having(
+                (s) => s.availableTagsLoading,
+                'availableTagsLoading',
+                isFalse,
+              )
+              .having((s) => s.availableTags, 'availableTags', ['Roofing']),
+        ],
+        verify: (_) {
+          final tagFetches = fakeSupabase
+              .getMethodCallsFor('selectMatch')
+              .where(
+                (call) => call['table'] == DatabaseConstants.tagsTable,
+              );
+          expect(tagFetches, hasLength(1));
+        },
+      );
     });
 
     group('GlobalSearchTagSearchQueryUpdated', () {
@@ -1800,6 +2080,56 @@ void main() {
             2,
             reason: 'a failed fetch must not cache; the retry refetches',
           );
+        },
+      );
+
+      blocTest<GlobalSearchBloc, GlobalSearchState>(
+        'does not start a duplicate owners fetch when one is already in '
+        'flight',
+        setUp: () {
+          seedOwners([(id: 'owner-1', firstName: 'John')]);
+          fakeSupabase.shouldDelayOperations = true;
+          fakeSupabase.completer = Completer<void>();
+        },
+        build: () => Modular.get<GlobalSearchBloc>(),
+        act: (bloc) async {
+          bloc.add(const GlobalSearchAvailableOwnersRequested());
+          // Wait for the in-flight loading emission, then request owners
+          // again — the second request must reuse the in-flight fetch
+          // instead of starting another, whose earlier completion would
+          // clear the loading flag while the later fetch is still running.
+          await bloc.stream.firstWhere(
+            (state) =>
+                state is GlobalSearchReady && state.availableOwnersLoading,
+          );
+          bloc.add(const GlobalSearchAvailableOwnersRequested());
+          fakeSupabase.completer!.complete();
+        },
+        expect: () => [
+          isA<GlobalSearchReady>().having(
+            (s) => s.availableOwnersLoading,
+            'availableOwnersLoading',
+            isTrue,
+          ),
+          isA<GlobalSearchReady>()
+              .having(
+                (s) => s.availableOwnersLoading,
+                'availableOwnersLoading',
+                isFalse,
+              )
+              .having(
+                (s) => s.availableOwners.map((o) => o.id).toList(),
+                'availableOwners',
+                ['owner-1'],
+              ),
+        ],
+        verify: (_) {
+          final ownerFetches = fakeSupabase.getMethodCallsFor('rpc').where(
+                (call) =>
+                    call['functionName'] ==
+                    DatabaseConstants.projectOwnersRpcFunction,
+              );
+          expect(ownerFetches, hasLength(1));
         },
       );
     });

--- a/test/features/global_search/units/blocs/global_search_bloc_test.dart
+++ b/test/features/global_search/units/blocs/global_search_bloc_test.dart
@@ -1424,6 +1424,51 @@ void main() {
           ),
         ],
       );
+
+      blocTest<GlobalSearchBloc, GlobalSearchState>(
+        'clears availableTags when GlobalSearchStarted is dispatched after '
+        'tags were fetched',
+        setUp: () {
+          fakeSupabase.setCurrentUser(null);
+          seedTags(['Roofing']);
+        },
+        build: () => Modular.get<GlobalSearchBloc>(),
+        act: (bloc) async {
+          bloc.add(const GlobalSearchAvailableTagsRequested());
+          await bloc.stream.firstWhere(
+            (state) =>
+                state is GlobalSearchReady && !state.availableTagsLoading,
+          );
+          bloc.add(const GlobalSearchStarted());
+          await bloc.stream.firstWhere(
+            (state) =>
+                state is GlobalSearchReady && state.availableTags.isEmpty,
+          );
+        },
+        expect: () => [
+          isA<GlobalSearchReady>().having(
+            (s) => s.availableTagsLoading,
+            'availableTagsLoading',
+            isTrue,
+          ),
+          isA<GlobalSearchReady>().having(
+            (s) => s.availableTags,
+            'availableTags',
+            ['Roofing'],
+          ),
+          isA<GlobalSearchReady>()
+              .having(
+                (s) => s.availableTags,
+                'availableTags cleared on restart',
+                isEmpty,
+              )
+              .having(
+                (s) => s.availableTagsLoading,
+                'availableTagsLoading',
+                isFalse,
+              ),
+        ],
+      );
     });
 
     group('GlobalSearchAvailableTagsRequested', () {
@@ -1871,6 +1916,51 @@ void main() {
             'owners reset on restart',
             isEmpty,
           ),
+        ],
+      );
+
+      blocTest<GlobalSearchBloc, GlobalSearchState>(
+        'clears availableOwners when GlobalSearchStarted is dispatched after '
+        'owners were fetched',
+        setUp: () {
+          fakeSupabase.setCurrentUser(null);
+          seedOwners([(id: 'owner-1', firstName: 'John')]);
+        },
+        build: () => Modular.get<GlobalSearchBloc>(),
+        act: (bloc) async {
+          bloc.add(const GlobalSearchAvailableOwnersRequested());
+          await bloc.stream.firstWhere(
+            (state) =>
+                state is GlobalSearchReady && !state.availableOwnersLoading,
+          );
+          bloc.add(const GlobalSearchStarted());
+          await bloc.stream.firstWhere(
+            (state) =>
+                state is GlobalSearchReady && state.availableOwners.isEmpty,
+          );
+        },
+        expect: () => [
+          isA<GlobalSearchReady>().having(
+            (s) => s.availableOwnersLoading,
+            'availableOwnersLoading',
+            isTrue,
+          ),
+          isA<GlobalSearchReady>().having(
+            (s) => s.availableOwners.map((owner) => owner.id),
+            'availableOwners',
+            ['owner-1'],
+          ),
+          isA<GlobalSearchReady>()
+              .having(
+                (s) => s.availableOwners,
+                'availableOwners cleared on restart',
+                isEmpty,
+              )
+              .having(
+                (s) => s.availableOwnersLoading,
+                'availableOwnersLoading',
+                isFalse,
+              ),
         ],
       );
     });

--- a/test/features/global_search/units/blocs/global_search_bloc_test.dart
+++ b/test/features/global_search/units/blocs/global_search_bloc_test.dart
@@ -795,9 +795,10 @@ void main() {
           await bloc.stream.firstWhere(
             (state) => state is GlobalSearchReady && state.query.isEmpty,
           );
+          // Release the cancelled fetch; its generation-guarded continuation
+          // runs to completion during bloc.close() without emitting.
           fakeSupabase.completer!.complete();
         },
-        wait: const Duration(milliseconds: 700),
         expect: () => [
           isA<GlobalSearchReady>()
               .having((s) => s.query, 'query', 'foundation')
@@ -845,14 +846,10 @@ void main() {
           await bloc.stream.firstWhere(
             (state) => state is GlobalSearchReady && state.query == 'found',
           );
-          // Release the superseded first fetch and let its continuation run
-          // through the repository chain; it must not touch the flag.
+          // Release the superseded first fetch; its continuation must not
+          // touch the flag. A concurrently-handled event emitting afterwards
+          // must still see the newer fetch's loading flag.
           firstFetchGate.complete();
-          for (var i = 0; i < 10; i++) {
-            await Future<void>.value();
-          }
-          // A concurrently-handled event emitting now must still see the
-          // newer fetch's loading flag.
           bloc.add(
             const GlobalSearchOwnerFiltersApplied(ownerIds: {'owner-1'}),
           );
@@ -862,8 +859,10 @@ void main() {
                 state.selectedOwnerIds.contains('owner-1'),
           );
           secondFetchGate.complete();
+          await bloc.stream.firstWhere(
+            (state) => state is GlobalSearchReady && !state.suggestionsLoading,
+          );
         },
-        wait: const Duration(milliseconds: 700),
         expect: () => [
           isA<GlobalSearchReady>()
               .having((s) => s.query, 'query', 'fo')
@@ -919,14 +918,18 @@ void main() {
             (state) => state is GlobalSearchReady && !state.suggestionsLoading,
           );
           // Release the pre-reset fetch; the reset disowned it, so it must
-          // not resurrect the cache or mark suggestions as fetched.
+          // not resurrect the cache or mark suggestions as fetched. Its
+          // pure-microtask continuation drains before the debounce timer
+          // delivers the next keystroke, so no pump loop is needed.
           suggestionsFetchGate.complete();
-          for (var i = 0; i < 10; i++) {
-            await Future<void>.value();
-          }
           bloc.add(const GlobalSearchQueryUpdated(query: 'found'));
+          await bloc.stream.firstWhere(
+            (state) =>
+                state is GlobalSearchReady &&
+                state.query == 'found' &&
+                !state.suggestionsLoading,
+          );
         },
-        wait: const Duration(milliseconds: 700),
         expect: () => [
           isA<GlobalSearchReady>()
               .having((s) => s.query, 'query', 'fo')
@@ -1519,7 +1522,16 @@ void main() {
           bloc.add(
             const GlobalSearchOwnerFiltersApplied(ownerIds: {'owner-1'}),
           );
+          await bloc.stream.firstWhere(
+            (state) =>
+                state is GlobalSearchReady &&
+                state.selectedOwnerIds.contains('owner-1'),
+          );
           fakeSupabase.completer!.complete();
+          await bloc.stream.firstWhere(
+            (state) =>
+                state is GlobalSearchReady && !state.availableTagsLoading,
+          );
         },
         expect: () => [
           isA<GlobalSearchReady>()
@@ -1567,6 +1579,10 @@ void main() {
           );
           bloc.add(const GlobalSearchAvailableTagsRequested());
           fakeSupabase.completer!.complete();
+          await bloc.stream.firstWhere(
+            (state) =>
+                state is GlobalSearchReady && !state.availableTagsLoading,
+          );
         },
         expect: () => [
           isA<GlobalSearchReady>().having(
@@ -1589,6 +1605,80 @@ void main() {
                 (call) => call['table'] == DatabaseConstants.tagsTable,
               );
           expect(tagFetches, hasLength(1));
+        },
+      );
+
+      blocTest<GlobalSearchBloc, GlobalSearchState>(
+        'a tags fetch surviving a GlobalSearchStarted reset neither stomps '
+        'the reset flag nor marks tags as fetched — the next sheet open '
+        'refetches',
+        setUp: () {
+          fakeSupabase.setCurrentUser(null);
+          seedTags(['Roofing']);
+          fakeSupabase.shouldDelayOperations = true;
+          fakeSupabase.completer = Completer<void>();
+        },
+        build: () => Modular.get<GlobalSearchBloc>(),
+        act: (bloc) async {
+          final tagsFetchGate = fakeSupabase.completer!;
+          bloc.add(const GlobalSearchAvailableTagsRequested());
+          await bloc.stream.firstWhere(
+            (state) => state is GlobalSearchReady && state.availableTagsLoading,
+          );
+          // Later operations run ungated; only the in-flight tags fetch
+          // stays parked on the gate.
+          fakeSupabase.shouldDelayOperations = false;
+          bloc.add(const GlobalSearchStarted());
+          await bloc.stream.firstWhere(
+            (state) =>
+                state is GlobalSearchReady && !state.availableTagsLoading,
+          );
+          // Release the pre-reset fetch; the reset disowned it, so it must
+          // not mark tags as fetched or emit over the reset state.
+          tagsFetchGate.complete();
+          bloc.add(const GlobalSearchAvailableTagsRequested());
+          await bloc.stream.firstWhere(
+            (state) =>
+                state is GlobalSearchReady &&
+                !state.availableTagsLoading &&
+                state.availableTags.isNotEmpty,
+          );
+        },
+        expect: () => [
+          isA<GlobalSearchReady>().having(
+            (s) => s.availableTagsLoading,
+            'availableTagsLoading',
+            isTrue,
+          ),
+          isA<GlobalSearchReady>()
+              .having(
+                (s) => s.availableTagsLoading,
+                'availableTagsLoading reset on restart',
+                isFalse,
+              )
+              .having((s) => s.availableTags, 'availableTags', isEmpty),
+          isA<GlobalSearchReady>()
+              .having(
+                (s) => s.availableTagsLoading,
+                'post-reset sheet open starts a fresh fetch',
+                isTrue,
+              )
+              .having((s) => s.availableTags, 'availableTags', isEmpty),
+          isA<GlobalSearchReady>()
+              .having(
+                (s) => s.availableTagsLoading,
+                'availableTagsLoading',
+                isFalse,
+              )
+              .having((s) => s.availableTags, 'availableTags', ['Roofing']),
+        ],
+        verify: (_) {
+          final tagFetches = fakeSupabase
+              .getMethodCallsFor('selectMatch')
+              .where(
+                (call) => call['table'] == DatabaseConstants.tagsTable,
+              );
+          expect(tagFetches, hasLength(2));
         },
       );
     });
@@ -2104,6 +2194,10 @@ void main() {
           );
           bloc.add(const GlobalSearchAvailableOwnersRequested());
           fakeSupabase.completer!.complete();
+          await bloc.stream.firstWhere(
+            (state) =>
+                state is GlobalSearchReady && !state.availableOwnersLoading,
+          );
         },
         expect: () => [
           isA<GlobalSearchReady>().having(
@@ -2130,6 +2224,85 @@ void main() {
                     DatabaseConstants.projectOwnersRpcFunction,
               );
           expect(ownerFetches, hasLength(1));
+        },
+      );
+
+      blocTest<GlobalSearchBloc, GlobalSearchState>(
+        'an owners fetch surviving a GlobalSearchStarted reset neither '
+        'stomps the reset flag nor marks owners as fetched — the next sheet '
+        'open refetches',
+        setUp: () {
+          fakeSupabase.setCurrentUser(null);
+          seedOwners([(id: 'owner-1', firstName: 'John')]);
+          fakeSupabase.shouldDelayOperations = true;
+          fakeSupabase.completer = Completer<void>();
+        },
+        build: () => Modular.get<GlobalSearchBloc>(),
+        act: (bloc) async {
+          final ownersFetchGate = fakeSupabase.completer!;
+          bloc.add(const GlobalSearchAvailableOwnersRequested());
+          await bloc.stream.firstWhere(
+            (state) =>
+                state is GlobalSearchReady && state.availableOwnersLoading,
+          );
+          // Later operations run ungated; only the in-flight owners fetch
+          // stays parked on the gate.
+          fakeSupabase.shouldDelayOperations = false;
+          bloc.add(const GlobalSearchStarted());
+          await bloc.stream.firstWhere(
+            (state) =>
+                state is GlobalSearchReady && !state.availableOwnersLoading,
+          );
+          // Release the pre-reset fetch; the reset disowned it, so it must
+          // not mark owners as fetched or emit over the reset state.
+          ownersFetchGate.complete();
+          bloc.add(const GlobalSearchAvailableOwnersRequested());
+          await bloc.stream.firstWhere(
+            (state) =>
+                state is GlobalSearchReady &&
+                !state.availableOwnersLoading &&
+                state.availableOwners.isNotEmpty,
+          );
+        },
+        expect: () => [
+          isA<GlobalSearchReady>().having(
+            (s) => s.availableOwnersLoading,
+            'availableOwnersLoading',
+            isTrue,
+          ),
+          isA<GlobalSearchReady>()
+              .having(
+                (s) => s.availableOwnersLoading,
+                'availableOwnersLoading reset on restart',
+                isFalse,
+              )
+              .having((s) => s.availableOwners, 'availableOwners', isEmpty),
+          isA<GlobalSearchReady>()
+              .having(
+                (s) => s.availableOwnersLoading,
+                'post-reset sheet open starts a fresh fetch',
+                isTrue,
+              )
+              .having((s) => s.availableOwners, 'availableOwners', isEmpty),
+          isA<GlobalSearchReady>()
+              .having(
+                (s) => s.availableOwnersLoading,
+                'availableOwnersLoading',
+                isFalse,
+              )
+              .having(
+                (s) => s.availableOwners.map((o) => o.id).toList(),
+                'availableOwners',
+                ['owner-1'],
+              ),
+        ],
+        verify: (_) {
+          final ownerFetches = fakeSupabase.getMethodCallsFor('rpc').where(
+                (call) =>
+                    call['functionName'] ==
+                    DatabaseConstants.projectOwnersRpcFunction,
+              );
+          expect(ownerFetches, hasLength(2));
         },
       );
     });


### PR DESCRIPTION
# PR Review: CA-797-refactor/loading-flags-instance-state → main

## 📝 PR Description

Fixes a state-stomping race in the search BLoCs: `_readyState()` / `_initialFromCache()` took loading flags as caller-supplied parameters defaulting to `false`, so any concurrently-handled event that emitted a bare rebuild reset an in-flight spinner prematurely. The flags (`suggestionsLoading`, `availableTagsLoading`, `availableOwnersLoading` in `GlobalSearchBloc`; `suggestionsLoading` in `ProjectSearchBloc` — the two extra ProjectSearch flags from PR #424 are not on main yet) are now private instance fields set by the fetch handlers and read internally by the state builders, following the existing `_availableTagsFetched` pattern. Both blocs reset the flags in their session-restart handlers.

**Type:** Bugfix ·
**Size:** S (94 production lines) ·
**Rules applied:** Digestible PR, Naming & Abstraction, Self-Documenting Code, UI / Business Separation, Stream Lifecycle, Test Double Pattern, Unit Test Behavior

### What changed
- `lib/features/global_search/presentation/bloc/global_search_bloc/global_search_bloc.dart` — three loading flags become instance fields; parameters removed from `_readyState()`; flags set before the fetch, cleared after the await, reset in `_onStarted`
- `lib/features/dashboard/presentation/bloc/project_search_bloc/project_search_bloc.dart` — same conversion for `_suggestionsLoading`; reset in `_onHistoryRequested`
- Regression tests in both bloc suites reproduce the stomp deterministically using `FakeSupabaseWrapper.shouldDelayOperations` + `Completer`: a concurrent event emitted mid-fetch must not clear the loading flag
- Review follow-up folded in: a `_suggestionsFetchGeneration` counter stops a superseded (switchMap-cancelled) fetch from clearing the newer fetch's flag, and the empty-query branch resets the flag since it cancels the same-pipeline fetch whose completion can no longer emit — with 4 more interleaving regression tests
- Second review round folded in: tags/owners requests now dedupe while a fetch is in flight (concurrent transformer race), and the session-restart handlers bump the fetch generation so a pre-reset fetch cannot resurrect the suggestions cache — with 4 more regression tests

---

## 🔍 Review Summary

> Found 3 issue(s): 0 🔴 critical · 0 🟠 major · 1 🟡 minor · 2 🔵 suggestion — across 2 file(s).

| # | Issue | Severity | Location | Description | Suggested Fix | Status | Notes |
|---|-------|----------|----------|-------------|---------------|--------|-------|
| 1 | Duplicate tags/owners fetch clears the loading flag prematurely | 🟡 Minor | `lib/features/global_search/presentation/bloc/global_search_bloc/global_search_bloc.dart:164` | `_onAvailableTagsRequested` / `_onAvailableOwnersRequested` run on bloc's default concurrent transformer and only guard on `_availableTagsFetched` / `_availableOwnersFetched`. Two requests while the first fetch is in flight (e.g. rapid sheet reopen) start duplicate network fetches, and the earlier completion sets the loading flag `false` and emits while the later fetch is still running — the exact stomp class this PR fixes. | Also gate on the in-flight flag: `if (_availableTagsFetched \|\| _availableTagsLoading) { emit(_readyState()); return; }` (same for owners), deduplicating the fetch and keeping the flag truthful. | ✅ Addressed | In-flight guards added to both handlers; 2 regression tests assert a single repository call via `getMethodCallsFor` |
| 2 | Cancelled fetch can briefly clear a newer fetch's flag | 🔵 Suggestion | `lib/features/global_search/presentation/bloc/global_search_bloc/global_search_bloc.dart:341` | `_onQueryUpdated` uses a switchMap transformer: if fetch A is cancelled by a newer query, A's continuation still runs `_suggestionsLoading = false` while fetch B is in flight — and worse, clearing the query mid-fetch would leave the emitted state stuck at `loading: true` since the cancelled handler can no longer emit. | Guard the clear with a fetch-generation counter, and reset the flag in the empty-query branch (which cancels the same-pipeline fetch). | ✅ Addressed | `_suggestionsFetchGeneration` guard + empty-query reset in both blocs; 4 regression tests added (two-completer interleaving) |
| 3 | In-flight fetch survives session restart with stale data | 🔵 Suggestion | `lib/features/global_search/presentation/bloc/global_search_bloc/global_search_bloc.dart:199` | `_onStarted` (and `ProjectSearchBloc._onHistoryRequested`) resets the suggestions cache but does not invalidate a fetch already in flight — its continuation repopulates the cache with pre-restart data and marks suggestions fetched, so the new session filters stale suggestions and never refetches; in `ProjectSearchBloc` its trailing emit can also stomp the `isLoadingHistory: true` spinner mid-history-load. | Bump `_suggestionsFetchGeneration` in the restart handlers so a superseded fetch discards its result and never emits. | ✅ Addressed | Was deferred to CA-824; implemented in this PR instead — generation bumped in `_onStarted` and `_onHistoryRequested`, with a refetch-after-reset regression test per bloc. CA-824 can be closed once this merges |

**Status (author fills):** ✅ Addressed · 📋 Future Story (add YouTrack ID) ·
❌ Disagree (justify) · 🔄 In Progress

<!-- Skipped: CoreUI Components (no widget code changed), Localization (no user-facing strings changed), Widget Test Finders (no widget tests changed), Mutation Testing (flag bookkeeping only, no logic-heavy transforms), Accessibility (no user-facing UI changed), Sentry Logging (no AppLogger usage changed) -->
