### PR TITLE
CA-568: test(sentry): add SentrySdk boundary seam and unit tests for SentryWrapperImpl

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -53,6 +53,8 @@ custom_lint:
         - 'CancelableOperation'
         - 'AppLocalizationsEn'
         - 'Breadcrumb'
+        - 'SentryFlutterOptions'
+        - 'SentryId'
         - 'LogEvent'
         - 'AppLogFilter'
         - 'SentryUser'

--- a/lib/app/app_bootstrap.dart
+++ b/lib/app/app_bootstrap.dart
@@ -54,7 +54,11 @@ import 'package:construculator/libraries/supabase/interfaces/supabase_wrapper.da
 /// final supabaseWrapper = SupabaseWrapperImpl(envLoader: envLoader);
 /// await supabaseWrapper.initialize();
 ///
-/// final sentryWrapper = SentryWrapperImpl(envLoader: envLoader, config: config);
+/// final sentryWrapper = SentryWrapperImpl(
+///   envLoader: envLoader,
+///   config: config,
+///   sentrySdk: SentrySdkImpl(),
+/// );
 ///
 /// final bootstrap = AppBootstrap(
 ///   config: config,

--- a/lib/libraries/sentry/interfaces/sentry_sdk.dart
+++ b/lib/libraries/sentry/interfaces/sentry_sdk.dart
@@ -1,0 +1,47 @@
+import 'package:sentry_flutter/sentry_flutter.dart';
+
+/// Boundary over the static Sentry SDK entry points.
+///
+/// `SentryWrapperImpl` talks to this interface instead of the static
+/// [SentryFlutter] / [Sentry] APIs so its initialization guard and level
+/// mapping logic can be unit-tested against a fake boundary.
+abstract class SentrySdk {
+  /// Initializes the Sentry SDK; mirrors [SentryFlutter.init].
+  ///
+  /// [optionsConfiguration] configures the [SentryFlutterOptions] before the
+  /// SDK starts, and [appRunner] runs the Flutter app once the SDK is ready.
+  Future<void> init(
+    FlutterOptionsConfiguration optionsConfiguration, {
+    required void Function() appRunner,
+  });
+
+  /// Adds a breadcrumb to the current scope; mirrors [Sentry.addBreadcrumb].
+  ///
+  /// [breadcrumb] the breadcrumb to record.
+  Future<void> addBreadcrumb(Breadcrumb breadcrumb);
+
+  /// Captures an exception event; mirrors [Sentry.captureException].
+  ///
+  /// [throwable] the exception to capture, [stackTrace] its optional stack
+  /// trace, and [withScope] an optional callback to customize the event scope.
+  Future<SentryId> captureException(
+    Object throwable, {
+    StackTrace? stackTrace,
+    ScopeCallback? withScope,
+  });
+
+  /// Captures a message event; mirrors [Sentry.captureMessage].
+  ///
+  /// [message] the message to capture, [level] its severity, and [withScope]
+  /// an optional callback to customize the event scope.
+  Future<SentryId> captureMessage(
+    String message, {
+    SentryLevel? level,
+    ScopeCallback? withScope,
+  });
+
+  /// Configures the current scope; mirrors [Sentry.configureScope].
+  ///
+  /// [callback] receives the active scope to mutate.
+  Future<void> configureScope(ScopeCallback callback);
+}

--- a/lib/libraries/sentry/sentry_sdk_impl.dart
+++ b/lib/libraries/sentry/sentry_sdk_impl.dart
@@ -1,0 +1,50 @@
+// coverage:ignore-file
+// Thin pass-through to the static Sentry SDK entry points, which rely on
+// native platform channels and a running host app and therefore cannot be
+// exercised in unit tests.
+
+import 'package:construculator/libraries/sentry/interfaces/sentry_sdk.dart';
+import 'package:sentry_flutter/sentry_flutter.dart';
+
+/// Production [SentrySdk] that delegates to the static Sentry SDK APIs.
+class SentrySdkImpl implements SentrySdk {
+  @override
+  Future<void> init(
+    FlutterOptionsConfiguration optionsConfiguration, {
+    required void Function() appRunner,
+  }) {
+    return SentryFlutter.init(optionsConfiguration, appRunner: appRunner);
+  }
+
+  @override
+  Future<void> addBreadcrumb(Breadcrumb breadcrumb) {
+    return Sentry.addBreadcrumb(breadcrumb);
+  }
+
+  @override
+  Future<SentryId> captureException(
+    Object throwable, {
+    StackTrace? stackTrace,
+    ScopeCallback? withScope,
+  }) {
+    return Sentry.captureException(
+      throwable,
+      stackTrace: stackTrace,
+      withScope: withScope,
+    );
+  }
+
+  @override
+  Future<SentryId> captureMessage(
+    String message, {
+    SentryLevel? level,
+    ScopeCallback? withScope,
+  }) {
+    return Sentry.captureMessage(message, level: level, withScope: withScope);
+  }
+
+  @override
+  Future<void> configureScope(ScopeCallback callback) async {
+    await Sentry.configureScope(callback);
+  }
+}

--- a/lib/libraries/sentry/sentry_wrapper_impl.dart
+++ b/lib/libraries/sentry/sentry_wrapper_impl.dart
@@ -1,22 +1,24 @@
-// coverage:ignore-file
-// Sentry SDK relies on native platform channels and a running host app,
-// making it impossible to unit test without a full integration environment.
-
 import 'package:construculator/libraries/config/env_constants.dart';
 import 'package:construculator/libraries/config/interfaces/config.dart';
 import 'package:construculator/libraries/config/interfaces/env_loader.dart';
+import 'package:construculator/libraries/sentry/interfaces/sentry_sdk.dart';
 import 'package:construculator/libraries/sentry/interfaces/sentry_wrapper.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
 
 class SentryWrapperImpl implements SentryWrapper {
   final EnvLoader _envLoader;
   final Config _config;
+  final SentrySdk _sentrySdk;
   // Guarded by _isInitialized; all callers are expected to call initialize() first.
   bool _isInitialized = false;
 
-  SentryWrapperImpl({required EnvLoader envLoader, required Config config})
-    : _envLoader = envLoader,
-      _config = config;
+  SentryWrapperImpl({
+    required EnvLoader envLoader,
+    required Config config,
+    required SentrySdk sentrySdk,
+  }) : _envLoader = envLoader,
+       _config = config,
+       _sentrySdk = sentrySdk;
 
   @override
   Future<void> initialize(void Function() appRunner) async {
@@ -30,7 +32,7 @@ class SentryWrapperImpl implements SentryWrapper {
       return;
     }
 
-    await SentryFlutter.init((options) {
+    await _sentrySdk.init((options) {
       options.dsn = dsn;
       options.environment = _config.getEnvironmentName(_config.environment);
 
@@ -53,7 +55,7 @@ class SentryWrapperImpl implements SentryWrapper {
   }) async {
     if (!_isInitialized) return;
 
-    await Sentry.addBreadcrumb(
+    await _sentrySdk.addBreadcrumb(
       Breadcrumb(
         message: message,
         level: _getSentryLevel(level),
@@ -72,7 +74,7 @@ class SentryWrapperImpl implements SentryWrapper {
   }) async {
     if (!_isInitialized) return;
 
-    await Sentry.captureException(
+    await _sentrySdk.captureException(
       exception,
       stackTrace: stackTrace,
       withScope: (scope) {
@@ -94,7 +96,7 @@ class SentryWrapperImpl implements SentryWrapper {
   }) async {
     if (!_isInitialized) return;
 
-    await Sentry.captureMessage(
+    await _sentrySdk.captureMessage(
       message,
       level: _getSentryLevel(level),
       withScope: (scope) {
@@ -114,7 +116,7 @@ class SentryWrapperImpl implements SentryWrapper {
   Future<void> setUser(String? userId) async {
     if (!_isInitialized) return;
 
-    await Sentry.configureScope((scope) {
+    await _sentrySdk.configureScope((scope) {
       if (userId != null) {
         scope.setUser(SentryUser(id: userId));
       } else {

--- a/lib/libraries/sentry/testing/fake_sentry_sdk.dart
+++ b/lib/libraries/sentry/testing/fake_sentry_sdk.dart
@@ -1,0 +1,100 @@
+import 'package:construculator/libraries/sentry/interfaces/sentry_sdk.dart';
+import 'package:sentry_flutter/sentry_flutter.dart';
+
+/// Fake [SentrySdk] boundary that records calls for unit tests.
+///
+/// Mirrors the real [SentrySdk] contract: [init] runs the options
+/// configuration against a fresh [SentryFlutterOptions] (exposed via
+/// [lastConfiguredOptions]) and then invokes the app runner, matching the
+/// real SDK's behavior.
+class FakeSentrySdk implements SentrySdk {
+  /// Number of times [init] was called.
+  int initCallCount = 0;
+
+  /// The options produced by the configuration callback of the last [init].
+  SentryFlutterOptions? lastConfiguredOptions;
+
+  /// Breadcrumbs recorded via [addBreadcrumb].
+  final List<Breadcrumb> addedBreadcrumbs = [];
+
+  /// Exceptions recorded via [captureException].
+  final List<Object> capturedExceptions = [];
+
+  /// Stack traces recorded via [captureException], aligned by index.
+  final List<StackTrace?> capturedExceptionStackTraces = [];
+
+  /// Scope callbacks recorded via [captureException], aligned by index.
+  final List<ScopeCallback?> capturedExceptionScopeCallbacks = [];
+
+  /// Messages recorded via [captureMessage].
+  final List<String> capturedMessages = [];
+
+  /// Levels recorded via [captureMessage], aligned by index.
+  final List<SentryLevel?> capturedMessageLevels = [];
+
+  /// Scope callbacks recorded via [captureMessage], aligned by index.
+  final List<ScopeCallback?> capturedMessageScopeCallbacks = [];
+
+  /// Scope callbacks recorded via [configureScope].
+  final List<ScopeCallback> configureScopeCallbacks = [];
+
+  /// Restores the fake to its initial state.
+  void reset() {
+    initCallCount = 0;
+    lastConfiguredOptions = null;
+    addedBreadcrumbs.clear();
+    capturedExceptions.clear();
+    capturedExceptionStackTraces.clear();
+    capturedExceptionScopeCallbacks.clear();
+    capturedMessages.clear();
+    capturedMessageLevels.clear();
+    capturedMessageScopeCallbacks.clear();
+    configureScopeCallbacks.clear();
+  }
+
+  @override
+  Future<void> init(
+    FlutterOptionsConfiguration optionsConfiguration, {
+    required void Function() appRunner,
+  }) async {
+    initCallCount++;
+    final options = SentryFlutterOptions();
+    await optionsConfiguration(options);
+    lastConfiguredOptions = options;
+    appRunner();
+  }
+
+  @override
+  Future<void> addBreadcrumb(Breadcrumb breadcrumb) async {
+    addedBreadcrumbs.add(breadcrumb);
+  }
+
+  @override
+  Future<SentryId> captureException(
+    Object throwable, {
+    StackTrace? stackTrace,
+    ScopeCallback? withScope,
+  }) async {
+    capturedExceptions.add(throwable);
+    capturedExceptionStackTraces.add(stackTrace);
+    capturedExceptionScopeCallbacks.add(withScope);
+    return SentryId.newId();
+  }
+
+  @override
+  Future<SentryId> captureMessage(
+    String message, {
+    SentryLevel? level,
+    ScopeCallback? withScope,
+  }) async {
+    capturedMessages.add(message);
+    capturedMessageLevels.add(level);
+    capturedMessageScopeCallbacks.add(withScope);
+    return SentryId.newId();
+  }
+
+  @override
+  Future<void> configureScope(ScopeCallback callback) async {
+    configureScopeCallbacks.add(callback);
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -5,6 +5,7 @@ import 'package:construculator/libraries/config/app_config_impl.dart';
 import 'package:construculator/libraries/config/env_constants.dart';
 import 'package:construculator/libraries/config/env_loader_impl.dart';
 import 'package:construculator/libraries/logging/app_logger.dart';
+import 'package:construculator/libraries/sentry/sentry_sdk_impl.dart';
 import 'package:construculator/libraries/sentry/sentry_wrapper_impl.dart';
 import 'package:construculator/libraries/supabase/supabase_wrapper_impl.dart';
 import 'package:flutter/material.dart';
@@ -37,7 +38,11 @@ Future<AppBootstrap> _initializeApp() async {
   await config.initialize(env);
   final wrapper = SupabaseWrapperImpl(envLoader: envLoader);
   await wrapper.initialize();
-  final sentryWrapper = SentryWrapperImpl(envLoader: envLoader, config: config);
+  final sentryWrapper = SentryWrapperImpl(
+    envLoader: envLoader,
+    config: config,
+    sentrySdk: SentrySdkImpl(),
+  );
   return AppBootstrap(
     config: config,
     envLoader: envLoader,

--- a/test/libraries/sentry/units/sentry_wrapper_impl_test.dart
+++ b/test/libraries/sentry/units/sentry_wrapper_impl_test.dart
@@ -233,6 +233,19 @@ void main() {
         await fakeSentrySdk.capturedMessageScopeCallbacks.single!(scope);
         expect(scope.tags, {'feature': 'search'});
       });
+
+      test('leaves the event scope untouched when tags are omitted', () async {
+        await initializeWithDsn();
+
+        await sentryWrapper.captureMessage(
+          'something happened',
+          level: SentryEventLevel.warning,
+        );
+
+        final scope = Scope(SentryFlutterOptions());
+        await fakeSentrySdk.capturedMessageScopeCallbacks.single!(scope);
+        expect(scope.tags, isEmpty);
+      });
     });
 
     group('setUser', () {

--- a/test/libraries/sentry/units/sentry_wrapper_impl_test.dart
+++ b/test/libraries/sentry/units/sentry_wrapper_impl_test.dart
@@ -1,0 +1,261 @@
+// ignore_for_file: no_direct_instantiation
+
+import 'package:construculator/libraries/config/env_constants.dart';
+import 'package:construculator/libraries/config/testing/fake_app_config.dart';
+import 'package:construculator/libraries/config/testing/fake_env_loader.dart';
+import 'package:construculator/libraries/sentry/interfaces/sentry_wrapper.dart';
+import 'package:construculator/libraries/sentry/sentry_wrapper_impl.dart';
+import 'package:construculator/libraries/sentry/testing/fake_sentry_sdk.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sentry_flutter/sentry_flutter.dart';
+
+void main() {
+  group('SentryWrapperImpl', () {
+    const testDsn = 'https://key@sentry.example.com/1';
+
+    late FakeEnvLoader fakeEnvLoader;
+    late FakeAppConfig fakeConfig;
+    late FakeSentrySdk fakeSentrySdk;
+    late SentryWrapperImpl sentryWrapper;
+
+    setUp(() {
+      fakeEnvLoader = FakeEnvLoader();
+      fakeConfig = FakeAppConfig();
+      fakeSentrySdk = FakeSentrySdk();
+      sentryWrapper = SentryWrapperImpl(
+        envLoader: fakeEnvLoader,
+        config: fakeConfig,
+        sentrySdk: fakeSentrySdk,
+      );
+    });
+
+    tearDown(() {
+      fakeEnvLoader.clearEnvVars();
+      fakeSentrySdk.reset();
+    });
+
+    Future<void> initializeWithDsn() async {
+      fakeEnvLoader.setEnvVar(sentryDsnKey, testDsn);
+      await sentryWrapper.initialize(() {});
+    }
+
+    group('initialize', () {
+      test('skips SDK init and still runs the app when DSN is missing',
+          () async {
+        var appRunnerCalled = false;
+
+        await sentryWrapper.initialize(() => appRunnerCalled = true);
+
+        expect(appRunnerCalled, isTrue);
+        expect(fakeSentrySdk.initCallCount, 0);
+      });
+
+      test('skips SDK init and still runs the app when DSN is empty',
+          () async {
+        fakeEnvLoader.setEnvVar(sentryDsnKey, '');
+        var appRunnerCalled = false;
+
+        await sentryWrapper.initialize(() => appRunnerCalled = true);
+
+        expect(appRunnerCalled, isTrue);
+        expect(fakeSentrySdk.initCallCount, 0);
+      });
+
+      test('initializes the SDK with the configured DSN and options',
+          () async {
+        fakeEnvLoader.setEnvVar(sentryDsnKey, testDsn);
+        var appRunnerCalled = false;
+
+        await sentryWrapper.initialize(() => appRunnerCalled = true);
+
+        expect(appRunnerCalled, isTrue);
+        expect(fakeSentrySdk.initCallCount, 1);
+        final options = fakeSentrySdk.lastConfiguredOptions;
+        expect(options, isNotNull);
+        expect(options!.dsn, testDsn);
+        expect(options.environment, devReadableName);
+        expect(options.tracesSampleRate, 0.0);
+        expect(options.attachScreenshot, isFalse);
+        expect(options.enableAutoSessionTracking, isTrue);
+        expect(options.captureFailedRequests, isTrue);
+      });
+    });
+
+    group('before initialization', () {
+      test('addBreadcrumb is a no-op before initialization', () async {
+        await sentryWrapper.addBreadcrumb(
+          message: 'test',
+          level: SentryEventLevel.info,
+        );
+
+        expect(fakeSentrySdk.addedBreadcrumbs, isEmpty);
+      });
+
+      test('captureException is a no-op before initialization', () async {
+        await sentryWrapper.captureException(Exception('boom'));
+
+        expect(fakeSentrySdk.capturedExceptions, isEmpty);
+      });
+
+      test('captureMessage is a no-op before initialization', () async {
+        await sentryWrapper.captureMessage(
+          'test',
+          level: SentryEventLevel.error,
+        );
+
+        expect(fakeSentrySdk.capturedMessages, isEmpty);
+      });
+
+      test('setUser is a no-op before initialization', () async {
+        await sentryWrapper.setUser('user-1');
+
+        expect(fakeSentrySdk.configureScopeCallbacks, isEmpty);
+      });
+
+      test('stays a no-op after initialize ran with an empty DSN', () async {
+        // Empty DSN leaves the wrapper uninitialized, so calls stay no-ops.
+        await sentryWrapper.initialize(() {});
+        await sentryWrapper.captureMessage(
+          'test',
+          level: SentryEventLevel.error,
+        );
+
+        expect(fakeSentrySdk.capturedMessages, isEmpty);
+      });
+    });
+
+    group('addBreadcrumb', () {
+      test('forwards message, category, and data after initialization',
+          () async {
+        await initializeWithDsn();
+
+        await sentryWrapper.addBreadcrumb(
+          message: 'tapped button',
+          level: SentryEventLevel.info,
+          category: 'ui',
+          data: {'key': 'value'},
+        );
+
+        expect(fakeSentrySdk.addedBreadcrumbs, hasLength(1));
+        final breadcrumb = fakeSentrySdk.addedBreadcrumbs.single;
+        expect(breadcrumb.message, 'tapped button');
+        expect(breadcrumb.category, 'ui');
+        expect(breadcrumb.data, {'key': 'value'});
+        expect(breadcrumb.level, SentryLevel.info);
+      });
+    });
+
+    group('severity level mapping', () {
+      const expectedLevels = {
+        SentryEventLevel.debug: SentryLevel.debug,
+        SentryEventLevel.info: SentryLevel.info,
+        SentryEventLevel.warning: SentryLevel.warning,
+        SentryEventLevel.error: SentryLevel.error,
+        SentryEventLevel.fatal: SentryLevel.fatal,
+      };
+
+      for (final entry in expectedLevels.entries) {
+        test('maps SentryEventLevel.${entry.key.name} for captureMessage',
+            () async {
+          await initializeWithDsn();
+
+          await sentryWrapper.captureMessage('test', level: entry.key);
+
+          expect(fakeSentrySdk.capturedMessageLevels.single, entry.value);
+        });
+
+        test('maps SentryEventLevel.${entry.key.name} for addBreadcrumb',
+            () async {
+          await initializeWithDsn();
+
+          await sentryWrapper.addBreadcrumb(
+            message: 'test',
+            level: entry.key,
+          );
+
+          expect(
+            fakeSentrySdk.addedBreadcrumbs.single.level,
+            entry.value,
+          );
+        });
+      }
+    });
+
+    group('captureException', () {
+      test('forwards the exception and stack trace, and applies tags and '
+          'contexts to the event scope', () async {
+        await initializeWithDsn();
+        final exception = Exception('boom');
+        final stackTrace = StackTrace.current;
+
+        await sentryWrapper.captureException(
+          exception,
+          stackTrace: stackTrace,
+          tags: {'feature': 'search'},
+          contexts: {
+            'request': {'id': 'r-1'},
+          },
+        );
+
+        expect(fakeSentrySdk.capturedExceptions.single, exception);
+        expect(fakeSentrySdk.capturedExceptionStackTraces.single, stackTrace);
+        final scope = Scope(SentryFlutterOptions());
+        await fakeSentrySdk.capturedExceptionScopeCallbacks.single!(scope);
+        expect(scope.tags, {'feature': 'search'});
+        expect(scope.contexts['request'], {'id': 'r-1'});
+      });
+
+      test('leaves the event scope untouched when tags and contexts are '
+          'omitted', () async {
+        await initializeWithDsn();
+
+        await sentryWrapper.captureException(Exception('boom'));
+
+        final scope = Scope(SentryFlutterOptions());
+        await fakeSentrySdk.capturedExceptionScopeCallbacks.single!(scope);
+        expect(scope.tags, isEmpty);
+      });
+    });
+
+    group('captureMessage', () {
+      test('forwards the message and applies tags to the event scope',
+          () async {
+        await initializeWithDsn();
+
+        await sentryWrapper.captureMessage(
+          'something happened',
+          level: SentryEventLevel.warning,
+          tags: {'feature': 'search'},
+        );
+
+        expect(fakeSentrySdk.capturedMessages.single, 'something happened');
+        final scope = Scope(SentryFlutterOptions());
+        await fakeSentrySdk.capturedMessageScopeCallbacks.single!(scope);
+        expect(scope.tags, {'feature': 'search'});
+      });
+    });
+
+    group('setUser', () {
+      test('sets the scope user after initialization', () async {
+        await initializeWithDsn();
+
+        await sentryWrapper.setUser('user-1');
+
+        final scope = Scope(SentryFlutterOptions());
+        await fakeSentrySdk.configureScopeCallbacks.single(scope);
+        expect(scope.user?.id, 'user-1');
+      });
+
+      test('clears the scope user when passed null', () async {
+        await initializeWithDsn();
+        final scope = Scope(SentryFlutterOptions());
+        await scope.setUser(SentryUser(id: 'stale-user'));
+
+        await sentryWrapper.setUser(null);
+
+        await fakeSentrySdk.configureScopeCallbacks.single(scope);
+        expect(scope.user, isNull);
+      });
+    });
+  });
+}

--- a/test/libraries/sentry/units/sentry_wrapper_impl_test.dart
+++ b/test/libraries/sentry/units/sentry_wrapper_impl_test.dart
@@ -256,7 +256,10 @@ void main() {
 
         final scope = Scope(SentryFlutterOptions());
         await fakeSentrySdk.configureScopeCallbacks.single(scope);
-        expect(scope.user?.id, 'user-1');
+        expect(
+          scope.user,
+          isA<SentryUser>().having((user) => user.id, 'id', 'user-1'),
+        );
       });
 
       test('clears the scope user when passed null', () async {


### PR DESCRIPTION
# PR Review: CA-568-test/sentry-wrapper-unit-tests → main

## 📝 PR Description

Makes `SentryWrapperImpl` unit-testable by introducing a `SentrySdk` boundary interface over the static `SentryFlutter`/`Sentry` entry points, per the ticket's requirement to exercise the wrapper "directly against a fake boundary". The wrapper loses its `coverage:ignore-file` exemption; only the thin pass-through `SentrySdkImpl` keeps it. 23 new unit tests cover the `_isInitialized` guard (missing/empty DSN, no-op forwarding on every method), the full options configuration (DSN, environment, sample rate, screenshot/session/failed-request flags), and the `_getSentryLevel` mapping for all 5 enum values via both `captureMessage` and `addBreadcrumb`.

**Type:** Test ·
**Size:** L (216 production lines — see issue 1) ·
**Rules applied:** Digestible PR, Naming & Abstraction, Self-Documenting Code, Test Double Pattern, Unit Test Behavior

### What changed
- `lib/libraries/sentry/interfaces/sentry_sdk.dart` (new) — boundary interface mirroring `SentryFlutter.init` / `Sentry.addBreadcrumb` / `captureException` / `captureMessage` / `configureScope`
- `lib/libraries/sentry/sentry_sdk_impl.dart` (new) — production pass-through, `coverage:ignore-file` (platform channels)
- `lib/libraries/sentry/testing/fake_sentry_sdk.dart` (new) — recording fake that mirrors the real init behavior (runs the options configuration, then the app runner)
- `lib/libraries/sentry/sentry_wrapper_impl.dart` — takes `SentrySdk` as a constructor dependency; all static SDK calls replaced; coverage exemption removed
- `lib/main.dart` + `lib/app/app_bootstrap.dart` doc — construction updated to pass `SentrySdkImpl()`
- `analysis_options.yaml` — `SentryFlutterOptions` and `SentryId` added to the `no_direct_instantiation` allowlist (same precedent as `Breadcrumb`, `SentryUser`)
- `test/libraries/sentry/units/sentry_wrapper_impl_test.dart` (new) — 24 tests
- Second review round folded in: scope callbacks are now executed against a real `Scope` and their observable effects asserted (tags/contexts applied on capture, user set/cleared on `setUser`), plus a no-tags/no-contexts case; private-member group titles renamed to behavior names

---

## 🔍 Review Summary

> Found 3 issue(s): 0 🔴 critical · 1 🟠 major · 1 🟡 minor · 1 🔵 suggestion — across 2 file(s).

| # | Issue | Severity | Location | Description | Suggested Fix | Status | Notes |
|---|-------|----------|----------|-------------|---------------|--------|-------|
| 1 | Scope-callback logic recorded but never executed | 🟠 Major | `test/libraries/sentry/units/sentry_wrapper_impl_test.dart:200` | The wrapper's `withScope`/`configureScope` closures hold real logic — tag/context `forEach` loops and the `setUser` null-branch — but tests only asserted the callbacks were `isNotNull`. A mutant deleting `scope.setTag(...)`, `scope.setContexts(...)`, or swapping the `setUser` branches survives the suite. | Invoke the recorded callback against a real `Scope(SentryFlutterOptions())` and assert the observable scope state (`scope.tags`, `scope.contexts`, `scope.user`). | ✅ Addressed | Callbacks executed in `captureException`, `captureMessage`, and both `setUser` tests; empty-scope case added |
| 2 | Production diff exceeds the M threshold | 🟡 Minor | PR-level | 216 production lines is L (>200). ~150 of them are the mechanical pass-through (`SentrySdkImpl`) and the recording fake — the seam, fake, and tests are one atomic change that cannot pass independently if split. | Accept as-is; the reviewable surface (interface + wrapper delta) is ~90 lines. | | |
| 3 | Test group titles name private members | 🔵 Suggestion | `test/libraries/sentry/units/sentry_wrapper_impl_test.dart:91` | Groups `'_isInitialized guard'` and `'_getSentryLevel mapping'` couple test names to private implementation identifiers. | Rename to behavior-focused titles. | ✅ Addressed | Renamed to `'before initialization'` and `'severity level mapping'` |

**Status (author fills):** ✅ Addressed · 📋 Future Story (add YouTrack ID) ·
❌ Disagree (justify) · 🔄 In Progress

<!-- Skipped: CoreUI Components (no presentation files changed), UI / Business Separation (no presentation files changed), Stream Lifecycle (no stream-owning code changed), Widget Test Finders (no widget tests), Localization (no presentation files changed), Mutation Testing (mapping switch is fully enumerated by tests), Accessibility (no user-facing UI changed), Sentry Logging (wrapper internals only; AppLogger call sites unchanged) -->
