### PR TITLE
CA-825: Migrate all deprecated_member_use sites from Flutter 3.44.4 upgrade

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -14,7 +14,6 @@ analyzer:
     - custom_lint
   errors:
     invalid_annotation_target: ignore
-    deprecated_member_use: ignore # TODO: [CA-825] [Chore] Migrate all deprecated_member_use sites surfaced by Flutter 3.44.4 upgrade https://ripplearc.youtrack.cloud/issue/CA-825/Chore-Migrate-all-deprecated-member-use-sites-surfaced-by-Flutter-3.44.4-upgrade
     unnecessary_underscores: ignore # TODO: [CA-826] [Chore] Fix lint violations for rules suppressed without a migration ticket (lints 6.1.0 upgrade) https://ripplearc.youtrack.cloud/issue/CA-826/Chore-Fix-lint-violations-for-rules-suppressed-without-a-migration-ticket-lints-6.1.0-upgrade
     strict_top_level_inference: ignore # TODO: [CA-826] [Chore] Fix lint violations for rules suppressed without a migration ticket (lints 6.1.0 upgrade) https://ripplearc.youtrack.cloud/issue/CA-826/Chore-Fix-lint-violations-for-rules-suppressed-without-a-migration-ticket-lints-6.1.0-upgrade
     use_null_aware_elements: ignore # TODO: [CA-826] [Chore] Fix lint violations for rules suppressed without a migration ticket (lints 6.1.0 upgrade) https://ripplearc.youtrack.cloud/issue/CA-826/Chore-Fix-lint-violations-for-rules-suppressed-without-a-migration-ticket-lints-6.1.0-upgrade

--- a/lib/libraries/search_filters/presentation/widgets/date_range_bottom_sheet.dart
+++ b/lib/libraries/search_filters/presentation/widgets/date_range_bottom_sheet.dart
@@ -160,36 +160,39 @@ class _DateRangeBottomSheetState extends State<DateRangeBottomSheet> {
 
     return Material(
       type: MaterialType.transparency,
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: options.entries.map((entry) {
-          final range = entry.key;
-          return RadioListTile<_PredefinedRange>(
-            key: Key('date_range_option_${range.name}'),
-            value: range,
-            groupValue: _selected,
-            title: Text(entry.value, style: typography.bodyLargeRegular),
-            controlAffinity: ListTileControlAffinity.leading,
-            onChanged: (_) {
-              if (range == _PredefinedRange.custom) {
-                // Only reopen the pickers when there is no complete custom
-                // range yet, or the user is switching back to Custom from
-                // another option. Re-tapping an already-complete Custom
-                // selection just keeps it instead of forcing the pickers open
-                // again.
-                if (_customStart == null ||
-                    _customEnd == null ||
-                    _selected != _PredefinedRange.custom) {
-                  _pickCustomRange(l10n);
-                } else {
-                  setState(() => _selected = _PredefinedRange.custom);
-                }
-              } else {
-                setState(() => _selected = range);
-              }
-            },
-          );
-        }).toList(),
+      child: RadioGroup<_PredefinedRange>(
+        groupValue: _selected,
+        onChanged: (range) {
+          if (range == null) return;
+          if (range == _PredefinedRange.custom) {
+            // Only reopen the pickers when there is no complete custom
+            // range yet, or the user is switching back to Custom from
+            // another option. Re-tapping an already-complete Custom
+            // selection just keeps it instead of forcing the pickers open
+            // again.
+            if (_customStart == null ||
+                _customEnd == null ||
+                _selected != _PredefinedRange.custom) {
+              _pickCustomRange(l10n);
+            } else {
+              setState(() => _selected = _PredefinedRange.custom);
+            }
+          } else {
+            setState(() => _selected = range);
+          }
+        },
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: options.entries.map((entry) {
+            final range = entry.key;
+            return RadioListTile<_PredefinedRange>(
+              key: Key('date_range_option_${range.name}'),
+              value: range,
+              title: Text(entry.value, style: typography.bodyLargeRegular),
+              controlAffinity: ListTileControlAffinity.leading,
+            );
+          }).toList(),
+        ),
       ),
     );
   }

--- a/lib/libraries/search_filters/presentation/widgets/date_range_bottom_sheet.dart
+++ b/lib/libraries/search_filters/presentation/widgets/date_range_bottom_sheet.dart
@@ -161,6 +161,7 @@ class _DateRangeBottomSheetState extends State<DateRangeBottomSheet> {
     return Material(
       type: MaterialType.transparency,
       child: RadioGroup<_PredefinedRange>(
+        key: const Key('date_range_radio_group'),
         groupValue: _selected,
         onChanged: (range) {
           if (range == null) return;

--- a/lib/libraries/supabase/supabase_wrapper_impl.dart
+++ b/lib/libraries/supabase/supabase_wrapper_impl.dart
@@ -22,7 +22,7 @@ class SupabaseWrapperImpl implements SupabaseWrapper {
     if (supabaseUrl != null && supabaseAnonKey != null) {
       await supabase.Supabase.initialize(
         url: supabaseUrl,
-        anonKey: supabaseAnonKey,
+        publishableKey: supabaseAnonKey,
         debug: _envLoader.get('DEBUG_MODE') == 'true',
       );
       _supabaseClient = supabase.Supabase.instance.client;

--- a/test/features/estimations/widgets/labour_cost_form_fields_test.dart
+++ b/test/features/estimations/widgets/labour_cost_form_fields_test.dart
@@ -5,7 +5,6 @@ import 'package:construculator/l10n/generated/app_localizations.dart';
 import 'package:construculator/libraries/supabase/testing/fake_supabase_wrapper.dart';
 import 'package:construculator/libraries/time/testing/fake_clock_impl.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/semantics.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_modular/flutter_modular.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -148,7 +147,7 @@ void main() {
       await tester.pumpAndSettle();
 
       final perDay = tester.getSemantics(find.byKey(const Key('per_day_option')));
-      expect(perDay.hasFlag(SemanticsFlag.isSelected), isTrue);
+      expect(perDay.flagsCollection.isSelected.toBoolOrNull(), isTrue);
     });
 
     testWidgets('tapping per hours changes conditional field label', (
@@ -175,8 +174,8 @@ void main() {
         find.byKey(const Key('per_hours_option')),
       );
       final perDay = tester.getSemantics(find.byKey(const Key('per_day_option')));
-      expect(perHours.hasFlag(SemanticsFlag.isSelected), isTrue);
-      expect(perDay.hasFlag(SemanticsFlag.isSelected), isFalse);
+      expect(perHours.flagsCollection.isSelected.toBoolOrNull(), isTrue);
+      expect(perDay.flagsCollection.isSelected.toBoolOrNull(), isFalse);
     });
   });
 

--- a/test/features/estimations/widgets/pages/cost_item_form_screen_test.dart
+++ b/test/features/estimations/widgets/pages/cost_item_form_screen_test.dart
@@ -12,7 +12,6 @@ import 'package:construculator/libraries/time/interfaces/clock.dart';
 import 'package:construculator/libraries/time/testing/clock_test_module.dart';
 import 'package:construculator/libraries/time/testing/fake_clock_impl.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/semantics.dart';
 import 'package:flutter_modular/flutter_modular.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:ripplearc_coreui/ripplearc_coreui.dart';
@@ -178,7 +177,7 @@ void main() {
       final semantics = tester.getSemantics(
         find.byKey(const Key('from_cost_file_pill')),
       );
-      expect(semantics.hasFlag(SemanticsFlag.isSelected), isTrue);
+      expect(semantics.flagsCollection.isSelected.toBoolOrNull(), isTrue);
     });
 
     testWidgets('add to cost button is present and disabled initially', (
@@ -191,7 +190,7 @@ void main() {
       final semantics = tester.getSemantics(
         find.byKey(const Key('add_to_cost_button')),
       );
-      expect(semantics.hasFlag(SemanticsFlag.isEnabled), isFalse);
+      expect(semantics.flagsCollection.isEnabled.toBoolOrNull(), isFalse);
     });
 
     testWidgets('displays edit title button', (tester) async {
@@ -216,7 +215,7 @@ void main() {
       final semantics = tester.getSemantics(
         find.byKey(const Key('add_to_cost_button')),
       );
-      expect(semantics.hasFlag(SemanticsFlag.isEnabled), isTrue);
+      expect(semantics.flagsCollection.isEnabled.toBoolOrNull(), isTrue);
     });
 
     testWidgets(
@@ -239,7 +238,7 @@ void main() {
       final semantics = tester.getSemantics(
         find.byKey(const Key('add_to_cost_button')),
       );
-      expect(semantics.hasFlag(SemanticsFlag.isEnabled), isFalse);
+      expect(semantics.flagsCollection.isEnabled.toBoolOrNull(), isFalse);
     });
 
     testWidgets('displays total label', (tester) async {

--- a/test/features/estimations/widgets/widgets/calc_method_card_test.dart
+++ b/test/features/estimations/widgets/widgets/calc_method_card_test.dart
@@ -2,7 +2,6 @@ import 'package:construculator/features/estimation/domain/entities/cost_item_ent
 import 'package:construculator/features/estimation/presentation/widgets/calc_method_card.dart';
 import 'package:construculator/l10n/generated/app_localizations.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/semantics.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:ripplearc_coreui/ripplearc_coreui.dart';
 
@@ -47,7 +46,7 @@ void main() {
       await tester.pumpAndSettle();
 
       final perDay = tester.getSemantics(find.byKey(const Key('per_day_option')));
-      expect(perDay.hasFlag(SemanticsFlag.isSelected), isTrue);
+      expect(perDay.flagsCollection.isSelected.toBoolOrNull(), isTrue);
     });
 
     testWidgets('per hours is selected when calcMethod is perHour', (tester) async {
@@ -59,7 +58,7 @@ void main() {
       final perHours = tester.getSemantics(
         find.byKey(const Key('per_hours_option')),
       );
-      expect(perHours.hasFlag(SemanticsFlag.isSelected), isTrue);
+      expect(perHours.flagsCollection.isSelected.toBoolOrNull(), isTrue);
     });
 
     testWidgets('calls onMethodChanged with perHour when per hours tapped', (

--- a/test/features/estimations/widgets/widgets/cost_item_mode_toggle_test.dart
+++ b/test/features/estimations/widgets/widgets/cost_item_mode_toggle_test.dart
@@ -1,7 +1,6 @@
 import 'package:construculator/features/estimation/presentation/widgets/cost_item_mode_toggle.dart';
 import 'package:construculator/l10n/generated/app_localizations.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/semantics.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:ripplearc_coreui/ripplearc_coreui.dart';
 
@@ -48,8 +47,8 @@ void main() {
       final manually = tester.getSemantics(find.byKey(const Key('manually_pill')));
       final fromFile = tester.getSemantics(find.byKey(const Key('from_cost_file_pill')));
 
-      expect(manually.hasFlag(SemanticsFlag.isSelected), isTrue);
-      expect(fromFile.hasFlag(SemanticsFlag.isSelected), isFalse);
+      expect(manually.flagsCollection.isSelected.toBoolOrNull(), isTrue);
+      expect(fromFile.flagsCollection.isSelected.toBoolOrNull(), isFalse);
     });
 
     testWidgets('from cost file pill is selected when fromCostFile is true', (
@@ -61,8 +60,8 @@ void main() {
       final fromFile = tester.getSemantics(find.byKey(const Key('from_cost_file_pill')));
       final manually = tester.getSemantics(find.byKey(const Key('manually_pill')));
 
-      expect(fromFile.hasFlag(SemanticsFlag.isSelected), isTrue);
-      expect(manually.hasFlag(SemanticsFlag.isSelected), isFalse);
+      expect(fromFile.flagsCollection.isSelected.toBoolOrNull(), isTrue);
+      expect(manually.flagsCollection.isSelected.toBoolOrNull(), isFalse);
     });
 
     testWidgets('tapping from cost file pill calls onFromCostFile', (

--- a/test/features/project_settings/widgets/project_stats_cards_test.dart
+++ b/test/features/project_settings/widgets/project_stats_cards_test.dart
@@ -1,7 +1,6 @@
 import 'package:construculator/features/project_settings/presentation/widgets/project_stats_cards.dart';
 import 'package:construculator/l10n/generated/app_localizations.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:ripplearc_coreui/ripplearc_coreui.dart';
 
@@ -154,13 +153,13 @@ void main() {
       expect(
         tester
             .getSemantics(find.byKey(const Key('project_stats_estimations_card')))
-            .hasFlag(SemanticsFlag.isButton),
+            .flagsCollection.isButton,
         isTrue,
       );
       expect(
         tester
             .getSemantics(find.byKey(const Key('project_stats_members_card')))
-            .hasFlag(SemanticsFlag.isButton),
+            .flagsCollection.isButton,
         isTrue,
       );
 

--- a/test/libraries/search_filters/widgets/date_range_bottom_sheet_test.dart
+++ b/test/libraries/search_filters/widgets/date_range_bottom_sheet_test.dart
@@ -14,6 +14,11 @@ class _ResultHolder {
   bool resolved = false;
 }
 
+Object? _groupValue(WidgetTester tester) => (tester.firstWidget(
+      find.byWidgetPredicate((w) => w is RadioGroup<Object?>),
+    ) as RadioGroup<Object?>)
+        .groupValue;
+
 void main() {
   final l10n = lookupAppLocalizations(const Locale('en'));
 
@@ -70,7 +75,7 @@ void main() {
     final todayTile = tester.widget<RadioListTile<Object?>>(
       find.byKey(const Key('date_range_option_today')),
     );
-    expect(todayTile.groupValue, todayTile.value);
+    expect(_groupValue(tester), todayTile.value);
   });
 
   testWidgets('applying Today resolves with start == end == today', (
@@ -161,7 +166,7 @@ void main() {
       final customTile = tester.widget<RadioListTile<Object?>>(
         find.byKey(const Key('date_range_option_custom')),
       );
-      expect(customTile.groupValue, customTile.value);
+      expect(_groupValue(tester), customTile.value);
 
       await tester.tap(find.byKey(const Key('date_range_apply_button')));
       await tester.pumpAndSettle();
@@ -185,7 +190,7 @@ void main() {
       final todayTile = tester.widget<RadioListTile<Object?>>(
         find.byKey(const Key('date_range_option_today')),
       );
-      expect(todayTile.groupValue, todayTile.value);
+      expect(_groupValue(tester), todayTile.value);
     },
   );
 
@@ -216,7 +221,7 @@ void main() {
     final customTile = tester.widget<RadioListTile<Object?>>(
       find.byKey(const Key('date_range_option_custom')),
     );
-    expect(customTile.groupValue, customTile.value);
+    expect(_groupValue(tester), customTile.value);
   });
 
   testWidgets(
@@ -255,7 +260,7 @@ void main() {
       final todayTile = tester.widget<RadioListTile<Object?>>(
         find.byKey(const Key('date_range_option_today')),
       );
-      expect(todayTile.groupValue, todayTile.value);
+      expect(_groupValue(tester), todayTile.value);
 
       await tester.tap(find.byKey(const Key('date_range_apply_button')));
       await tester.pumpAndSettle();

--- a/test/libraries/search_filters/widgets/date_range_bottom_sheet_test.dart
+++ b/test/libraries/search_filters/widgets/date_range_bottom_sheet_test.dart
@@ -14,9 +14,9 @@ class _ResultHolder {
   bool resolved = false;
 }
 
-Object? _groupValue(WidgetTester tester) => (tester.firstWidget(
-      find.byWidgetPredicate((w) => w is RadioGroup<Object?>),
-    ) as RadioGroup<Object?>)
+Object? _groupValue(WidgetTester tester) =>
+    (tester.widget(find.byKey(const Key('date_range_radio_group')))
+            as RadioGroup<Object?>)
         .groupValue;
 
 void main() {


### PR DESCRIPTION
### 1. PR SUMMARY

Removes the global `deprecated_member_use: ignore` suppression added during the Flutter 3.44.4 upgrade (CA-805) by migrating all 20 affected call sites across 3 distinct API changes:

- **Radio → RadioGroup**: Wraps `DateRangeBottomSheet`'s `RadioListTile` column in a `RadioGroup<_PredefinedRange>` ancestor; combined `onChanged` logic moved to the group level. Added a `Key('date_range_radio_group')` so the test helper can find it by key rather than type predicate.
- **`hasFlag` → `flagsCollection`**: Replaces `SemanticsData.hasFlag(SemanticsFlag.X)` with typed property access across 5 test files — `isSelected`/`isEnabled` are `Tristate` (accessed via `.toBoolOrNull()`), `isButton` is `bool`.
- **`anonKey` → `publishableKey`**: Renames the single Supabase initialisation parameter in `SupabaseWrapperImpl`.

### 2. REVIEW SUMMARY TABLE

No issues found.

## Test plan

- [ ] `fvm dart run custom_lint` — only pre-existing `fake_router.dart` issue, no new violations
- [ ] `fvm flutter test test/libraries/search_filters/widgets/date_range_bottom_sheet_test.dart` — 13/13 pass
- [ ] `fvm flutter test test/features/estimations/ test/features/project_settings/` — all pass
- [ ] `fvm flutter test` — 3016 pass, 17 pre-existing failures unchanged (auth a11y + app shell)