### PR TITLE
chore(CA-826): fix lint violations and remove lints 6.1.0 suppressions

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -14,9 +14,6 @@ analyzer:
     - custom_lint
   errors:
     invalid_annotation_target: ignore
-    unnecessary_underscores: ignore # TODO: [CA-826] [Chore] Fix lint violations for rules suppressed without a migration ticket (lints 6.1.0 upgrade) https://ripplearc.youtrack.cloud/issue/CA-826/Chore-Fix-lint-violations-for-rules-suppressed-without-a-migration-ticket-lints-6.1.0-upgrade
-    strict_top_level_inference: ignore # TODO: [CA-826] [Chore] Fix lint violations for rules suppressed without a migration ticket (lints 6.1.0 upgrade) https://ripplearc.youtrack.cloud/issue/CA-826/Chore-Fix-lint-violations-for-rules-suppressed-without-a-migration-ticket-lints-6.1.0-upgrade
-    use_null_aware_elements: ignore # TODO: [CA-826] [Chore] Fix lint violations for rules suppressed without a migration ticket (lints 6.1.0 upgrade) https://ripplearc.youtrack.cloud/issue/CA-826/Chore-Fix-lint-violations-for-rules-suppressed-without-a-migration-ticket-lints-6.1.0-upgrade
     prefer_initializing_formals: ignore # TODO: [CA-827] [Chore] Fix prefer_initializing_formals violations surfaced by Dart 3.12.2 analyzer expansion https://ripplearc.youtrack.cloud/issue/CA-827/Chore-Fix-prefer_initializing_formals-violations-surfaced-by-Dart-3.12.2-analyzer-expansion
   exclude:
     - lib/generated/**

--- a/lib/features/auth/presentation/pages/login_with_email_page.dart
+++ b/lib/features/auth/presentation/pages/login_with_email_page.dart
@@ -31,7 +31,7 @@ class _LoginWithEmailPageState extends State<LoginWithEmailPage> {
   List<String>? _emailErrorList;
   List<Widget>? _emailErrorWidgetList;
 
-  _getContinueButtonText(LoginWithEmailState state) {
+  String _getContinueButtonText(LoginWithEmailState state) {
     final l10n = context.l10n;
     if (state is LoginWithEmailLoading) {
       return l10n.loggingInButton;
@@ -42,7 +42,7 @@ class _LoginWithEmailPageState extends State<LoginWithEmailPage> {
     return l10n.continueButton;
   }
 
-  _handleFailure(Failure failure) {
+  void _handleFailure(Failure failure) {
     final l10n = context.l10n;
     if (failure is AuthFailure) {
       CoreToast.showError(

--- a/lib/features/members/presentation/widgets/invited_members_list.dart
+++ b/lib/features/members/presentation/widgets/invited_members_list.dart
@@ -24,7 +24,7 @@ class InvitedMembersList extends StatelessWidget {
       shrinkWrap: true,
       physics: const NeverScrollableScrollPhysics(),
       itemCount: members.length,
-      separatorBuilder: (_, __) => const SizedBox(height: CoreSpacing.space2),
+      separatorBuilder: (_, _) => const SizedBox(height: CoreSpacing.space2),
       itemBuilder: (context, index) {
         final member = members[index];
         return _MemberTile(

--- a/lib/libraries/errors/exceptions.dart
+++ b/lib/libraries/errors/exceptions.dart
@@ -61,7 +61,7 @@ class NotFoundException extends AppException {
 /// [message] is the user friendly message that will be displayed to the user.
 class ClientException extends AppException {
   final String message;
-  ClientException(stackTrace, this.message)
+  ClientException(trace.Trace stackTrace, this.message)
     : super(stackTrace, Exception(message));
   @override
   String toString() {
@@ -74,7 +74,7 @@ class ClientException extends AppException {
 /// [message] is the error message containing the details of the configuration error.
 class ConfigException extends AppException {
   final String message;
-  ConfigException(stackTrace, this.message)
+  ConfigException(trace.Trace stackTrace, this.message)
     : super(stackTrace, Exception(message));
   @override
   String toString() {

--- a/lib/libraries/supabase/testing/fake_supabase_wrapper.dart
+++ b/lib/libraries/supabase/testing/fake_supabase_wrapper.dart
@@ -492,9 +492,9 @@ class FakeSupabaseWrapper implements SupabaseWrapper {
       'table': table,
       'columns': columns,
       'filters': Map<String, dynamic>.from(filters),
-      ?'orderBy': orderBy,
+      'orderBy': ?orderBy,
       'ascending': ascending,
-      ?'limit': limit,
+      'limit': ?limit,
     });
 
     if (shouldDelayOperations) {

--- a/lib/libraries/supabase/testing/fake_supabase_wrapper.dart
+++ b/lib/libraries/supabase/testing/fake_supabase_wrapper.dart
@@ -492,9 +492,9 @@ class FakeSupabaseWrapper implements SupabaseWrapper {
       'table': table,
       'columns': columns,
       'filters': Map<String, dynamic>.from(filters),
-      if (orderBy != null) 'orderBy': orderBy,
+      ?'orderBy': orderBy,
       'ascending': ascending,
-      if (limit != null) 'limit': limit,
+      ?'limit': limit,
     });
 
     if (shouldDelayOperations) {

--- a/test/libraries/supabase/units/fakes/fake_supabase_wrapper_test.dart
+++ b/test/libraries/supabase/units/fakes/fake_supabase_wrapper_test.dart
@@ -1293,6 +1293,38 @@ void main() {
           expect(call['limit'], equals(3));
         });
 
+        test('omits orderBy key from recorded call when orderBy is null', () async {
+          fakeWrapper.addTableData('items', []);
+
+          await fakeWrapper.selectMatch(
+            table: 'items',
+            filters: {'project_id': 'p1'},
+          );
+
+          final call = fakeWrapper.getMethodCallsFor('selectMatch').first;
+          expect(
+            call.containsKey('orderBy'),
+            isFalse,
+            reason: 'orderBy must not appear in the recorded call when omitted',
+          );
+        });
+
+        test('omits limit key from recorded call when limit is null', () async {
+          fakeWrapper.addTableData('items', []);
+
+          await fakeWrapper.selectMatch(
+            table: 'items',
+            filters: {'project_id': 'p1'},
+          );
+
+          final call = fakeWrapper.getMethodCallsFor('selectMatch').first;
+          expect(
+            call.containsKey('limit'),
+            isFalse,
+            reason: 'limit must not appear in the recorded call when omitted',
+          );
+        });
+
         test('truncates matching rows to limit after ordering', () async {
           fakeWrapper.addTableData('items', [
             {'id': '1', 'project_id': 'p1', 'rank': 3},


### PR DESCRIPTION
### 1. PR SUMMARY
Fixes all 7 violation sites for three lint rules (`unnecessary_underscores`, `strict_top_level_inference`, `use_null_aware_elements`) that were suppressed globally in `analysis_options.yaml` during the Flutter 3.44.4 / lints 6.1.0 upgrade. Removes the three global suppression lines once all sites are resolved.

### 2. REVIEW SUMMARY TABLE
No issues found.

## Test plan
- [ ] `fvm dart run custom_lint` passes (pre-existing `fake_router.dart` warning is unchanged)
- [ ] `fvm flutter test` passes (2 pre-existing failures in `remote_cost_item_data_source_test.dart` are unchanged from main)