### PR TITLE
chore(CA-827): fix prefer_initializing_formals violations surfaced by Dart 3.12.2

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -14,7 +14,6 @@ analyzer:
     - custom_lint
   errors:
     invalid_annotation_target: ignore
-    prefer_initializing_formals: ignore # TODO: [CA-827] [Chore] Fix prefer_initializing_formals violations surfaced by Dart 3.12.2 analyzer expansion https://ripplearc.youtrack.cloud/issue/CA-827/Chore-Fix-prefer_initializing_formals-violations-surfaced-by-Dart-3.12.2-analyzer-expansion
   exclude:
     - lib/generated/**
     - lib/**.g.dart

--- a/lib/app/shell/app_shell_bloc/app_shell_bloc.dart
+++ b/lib/app/shell/app_shell_bloc/app_shell_bloc.dart
@@ -12,9 +12,8 @@ part 'app_shell_state.dart';
 class AppShellBloc extends Bloc<AppShellEvent, AppShellState> {
   final TabModuleManager _moduleLoader;
 
-  AppShellBloc({required TabModuleManager moduleLoader})
-    : _moduleLoader = moduleLoader,
-      super(
+  AppShellBloc({required this._moduleLoader})
+    : super(
         const AppShellState(selectedTabIndex: 0, loadedTabIndexes: {}),
       ) {
     on<AppShellInitialized>(_onInitialized);

--- a/lib/app/shell/app_shell_bloc/app_shell_bloc.dart
+++ b/lib/app/shell/app_shell_bloc/app_shell_bloc.dart
@@ -12,8 +12,9 @@ part 'app_shell_state.dart';
 class AppShellBloc extends Bloc<AppShellEvent, AppShellState> {
   final TabModuleManager _moduleLoader;
 
-  AppShellBloc({required this._moduleLoader})
-    : super(
+  AppShellBloc({required TabModuleManager moduleLoader})
+    : _moduleLoader = moduleLoader,
+      super(
         const AppShellState(selectedTabIndex: 0, loadedTabIndexes: {}),
       ) {
     on<AppShellInitialized>(_onInitialized);

--- a/lib/features/auth/presentation/bloc/create_account_bloc/create_account_bloc.dart
+++ b/lib/features/auth/presentation/bloc/create_account_bloc/create_account_bloc.dart
@@ -22,10 +22,13 @@ class CreateAccountBloc extends Bloc<CreateAccountEvent, CreateAccountState> {
   final SendOtpUseCase _sendOtpUseCase;
 
   CreateAccountBloc({
-    required this._createAccountUseCase,
-    required this._getProfessionalRolesUseCase,
-    required this._sendOtpUseCase,
-  }) : super(CreateAccountInitial()) {
+    required CreateAccountUseCase createAccountUseCase,
+    required GetProfessionalRolesUseCase getProfessionalRolesUseCase,
+    required SendOtpUseCase sendOtpUseCase,
+  }) : _createAccountUseCase = createAccountUseCase,
+       _getProfessionalRolesUseCase = getProfessionalRolesUseCase,
+       _sendOtpUseCase = sendOtpUseCase,
+       super(CreateAccountInitial()) {
     on<CreateAccountSubmitted>(_onSubmitted);
     on<CreateAccountGetProfessionalRolesRequested>(_onLoadProfessionalRoles);
     on<CreateAccountSendOtpRequested>(_onSendOtp);

--- a/lib/features/auth/presentation/bloc/create_account_bloc/create_account_bloc.dart
+++ b/lib/features/auth/presentation/bloc/create_account_bloc/create_account_bloc.dart
@@ -22,13 +22,10 @@ class CreateAccountBloc extends Bloc<CreateAccountEvent, CreateAccountState> {
   final SendOtpUseCase _sendOtpUseCase;
 
   CreateAccountBloc({
-    required CreateAccountUseCase createAccountUseCase,
-    required GetProfessionalRolesUseCase getProfessionalRolesUseCase,
-    required SendOtpUseCase sendOtpUseCase,
-  }) : _createAccountUseCase = createAccountUseCase,
-       _getProfessionalRolesUseCase = getProfessionalRolesUseCase,
-       _sendOtpUseCase = sendOtpUseCase,
-       super(CreateAccountInitial()) {
+    required this._createAccountUseCase,
+    required this._getProfessionalRolesUseCase,
+    required this._sendOtpUseCase,
+  }) : super(CreateAccountInitial()) {
     on<CreateAccountSubmitted>(_onSubmitted);
     on<CreateAccountGetProfessionalRolesRequested>(_onLoadProfessionalRoles);
     on<CreateAccountSendOtpRequested>(_onSendOtp);

--- a/lib/features/auth/presentation/bloc/enter_password_bloc/enter_password_bloc.dart
+++ b/lib/features/auth/presentation/bloc/enter_password_bloc/enter_password_bloc.dart
@@ -10,8 +10,9 @@ part 'enter_password_state.dart';
 class EnterPasswordBloc extends Bloc<EnterPasswordEvent, EnterPasswordState> {
   final LoginUseCase _loginUseCase;
 
-  EnterPasswordBloc({required this._loginUseCase})
-    : super(EnterPasswordInitial()) {
+  EnterPasswordBloc({required LoginUseCase loginUseCase})
+    : _loginUseCase = loginUseCase,
+      super(EnterPasswordInitial()) {
     on<EnterPasswordSubmitted>(_onSubmitted);
   }
 

--- a/lib/features/auth/presentation/bloc/enter_password_bloc/enter_password_bloc.dart
+++ b/lib/features/auth/presentation/bloc/enter_password_bloc/enter_password_bloc.dart
@@ -10,9 +10,8 @@ part 'enter_password_state.dart';
 class EnterPasswordBloc extends Bloc<EnterPasswordEvent, EnterPasswordState> {
   final LoginUseCase _loginUseCase;
 
-  EnterPasswordBloc({required LoginUseCase loginUseCase})
-    : _loginUseCase = loginUseCase,
-      super(EnterPasswordInitial()) {
+  EnterPasswordBloc({required this._loginUseCase})
+    : super(EnterPasswordInitial()) {
     on<EnterPasswordSubmitted>(_onSubmitted);
   }
 

--- a/lib/features/auth/presentation/bloc/forgot_password_bloc/forgot_password_bloc.dart
+++ b/lib/features/auth/presentation/bloc/forgot_password_bloc/forgot_password_bloc.dart
@@ -14,8 +14,9 @@ class ForgotPasswordBloc
     extends Bloc<ForgotPasswordEvent, ForgotPasswordState> {
   final ResetPasswordUseCase _resetPasswordUseCase;
 
-  ForgotPasswordBloc({required this._resetPasswordUseCase})
-    : super(ForgotPasswordInitial()) {
+  ForgotPasswordBloc({required ResetPasswordUseCase resetPasswordUseCase})
+    : _resetPasswordUseCase = resetPasswordUseCase,
+      super(ForgotPasswordInitial()) {
     on<ForgotPasswordSubmitted>(_onSubmitted);
     on<ForgotPasswordEditEmailRequested>(_onEditEmail);
     on<ForgotPasswordFormFieldChanged>(_onFormFieldChanged);

--- a/lib/features/auth/presentation/bloc/forgot_password_bloc/forgot_password_bloc.dart
+++ b/lib/features/auth/presentation/bloc/forgot_password_bloc/forgot_password_bloc.dart
@@ -14,9 +14,8 @@ class ForgotPasswordBloc
     extends Bloc<ForgotPasswordEvent, ForgotPasswordState> {
   final ResetPasswordUseCase _resetPasswordUseCase;
 
-  ForgotPasswordBloc({required ResetPasswordUseCase resetPasswordUseCase})
-    : _resetPasswordUseCase = resetPasswordUseCase,
-      super(ForgotPasswordInitial()) {
+  ForgotPasswordBloc({required this._resetPasswordUseCase})
+    : super(ForgotPasswordInitial()) {
     on<ForgotPasswordSubmitted>(_onSubmitted);
     on<ForgotPasswordEditEmailRequested>(_onEditEmail);
     on<ForgotPasswordFormFieldChanged>(_onFormFieldChanged);

--- a/lib/features/auth/presentation/bloc/login_with_email_bloc/login_with_email_bloc.dart
+++ b/lib/features/auth/presentation/bloc/login_with_email_bloc/login_with_email_bloc.dart
@@ -14,8 +14,9 @@ class LoginWithEmailBloc
   final CheckEmailAvailabilityUseCase _checkEmailAvailabilityUseCase;
 
   LoginWithEmailBloc({
-    required this._checkEmailAvailabilityUseCase,
-  }) : super(LoginWithEmailInitial()) {
+    required CheckEmailAvailabilityUseCase checkEmailAvailabilityUseCase,
+  }) : _checkEmailAvailabilityUseCase = checkEmailAvailabilityUseCase,
+       super(LoginWithEmailInitial()) {
     on<LoginEmailAvailabilityCheckRequested>(_onEmailChanged);
     on<LoginWithEmailFormFieldChanged>(_onFormFieldChanged);
   }

--- a/lib/features/auth/presentation/bloc/login_with_email_bloc/login_with_email_bloc.dart
+++ b/lib/features/auth/presentation/bloc/login_with_email_bloc/login_with_email_bloc.dart
@@ -14,9 +14,8 @@ class LoginWithEmailBloc
   final CheckEmailAvailabilityUseCase _checkEmailAvailabilityUseCase;
 
   LoginWithEmailBloc({
-    required CheckEmailAvailabilityUseCase checkEmailAvailabilityUseCase,
-  }) : _checkEmailAvailabilityUseCase = checkEmailAvailabilityUseCase,
-       super(LoginWithEmailInitial()) {
+    required this._checkEmailAvailabilityUseCase,
+  }) : super(LoginWithEmailInitial()) {
     on<LoginEmailAvailabilityCheckRequested>(_onEmailChanged);
     on<LoginWithEmailFormFieldChanged>(_onFormFieldChanged);
   }

--- a/lib/features/auth/presentation/bloc/otp_verification_bloc/otp_verification_bloc.dart
+++ b/lib/features/auth/presentation/bloc/otp_verification_bloc/otp_verification_bloc.dart
@@ -16,11 +16,9 @@ class OtpVerificationBloc
   final SendOtpUseCase _sendOtpUseCase;
 
   OtpVerificationBloc({
-    required VerifyOtpUseCase verifyOtpUseCase,
-    required SendOtpUseCase sendOtpUseCase,
-  }) : _verifyOtpUseCase = verifyOtpUseCase,
-       _sendOtpUseCase = sendOtpUseCase,
-       super(OtpVerificationInitial()) {
+    required this._verifyOtpUseCase,
+    required this._sendOtpUseCase,
+  }) : super(OtpVerificationInitial()) {
     on<OtpVerificationOtpChanged>(_onOtpChanged);
     on<OtpVerificationSubmitted>(_onOtpSubmitted);
     on<OtpVerificationResendRequested>(_onResendRequested);

--- a/lib/features/auth/presentation/bloc/otp_verification_bloc/otp_verification_bloc.dart
+++ b/lib/features/auth/presentation/bloc/otp_verification_bloc/otp_verification_bloc.dart
@@ -16,9 +16,11 @@ class OtpVerificationBloc
   final SendOtpUseCase _sendOtpUseCase;
 
   OtpVerificationBloc({
-    required this._verifyOtpUseCase,
-    required this._sendOtpUseCase,
-  }) : super(OtpVerificationInitial()) {
+    required VerifyOtpUseCase verifyOtpUseCase,
+    required SendOtpUseCase sendOtpUseCase,
+  }) : _verifyOtpUseCase = verifyOtpUseCase,
+       _sendOtpUseCase = sendOtpUseCase,
+       super(OtpVerificationInitial()) {
     on<OtpVerificationOtpChanged>(_onOtpChanged);
     on<OtpVerificationSubmitted>(_onOtpSubmitted);
     on<OtpVerificationResendRequested>(_onResendRequested);

--- a/lib/features/auth/presentation/bloc/register_with_email_bloc/register_with_email_bloc.dart
+++ b/lib/features/auth/presentation/bloc/register_with_email_bloc/register_with_email_bloc.dart
@@ -19,9 +19,11 @@ class RegisterWithEmailBloc
   final SendOtpUseCase _sendOtpUseCase;
 
   RegisterWithEmailBloc({
-    required this._checkEmailAvailabilityUseCase,
-    required this._sendOtpUseCase,
-  }) : super(RegisterWithEmailInitial()) {
+    required CheckEmailAvailabilityUseCase checkEmailAvailabilityUseCase,
+    required SendOtpUseCase sendOtpUseCase,
+  }) : _checkEmailAvailabilityUseCase = checkEmailAvailabilityUseCase,
+       _sendOtpUseCase = sendOtpUseCase,
+       super(RegisterWithEmailInitial()) {
     on<RegisterWithEmailEmailChanged>(
       _onEmailChanged,
       transformer: (events, mapper) {

--- a/lib/features/auth/presentation/bloc/register_with_email_bloc/register_with_email_bloc.dart
+++ b/lib/features/auth/presentation/bloc/register_with_email_bloc/register_with_email_bloc.dart
@@ -19,11 +19,9 @@ class RegisterWithEmailBloc
   final SendOtpUseCase _sendOtpUseCase;
 
   RegisterWithEmailBloc({
-    required CheckEmailAvailabilityUseCase checkEmailAvailabilityUseCase,
-    required SendOtpUseCase sendOtpUseCase,
-  }) : _checkEmailAvailabilityUseCase = checkEmailAvailabilityUseCase,
-       _sendOtpUseCase = sendOtpUseCase,
-       super(RegisterWithEmailInitial()) {
+    required this._checkEmailAvailabilityUseCase,
+    required this._sendOtpUseCase,
+  }) : super(RegisterWithEmailInitial()) {
     on<RegisterWithEmailEmailChanged>(
       _onEmailChanged,
       transformer: (events, mapper) {

--- a/lib/features/auth/presentation/bloc/set_new_password_bloc/set_new_password_bloc.dart
+++ b/lib/features/auth/presentation/bloc/set_new_password_bloc/set_new_password_bloc.dart
@@ -14,9 +14,8 @@ class SetNewPasswordBloc
     extends Bloc<SetNewPasswordEvent, SetNewPasswordState> {
   final SetNewPasswordUseCase _setNewPasswordUseCase;
 
-  SetNewPasswordBloc({required SetNewPasswordUseCase setNewPasswordUseCase})
-    : _setNewPasswordUseCase = setNewPasswordUseCase,
-      super(SetNewPasswordInitial()) {
+  SetNewPasswordBloc({required this._setNewPasswordUseCase})
+    : super(SetNewPasswordInitial()) {
     on<SetNewPasswordSubmitted>(_onSubmitted);
     on<SetNewPasswordPasswordValidationRequested>(
       _onPasswordValidationRequested,

--- a/lib/features/auth/presentation/bloc/set_new_password_bloc/set_new_password_bloc.dart
+++ b/lib/features/auth/presentation/bloc/set_new_password_bloc/set_new_password_bloc.dart
@@ -14,8 +14,9 @@ class SetNewPasswordBloc
     extends Bloc<SetNewPasswordEvent, SetNewPasswordState> {
   final SetNewPasswordUseCase _setNewPasswordUseCase;
 
-  SetNewPasswordBloc({required this._setNewPasswordUseCase})
-    : super(SetNewPasswordInitial()) {
+  SetNewPasswordBloc({required SetNewPasswordUseCase setNewPasswordUseCase})
+    : _setNewPasswordUseCase = setNewPasswordUseCase,
+      super(SetNewPasswordInitial()) {
     on<SetNewPasswordSubmitted>(_onSubmitted);
     on<SetNewPasswordPasswordValidationRequested>(
       _onPasswordValidationRequested,

--- a/lib/features/dashboard/data/data_source/remote_project_search_data_source.dart
+++ b/lib/features/dashboard/data/data_source/remote_project_search_data_source.dart
@@ -15,8 +15,8 @@ class RemoteProjectSearchDataSource implements ProjectSearchDataSource {
   static final _logger = AppLogger().tag('RemoteProjectSearchDataSource');
 
   const RemoteProjectSearchDataSource({
-    required SupabaseWrapper supabaseWrapper,
-  }) : _supabaseWrapper = supabaseWrapper;
+    required this._supabaseWrapper,
+  });
 
   @override
   Future<List<ProjectDto>> fetchProjectsBySearchQuery(String query) async {

--- a/lib/features/dashboard/data/data_source/remote_project_search_data_source.dart
+++ b/lib/features/dashboard/data/data_source/remote_project_search_data_source.dart
@@ -15,8 +15,8 @@ class RemoteProjectSearchDataSource implements ProjectSearchDataSource {
   static final _logger = AppLogger().tag('RemoteProjectSearchDataSource');
 
   const RemoteProjectSearchDataSource({
-    required this._supabaseWrapper,
-  });
+    required SupabaseWrapper supabaseWrapper,
+  }) : _supabaseWrapper = supabaseWrapper;
 
   @override
   Future<List<ProjectDto>> fetchProjectsBySearchQuery(String query) async {

--- a/lib/features/dashboard/presentation/bloc/dashboard_bloc/dashboard_bloc.dart
+++ b/lib/features/dashboard/presentation/bloc/dashboard_bloc/dashboard_bloc.dart
@@ -24,11 +24,15 @@ class DashboardBloc extends Bloc<DashboardEvent, DashboardState> {
   String _userDisplayName = '...';
 
   DashboardBloc({
-    required this._projectRepository,
-    required this._currentProjectNotifier,
-    required this._authNotifier,
-    required this._authManager,
-  })  : super(const DashboardInitial()) {
+    required ProjectRepository projectRepository,
+    required CurrentProjectNotifier currentProjectNotifier,
+    required AuthNotifier authNotifier,
+    required AuthManager authManager,
+  })  : _projectRepository = projectRepository,
+        _currentProjectNotifier = currentProjectNotifier,
+        _authNotifier = authNotifier,
+        _authManager = authManager,
+        super(const DashboardInitial()) {
     on<DashboardStarted>(_onDashboardStarted);
     on<DashboardLoadedEvent>(_onDashboardLoaded);
     on<DashboardRefreshedEvent>(_onDashboardRefreshed);

--- a/lib/features/dashboard/presentation/bloc/dashboard_bloc/dashboard_bloc.dart
+++ b/lib/features/dashboard/presentation/bloc/dashboard_bloc/dashboard_bloc.dart
@@ -24,15 +24,11 @@ class DashboardBloc extends Bloc<DashboardEvent, DashboardState> {
   String _userDisplayName = '...';
 
   DashboardBloc({
-    required ProjectRepository projectRepository,
-    required CurrentProjectNotifier currentProjectNotifier,
-    required AuthNotifier authNotifier,
-    required AuthManager authManager,
-  })  : _projectRepository = projectRepository,
-        _currentProjectNotifier = currentProjectNotifier,
-        _authNotifier = authNotifier,
-        _authManager = authManager,
-        super(const DashboardInitial()) {
+    required this._projectRepository,
+    required this._currentProjectNotifier,
+    required this._authNotifier,
+    required this._authManager,
+  })  : super(const DashboardInitial()) {
     on<DashboardStarted>(_onDashboardStarted);
     on<DashboardLoadedEvent>(_onDashboardLoaded);
     on<DashboardRefreshedEvent>(_onDashboardRefreshed);

--- a/lib/features/dashboard/presentation/bloc/project_dropdown_bloc/project_dropdown_bloc.dart
+++ b/lib/features/dashboard/presentation/bloc/project_dropdown_bloc/project_dropdown_bloc.dart
@@ -24,12 +24,14 @@ class ProjectDropdownBloc
 
   /// Creates a [ProjectDropdownBloc].
   ///
-  /// [_projectRepository] provides the project list stream.
-  /// [_authManager] supplies the authenticated user identity.
+  /// [projectRepository] provides the project list stream.
+  /// [authManager] supplies the authenticated user identity.
   ProjectDropdownBloc({
-    required this._projectRepository,
-    required this._authManager,
-  }) : super(const ProjectDropdownInitial()) {
+    required ProjectRepository projectRepository,
+    required AuthManager authManager,
+  }) : _projectRepository = projectRepository,
+       _authManager = authManager,
+       super(const ProjectDropdownInitial()) {
     on<ProjectDropdownStarted>(_onStarted);
     on<ProjectDropdownSelected>(_onSelected);
     on<ProjectDropdownSearchChanged>(_onSearchChanged);

--- a/lib/features/dashboard/presentation/bloc/project_dropdown_bloc/project_dropdown_bloc.dart
+++ b/lib/features/dashboard/presentation/bloc/project_dropdown_bloc/project_dropdown_bloc.dart
@@ -24,14 +24,12 @@ class ProjectDropdownBloc
 
   /// Creates a [ProjectDropdownBloc].
   ///
-  /// [projectRepository] provides the project list stream.
-  /// [authManager] supplies the authenticated user identity.
+  /// [_projectRepository] provides the project list stream.
+  /// [_authManager] supplies the authenticated user identity.
   ProjectDropdownBloc({
-    required ProjectRepository projectRepository,
-    required AuthManager authManager,
-  }) : _projectRepository = projectRepository,
-       _authManager = authManager,
-       super(const ProjectDropdownInitial()) {
+    required this._projectRepository,
+    required this._authManager,
+  }) : super(const ProjectDropdownInitial()) {
     on<ProjectDropdownStarted>(_onStarted);
     on<ProjectDropdownSelected>(_onSelected);
     on<ProjectDropdownSearchChanged>(_onSearchChanged);

--- a/lib/features/dashboard/presentation/bloc/project_search_bloc/project_search_bloc.dart
+++ b/lib/features/dashboard/presentation/bloc/project_search_bloc/project_search_bloc.dart
@@ -110,14 +110,18 @@ class ProjectSearchBloc extends Bloc<ProjectSearchEvent, ProjectSearchState> {
   @visibleForTesting
   int availableOwnersHandlerRuns = 0;
 
-  /// Creates a [ProjectSearchBloc] with the given [_repository], [_authManager],
-  /// [_tagRepository], and [_ownerRepository].
+  /// Creates a [ProjectSearchBloc] with the given [repository], [authManager],
+  /// [tagRepository], and [ownerRepository].
   ProjectSearchBloc({
-    required this._repository,
-    required this._authManager,
-    required this._tagRepository,
-    required this._ownerRepository,
-  }) : super(const ProjectSearchInitial()) {
+    required ProjectSearchRepository repository,
+    required AuthManager authManager,
+    required TagRepository tagRepository,
+    required OwnerRepository ownerRepository,
+  }) : _repository = repository,
+       _authManager = authManager,
+       _tagRepository = tagRepository,
+       _ownerRepository = ownerRepository,
+       super(const ProjectSearchInitial()) {
     on<ProjectSearchQueryUpdatedEvent>(
       (event, emit) => _handleQuery(event.query, emit),
       transformer: _debounce(_kQueryDebounceDuration),

--- a/lib/features/dashboard/presentation/bloc/project_search_bloc/project_search_bloc.dart
+++ b/lib/features/dashboard/presentation/bloc/project_search_bloc/project_search_bloc.dart
@@ -110,18 +110,14 @@ class ProjectSearchBloc extends Bloc<ProjectSearchEvent, ProjectSearchState> {
   @visibleForTesting
   int availableOwnersHandlerRuns = 0;
 
-  /// Creates a [ProjectSearchBloc] with the given [repository], [authManager],
-  /// [tagRepository], and [ownerRepository].
+  /// Creates a [ProjectSearchBloc] with the given [_repository], [_authManager],
+  /// [_tagRepository], and [_ownerRepository].
   ProjectSearchBloc({
-    required ProjectSearchRepository repository,
-    required AuthManager authManager,
-    required TagRepository tagRepository,
-    required OwnerRepository ownerRepository,
-  }) : _repository = repository,
-       _authManager = authManager,
-       _tagRepository = tagRepository,
-       _ownerRepository = ownerRepository,
-       super(const ProjectSearchInitial()) {
+    required this._repository,
+    required this._authManager,
+    required this._tagRepository,
+    required this._ownerRepository,
+  }) : super(const ProjectSearchInitial()) {
     on<ProjectSearchQueryUpdatedEvent>(
       (event, emit) => _handleQuery(event.query, emit),
       transformer: _debounce(_kQueryDebounceDuration),

--- a/lib/features/dashboard/presentation/bloc/recent_estimations_bloc/recent_estimations_bloc.dart
+++ b/lib/features/dashboard/presentation/bloc/recent_estimations_bloc/recent_estimations_bloc.dart
@@ -25,11 +25,9 @@ class RecentEstimationsBloc
 
   /// Defines constructor that takes a usecase as an injected dependency.
   RecentEstimationsBloc({
-    required WatchRecentEstimationsUseCase watchRecentEstimationsUseCase,
-    required CurrentProjectNotifier currentProjectNotifier,
-  }) : _watchRecentEstimationsUseCase = watchRecentEstimationsUseCase,
-       _currentProjectNotifier = currentProjectNotifier,
-       super(const RecentEstimationsLoading()) {
+    required this._watchRecentEstimationsUseCase,
+    required this._currentProjectNotifier,
+  }) : super(const RecentEstimationsLoading()) {
     on<RecentEstimationsWatchStarted>(_onWatchStarted);
     on<_RecentEstimationsProjectChanged>(_onProjectChanged);
     on<_RecentEstimationsUpdated>(_onUpdated);

--- a/lib/features/dashboard/presentation/bloc/recent_estimations_bloc/recent_estimations_bloc.dart
+++ b/lib/features/dashboard/presentation/bloc/recent_estimations_bloc/recent_estimations_bloc.dart
@@ -25,9 +25,11 @@ class RecentEstimationsBloc
 
   /// Defines constructor that takes a usecase as an injected dependency.
   RecentEstimationsBloc({
-    required this._watchRecentEstimationsUseCase,
-    required this._currentProjectNotifier,
-  }) : super(const RecentEstimationsLoading()) {
+    required WatchRecentEstimationsUseCase watchRecentEstimationsUseCase,
+    required CurrentProjectNotifier currentProjectNotifier,
+  }) : _watchRecentEstimationsUseCase = watchRecentEstimationsUseCase,
+       _currentProjectNotifier = currentProjectNotifier,
+       super(const RecentEstimationsLoading()) {
     on<RecentEstimationsWatchStarted>(_onWatchStarted);
     on<_RecentEstimationsProjectChanged>(_onProjectChanged);
     on<_RecentEstimationsUpdated>(_onUpdated);

--- a/lib/features/estimation/data/data_source/remote_cost_item_data_source.dart
+++ b/lib/features/estimation/data/data_source/remote_cost_item_data_source.dart
@@ -15,8 +15,7 @@ class RemoteCostItemDataSource implements CostItemDataSource {
   final SupabaseWrapper _supabaseWrapper;
   static final _logger = AppLogger().tag('RemoteCostItemDataSource');
 
-  RemoteCostItemDataSource({required SupabaseWrapper supabaseWrapper})
-      : _supabaseWrapper = supabaseWrapper;
+  RemoteCostItemDataSource({required this._supabaseWrapper});
 
   @override
   Future<List<CostItemDto>> fetchCostItemsByEstimateId({

--- a/lib/features/estimation/data/data_source/remote_cost_item_data_source.dart
+++ b/lib/features/estimation/data/data_source/remote_cost_item_data_source.dart
@@ -15,7 +15,8 @@ class RemoteCostItemDataSource implements CostItemDataSource {
   final SupabaseWrapper _supabaseWrapper;
   static final _logger = AppLogger().tag('RemoteCostItemDataSource');
 
-  RemoteCostItemDataSource({required this._supabaseWrapper});
+  RemoteCostItemDataSource({required SupabaseWrapper supabaseWrapper})
+      : _supabaseWrapper = supabaseWrapper;
 
   @override
   Future<List<CostItemDto>> fetchCostItemsByEstimateId({

--- a/lib/features/estimation/domain/usecases/add_cost_estimation_usecase.dart
+++ b/lib/features/estimation/domain/usecases/add_cost_estimation_usecase.dart
@@ -27,14 +27,11 @@ class AddCostEstimationUseCase {
   static final _logger = AppLogger().tag('AddCostEstimationUseCase');
 
   AddCostEstimationUseCase({
-    required CostEstimationRepository repository,
-    required AuthRepository authRepository,
-    required Clock clock,
-    required CurrentProjectNotifier currentProjectNotifier,
-  }) : _repository = repository,
-       _authRepository = authRepository,
-       _clock = clock,
-       _currentProjectNotifier = currentProjectNotifier;
+    required this._repository,
+    required this._authRepository,
+    required this._clock,
+    required this._currentProjectNotifier,
+  });
 
   /// Creates a new cost estimation with the specified name.
   ///

--- a/lib/features/estimation/domain/usecases/add_cost_estimation_usecase.dart
+++ b/lib/features/estimation/domain/usecases/add_cost_estimation_usecase.dart
@@ -27,11 +27,14 @@ class AddCostEstimationUseCase {
   static final _logger = AppLogger().tag('AddCostEstimationUseCase');
 
   AddCostEstimationUseCase({
-    required this._repository,
-    required this._authRepository,
-    required this._clock,
-    required this._currentProjectNotifier,
-  });
+    required CostEstimationRepository repository,
+    required AuthRepository authRepository,
+    required Clock clock,
+    required CurrentProjectNotifier currentProjectNotifier,
+  }) : _repository = repository,
+       _authRepository = authRepository,
+       _clock = clock,
+       _currentProjectNotifier = currentProjectNotifier;
 
   /// Creates a new cost estimation with the specified name.
   ///

--- a/lib/features/estimation/presentation/bloc/add_cost_estimation_bloc/add_cost_estimation_bloc.dart
+++ b/lib/features/estimation/presentation/bloc/add_cost_estimation_bloc/add_cost_estimation_bloc.dart
@@ -17,8 +17,9 @@ class AddCostEstimationBloc
   final AddCostEstimationUseCase _addCostEstimationUseCase;
 
   AddCostEstimationBloc({
-    required this._addCostEstimationUseCase,
-  }) : super(const AddCostEstimationInitial()) {
+    required AddCostEstimationUseCase addCostEstimationUseCase,
+  }) : _addCostEstimationUseCase = addCostEstimationUseCase,
+       super(const AddCostEstimationInitial()) {
     on<AddCostEstimationSubmitted>(_onSubmitted);
   }
 

--- a/lib/features/estimation/presentation/bloc/add_cost_estimation_bloc/add_cost_estimation_bloc.dart
+++ b/lib/features/estimation/presentation/bloc/add_cost_estimation_bloc/add_cost_estimation_bloc.dart
@@ -17,9 +17,8 @@ class AddCostEstimationBloc
   final AddCostEstimationUseCase _addCostEstimationUseCase;
 
   AddCostEstimationBloc({
-    required AddCostEstimationUseCase addCostEstimationUseCase,
-  }) : _addCostEstimationUseCase = addCostEstimationUseCase,
-       super(const AddCostEstimationInitial()) {
+    required this._addCostEstimationUseCase,
+  }) : super(const AddCostEstimationInitial()) {
     on<AddCostEstimationSubmitted>(_onSubmitted);
   }
 

--- a/lib/features/estimation/presentation/bloc/change_lock_status_bloc/change_lock_status_bloc.dart
+++ b/lib/features/estimation/presentation/bloc/change_lock_status_bloc/change_lock_status_bloc.dart
@@ -17,13 +17,10 @@ class ChangeLockStatusBloc
   final CurrentProjectNotifier _currentProjectNotifier;
 
   ChangeLockStatusBloc({
-    required CostEstimationRepository repository,
-    required ProjectRepository projectRepository,
-    required CurrentProjectNotifier currentProjectNotifier,
-  }) : _repository = repository,
-       _projectRepository = projectRepository,
-       _currentProjectNotifier = currentProjectNotifier,
-       super(const ChangeLockStatusInitial()) {
+    required this._repository,
+    required this._projectRepository,
+    required this._currentProjectNotifier,
+  }) : super(const ChangeLockStatusInitial()) {
     on<ChangeLockStatusRequested>(_onChangeLockStatusRequested);
   }
 

--- a/lib/features/estimation/presentation/bloc/change_lock_status_bloc/change_lock_status_bloc.dart
+++ b/lib/features/estimation/presentation/bloc/change_lock_status_bloc/change_lock_status_bloc.dart
@@ -17,10 +17,13 @@ class ChangeLockStatusBloc
   final CurrentProjectNotifier _currentProjectNotifier;
 
   ChangeLockStatusBloc({
-    required this._repository,
-    required this._projectRepository,
-    required this._currentProjectNotifier,
-  }) : super(const ChangeLockStatusInitial()) {
+    required CostEstimationRepository repository,
+    required ProjectRepository projectRepository,
+    required CurrentProjectNotifier currentProjectNotifier,
+  }) : _repository = repository,
+       _projectRepository = projectRepository,
+       _currentProjectNotifier = currentProjectNotifier,
+       super(const ChangeLockStatusInitial()) {
     on<ChangeLockStatusRequested>(_onChangeLockStatusRequested);
   }
 

--- a/lib/features/estimation/presentation/bloc/cost_estimation_list_bloc/cost_estimation_list_bloc.dart
+++ b/lib/features/estimation/presentation/bloc/cost_estimation_list_bloc/cost_estimation_list_bloc.dart
@@ -24,9 +24,11 @@ class CostEstimationListBloc
   static final _logger = AppLogger().tag('CostEstimationListBloc');
 
   CostEstimationListBloc({
-    required this._repository,
-    required this._currentProjectNotifier,
-  }) : super(const CostEstimationListInitial()) {
+    required CostEstimationRepository repository,
+    required CurrentProjectNotifier currentProjectNotifier,
+  }) : _repository = repository,
+       _currentProjectNotifier = currentProjectNotifier,
+       super(const CostEstimationListInitial()) {
     on<CostEstimationListStartWatching>(_onStartWatching);
     on<CostEstimationListLoadMore>(_onLoadMore);
     on<CostEstimationListRefresh>(_onRefreshed);

--- a/lib/features/estimation/presentation/bloc/cost_estimation_list_bloc/cost_estimation_list_bloc.dart
+++ b/lib/features/estimation/presentation/bloc/cost_estimation_list_bloc/cost_estimation_list_bloc.dart
@@ -24,11 +24,9 @@ class CostEstimationListBloc
   static final _logger = AppLogger().tag('CostEstimationListBloc');
 
   CostEstimationListBloc({
-    required CostEstimationRepository repository,
-    required CurrentProjectNotifier currentProjectNotifier,
-  }) : _repository = repository,
-       _currentProjectNotifier = currentProjectNotifier,
-       super(const CostEstimationListInitial()) {
+    required this._repository,
+    required this._currentProjectNotifier,
+  }) : super(const CostEstimationListInitial()) {
     on<CostEstimationListStartWatching>(_onStartWatching);
     on<CostEstimationListLoadMore>(_onLoadMore);
     on<CostEstimationListRefresh>(_onRefreshed);

--- a/lib/features/estimation/presentation/bloc/cost_estimation_log_bloc/cost_estimation_log_bloc.dart
+++ b/lib/features/estimation/presentation/bloc/cost_estimation_log_bloc/cost_estimation_log_bloc.dart
@@ -25,8 +25,9 @@ class CostEstimationLogBloc
   CancelableOperation<Either<Failure, List<CostEstimationLog>>>?
   _inFlightLoadMore;
 
-  CostEstimationLogBloc({required this._repository})
-    : super(const CostEstimationLogInitial()) {
+  CostEstimationLogBloc({required CostEstimationLogRepository repository})
+    : _repository = repository,
+      super(const CostEstimationLogInitial()) {
     on<CostEstimationLogFetchInitial>(_onFetchInitial);
     on<CostEstimationLogLoadMore>(_onLoadMore);
   }

--- a/lib/features/estimation/presentation/bloc/cost_estimation_log_bloc/cost_estimation_log_bloc.dart
+++ b/lib/features/estimation/presentation/bloc/cost_estimation_log_bloc/cost_estimation_log_bloc.dart
@@ -25,9 +25,8 @@ class CostEstimationLogBloc
   CancelableOperation<Either<Failure, List<CostEstimationLog>>>?
   _inFlightLoadMore;
 
-  CostEstimationLogBloc({required CostEstimationLogRepository repository})
-    : _repository = repository,
-      super(const CostEstimationLogInitial()) {
+  CostEstimationLogBloc({required this._repository})
+    : super(const CostEstimationLogInitial()) {
     on<CostEstimationLogFetchInitial>(_onFetchInitial);
     on<CostEstimationLogLoadMore>(_onLoadMore);
   }

--- a/lib/features/estimation/presentation/bloc/delete_cost_estimation_bloc/delete_cost_estimation_bloc.dart
+++ b/lib/features/estimation/presentation/bloc/delete_cost_estimation_bloc/delete_cost_estimation_bloc.dart
@@ -16,11 +16,9 @@ class DeleteCostEstimationBloc
   static final _logger = AppLogger().tag('DeleteCostEstimationBloc');
 
   DeleteCostEstimationBloc({
-    required CostEstimationRepository costEstimationRepository,
-    required CurrentProjectNotifier currentProjectNotifier,
-  }) : _costEstimationRepository = costEstimationRepository,
-       _currentProjectNotifier = currentProjectNotifier,
-       super(const DeleteCostEstimationInitial()) {
+    required this._costEstimationRepository,
+    required this._currentProjectNotifier,
+  }) : super(const DeleteCostEstimationInitial()) {
     on<DeleteCostEstimationRequested>(_onRequested);
   }
 

--- a/lib/features/estimation/presentation/bloc/delete_cost_estimation_bloc/delete_cost_estimation_bloc.dart
+++ b/lib/features/estimation/presentation/bloc/delete_cost_estimation_bloc/delete_cost_estimation_bloc.dart
@@ -16,9 +16,11 @@ class DeleteCostEstimationBloc
   static final _logger = AppLogger().tag('DeleteCostEstimationBloc');
 
   DeleteCostEstimationBloc({
-    required this._costEstimationRepository,
-    required this._currentProjectNotifier,
-  }) : super(const DeleteCostEstimationInitial()) {
+    required CostEstimationRepository costEstimationRepository,
+    required CurrentProjectNotifier currentProjectNotifier,
+  }) : _costEstimationRepository = costEstimationRepository,
+       _currentProjectNotifier = currentProjectNotifier,
+       super(const DeleteCostEstimationInitial()) {
     on<DeleteCostEstimationRequested>(_onRequested);
   }
 

--- a/lib/features/estimation/presentation/bloc/rename_estimation_bloc/rename_estimation_bloc.dart
+++ b/lib/features/estimation/presentation/bloc/rename_estimation_bloc/rename_estimation_bloc.dart
@@ -17,10 +17,13 @@ class RenameEstimationBloc
   final CurrentProjectNotifier _currentProjectNotifier;
 
   RenameEstimationBloc({
-    required this._repository,
-    required this._projectRepository,
-    required this._currentProjectNotifier,
-  }) : super(const RenameEstimationInitial()) {
+    required CostEstimationRepository repository,
+    required ProjectRepository projectRepository,
+    required CurrentProjectNotifier currentProjectNotifier,
+  }) : _repository = repository,
+       _projectRepository = projectRepository,
+       _currentProjectNotifier = currentProjectNotifier,
+       super(const RenameEstimationInitial()) {
     on<RenameEstimationReset>(_onReset);
     on<RenameEstimationTextChanged>(_onTextChanged);
     on<RenameEstimationRequested>(_onRenameEstimationRequested);

--- a/lib/features/estimation/presentation/bloc/rename_estimation_bloc/rename_estimation_bloc.dart
+++ b/lib/features/estimation/presentation/bloc/rename_estimation_bloc/rename_estimation_bloc.dart
@@ -17,13 +17,10 @@ class RenameEstimationBloc
   final CurrentProjectNotifier _currentProjectNotifier;
 
   RenameEstimationBloc({
-    required CostEstimationRepository repository,
-    required ProjectRepository projectRepository,
-    required CurrentProjectNotifier currentProjectNotifier,
-  }) : _repository = repository,
-       _projectRepository = projectRepository,
-       _currentProjectNotifier = currentProjectNotifier,
-       super(const RenameEstimationInitial()) {
+    required this._repository,
+    required this._projectRepository,
+    required this._currentProjectNotifier,
+  }) : super(const RenameEstimationInitial()) {
     on<RenameEstimationReset>(_onReset);
     on<RenameEstimationTextChanged>(_onTextChanged);
     on<RenameEstimationRequested>(_onRenameEstimationRequested);

--- a/lib/features/estimation/presentation/widgets/cost_estimation_tile.dart
+++ b/lib/features/estimation/presentation/widgets/cost_estimation_tile.dart
@@ -25,8 +25,8 @@ class CostEstimationTile extends StatelessWidget {
     required this.estimation,
     required this.onTap,
     this.onMenuTap,
-    required this._provider,
-  });
+    required EstimationTileProvider provider,
+  }) : _provider = provider;
 
   @override
   Widget build(BuildContext context) {

--- a/lib/features/estimation/presentation/widgets/cost_estimation_tile.dart
+++ b/lib/features/estimation/presentation/widgets/cost_estimation_tile.dart
@@ -25,8 +25,8 @@ class CostEstimationTile extends StatelessWidget {
     required this.estimation,
     required this.onTap,
     this.onMenuTap,
-    required EstimationTileProvider provider,
-  }) : _provider = provider;
+    required this._provider,
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/features/global_search/data/data_source/remote_global_search_data_source.dart
+++ b/lib/features/global_search/data/data_source/remote_global_search_data_source.dart
@@ -18,8 +18,7 @@ class RemoteGlobalSearchDataSource implements GlobalSearchDataSource {
   final SupabaseWrapper _supabaseWrapper;
   static final _logger = AppLogger().tag('RemoteGlobalSearchDataSource');
 
-  const RemoteGlobalSearchDataSource({required SupabaseWrapper supabaseWrapper})
-    : _supabaseWrapper = supabaseWrapper;
+  const RemoteGlobalSearchDataSource({required this._supabaseWrapper});
 
   @override
   Future<SearchResultsDto> search(SearchParamsDto params) async {

--- a/lib/features/global_search/data/data_source/remote_global_search_data_source.dart
+++ b/lib/features/global_search/data/data_source/remote_global_search_data_source.dart
@@ -18,7 +18,8 @@ class RemoteGlobalSearchDataSource implements GlobalSearchDataSource {
   final SupabaseWrapper _supabaseWrapper;
   static final _logger = AppLogger().tag('RemoteGlobalSearchDataSource');
 
-  const RemoteGlobalSearchDataSource({required this._supabaseWrapper});
+  const RemoteGlobalSearchDataSource({required SupabaseWrapper supabaseWrapper})
+    : _supabaseWrapper = supabaseWrapper;
 
   @override
   Future<SearchResultsDto> search(SearchParamsDto params) async {

--- a/lib/features/global_search/data/repositories/global_search_repository_impl.dart
+++ b/lib/features/global_search/data/repositories/global_search_repository_impl.dart
@@ -24,7 +24,8 @@ class GlobalSearchRepositoryImpl implements GlobalSearchRepository {
   final GlobalSearchDataSource _dataSource;
   static final _logger = AppLogger().tag('GlobalSearchRepositoryImpl');
 
-  GlobalSearchRepositoryImpl({required this._dataSource});
+  GlobalSearchRepositoryImpl({required GlobalSearchDataSource dataSource})
+    : _dataSource = dataSource;
 
   SearchScopeDto _toDataScope(SearchScope entity) {
     switch (entity) {

--- a/lib/features/global_search/data/repositories/global_search_repository_impl.dart
+++ b/lib/features/global_search/data/repositories/global_search_repository_impl.dart
@@ -24,8 +24,7 @@ class GlobalSearchRepositoryImpl implements GlobalSearchRepository {
   final GlobalSearchDataSource _dataSource;
   static final _logger = AppLogger().tag('GlobalSearchRepositoryImpl');
 
-  GlobalSearchRepositoryImpl({required GlobalSearchDataSource dataSource})
-    : _dataSource = dataSource;
+  GlobalSearchRepositoryImpl({required this._dataSource});
 
   SearchScopeDto _toDataScope(SearchScope entity) {
     switch (entity) {

--- a/lib/features/global_search/presentation/bloc/global_search_bloc/global_search_bloc.dart
+++ b/lib/features/global_search/presentation/bloc/global_search_bloc/global_search_bloc.dart
@@ -88,10 +88,13 @@ class GlobalSearchBloc extends Bloc<GlobalSearchEvent, GlobalSearchState> {
   DateRange? _selectedDateRange;
 
   GlobalSearchBloc({
-    required this._repository,
-    required this._tagRepository,
-    required this._ownerRepository,
-  }) : super(const GlobalSearchInitial()) {
+    required GlobalSearchRepository repository,
+    required TagRepository tagRepository,
+    required OwnerRepository ownerRepository,
+  }) : _repository = repository,
+       _tagRepository = tagRepository,
+       _ownerRepository = ownerRepository,
+       super(const GlobalSearchInitial()) {
     on<GlobalSearchStarted>(_onStarted);
     on<GlobalSearchQueryUpdated>(
       _onQueryUpdated,

--- a/lib/features/global_search/presentation/bloc/global_search_bloc/global_search_bloc.dart
+++ b/lib/features/global_search/presentation/bloc/global_search_bloc/global_search_bloc.dart
@@ -88,13 +88,10 @@ class GlobalSearchBloc extends Bloc<GlobalSearchEvent, GlobalSearchState> {
   DateRange? _selectedDateRange;
 
   GlobalSearchBloc({
-    required GlobalSearchRepository repository,
-    required TagRepository tagRepository,
-    required OwnerRepository ownerRepository,
-  }) : _repository = repository,
-       _tagRepository = tagRepository,
-       _ownerRepository = ownerRepository,
-       super(const GlobalSearchInitial()) {
+    required this._repository,
+    required this._tagRepository,
+    required this._ownerRepository,
+  }) : super(const GlobalSearchInitial()) {
     on<GlobalSearchStarted>(_onStarted);
     on<GlobalSearchQueryUpdated>(
       _onQueryUpdated,

--- a/lib/features/global_search/presentation/widgets/estimation_card_widget.dart
+++ b/lib/features/global_search/presentation/widgets/estimation_card_widget.dart
@@ -25,8 +25,8 @@ class EstimationCard extends StatelessWidget {
     required this.estimation,
     required this.onTap,
     this.onMenuTap,
-    required this._provider,
-  });
+    required EstimationTileProvider provider,
+  }) : _provider = provider;
 
   @override
   Widget build(BuildContext context) {

--- a/lib/features/global_search/presentation/widgets/estimation_card_widget.dart
+++ b/lib/features/global_search/presentation/widgets/estimation_card_widget.dart
@@ -25,8 +25,8 @@ class EstimationCard extends StatelessWidget {
     required this.estimation,
     required this.onTap,
     this.onMenuTap,
-    required EstimationTileProvider provider,
-  }) : _provider = provider;
+    required this._provider,
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/features/global_search/presentation/widgets/search_results_views.dart
+++ b/lib/features/global_search/presentation/widgets/search_results_views.dart
@@ -35,8 +35,8 @@ class SearchResultsList extends StatelessWidget {
     required this.results,
     required this.onEstimationTap,
     this.onEstimationMenuTap,
-    required EstimationTileProvider estimationTileProvider,
-  }) : _estimationTileProvider = estimationTileProvider;
+    required this._estimationTileProvider,
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/features/global_search/presentation/widgets/search_results_views.dart
+++ b/lib/features/global_search/presentation/widgets/search_results_views.dart
@@ -35,8 +35,8 @@ class SearchResultsList extends StatelessWidget {
     required this.results,
     required this.onEstimationTap,
     this.onEstimationMenuTap,
-    required this._estimationTileProvider,
-  });
+    required EstimationTileProvider estimationTileProvider,
+  }) : _estimationTileProvider = estimationTileProvider;
 
   @override
   Widget build(BuildContext context) {

--- a/lib/features/project/presentation/bloc/get_project_bloc/get_project_bloc.dart
+++ b/lib/features/project/presentation/bloc/get_project_bloc/get_project_bloc.dart
@@ -18,9 +18,11 @@ class GetProjectBloc extends Bloc<GetProjectEvent, GetProjectState> {
   StreamSubscription<String?>? _projectSubscription;
 
   GetProjectBloc({
-    required this._getProjectHeaderUseCase,
-    required this._currentProjectNotifier,
-  }) : super(GetProjectInitial()) {
+    required GetProjectHeaderUseCase getProjectHeaderUseCase,
+    required CurrentProjectNotifier currentProjectNotifier,
+  }) : _getProjectHeaderUseCase = getProjectHeaderUseCase,
+       _currentProjectNotifier = currentProjectNotifier,
+       super(GetProjectInitial()) {
     on<GetProjectWatchStarted>(_onWatchStarted);
     on<GetProjectByIdLoadRequested>(_onProjectLoadRequested);
     on<GetProjectByIdRefreshRequested>(_onProjectRefreshRequested);

--- a/lib/features/project/presentation/bloc/get_project_bloc/get_project_bloc.dart
+++ b/lib/features/project/presentation/bloc/get_project_bloc/get_project_bloc.dart
@@ -18,11 +18,9 @@ class GetProjectBloc extends Bloc<GetProjectEvent, GetProjectState> {
   StreamSubscription<String?>? _projectSubscription;
 
   GetProjectBloc({
-    required GetProjectHeaderUseCase getProjectHeaderUseCase,
-    required CurrentProjectNotifier currentProjectNotifier,
-  }) : _getProjectHeaderUseCase = getProjectHeaderUseCase,
-       _currentProjectNotifier = currentProjectNotifier,
-       super(GetProjectInitial()) {
+    required this._getProjectHeaderUseCase,
+    required this._currentProjectNotifier,
+  }) : super(GetProjectInitial()) {
     on<GetProjectWatchStarted>(_onWatchStarted);
     on<GetProjectByIdLoadRequested>(_onProjectLoadRequested);
     on<GetProjectByIdRefreshRequested>(_onProjectRefreshRequested);

--- a/lib/features/project_settings/presentation/bloc/project_details_bloc/project_details_bloc.dart
+++ b/lib/features/project_settings/presentation/bloc/project_details_bloc/project_details_bloc.dart
@@ -16,9 +16,8 @@ class ProjectDetailsBloc
     extends Bloc<ProjectDetailsEvent, ProjectDetailsState> {
   final ProjectRepository _projectRepository;
 
-  ProjectDetailsBloc({required ProjectRepository projectRepository})
-    : _projectRepository = projectRepository,
-      super(const ProjectDetailsInitial()) {
+  ProjectDetailsBloc({required this._projectRepository})
+    : super(const ProjectDetailsInitial()) {
     on<ProjectDetailsStarted>(_onStarted);
     on<ProjectDetailsRefreshed>(_onRefreshed);
   }

--- a/lib/features/project_settings/presentation/bloc/project_details_bloc/project_details_bloc.dart
+++ b/lib/features/project_settings/presentation/bloc/project_details_bloc/project_details_bloc.dart
@@ -16,8 +16,9 @@ class ProjectDetailsBloc
     extends Bloc<ProjectDetailsEvent, ProjectDetailsState> {
   final ProjectRepository _projectRepository;
 
-  ProjectDetailsBloc({required this._projectRepository})
-    : super(const ProjectDetailsInitial()) {
+  ProjectDetailsBloc({required ProjectRepository projectRepository})
+    : _projectRepository = projectRepository,
+      super(const ProjectDetailsInitial()) {
     on<ProjectDetailsStarted>(_onStarted);
     on<ProjectDetailsRefreshed>(_onRefreshed);
   }

--- a/lib/features/project_settings/presentation/bloc/project_settings_bloc/project_settings_bloc.dart
+++ b/lib/features/project_settings/presentation/bloc/project_settings_bloc/project_settings_bloc.dart
@@ -14,8 +14,9 @@ class ProjectSettingsBloc
     extends Bloc<ProjectSettingsEvent, ProjectSettingsState> {
   final ProjectSettingRepository _repository;
 
-  ProjectSettingsBloc({required this._repository})
-      : super(const ProjectSettingsInitial()) {
+  ProjectSettingsBloc({required ProjectSettingRepository repository})
+      : _repository = repository,
+        super(const ProjectSettingsInitial()) {
     on<ProjectSettingsLoadRequested>(_onLoadRequested);
     on<ProjectSettingsEditingStarted>(_onEditingStarted);
     on<ProjectSettingsUpdateSubmitted>(_onUpdateSubmitted);

--- a/lib/features/project_settings/presentation/bloc/project_settings_bloc/project_settings_bloc.dart
+++ b/lib/features/project_settings/presentation/bloc/project_settings_bloc/project_settings_bloc.dart
@@ -14,9 +14,8 @@ class ProjectSettingsBloc
     extends Bloc<ProjectSettingsEvent, ProjectSettingsState> {
   final ProjectSettingRepository _repository;
 
-  ProjectSettingsBloc({required ProjectSettingRepository repository})
-      : _repository = repository,
-        super(const ProjectSettingsInitial()) {
+  ProjectSettingsBloc({required this._repository})
+      : super(const ProjectSettingsInitial()) {
     on<ProjectSettingsLoadRequested>(_onLoadRequested);
     on<ProjectSettingsEditingStarted>(_onEditingStarted);
     on<ProjectSettingsUpdateSubmitted>(_onUpdateSubmitted);

--- a/lib/libraries/auth/auth_manager_impl.dart
+++ b/lib/libraries/auth/auth_manager_impl.dart
@@ -22,14 +22,11 @@ class AuthManagerImpl implements AuthManager {
   final _logger = AppLogger().tag('AuthManagerImpl');
 
   AuthManagerImpl({
-    required SupabaseWrapper wrapper,
-    required AuthRepository authRepository,
-    required AuthNotifierController authNotifier,
-    required SentryWrapper sentryWrapper,
-  }) : _wrapper = wrapper,
-       _authRepository = authRepository,
-       _authNotifier = authNotifier,
-       _sentryWrapper = sentryWrapper {
+    required this._wrapper,
+    required this._authRepository,
+    required this._authNotifier,
+    required this._sentryWrapper,
+  }) {
     _initAuthListener();
   }
 

--- a/lib/libraries/auth/auth_manager_impl.dart
+++ b/lib/libraries/auth/auth_manager_impl.dart
@@ -22,11 +22,14 @@ class AuthManagerImpl implements AuthManager {
   final _logger = AppLogger().tag('AuthManagerImpl');
 
   AuthManagerImpl({
-    required this._wrapper,
-    required this._authRepository,
-    required this._authNotifier,
-    required this._sentryWrapper,
-  }) {
+    required SupabaseWrapper wrapper,
+    required AuthRepository authRepository,
+    required AuthNotifierController authNotifier,
+    required SentryWrapper sentryWrapper,
+  }) : _wrapper = wrapper,
+       _authRepository = authRepository,
+       _authNotifier = authNotifier,
+       _sentryWrapper = sentryWrapper {
     _initAuthListener();
   }
 

--- a/lib/libraries/auth/testing/fake_auth_manager.dart
+++ b/lib/libraries/auth/testing/fake_auth_manager.dart
@@ -52,14 +52,11 @@ class FakeAuthManager implements AuthManager {
 
   /// Creates a new [FakeAuthManager]
   FakeAuthManager({
-    required AuthNotifierController authNotifier,
-    required AuthRepository authRepository,
-    required SupabaseWrapper wrapper,
-    required Clock clock,
-  }) : _authNotifier = authNotifier,
-       _authRepository = authRepository,
-       _wrapper = wrapper,
-       _clock = clock {
+    required this._authNotifier,
+    required this._authRepository,
+    required this._wrapper,
+    required this._clock,
+  }) {
     // Initialize with unauthenticated state
     _authNotifier.emitAuthStateChanged(
       AuthState(status: AuthStatus.unauthenticated, user: null),

--- a/lib/libraries/auth/testing/fake_auth_manager.dart
+++ b/lib/libraries/auth/testing/fake_auth_manager.dart
@@ -52,11 +52,14 @@ class FakeAuthManager implements AuthManager {
 
   /// Creates a new [FakeAuthManager]
   FakeAuthManager({
-    required this._authNotifier,
-    required this._authRepository,
-    required this._wrapper,
-    required this._clock,
-  }) {
+    required AuthNotifierController authNotifier,
+    required AuthRepository authRepository,
+    required SupabaseWrapper wrapper,
+    required Clock clock,
+  }) : _authNotifier = authNotifier,
+       _authRepository = authRepository,
+       _wrapper = wrapper,
+       _clock = clock {
     // Initialize with unauthenticated state
     _authNotifier.emitAuthStateChanged(
       AuthState(status: AuthStatus.unauthenticated, user: null),

--- a/lib/libraries/auth/testing/fake_auth_repository.dart
+++ b/lib/libraries/auth/testing/fake_auth_repository.dart
@@ -51,7 +51,7 @@ class FakeAuthRepository implements AuthRepository {
   final Clock _clock;
 
   /// Constructor for fake auth repository
-  FakeAuthRepository({required this._clock});
+  FakeAuthRepository({required Clock clock}) : _clock = clock;
 
   /// Resets all fake state and recorded calls
   void reset() {

--- a/lib/libraries/auth/testing/fake_auth_repository.dart
+++ b/lib/libraries/auth/testing/fake_auth_repository.dart
@@ -51,7 +51,7 @@ class FakeAuthRepository implements AuthRepository {
   final Clock _clock;
 
   /// Constructor for fake auth repository
-  FakeAuthRepository({required Clock clock}) : _clock = clock;
+  FakeAuthRepository({required this._clock});
 
   /// Resets all fake state and recorded calls
   void reset() {

--- a/lib/libraries/config/app_config_impl.dart
+++ b/lib/libraries/config/app_config_impl.dart
@@ -4,8 +4,9 @@ import 'package:construculator/libraries/config/interfaces/env_loader.dart';
 import 'package:construculator/libraries/logging/app_logger.dart';
 
 class AppConfigImpl implements Config {
-  AppConfigImpl({required this._envLoader})
-    : _logger = AppLogger().tag('AppConfig');
+  AppConfigImpl({required EnvLoader envLoader})
+    : _envLoader = envLoader,
+      _logger = AppLogger().tag('AppConfig');
 
   final EnvLoader _envLoader;
   final AppLogger _logger;

--- a/lib/libraries/config/app_config_impl.dart
+++ b/lib/libraries/config/app_config_impl.dart
@@ -4,9 +4,8 @@ import 'package:construculator/libraries/config/interfaces/env_loader.dart';
 import 'package:construculator/libraries/logging/app_logger.dart';
 
 class AppConfigImpl implements Config {
-  AppConfigImpl({required EnvLoader envLoader})
-    : _envLoader = envLoader,
-      _logger = AppLogger().tag('AppConfig');
+  AppConfigImpl({required this._envLoader})
+    : _logger = AppLogger().tag('AppConfig');
 
   final EnvLoader _envLoader;
   final AppLogger _logger;

--- a/lib/libraries/estimation/data/repositories/cost_estimation_repository_impl.dart
+++ b/lib/libraries/estimation/data/repositories/cost_estimation_repository_impl.dart
@@ -32,7 +32,8 @@ class CostEstimationRepositoryImpl implements CostEstimationRepository {
 
   static const int defaultPageSize = 10;
 
-  CostEstimationRepositoryImpl({required this._dataSource});
+  CostEstimationRepositoryImpl({required CostEstimationDataSource dataSource})
+    : _dataSource = dataSource;
 
   String _buildStreamKey(
     String projectId,

--- a/lib/libraries/estimation/data/repositories/cost_estimation_repository_impl.dart
+++ b/lib/libraries/estimation/data/repositories/cost_estimation_repository_impl.dart
@@ -32,8 +32,7 @@ class CostEstimationRepositoryImpl implements CostEstimationRepository {
 
   static const int defaultPageSize = 10;
 
-  CostEstimationRepositoryImpl({required CostEstimationDataSource dataSource})
-    : _dataSource = dataSource;
+  CostEstimationRepositoryImpl({required this._dataSource});
 
   String _buildStreamKey(
     String projectId,

--- a/lib/libraries/owner/data/data_source/remote_owner_data_source.dart
+++ b/lib/libraries/owner/data/data_source/remote_owner_data_source.dart
@@ -15,8 +15,7 @@ class RemoteOwnerDataSource implements OwnerDataSource {
   static final _logger = AppLogger().tag('RemoteOwnerDataSource');
 
   /// Creates a [RemoteOwnerDataSource].
-  const RemoteOwnerDataSource({required SupabaseWrapper supabaseWrapper})
-    : _supabaseWrapper = supabaseWrapper;
+  const RemoteOwnerDataSource({required this._supabaseWrapper});
 
   @override
   Future<List<UserProfileDto>> fetchOwners() async {

--- a/lib/libraries/owner/data/data_source/remote_owner_data_source.dart
+++ b/lib/libraries/owner/data/data_source/remote_owner_data_source.dart
@@ -15,7 +15,8 @@ class RemoteOwnerDataSource implements OwnerDataSource {
   static final _logger = AppLogger().tag('RemoteOwnerDataSource');
 
   /// Creates a [RemoteOwnerDataSource].
-  const RemoteOwnerDataSource({required this._supabaseWrapper});
+  const RemoteOwnerDataSource({required SupabaseWrapper supabaseWrapper})
+    : _supabaseWrapper = supabaseWrapper;
 
   @override
   Future<List<UserProfileDto>> fetchOwners() async {

--- a/lib/libraries/owner/data/repositories/owner_repository_impl.dart
+++ b/lib/libraries/owner/data/repositories/owner_repository_impl.dart
@@ -23,7 +23,8 @@ class OwnerRepositoryImpl implements OwnerRepository {
   static final _logger = AppLogger().tag('OwnerRepositoryImpl');
 
   /// Creates an [OwnerRepositoryImpl].
-  OwnerRepositoryImpl({required this._dataSource});
+  OwnerRepositoryImpl({required OwnerDataSource dataSource})
+    : _dataSource = dataSource;
 
   Failure _handleError(Object error, String operation) {
     if (error is TimeoutException) {

--- a/lib/libraries/owner/data/repositories/owner_repository_impl.dart
+++ b/lib/libraries/owner/data/repositories/owner_repository_impl.dart
@@ -23,8 +23,7 @@ class OwnerRepositoryImpl implements OwnerRepository {
   static final _logger = AppLogger().tag('OwnerRepositoryImpl');
 
   /// Creates an [OwnerRepositoryImpl].
-  OwnerRepositoryImpl({required OwnerDataSource dataSource})
-    : _dataSource = dataSource;
+  OwnerRepositoryImpl({required this._dataSource});
 
   Failure _handleError(Object error, String operation) {
     if (error is TimeoutException) {

--- a/lib/libraries/powersync/data/connectors/supabase_powersync_connector.dart
+++ b/lib/libraries/powersync/data/connectors/supabase_powersync_connector.dart
@@ -17,9 +17,10 @@ class SupabasePowerSyncConnector extends PowerSyncBackendConnector {
 
   /// Creates a connector for syncing PowerSync with Supabase.
   SupabasePowerSyncConnector({
-    required this._supabaseWrapper,
-    required this._envLoader,
-  });
+    required SupabaseWrapper supabaseWrapper,
+    required EnvLoader envLoader,
+  }) : _supabaseWrapper = supabaseWrapper,
+       _envLoader = envLoader;
 
   /// Fetches the current PowerSync credentials from Supabase.
   @override

--- a/lib/libraries/powersync/data/connectors/supabase_powersync_connector.dart
+++ b/lib/libraries/powersync/data/connectors/supabase_powersync_connector.dart
@@ -17,10 +17,9 @@ class SupabasePowerSyncConnector extends PowerSyncBackendConnector {
 
   /// Creates a connector for syncing PowerSync with Supabase.
   SupabasePowerSyncConnector({
-    required SupabaseWrapper supabaseWrapper,
-    required EnvLoader envLoader,
-  }) : _supabaseWrapper = supabaseWrapper,
-       _envLoader = envLoader;
+    required this._supabaseWrapper,
+    required this._envLoader,
+  });
 
   /// Fetches the current PowerSync credentials from Supabase.
   @override

--- a/lib/libraries/project/data/data_source/local_jwt_project_permission_data_source.dart
+++ b/lib/libraries/project/data/data_source/local_jwt_project_permission_data_source.dart
@@ -10,8 +10,8 @@ class LocalJwtProjectPermissionDataSource
   final SupabaseWrapper _supabaseWrapper;
 
   LocalJwtProjectPermissionDataSource({
-    required this._supabaseWrapper,
-  });
+    required SupabaseWrapper supabaseWrapper,
+  }) : _supabaseWrapper = supabaseWrapper;
 
   @override
   List<String> getProjectPermissions(String projectId) {

--- a/lib/libraries/project/data/data_source/local_jwt_project_permission_data_source.dart
+++ b/lib/libraries/project/data/data_source/local_jwt_project_permission_data_source.dart
@@ -10,8 +10,8 @@ class LocalJwtProjectPermissionDataSource
   final SupabaseWrapper _supabaseWrapper;
 
   LocalJwtProjectPermissionDataSource({
-    required SupabaseWrapper supabaseWrapper,
-  }) : _supabaseWrapper = supabaseWrapper;
+    required this._supabaseWrapper,
+  });
 
   @override
   List<String> getProjectPermissions(String projectId) {

--- a/lib/libraries/project/data/data_source/remote_project_data_source.dart
+++ b/lib/libraries/project/data/data_source/remote_project_data_source.dart
@@ -11,7 +11,8 @@ class RemoteProjectDataSource implements ProjectDataSource {
   final SupabaseWrapper _supabaseWrapper;
   static final _logger = AppLogger().tag('RemoteProjectDataSource');
 
-  const RemoteProjectDataSource({required this._supabaseWrapper});
+  const RemoteProjectDataSource({required SupabaseWrapper supabaseWrapper})
+    : _supabaseWrapper = supabaseWrapper;
 
   @override
   Future<List<ProjectDto>> getOwnedProjects(String userId) async {

--- a/lib/libraries/project/data/data_source/remote_project_data_source.dart
+++ b/lib/libraries/project/data/data_source/remote_project_data_source.dart
@@ -11,8 +11,7 @@ class RemoteProjectDataSource implements ProjectDataSource {
   final SupabaseWrapper _supabaseWrapper;
   static final _logger = AppLogger().tag('RemoteProjectDataSource');
 
-  const RemoteProjectDataSource({required SupabaseWrapper supabaseWrapper})
-    : _supabaseWrapper = supabaseWrapper;
+  const RemoteProjectDataSource({required this._supabaseWrapper});
 
   @override
   Future<List<ProjectDto>> getOwnedProjects(String userId) async {

--- a/lib/libraries/project/data/data_source/remote_project_search_data_source.dart
+++ b/lib/libraries/project/data/data_source/remote_project_search_data_source.dart
@@ -18,9 +18,8 @@ class RemoteProjectSearchDataSource implements ProjectSearchDataSource {
   final SupabaseWrapper _supabaseWrapper;
   static final _logger = AppLogger().tag('RemoteProjectSearchDataSource');
 
-  /// Creates a [RemoteProjectSearchDataSource] with the given [supabaseWrapper].
-  const RemoteProjectSearchDataSource({required SupabaseWrapper supabaseWrapper})
-    : _supabaseWrapper = supabaseWrapper;
+  /// Creates a [RemoteProjectSearchDataSource] with the given [_supabaseWrapper].
+  const RemoteProjectSearchDataSource({required this._supabaseWrapper});
 
   @override
   Future<List<ProjectDto>> fetchProjectsBySearchQuery({

--- a/lib/libraries/project/data/data_source/remote_project_search_data_source.dart
+++ b/lib/libraries/project/data/data_source/remote_project_search_data_source.dart
@@ -18,8 +18,9 @@ class RemoteProjectSearchDataSource implements ProjectSearchDataSource {
   final SupabaseWrapper _supabaseWrapper;
   static final _logger = AppLogger().tag('RemoteProjectSearchDataSource');
 
-  /// Creates a [RemoteProjectSearchDataSource] with the given [_supabaseWrapper].
-  const RemoteProjectSearchDataSource({required this._supabaseWrapper});
+  /// Creates a [RemoteProjectSearchDataSource] with the given [supabaseWrapper].
+  const RemoteProjectSearchDataSource({required SupabaseWrapper supabaseWrapper})
+    : _supabaseWrapper = supabaseWrapper;
 
   @override
   Future<List<ProjectDto>> fetchProjectsBySearchQuery({

--- a/lib/libraries/project/data/data_source/remote_project_setting_data_source.dart
+++ b/lib/libraries/project/data/data_source/remote_project_setting_data_source.dart
@@ -21,8 +21,8 @@ class RemoteProjectSettingDataSource implements ProjectSettingDataSource {
 
   /// Creates a remote project setting data source.
   const RemoteProjectSettingDataSource({
-    required SupabaseWrapper supabaseWrapper,
-  }) : _supabaseWrapper = supabaseWrapper;
+    required this._supabaseWrapper,
+  });
 
   /// Creates a new project row from [projectDto] and returns the persisted row.
   ///

--- a/lib/libraries/project/data/data_source/remote_project_setting_data_source.dart
+++ b/lib/libraries/project/data/data_source/remote_project_setting_data_source.dart
@@ -21,8 +21,8 @@ class RemoteProjectSettingDataSource implements ProjectSettingDataSource {
 
   /// Creates a remote project setting data source.
   const RemoteProjectSettingDataSource({
-    required this._supabaseWrapper,
-  });
+    required SupabaseWrapper supabaseWrapper,
+  }) : _supabaseWrapper = supabaseWrapper;
 
   /// Creates a new project row from [projectDto] and returns the persisted row.
   ///

--- a/lib/libraries/project/data/repositories/project_repository_impl.dart
+++ b/lib/libraries/project/data/repositories/project_repository_impl.dart
@@ -28,15 +28,18 @@ class ProjectRepositoryImpl implements ProjectRepository {
 
   /// Creates a [ProjectRepositoryImpl].
   ///
-  /// [_projectDataSource] provides remote project data.
-  /// [_permissionDataSource] provides JWT-based permission checks.
-  /// [_currentProjectNotifier] is read in [findCurrentProjectForUser] to resolve the selected project id.
+  /// [projectDataSource] provides remote project data.
+  /// [permissionDataSource] provides JWT-based permission checks.
+  /// [currentProjectNotifier] is read in [findCurrentProjectForUser] to resolve the selected project id.
   ProjectRepositoryImpl({
-    required this._projectDataSource,
-    required this._permissionDataSource,
-    required this._currentProjectNotifier,
-    required this._clock,
-  });
+    required ProjectDataSource projectDataSource,
+    required ProjectPermissionDataSource permissionDataSource,
+    required CurrentProjectNotifier currentProjectNotifier,
+    required Clock clock,
+  }) : _projectDataSource = projectDataSource,
+       _permissionDataSource = permissionDataSource,
+       _currentProjectNotifier = currentProjectNotifier,
+       _clock = clock;
 
   @override
   Future<Project> getProject(String id) async {

--- a/lib/libraries/project/data/repositories/project_repository_impl.dart
+++ b/lib/libraries/project/data/repositories/project_repository_impl.dart
@@ -28,18 +28,15 @@ class ProjectRepositoryImpl implements ProjectRepository {
 
   /// Creates a [ProjectRepositoryImpl].
   ///
-  /// [projectDataSource] provides remote project data.
-  /// [permissionDataSource] provides JWT-based permission checks.
-  /// [currentProjectNotifier] is read in [findCurrentProjectForUser] to resolve the selected project id.
+  /// [_projectDataSource] provides remote project data.
+  /// [_permissionDataSource] provides JWT-based permission checks.
+  /// [_currentProjectNotifier] is read in [findCurrentProjectForUser] to resolve the selected project id.
   ProjectRepositoryImpl({
-    required ProjectDataSource projectDataSource,
-    required ProjectPermissionDataSource permissionDataSource,
-    required CurrentProjectNotifier currentProjectNotifier,
-    required Clock clock,
-  }) : _projectDataSource = projectDataSource,
-       _permissionDataSource = permissionDataSource,
-       _currentProjectNotifier = currentProjectNotifier,
-       _clock = clock;
+    required this._projectDataSource,
+    required this._permissionDataSource,
+    required this._currentProjectNotifier,
+    required this._clock,
+  });
 
   @override
   Future<Project> getProject(String id) async {

--- a/lib/libraries/project/data/repositories/project_search_repository_impl.dart
+++ b/lib/libraries/project/data/repositories/project_search_repository_impl.dart
@@ -19,8 +19,9 @@ class ProjectSearchRepositoryImpl implements ProjectSearchRepository {
   final ProjectSearchDataSource _dataSource;
   static final _logger = AppLogger().tag('ProjectSearchRepositoryImpl');
 
-  /// Creates a [ProjectSearchRepositoryImpl] with the given [_dataSource].
-  ProjectSearchRepositoryImpl({required this._dataSource});
+  /// Creates a [ProjectSearchRepositoryImpl] with the given [dataSource].
+  ProjectSearchRepositoryImpl({required ProjectSearchDataSource dataSource})
+    : _dataSource = dataSource;
 
   Failure _handleError(Object error, String operation) {
     if (error is TimeoutException) {

--- a/lib/libraries/project/data/repositories/project_search_repository_impl.dart
+++ b/lib/libraries/project/data/repositories/project_search_repository_impl.dart
@@ -19,9 +19,8 @@ class ProjectSearchRepositoryImpl implements ProjectSearchRepository {
   final ProjectSearchDataSource _dataSource;
   static final _logger = AppLogger().tag('ProjectSearchRepositoryImpl');
 
-  /// Creates a [ProjectSearchRepositoryImpl] with the given [dataSource].
-  ProjectSearchRepositoryImpl({required ProjectSearchDataSource dataSource})
-    : _dataSource = dataSource;
+  /// Creates a [ProjectSearchRepositoryImpl] with the given [_dataSource].
+  ProjectSearchRepositoryImpl({required this._dataSource});
 
   Failure _handleError(Object error, String operation) {
     if (error is TimeoutException) {

--- a/lib/libraries/project/data/repositories/project_setting_repository_impl.dart
+++ b/lib/libraries/project/data/repositories/project_setting_repository_impl.dart
@@ -15,9 +15,10 @@ class ProjectSettingRepositoryImpl implements ProjectSettingRepository {
   final ProjectPermissionDataSource _permissionDataSource;
 
   ProjectSettingRepositoryImpl({
-    required this._dataSource,
-    required this._permissionDataSource,
-  });
+    required ProjectSettingDataSource dataSource,
+    required ProjectPermissionDataSource permissionDataSource,
+  }) : _dataSource = dataSource,
+       _permissionDataSource = permissionDataSource;
 
   @override
   Future<Either<Failure, Project>> createProject(Project project) async {

--- a/lib/libraries/project/data/repositories/project_setting_repository_impl.dart
+++ b/lib/libraries/project/data/repositories/project_setting_repository_impl.dart
@@ -15,10 +15,9 @@ class ProjectSettingRepositoryImpl implements ProjectSettingRepository {
   final ProjectPermissionDataSource _permissionDataSource;
 
   ProjectSettingRepositoryImpl({
-    required ProjectSettingDataSource dataSource,
-    required ProjectPermissionDataSource permissionDataSource,
-  }) : _dataSource = dataSource,
-       _permissionDataSource = permissionDataSource;
+    required this._dataSource,
+    required this._permissionDataSource,
+  });
 
   @override
   Future<Either<Failure, Project>> createProject(Project project) async {

--- a/lib/libraries/sentry/sentry_wrapper_impl.dart
+++ b/lib/libraries/sentry/sentry_wrapper_impl.dart
@@ -13,10 +13,12 @@ class SentryWrapperImpl implements SentryWrapper {
   bool _isInitialized = false;
 
   SentryWrapperImpl({
-    required this._envLoader,
-    required this._config,
-    required this._sentrySdk,
-  });
+    required EnvLoader envLoader,
+    required Config config,
+    required SentrySdk sentrySdk,
+  }) : _envLoader = envLoader,
+       _config = config,
+       _sentrySdk = sentrySdk;
 
   @override
   Future<void> initialize(void Function() appRunner) async {

--- a/lib/libraries/sentry/sentry_wrapper_impl.dart
+++ b/lib/libraries/sentry/sentry_wrapper_impl.dart
@@ -13,12 +13,10 @@ class SentryWrapperImpl implements SentryWrapper {
   bool _isInitialized = false;
 
   SentryWrapperImpl({
-    required EnvLoader envLoader,
-    required Config config,
-    required SentrySdk sentrySdk,
-  }) : _envLoader = envLoader,
-       _config = config,
-       _sentrySdk = sentrySdk;
+    required this._envLoader,
+    required this._config,
+    required this._sentrySdk,
+  });
 
   @override
   Future<void> initialize(void Function() appRunner) async {

--- a/lib/libraries/supabase/supabase_wrapper_impl.dart
+++ b/lib/libraries/supabase/supabase_wrapper_impl.dart
@@ -13,7 +13,7 @@ class SupabaseWrapperImpl implements SupabaseWrapper {
   final EnvLoader _envLoader;
   static final _logger = AppLogger().tag('SupabaseWrapperImpl');
 
-  SupabaseWrapperImpl({required this._envLoader});
+  SupabaseWrapperImpl({required EnvLoader envLoader}) : _envLoader = envLoader;
 
   @override
   Future<void> initialize() async {

--- a/lib/libraries/supabase/supabase_wrapper_impl.dart
+++ b/lib/libraries/supabase/supabase_wrapper_impl.dart
@@ -13,7 +13,7 @@ class SupabaseWrapperImpl implements SupabaseWrapper {
   final EnvLoader _envLoader;
   static final _logger = AppLogger().tag('SupabaseWrapperImpl');
 
-  SupabaseWrapperImpl({required EnvLoader envLoader}) : _envLoader = envLoader;
+  SupabaseWrapperImpl({required this._envLoader});
 
   @override
   Future<void> initialize() async {

--- a/lib/libraries/supabase/testing/fake_supabase_wrapper.dart
+++ b/lib/libraries/supabase/testing/fake_supabase_wrapper.dart
@@ -239,7 +239,7 @@ class FakeSupabaseWrapper implements SupabaseWrapper {
   final Clock _clock;
 
   /// Constructor for fake supabase wrapper
-  FakeSupabaseWrapper({required Clock clock}) : _clock = clock;
+  FakeSupabaseWrapper({required this._clock});
 
   /// Sets the current user
   void setCurrentUser(FakeUser? user) {

--- a/lib/libraries/supabase/testing/fake_supabase_wrapper.dart
+++ b/lib/libraries/supabase/testing/fake_supabase_wrapper.dart
@@ -239,7 +239,7 @@ class FakeSupabaseWrapper implements SupabaseWrapper {
   final Clock _clock;
 
   /// Constructor for fake supabase wrapper
-  FakeSupabaseWrapper({required this._clock});
+  FakeSupabaseWrapper({required Clock clock}) : _clock = clock;
 
   /// Sets the current user
   void setCurrentUser(FakeUser? user) {

--- a/lib/libraries/tag/data/data_source/remote_tag_data_source.dart
+++ b/lib/libraries/tag/data/data_source/remote_tag_data_source.dart
@@ -10,7 +10,8 @@ class RemoteTagDataSource implements TagDataSource {
   static final _logger = AppLogger().tag('RemoteTagDataSource');
 
   /// Creates a [RemoteTagDataSource].
-  const RemoteTagDataSource({required this._supabaseWrapper});
+  const RemoteTagDataSource({required SupabaseWrapper supabaseWrapper})
+    : _supabaseWrapper = supabaseWrapper;
 
   @override
   Future<List<TagDto>> getTags() async {

--- a/lib/libraries/tag/data/data_source/remote_tag_data_source.dart
+++ b/lib/libraries/tag/data/data_source/remote_tag_data_source.dart
@@ -10,8 +10,7 @@ class RemoteTagDataSource implements TagDataSource {
   static final _logger = AppLogger().tag('RemoteTagDataSource');
 
   /// Creates a [RemoteTagDataSource].
-  const RemoteTagDataSource({required SupabaseWrapper supabaseWrapper})
-    : _supabaseWrapper = supabaseWrapper;
+  const RemoteTagDataSource({required this._supabaseWrapper});
 
   @override
   Future<List<TagDto>> getTags() async {

--- a/lib/libraries/tag/data/repositories/tag_repository_impl.dart
+++ b/lib/libraries/tag/data/repositories/tag_repository_impl.dart
@@ -23,8 +23,7 @@ class TagRepositoryImpl implements TagRepository {
   static final _logger = AppLogger().tag('TagRepositoryImpl');
 
   /// Creates a [TagRepositoryImpl].
-  TagRepositoryImpl({required TagDataSource dataSource})
-    : _dataSource = dataSource;
+  TagRepositoryImpl({required this._dataSource});
 
   Failure _handleError(Object error, String operation) {
     if (error is TimeoutException) {

--- a/lib/libraries/tag/data/repositories/tag_repository_impl.dart
+++ b/lib/libraries/tag/data/repositories/tag_repository_impl.dart
@@ -23,7 +23,8 @@ class TagRepositoryImpl implements TagRepository {
   static final _logger = AppLogger().tag('TagRepositoryImpl');
 
   /// Creates a [TagRepositoryImpl].
-  TagRepositoryImpl({required this._dataSource});
+  TagRepositoryImpl({required TagDataSource dataSource})
+    : _dataSource = dataSource;
 
   Failure _handleError(Object error, String operation) {
     if (error is TimeoutException) {


### PR DESCRIPTION
### 1. PR SUMMARY

Removes the `prefer_initializing_formals` suppression from `analysis_options.yaml` and converts all 87 flagged initializer-list assignments (`: _field = param`) to initializing formals (`this._field`) across 50 files.

Applied via `dart fix --apply` for the constructor signature changes, plus manual dartdoc updates in 5 files where bracketed parameter references (e.g. `[repository]`) needed renaming to `[_repository]` — after the change, the identifier `repository` no longer exists as a parameter; only the field `_repository` is in scope. The rule was always enabled but suppressed since Dart 3.12.2 expanded its detection scope to include initializer-list style assignments.

### 2. REVIEW SUMMARY TABLE

No issues found.

## Test plan

- [ ] `fvm dart analyze` reports no issues
- [ ] `fvm flutter test` passes (all 3033 tests green)
- [ ] `fvm dart run custom_lint` has no new failures vs. main (pre-existing `specific_exception_types` in `fake_router.dart` only)