### PR TITLE
fix(test): advance fake clock past flutter_modular's navigate debounce in pumpAppAtRoute

### DIFF
--- a/test/utils/modular_pump_utils.dart
+++ b/test/utils/modular_pump_utils.dart
@@ -10,6 +10,10 @@ Future<void> pumpAppAtRoute(
   await tester.pumpWidget(app);
   await tester.pumpAndSettle();
   Modular.to.navigate(route);
-  await tester.pump(const Duration(milliseconds: 300));
+  // ModularRouterDelegate.navigate debounces calls made within 500ms of the
+  // previous one (measured on the wall clock) by scheduling a
+  // Future.delayed(500 - diff) before routing; pump past the full 500ms so the
+  // timer always fires regardless of how fast the previous test ran.
+  await tester.pump(const Duration(milliseconds: 500));
   await tester.pumpAndSettle();
 }


### PR DESCRIPTION
# PR Review: fix/pump-app-at-route-navigate-debounce → main

## 📝 PR Description

Fixes the long-standing `cost_item_form_screen_test.dart` flake (pending-timer failures under Docker/CI load) at its root: a fake-clock advance in the shared `pumpAppAtRoute` test util that was shorter than flutter_modular's navigation debounce.

**Type:** Fix ·
**Size:** XS (1 line + comment, test util only)

### Root cause

`ModularRouterDelegate.navigate` debounces navigations made within 500 ms of the previous one — measured on the **wall clock** (`DateTime.now()`) — by awaiting `Future.delayed(500 - diff)` before routing. Under `testWidgets`' fake async, that delayed future becomes a fake timer that only fires if the test advances the fake clock past it. `pumpAppAtRoute` pumped only 300 ms, so whenever consecutive tests started within ~200 ms of real time (fast or heavily loaded machines — exactly the Docker/CI case), the debounce timer was 300–500 ms and never fired:

- the navigation silently never happened → "Found 0 widgets with text …" failures, and
- the pending timer leaked into the framework's end-of-test invariant → "A Timer is still pending even after the widget tree was disposed" poisoning the *next* test.

This is why the failing subset differed run-to-run and why the flake correlated with load, and why it reproduces on plain `main` (4 failures standalone in the warm Flutter 3.44.4 Docker image).

### What changed

`test/utils/modular_pump_utils.dart`: pump `500 ms` (the debounce maximum) instead of `300 ms` after `Modular.to.navigate`, with a comment documenting the flutter_modular constraint. No production code touched.

---

**Verification** (Flutter 3.44.4 Docker image, main + this fix): `cost_item_form_screen_test.dart` — previously failing 3–4 tests on *every* standalone run — passes 3 consecutive runs (15/15 each); all 6 test files using `pumpAppAtRoute` (estimations pages + accessibility, 123 tests) pass.