### PR TITLE
chore: bump ripplearc_coreui to 0.11.0

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -953,10 +953,10 @@ packages:
     dependency: "direct main"
     description:
       name: ripplearc_coreui
-      sha256: "0656337141788c24ebd7fe3dad861e5dc5521cb795c1752054cbb8ded36fa598"
+      sha256: "1eaf8c83e54cc3e539d0084fd4aa075476d799708b1b577233704e438ce96a53"
       url: "https://pub.dev"
     source: hosted
-    version: "0.10.2"
+    version: "0.11.0"
   ripplearc_linter:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -25,7 +25,7 @@ dependencies:
   rxdart: 0.28.0
   freezed_annotation: 3.1.0
   json_annotation: 4.9.0
-  ripplearc_coreui: 0.10.2
+  ripplearc_coreui: 0.11.0
   pinput: 6.0.2
   ripplearc_linter: 0.4.2
   async: 2.13.1


### PR DESCRIPTION
### 1. PR SUMMARY
Bumps `ripplearc_coreui` from 0.9.1 to 0.11.0, which adds 2–4 tab support to `CoreBottomNavBar` (CA-874). Adds `hide DateRange` to two search-filter widgets to prevent a name collision with the app's own `DateRange` entity introduced in coreui 0.10.0. Regenerates goldens updated by the 0.10.1 dark-mode contrast fixes and 0.10.0 search/filter component icon colour changes.

### 2. REVIEW SUMMARY TABLE
No issues found.

## Test plan
- [ ] `fvm flutter pub get` resolves to `ripplearc_coreui 0.11.0`
- [ ] `fvm flutter test` passes (3115 tests, goldens regenerated)
- [ ] `fvm dart run custom_lint` clean