### PR TITLE
CA-755: feat(dashboard): open ProjectsBottomSheet from the header and navigate to project search

### DIFF
--- a/lib/app/shell/app_shell_page.dart
+++ b/lib/app/shell/app_shell_page.dart
@@ -108,7 +108,7 @@ class _AppShellPageState extends State<AppShellPage> {
               projectUIProvider: widget.projectUIProvider,
               onProjectTap: () => ProjectsBottomSheet.show(
                 context,
-                BlocProvider.of<ProjectDropdownBloc>(context),
+                context.read<ProjectDropdownBloc>(),
                 widget.router,
               ),
             ),

--- a/lib/app/shell/app_shell_page.dart
+++ b/lib/app/shell/app_shell_page.dart
@@ -5,6 +5,7 @@ import 'package:construculator/features/app_header/app_header_module.dart';
 import 'package:construculator/features/calculations/presentation/pages/calculations_page.dart';
 import 'package:construculator/features/dashboard/presentation/bloc/project_dropdown_bloc/project_dropdown_bloc.dart';
 import 'package:construculator/features/dashboard/presentation/pages/dashboard_page.dart';
+import 'package:construculator/features/dashboard/presentation/widgets/projects_bottom_sheet.dart';
 import 'package:construculator/features/estimation/estimation_module.dart';
 import 'package:construculator/features/members/presentation/pages/members_page.dart';
 import 'package:construculator/libraries/extensions/extensions.dart';
@@ -105,6 +106,11 @@ class _AppShellPageState extends State<AppShellPage> {
               currentProjectNotifier: widget.currentProjectNotifier,
               router: widget.router,
               projectUIProvider: widget.projectUIProvider,
+              onProjectTap: () => ProjectsBottomSheet.show(
+                context,
+                BlocProvider.of<ProjectDropdownBloc>(context),
+                widget.router,
+              ),
             ),
             body: Stack(
               children: List.generate(ShellTab.values.length, (index) {

--- a/lib/features/app_header/app_header_module.dart
+++ b/lib/features/app_header/app_header_module.dart
@@ -25,7 +25,8 @@ class AppHeaderModule extends Module {
   /// the project header provided by [projectUIProvider]. Otherwise shows the
   /// [HeaderRow] home header on the home tab ([isHomeTab] true) or a
   /// [TitleSearchAppBar] on other tabs, with search navigation wired through
-  /// [router] to the global search route in both cases.
+  /// [router] to the global search route in both cases. [onProjectTap] is
+  /// forwarded to the home header's project selector.
   ///
   /// Dependencies are passed in by the caller (resolved once at
   /// field-initialisation time) rather than looked up via `Modular.get()`
@@ -35,6 +36,7 @@ class AppHeaderModule extends Module {
     required CurrentProjectNotifier currentProjectNotifier,
     required AppRouter router,
     required ProjectUIProvider projectUIProvider,
+    VoidCallback? onProjectTap,
   }) {
     final projectId = currentProjectNotifier.currentProjectId;
     if (projectId != null && projectId.isNotEmpty) {
@@ -46,6 +48,7 @@ class AppHeaderModule extends Module {
     if (isHomeTab) {
       return HeaderRow(
         onSearchTap: onSearchTap,
+        onProjectTap: onProjectTap,
         // TODO: [CA-731] Wire NotificationBloc when NotificationModule is ready.
         // https://ripplearc.youtrack.cloud/issue/CA-731
         // TODO: [CA-732] Wire ProfileBloc when ProfileModule is ready.

--- a/lib/features/app_header/presentation/widgets/header_row.dart
+++ b/lib/features/app_header/presentation/widgets/header_row.dart
@@ -61,6 +61,7 @@ class HeaderRow extends StatelessWidget implements PreferredSizeWidget {
                   label: context.l10n.projectDropdownSemanticLabel,
                   button: true,
                   child: InkWell(
+                    key: const Key('header_row_project_selector'),
                     onTap: onProjectTap,
                     child: SizedBox(
                       height: CoreSpacing.space12,

--- a/test/app/shell/app_shell_page_test.dart
+++ b/test/app/shell/app_shell_page_test.dart
@@ -9,6 +9,7 @@ import 'package:construculator/features/dashboard/presentation/bloc/dashboard_bl
 import 'package:construculator/features/dashboard/presentation/bloc/project_dropdown_bloc/project_dropdown_bloc.dart';
 import 'package:construculator/features/dashboard/presentation/bloc/recent_estimations_bloc/recent_estimations_bloc.dart';
 import 'package:construculator/features/dashboard/presentation/pages/dashboard_page.dart';
+import 'package:construculator/features/dashboard/presentation/widgets/projects_bottom_sheet.dart';
 import 'package:construculator/features/estimation/presentation/pages/cost_estimation_landing_page.dart';
 import 'package:construculator/features/members/presentation/pages/members_page.dart';
 import 'package:construculator/l10n/generated/app_localizations.dart';
@@ -26,6 +27,7 @@ import 'package:construculator/libraries/project/testing/fake_project_repository
 import 'package:construculator/libraries/project/testing/fake_project_ui_provider.dart';
 import 'package:construculator/libraries/router/interfaces/app_router.dart';
 import 'package:construculator/libraries/router/routes/calculator_routes.dart';
+import 'package:construculator/libraries/router/routes/project_search_routes.dart';
 import 'package:construculator/libraries/router/testing/fake_router.dart';
 import 'package:construculator/libraries/supabase/interfaces/supabase_wrapper.dart';
 import 'package:construculator/libraries/supabase/testing/fake_supabase_user.dart';
@@ -329,6 +331,55 @@ void main() {
         contains(const RouteCall(calculatorBaseRoute, null)),
       );
     });
+  });
+
+  group('Project Search Entry', () {
+    // The sheet's full content needs more height than the default 800x600
+    // test view; width stays at 800 so the dashboard behind the sheet lays
+    // out as in the other tests.
+    void useTallSurface(WidgetTester tester) {
+      tester.view.physicalSize = const Size(800, 1200);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.reset);
+    }
+
+    testWidgets(
+      'tapping the header project selector opens the projects bottom sheet',
+      (tester) async {
+        useTallSurface(tester);
+        await tester.pumpWidget(makeApp());
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.text(l10n().appTitle));
+        await tester.pumpAndSettle();
+
+        expect(find.byType(ProjectsBottomSheet), findsOneWidget);
+        expect(find.text(l10n().projectsSheetTitle), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'tapping the sheet search field dismisses the sheet and navigates to '
+      'project search',
+      (tester) async {
+        final fakeRouter = FakeAppRouter();
+        Modular.replaceInstance<AppRouter>(fakeRouter);
+
+        useTallSurface(tester);
+        await tester.pumpWidget(makeApp());
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.text(l10n().appTitle));
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.byKey(const Key('projects_search_field')));
+        await tester.pumpAndSettle();
+
+        expect(find.byType(ProjectsBottomSheet), findsNothing);
+        expect(fakeRouter.navigationHistory, hasLength(1));
+        expect(fakeRouter.navigationHistory.single.route, projectSearchRoute);
+      },
+    );
   });
 
   group('Project Selection Wiring', () {

--- a/test/app/shell/app_shell_page_test.dart
+++ b/test/app/shell/app_shell_page_test.dart
@@ -350,7 +350,7 @@ void main() {
         await tester.pumpWidget(makeApp());
         await tester.pumpAndSettle();
 
-        await tester.tap(find.text(l10n().appTitle));
+        await tester.tap(find.byKey(const Key('header_row_project_selector')));
         await tester.pumpAndSettle();
 
         expect(find.byType(ProjectsBottomSheet), findsOneWidget);
@@ -369,7 +369,7 @@ void main() {
         await tester.pumpWidget(makeApp());
         await tester.pumpAndSettle();
 
-        await tester.tap(find.text(l10n().appTitle));
+        await tester.tap(find.byKey(const Key('header_row_project_selector')));
         await tester.pumpAndSettle();
 
         await tester.tap(find.byKey(const Key('projects_search_field')));

--- a/test/features/app_header/widgets/accessibility/header_row_a11y_test.dart
+++ b/test/features/app_header/widgets/accessibility/header_row_a11y_test.dart
@@ -11,20 +11,41 @@ void main() {
     await loadAppFontsAll();
   });
 
-  Widget makeTestableWidget({ThemeData? theme, int unreadCount = 0}) {
+  Widget makeTestableWidget({
+    ThemeData? theme,
+    int unreadCount = 0,
+    VoidCallback? onProjectTap,
+  }) {
     return MaterialApp(
       theme: theme ?? createTestTheme(),
       locale: const Locale('en'),
       localizationsDelegates: AppLocalizations.localizationsDelegates,
       supportedLocales: AppLocalizations.supportedLocales,
       home: Scaffold(
-        appBar: HeaderRow(unreadNotificationCount: unreadCount),
+        appBar: HeaderRow(
+          unreadNotificationCount: unreadCount,
+          onProjectTap: onProjectTap,
+        ),
         body: const SizedBox.shrink(),
       ),
     );
   }
 
   group('HeaderRow – accessibility', () {
+    testWidgets(
+      'project selector meets tap target and label guidelines in both themes',
+      (tester) async {
+        await setupA11yTest(tester);
+        await expectMeetsTapTargetAndLabelGuidelinesForEachTheme(
+          tester,
+          (theme) => makeTestableWidget(theme: theme, onProjectTap: () {}),
+          find.byKey(const Key('header_row_project_selector')),
+          checkTapTargetSize: true,
+          checkLabeledTapTarget: true,
+        );
+      },
+    );
+
     testWidgets(
       'search button meets tap target and label guidelines in both themes',
       (tester) async {


### PR DESCRIPTION
## Summary

[CA-755](https://ripplearc.youtrack.cloud/issue/CA-755) — `ProjectSearchPage` (with its history, suggestions, and filters) existed but was unreachable: the header's project selector (`Construculator ▾`) had a null `onProjectTap`, and `ProjectsBottomSheet` — the only widget that navigates to `/project-search` — was never shown from any live code.

Stacked on #483 (CA-899).

## Changes

- `AppHeaderModule.buildHeader` accepts and forwards `onProjectTap` to the home-tab `HeaderRow` (deps stay caller-passed; no `Modular.get` in the build path).
- `AppShellPage` supplies the callback: `ProjectsBottomSheet.show(context, ProjectDropdownBloc, router)` — the bloc was already provided at shell level, the sheet's search-field tap already navigates to `projectSearchRoute` and pops itself.
- `HeaderRow`'s selector `InkWell` gains `Key('header_row_project_selector')` for stable finders.

The full entry chain is now live: **header ▾ → Projects sheet → search field → ProjectSearchPage** (verified E2E on the emulator — first time the page is reachable through the real UI).

## Tests

- 2 new `AppShellPage` widget tests: selector tap opens the sheet; sheet search-field tap dismisses the sheet and pushes `projectSearchRoute` (FakeAppRouter-pinned).
- 1 new `HeaderRow` a11y test: the now-interactive project selector meets tap-target + label guidelines in both themes.
- `flutter analyze --fatal-infos` clean; custom_lint's only hit is the pre-existing `fake_router.dart` finding; shell/app_header/dashboard suites green (283+17).

## Notes

- E2E surfaced the likely root cause of CA-844 and the sheet's "Failed to load projects": **Supabase Realtime subscriptions fail locally** for `projects`/`project_members` (`RealtimeSubscribeException: Unable to subscribe`), so watch-based streams error out. Backend/environment issue, independent of this wiring — noted on the tickets.
- Next in the chain: CA-904 (render the project-search results list) stacks on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)