### PR TITLE
CA-901: fix(search): re-run the active search when a filter is applied or cleared

### DIFF
--- a/lib/features/dashboard/presentation/bloc/project_search_bloc/project_search_bloc.dart
+++ b/lib/features/dashboard/presentation/bloc/project_search_bloc/project_search_bloc.dart
@@ -172,6 +172,10 @@ class ProjectSearchBloc extends Bloc<ProjectSearchEvent, ProjectSearchState> {
     // Editing the query returns to the suggestions/recents surface; a filter
     // change must no longer resurrect the previous results.
     _searchIsActive = false;
+    // Disown any in-flight search, same as _onHistoryRequested: its late
+    // completion must not publish stale results over the suggestions surface
+    // the user navigated to.
+    _searchExecutionGeneration++;
 
     if (query.isEmpty) {
       // Clearing the field restores the history surface rather than blanking

--- a/lib/features/dashboard/presentation/bloc/project_search_bloc/project_search_bloc.dart
+++ b/lib/features/dashboard/presentation/bloc/project_search_bloc/project_search_bloc.dart
@@ -54,6 +54,16 @@ class ProjectSearchBloc extends Bloc<ProjectSearchEvent, ProjectSearchState> {
   List<String> _cachedSuggestions = const [];
   String _currentQuery = '';
 
+  // The last query a search actually executed for; used to re-run the
+  // search when a filter changes while results own the body.
+  String? _lastPerformedQuery;
+
+  // Whether a performed search currently owns the body surface. Tracked as a
+  // durable flag rather than derived from the current state, because opening
+  // a filter sheet emits the idle state (to render the sheet's option list)
+  // and would otherwise clear the signal before the user applies the filter.
+  bool _searchIsActive = false;
+
   bool _suggestionsFetched = false;
 
   bool _suggestionsLoading = false;
@@ -151,6 +161,9 @@ class ProjectSearchBloc extends Bloc<ProjectSearchEvent, ProjectSearchState> {
     Emitter<ProjectSearchState> emit,
   ) async {
     _currentQuery = query;
+    // Editing the query returns to the suggestions/recents surface; a filter
+    // change must no longer resurrect the previous results.
+    _searchIsActive = false;
 
     if (query.isEmpty) {
       // Clearing the field restores the history surface rather than blanking
@@ -243,6 +256,8 @@ class ProjectSearchBloc extends Bloc<ProjectSearchEvent, ProjectSearchState> {
     // resurrect the pre-reset cache, mark suggestions as fetched, or emit
     // over the isLoadingHistory state emitted below.
     _suggestionsFetchGeneration++;
+    _lastPerformedQuery = null;
+    _searchIsActive = false;
     _selectedTags = const {};
     _tagSearchQuery = '';
     _availableTags = const [];
@@ -334,6 +349,8 @@ class ProjectSearchBloc extends Bloc<ProjectSearchEvent, ProjectSearchState> {
       return;
     }
 
+    _lastPerformedQuery = query;
+    _searchIsActive = true;
     emit(ProjectSearchLoading(query: query));
 
     // The RPC accepts a single tag/owner, so a multi-selection is silently
@@ -509,12 +526,21 @@ class ProjectSearchBloc extends Bloc<ProjectSearchEvent, ProjectSearchState> {
     emit(_initialFromCache());
   }
 
+  // Re-dispatches the last performed search so a filter change is
+  // reflected in the visible results instead of leaving them stale.
+  void _reRunActiveSearch() {
+    final query = _lastPerformedQuery;
+    if (!_searchIsActive || query == null) return;
+    add(ProjectSearchPerformedEvent(query: query));
+  }
+
   void _onTagFiltersApplied(
     ProjectSearchTagFiltersAppliedEvent event,
     Emitter<ProjectSearchState> emit,
   ) {
     _selectedTags = Set.unmodifiable(event.tags);
     emit(_initialFromCache());
+    _reRunActiveSearch();
   }
 
   void _onTagFilterCleared(
@@ -525,6 +551,7 @@ class ProjectSearchBloc extends Bloc<ProjectSearchEvent, ProjectSearchState> {
       _selectedTags.where((t) => t != event.tag),
     );
     emit(_initialFromCache());
+    _reRunActiveSearch();
   }
 
   Future<void> _onAvailableOwnersRequested(
@@ -583,6 +610,7 @@ class ProjectSearchBloc extends Bloc<ProjectSearchEvent, ProjectSearchState> {
   ) {
     _selectedOwnerIds = Set.unmodifiable(event.ownerIds);
     emit(_initialFromCache());
+    _reRunActiveSearch();
   }
 
   void _onOwnerFilterCleared(
@@ -593,6 +621,7 @@ class ProjectSearchBloc extends Bloc<ProjectSearchEvent, ProjectSearchState> {
       _selectedOwnerIds.where((id) => id != event.ownerId),
     );
     emit(_initialFromCache());
+    _reRunActiveSearch();
   }
 
   void _onDateFilterApplied(
@@ -601,6 +630,7 @@ class ProjectSearchBloc extends Bloc<ProjectSearchEvent, ProjectSearchState> {
   ) {
     _selectedDateRange = event.range;
     emit(_initialFromCache());
+    _reRunActiveSearch();
   }
 
   void _onDateFilterCleared(
@@ -609,5 +639,6 @@ class ProjectSearchBloc extends Bloc<ProjectSearchEvent, ProjectSearchState> {
   ) {
     _selectedDateRange = null;
     emit(_initialFromCache());
+    _reRunActiveSearch();
   }
 }

--- a/lib/features/dashboard/presentation/bloc/project_search_bloc/project_search_bloc.dart
+++ b/lib/features/dashboard/presentation/bloc/project_search_bloc/project_search_bloc.dart
@@ -64,6 +64,14 @@ class ProjectSearchBloc extends Bloc<ProjectSearchEvent, ProjectSearchState> {
   // and would otherwise clear the signal before the user applies the filter.
   bool _searchIsActive = false;
 
+  // Guards the performed-search execution: [ProjectSearchPerformedEvent]
+  // runs under bloc's default flatMap transformer, so two overlapping
+  // dispatches (e.g. two quick filter-chip taps each re-running the active
+  // search) execute concurrently and whichever RPC resolves last would win
+  // the final emit. The older dispatch bails out on completion instead, so
+  // the visible results always reflect the newest dispatch.
+  int _searchExecutionGeneration = 0;
+
   bool _suggestionsFetched = false;
 
   bool _suggestionsLoading = false;
@@ -258,6 +266,9 @@ class ProjectSearchBloc extends Bloc<ProjectSearchEvent, ProjectSearchState> {
     _suggestionsFetchGeneration++;
     _lastPerformedQuery = null;
     _searchIsActive = false;
+    // Disown any in-flight performed search so its completion cannot
+    // publish results over the freshly reset surface.
+    _searchExecutionGeneration++;
     _selectedTags = const {};
     _tagSearchQuery = '';
     _availableTags = const [];
@@ -351,6 +362,10 @@ class ProjectSearchBloc extends Bloc<ProjectSearchEvent, ProjectSearchState> {
 
     _lastPerformedQuery = query;
     _searchIsActive = true;
+    // Captured before the await: a newer dispatch (or a reset) disowns this
+    // execution, so its slower RPC cannot publish stale results on top of
+    // the newer one's.
+    final generation = ++_searchExecutionGeneration;
     emit(ProjectSearchLoading(query: query));
 
     // The RPC accepts a single tag/owner, so a multi-selection is silently
@@ -387,6 +402,11 @@ class ProjectSearchBloc extends Bloc<ProjectSearchEvent, ProjectSearchState> {
       filterByDateFrom: _selectedDateRange?.start,
       filterByDateTo: _selectedDateRange?.end,
     );
+
+    // A newer dispatch (or a reset) disowned this execution while its RPC
+    // was in flight; the newer one owns the results surface and the
+    // history save.
+    if (generation != _searchExecutionGeneration) return;
 
     result.fold(
       (failure) {

--- a/lib/features/global_search/presentation/bloc/global_search_bloc/global_search_bloc.dart
+++ b/lib/features/global_search/presentation/bloc/global_search_bloc/global_search_bloc.dart
@@ -319,6 +319,10 @@ class GlobalSearchBloc extends Bloc<GlobalSearchEvent, GlobalSearchState> {
     // Editing the query returns to the suggestions/recents surface; a filter
     // change must no longer resurrect the previous results.
     _searchIsActive = false;
+    // Disown any in-flight search, same as the GlobalSearchStarted reset: its
+    // late completion must not publish stale results over the suggestions
+    // surface the user navigated to.
+    _searchExecutionGeneration++;
 
     if (trimmedQuery.isEmpty) {
       // Clearing the query cancels any same-pipeline suggestions fetch via

--- a/lib/features/global_search/presentation/bloc/global_search_bloc/global_search_bloc.dart
+++ b/lib/features/global_search/presentation/bloc/global_search_bloc/global_search_bloc.dart
@@ -55,6 +55,16 @@ class GlobalSearchBloc extends Bloc<GlobalSearchEvent, GlobalSearchState> {
 
   String _currentQuery = '';
 
+  // The last successfully dispatched (non-empty) search query; used to
+  // re-run the search when a filter changes while results own the body.
+  String? _lastPerformedQuery;
+
+  // Whether a performed search currently owns the body surface. Tracked as a
+  // durable flag rather than derived from the current state, because opening
+  // a filter sheet emits the ready state (to render the sheet's option list)
+  // and would otherwise clear the signal before the user applies the filter.
+  bool _searchIsActive = false;
+
   Set<String> _selectedTags = const {};
 
   // Full list of available tag names fetched from TagRepository.
@@ -246,6 +256,8 @@ class GlobalSearchBloc extends Bloc<GlobalSearchEvent, GlobalSearchState> {
       _availableTagsFetched = false;
       _availableTagsLoading = false;
       _availableTagsFetchGeneration++;
+      _lastPerformedQuery = null;
+      _searchIsActive = false;
       _selectedOwnerIds = const {};
       _ownerSearchQuery = '';
       _availableOwners = const [];
@@ -264,6 +276,7 @@ class GlobalSearchBloc extends Bloc<GlobalSearchEvent, GlobalSearchState> {
     if (event.scope == _selectedScope) return;
     _selectedScope = event.scope;
     emit(_readyState());
+    _reRunActiveSearch();
 
     // Recent searches are stored per scope, so switching scope reloads the
     // history for the newly selected one.
@@ -292,6 +305,9 @@ class GlobalSearchBloc extends Bloc<GlobalSearchEvent, GlobalSearchState> {
   ) async {
     final trimmedQuery = event.query.trim();
     _currentQuery = trimmedQuery;
+    // Editing the query returns to the suggestions/recents surface; a filter
+    // change must no longer resurrect the previous results.
+    _searchIsActive = false;
 
     if (trimmedQuery.isEmpty) {
       // Clearing the query cancels any same-pipeline suggestions fetch via
@@ -321,6 +337,8 @@ class GlobalSearchBloc extends Bloc<GlobalSearchEvent, GlobalSearchState> {
       return;
     }
     _currentQuery = trimmedQuery;
+    _lastPerformedQuery = trimmedQuery;
+    _searchIsActive = true;
     emit(GlobalSearchLoadInProgress(query: trimmedQuery));
 
     final result = await _repository.search(
@@ -443,12 +461,21 @@ class GlobalSearchBloc extends Bloc<GlobalSearchEvent, GlobalSearchState> {
         .toList();
   }
 
+  // Re-dispatches the last performed search so a filter change is
+  // reflected in the visible results instead of leaving them stale.
+  void _reRunActiveSearch() {
+    final query = _lastPerformedQuery;
+    if (!_searchIsActive || query == null) return;
+    add(GlobalSearchPerformed(query: query));
+  }
+
   void _onTagFiltersApplied(
     GlobalSearchTagFiltersApplied event,
     Emitter<GlobalSearchState> emit,
   ) {
     _selectedTags = Set.unmodifiable(event.tags);
     emit(_readyState());
+    _reRunActiveSearch();
   }
 
   void _onTagFilterCleared(
@@ -459,6 +486,7 @@ class GlobalSearchBloc extends Bloc<GlobalSearchEvent, GlobalSearchState> {
       _selectedTags.where((t) => t != event.tag),
     );
     emit(_readyState());
+    _reRunActiveSearch();
   }
 
   Future<void> _onAvailableOwnersRequested(
@@ -511,6 +539,7 @@ class GlobalSearchBloc extends Bloc<GlobalSearchEvent, GlobalSearchState> {
   ) {
     _selectedOwnerIds = Set.unmodifiable(event.ownerIds);
     emit(_readyState());
+    _reRunActiveSearch();
   }
 
   void _onOwnerFilterCleared(
@@ -521,6 +550,7 @@ class GlobalSearchBloc extends Bloc<GlobalSearchEvent, GlobalSearchState> {
       _selectedOwnerIds.where((id) => id != event.ownerId),
     );
     emit(_readyState());
+    _reRunActiveSearch();
   }
 
   void _onDateFilterApplied(
@@ -529,6 +559,7 @@ class GlobalSearchBloc extends Bloc<GlobalSearchEvent, GlobalSearchState> {
   ) {
     _selectedDateRange = event.range;
     emit(_readyState());
+    _reRunActiveSearch();
   }
 
   void _onDateFilterCleared(
@@ -537,5 +568,6 @@ class GlobalSearchBloc extends Bloc<GlobalSearchEvent, GlobalSearchState> {
   ) {
     _selectedDateRange = null;
     emit(_readyState());
+    _reRunActiveSearch();
   }
 }

--- a/lib/features/global_search/presentation/bloc/global_search_bloc/global_search_bloc.dart
+++ b/lib/features/global_search/presentation/bloc/global_search_bloc/global_search_bloc.dart
@@ -105,6 +105,14 @@ class GlobalSearchBloc extends Bloc<GlobalSearchEvent, GlobalSearchState> {
   // cannot stomp the newer scope's selection or history.
   int _recentsFetchGeneration = 0;
 
+  // Guards the performed-search execution: [GlobalSearchPerformed] runs
+  // under bloc's default flatMap transformer, so two overlapping dispatches
+  // (e.g. two quick filter-chip taps each re-running the active search)
+  // execute concurrently and whichever RPC resolves last would win the
+  // final emit. The older dispatch bails out on completion instead, so the
+  // visible results always reflect the newest dispatch.
+  int _searchExecutionGeneration = 0;
+
   GlobalSearchBloc({
     required this._repository,
     required this._tagRepository,
@@ -258,6 +266,9 @@ class GlobalSearchBloc extends Bloc<GlobalSearchEvent, GlobalSearchState> {
       _availableTagsFetchGeneration++;
       _lastPerformedQuery = null;
       _searchIsActive = false;
+      // Disown any in-flight performed search so its completion cannot
+      // publish results over the freshly reset surface.
+      _searchExecutionGeneration++;
       _selectedOwnerIds = const {};
       _ownerSearchQuery = '';
       _availableOwners = const [];
@@ -339,6 +350,10 @@ class GlobalSearchBloc extends Bloc<GlobalSearchEvent, GlobalSearchState> {
     _currentQuery = trimmedQuery;
     _lastPerformedQuery = trimmedQuery;
     _searchIsActive = true;
+    // Captured before the await: a newer dispatch (or a reset) disowns this
+    // execution, so its slower RPC cannot publish stale results on top of
+    // the newer one's.
+    final generation = ++_searchExecutionGeneration;
     emit(GlobalSearchLoadInProgress(query: trimmedQuery));
 
     final result = await _repository.search(
@@ -358,6 +373,11 @@ class GlobalSearchBloc extends Bloc<GlobalSearchEvent, GlobalSearchState> {
         filterByDateTo: _selectedDateRange?.end,
       ),
     );
+
+    // A newer dispatch (or a reset) disowned this execution while its RPC
+    // was in flight; the newer one owns the results surface and the
+    // history save.
+    if (generation != _searchExecutionGeneration) return;
 
     result.fold(
         (failure) => emit(

--- a/test/features/dashboard/units/blocs/project_search_bloc_test.dart
+++ b/test/features/dashboard/units/blocs/project_search_bloc_test.dart
@@ -1943,6 +1943,152 @@ void main() {
         },
       );
     });
+
+    group('Filter changes re-run the active search', () {
+      List<Map<String, dynamic>> searchCalls() => fakeSupabase
+          .getMethodCallsFor('rpc')
+          .where(
+            (call) =>
+                call['functionName'] ==
+                DatabaseConstants.globalSearchRpcFunction,
+          )
+          .toList();
+
+      void seedOneProjectResult() {
+        fakeSupabase.setRpcResponse(DatabaseConstants.globalSearchRpcFunction, {
+          'projects': [_fakeProjectData(id: 'p-1', projectName: 'Wall')],
+          'estimations': <Map<String, dynamic>>[],
+          'members': <Map<String, dynamic>>[],
+        });
+      }
+
+      blocTest<ProjectSearchBloc, ProjectSearchState>(
+        'applying a date filter while results are shown re-runs the search '
+        'with the new range',
+        setUp: seedOneProjectResult,
+        build: () => Modular.get<ProjectSearchBloc>(),
+        act: (bloc) async {
+          bloc.add(const ProjectSearchPerformedEvent(query: 'wall'));
+          await bloc.stream.firstWhere((s) => s is ProjectSearchResultsLoaded);
+          bloc.add(
+            ProjectSearchDateFilterAppliedEvent(
+              range: DateRange(
+                start: DateTime(2026, 1, 1),
+                end: DateTime(2026, 1, 5),
+              ),
+            ),
+          );
+          await bloc.stream.firstWhere((s) => s is ProjectSearchResultsLoaded);
+        },
+        verify: (_) {
+          final calls = searchCalls();
+          expect(calls, hasLength(2));
+          final params = calls.last['params'] as Map<String, dynamic>;
+          expect(
+            params['filter_by_date_from'],
+            DateTime(2026, 1, 1).toIso8601String(),
+          );
+          expect(
+            params['filter_by_date_to'],
+            DateTime(2026, 1, 5).toIso8601String(),
+          );
+        },
+      );
+
+      blocTest<ProjectSearchBloc, ProjectSearchState>(
+        'applying an owner filter while results are shown re-runs the '
+        'search with the owner',
+        setUp: seedOneProjectResult,
+        build: () => Modular.get<ProjectSearchBloc>(),
+        act: (bloc) async {
+          bloc.add(const ProjectSearchPerformedEvent(query: 'wall'));
+          await bloc.stream.firstWhere((s) => s is ProjectSearchResultsLoaded);
+          bloc.add(
+            const ProjectSearchOwnerFiltersAppliedEvent(ownerIds: {'owner-1'}),
+          );
+          await bloc.stream.firstWhere((s) => s is ProjectSearchResultsLoaded);
+        },
+        verify: (_) {
+          final calls = searchCalls();
+          expect(calls, hasLength(2));
+          final params = calls.last['params'] as Map<String, dynamic>;
+          expect(params['filter_by_owners'], ['owner-1']);
+        },
+      );
+
+      blocTest<ProjectSearchBloc, ProjectSearchState>(
+        'clearing a tag filter while results are shown re-runs the search '
+        'without the tag',
+        setUp: seedOneProjectResult,
+        build: () => Modular.get<ProjectSearchBloc>(),
+        act: (bloc) async {
+          bloc.add(
+            const ProjectSearchTagFiltersAppliedEvent(tags: {'Roofing'}),
+          );
+          bloc.add(const ProjectSearchPerformedEvent(query: 'wall'));
+          await bloc.stream.firstWhere((s) => s is ProjectSearchResultsLoaded);
+          bloc.add(const ProjectSearchTagFilterClearedEvent(tag: 'Roofing'));
+          await bloc.stream.firstWhere((s) => s is ProjectSearchResultsLoaded);
+        },
+        verify: (_) {
+          final calls = searchCalls();
+          expect(calls, hasLength(2));
+          final params = calls.last['params'] as Map<String, dynamic>;
+          expect(params['filter_by_tag'], isNull);
+        },
+      );
+
+      blocTest<ProjectSearchBloc, ProjectSearchState>(
+        're-runs the search when an owner filter is applied after the owner '
+        'sheet was opened (which emits the idle state)',
+        setUp: () {
+          seedOneProjectResult();
+          seedOwners([
+            (id: 'owner-1', firstName: 'Ada', lastName: 'Lovelace'),
+          ]);
+        },
+        build: () => Modular.get<ProjectSearchBloc>(),
+        act: (bloc) async {
+          bloc.add(const ProjectSearchPerformedEvent(query: 'wall'));
+          await bloc.stream.firstWhere((s) => s is ProjectSearchResultsLoaded);
+          // Opening the owner sheet emits the idle state — this must not
+          // clear the active-search signal used by the re-run.
+          bloc.add(const ProjectSearchAvailableOwnersRequestedEvent());
+          await bloc.stream.firstWhere(
+            (s) => s is ProjectSearchInitial && !s.availableOwnersLoading,
+          );
+          bloc.add(
+            const ProjectSearchOwnerFiltersAppliedEvent(ownerIds: {'owner-1'}),
+          );
+          await bloc.stream.firstWhere((s) => s is ProjectSearchResultsLoaded);
+        },
+        verify: (_) {
+          final calls = searchCalls();
+          expect(calls, hasLength(2));
+          final params = calls.last['params'] as Map<String, dynamic>;
+          expect(params['filter_by_owners'], ['owner-1']);
+        },
+      );
+
+      blocTest<ProjectSearchBloc, ProjectSearchState>(
+        'applying a date filter with no active search emits only the idle '
+        'state and performs no search',
+        setUp: seedOneProjectResult,
+        build: () => Modular.get<ProjectSearchBloc>(),
+        act: (bloc) => bloc.add(
+          ProjectSearchDateFilterAppliedEvent(
+            range: DateRange(
+              start: DateTime(2026, 1, 1),
+              end: DateTime(2026, 1, 5),
+            ),
+          ),
+        ),
+        expect: () => [isA<ProjectSearchInitial>()],
+        verify: (_) {
+          expect(searchCalls(), isEmpty);
+        },
+      );
+    });
   });
 }
 

--- a/test/features/dashboard/units/blocs/project_search_bloc_test.dart
+++ b/test/features/dashboard/units/blocs/project_search_bloc_test.dart
@@ -1980,6 +1980,20 @@ void main() {
           );
           await bloc.stream.firstWhere((s) => s is ProjectSearchResultsLoaded);
         },
+        // The interim idle state (carrying the new range) must be emitted
+        // before the re-run's loading state — pins the handler's
+        // emit-then-re-run ordering, not just the RPC call count.
+        expect: () => [
+          isA<ProjectSearchLoading>().having((s) => s.query, 'query', 'wall'),
+          isA<ProjectSearchResultsLoaded>(),
+          isA<ProjectSearchInitial>().having(
+            (s) => s.selectedDateRange,
+            'selectedDateRange',
+            isNotNull,
+          ),
+          isA<ProjectSearchLoading>().having((s) => s.query, 'query', 'wall'),
+          isA<ProjectSearchResultsLoaded>(),
+        ],
         verify: (_) {
           final calls = searchCalls();
           expect(calls, hasLength(2));
@@ -2008,6 +2022,19 @@ void main() {
           );
           await bloc.stream.firstWhere((s) => s is ProjectSearchResultsLoaded);
         },
+        // See the date-filter test above: the sequence pins the
+        // emit-then-re-run ordering.
+        expect: () => [
+          isA<ProjectSearchLoading>().having((s) => s.query, 'query', 'wall'),
+          isA<ProjectSearchResultsLoaded>(),
+          isA<ProjectSearchInitial>().having(
+            (s) => s.selectedOwnerIds,
+            'selectedOwnerIds',
+            {'owner-1'},
+          ),
+          isA<ProjectSearchLoading>().having((s) => s.query, 'query', 'wall'),
+          isA<ProjectSearchResultsLoaded>(),
+        ],
         verify: (_) {
           final calls = searchCalls();
           expect(calls, hasLength(2));
@@ -2030,6 +2057,24 @@ void main() {
           bloc.add(const ProjectSearchTagFilterClearedEvent(tag: 'Roofing'));
           await bloc.stream.firstWhere((s) => s is ProjectSearchResultsLoaded);
         },
+        // See the date-filter test above: the sequence pins the
+        // emit-then-re-run ordering.
+        expect: () => [
+          isA<ProjectSearchInitial>().having(
+            (s) => s.selectedTags,
+            'selectedTags',
+            {'Roofing'},
+          ),
+          isA<ProjectSearchLoading>().having((s) => s.query, 'query', 'wall'),
+          isA<ProjectSearchResultsLoaded>(),
+          isA<ProjectSearchInitial>().having(
+            (s) => s.selectedTags,
+            'selectedTags',
+            isEmpty,
+          ),
+          isA<ProjectSearchLoading>().having((s) => s.query, 'query', 'wall'),
+          isA<ProjectSearchResultsLoaded>(),
+        ],
         verify: (_) {
           final calls = searchCalls();
           expect(calls, hasLength(2));
@@ -2068,6 +2113,46 @@ void main() {
           final params = calls.last['params'] as Map<String, dynamic>;
           expect(params['filter_by_owners'], ['owner-1']);
         },
+      );
+
+      blocTest<ProjectSearchBloc, ProjectSearchState>(
+        'a search dispatched while an older one is still in flight wins: '
+        'the older RPC resolving last cannot publish stale results',
+        setUp: seedOneProjectResult,
+        build: () => Modular.get<ProjectSearchBloc>(),
+        act: (bloc) async {
+          // Park the older search's RPC on a gate. Its loading state is
+          // emitted before the RPC await, so once that state is observed the
+          // older search is parked.
+          fakeSupabase.shouldDelayOperations = true;
+          fakeSupabase.completer = Completer<void>();
+          final olderSearchGate = fakeSupabase.completer!;
+          bloc.add(const ProjectSearchPerformedEvent(query: 'wall'));
+          await bloc.stream.firstWhere(
+            (s) => s is ProjectSearchLoading && s.query == 'wall',
+          );
+          // The newer search runs ungated and publishes first.
+          fakeSupabase.shouldDelayOperations = false;
+          bloc.add(const ProjectSearchPerformedEvent(query: 'bridge'));
+          await bloc.stream.firstWhere(
+            (s) => s is ProjectSearchResultsLoaded && s.query == 'bridge',
+          );
+          // Release the disowned older search; its generation-guarded
+          // continuation runs to completion during bloc.close() without
+          // emitting.
+          olderSearchGate.complete();
+        },
+        // Exactly three emissions: the older search's late completion must
+        // not publish a stale ResultsLoaded('wall') over the newer results.
+        expect: () => [
+          isA<ProjectSearchLoading>().having((s) => s.query, 'query', 'wall'),
+          isA<ProjectSearchLoading>().having((s) => s.query, 'query', 'bridge'),
+          isA<ProjectSearchResultsLoaded>().having(
+            (s) => s.query,
+            'query',
+            'bridge',
+          ),
+        ],
       );
 
       blocTest<ProjectSearchBloc, ProjectSearchState>(

--- a/test/features/dashboard/units/blocs/project_search_bloc_test.dart
+++ b/test/features/dashboard/units/blocs/project_search_bloc_test.dart
@@ -2107,6 +2107,31 @@ void main() {
           );
           await bloc.stream.firstWhere((s) => s is ProjectSearchResultsLoaded);
         },
+        // Pins the emit-then-re-run ordering: results, sheet-open idle
+        // (loading then loaded), filter-applied idle, then the re-run pair.
+        expect: () => [
+          isA<ProjectSearchLoading>().having((s) => s.query, 'query', 'wall'),
+          isA<ProjectSearchResultsLoaded>(),
+          isA<ProjectSearchInitial>().having(
+            (s) => s.availableOwnersLoading,
+            'availableOwnersLoading',
+            true,
+          ),
+          isA<ProjectSearchInitial>()
+              .having(
+                (s) => s.availableOwnersLoading,
+                'availableOwnersLoading',
+                false,
+              )
+              .having((s) => s.selectedOwnerIds, 'selectedOwnerIds', isEmpty),
+          isA<ProjectSearchInitial>().having(
+            (s) => s.selectedOwnerIds,
+            'selectedOwnerIds',
+            {'owner-1'},
+          ),
+          isA<ProjectSearchLoading>().having((s) => s.query, 'query', 'wall'),
+          isA<ProjectSearchResultsLoaded>(),
+        ],
         verify: (_) {
           final calls = searchCalls();
           expect(calls, hasLength(2));
@@ -2152,6 +2177,40 @@ void main() {
             'query',
             'bridge',
           ),
+        ],
+      );
+
+      blocTest<ProjectSearchBloc, ProjectSearchState>(
+        'editing the query back while a search is in flight disowns it: the '
+        'late RPC completion cannot publish stale results over the '
+        'suggestions surface',
+        setUp: seedOneProjectResult,
+        build: () => Modular.get<ProjectSearchBloc>(),
+        act: (bloc) async {
+          // Park the search's RPC on a gate. Its loading state is emitted
+          // before the RPC await, so once that state is observed the search
+          // is parked.
+          fakeSupabase.shouldDelayOperations = true;
+          fakeSupabase.completer = Completer<void>();
+          final searchGate = fakeSupabase.completer!;
+          bloc.add(const ProjectSearchPerformedEvent(query: 'wall'));
+          await bloc.stream.firstWhere(
+            (s) => s is ProjectSearchLoading && s.query == 'wall',
+          );
+          // Clearing the field navigates back to the history surface while
+          // the search RPC is still parked; the edit must disown it.
+          fakeSupabase.shouldDelayOperations = false;
+          bloc.add(const ProjectSearchQueryUpdatedEvent(query: ''));
+          await bloc.stream.firstWhere((s) => s is ProjectSearchInitial);
+          // Release the disowned search; its generation-guarded continuation
+          // runs to completion during bloc.close() without emitting.
+          searchGate.complete();
+        },
+        // Exactly two emissions: the disowned search's late completion must
+        // not publish a stale ResultsLoaded over the suggestions surface.
+        expect: () => [
+          isA<ProjectSearchLoading>().having((s) => s.query, 'query', 'wall'),
+          isA<ProjectSearchInitial>(),
         ],
       );
 

--- a/test/features/global_search/units/blocs/global_search_bloc_test.dart
+++ b/test/features/global_search/units/blocs/global_search_bloc_test.dart
@@ -350,6 +350,10 @@ void main() {
           // GlobalSearchTagFiltersApplied echoes the bloc's current query in
           // GlobalSearchReady, exposing any mutation from the empty submission.
           bloc.add(const GlobalSearchTagFiltersApplied(tags: {'Roofing'}));
+          // The results surface was still active (the empty submission
+          // returned early without deactivating it), so applying the tag
+          // re-runs the preserved 'foundation' query (CA-901).
+          await bloc.stream.firstWhere((s) => s is GlobalSearchLoadEmpty);
         },
         expect: () => [
           const GlobalSearchLoadInProgress(query: 'foundation'),
@@ -360,6 +364,8 @@ void main() {
             'query unchanged by the empty submission',
             'foundation',
           ),
+          const GlobalSearchLoadInProgress(query: 'foundation'),
+          const GlobalSearchLoadEmpty(query: 'foundation'),
         ],
       );
 
@@ -2774,6 +2780,201 @@ void main() {
           final state = bloc.state as GlobalSearchReady;
           expect(state.selectedScope, SearchScope.dashboard);
           expect(state.recentSearches, ['foundation']);
+        },
+      );
+    });
+
+    group('Filter changes re-run the active search', () {
+      List<Map<String, dynamic>> searchCalls() => fakeSupabase
+          .getMethodCallsFor('rpc')
+          .where(
+            (call) =>
+                call['functionName'] ==
+                DatabaseConstants.globalSearchRpcFunction,
+          )
+          .toList();
+
+      void seedOneProjectResult() {
+        fakeSupabase.setRpcResponse(DatabaseConstants.globalSearchRpcFunction, {
+          'projects': [_fakeProjectData()],
+          'estimations': <Map<String, dynamic>>[],
+          'members': <Map<String, dynamic>>[],
+        });
+      }
+
+      blocTest<GlobalSearchBloc, GlobalSearchState>(
+        'applying a date filter while results are shown re-runs the search '
+        'with the new range',
+        setUp: seedOneProjectResult,
+        build: () => Modular.get<GlobalSearchBloc>(),
+        act: (bloc) async {
+          bloc.add(const GlobalSearchPerformed(query: 'foundation'));
+          await bloc.stream.firstWhere((s) => s is GlobalSearchLoadSuccess);
+          bloc.add(
+            GlobalSearchDateFilterApplied(
+              range: DateRange(
+                start: DateTime(2026, 1, 1),
+                end: DateTime(2026, 1, 5),
+              ),
+            ),
+          );
+          await bloc.stream.firstWhere((s) => s is GlobalSearchLoadSuccess);
+        },
+        verify: (bloc) {
+          final calls = searchCalls();
+          expect(calls, hasLength(2));
+          final params = calls.last['params'] as Map<String, dynamic>;
+          expect(
+            params['filter_by_date_from'],
+            DateTime(2026, 1, 1).toIso8601String(),
+          );
+          expect(
+            params['filter_by_date_to'],
+            DateTime(2026, 1, 5).toIso8601String(),
+          );
+        },
+      );
+
+      blocTest<GlobalSearchBloc, GlobalSearchState>(
+        'applying a tag filter while results are shown re-runs the search '
+        'with the tag',
+        setUp: seedOneProjectResult,
+        build: () => Modular.get<GlobalSearchBloc>(),
+        act: (bloc) async {
+          bloc.add(const GlobalSearchPerformed(query: 'foundation'));
+          await bloc.stream.firstWhere((s) => s is GlobalSearchLoadSuccess);
+          bloc.add(const GlobalSearchTagFiltersApplied(tags: {'Roofing'}));
+          await bloc.stream.firstWhere((s) => s is GlobalSearchLoadSuccess);
+        },
+        verify: (bloc) {
+          final calls = searchCalls();
+          expect(calls, hasLength(2));
+          final params = calls.last['params'] as Map<String, dynamic>;
+          expect(params['filter_by_tag'], 'Roofing');
+        },
+      );
+
+      blocTest<GlobalSearchBloc, GlobalSearchState>(
+        'clearing a tag filter while results are shown re-runs the search '
+        'without the tag',
+        setUp: seedOneProjectResult,
+        build: () => Modular.get<GlobalSearchBloc>(),
+        act: (bloc) async {
+          bloc.add(const GlobalSearchTagFiltersApplied(tags: {'Roofing'}));
+          bloc.add(const GlobalSearchPerformed(query: 'foundation'));
+          await bloc.stream.firstWhere((s) => s is GlobalSearchLoadSuccess);
+          bloc.add(const GlobalSearchTagFilterCleared(tag: 'Roofing'));
+          await bloc.stream.firstWhere((s) => s is GlobalSearchLoadSuccess);
+        },
+        verify: (bloc) {
+          final calls = searchCalls();
+          expect(calls, hasLength(2));
+          final params = calls.last['params'] as Map<String, dynamic>;
+          expect(params['filter_by_tag'], isNull);
+        },
+      );
+
+      blocTest<GlobalSearchBloc, GlobalSearchState>(
+        'changing the scope while results are shown re-runs the search '
+        'with the new scope',
+        setUp: seedOneProjectResult,
+        build: () => Modular.get<GlobalSearchBloc>(),
+        act: (bloc) async {
+          bloc.add(const GlobalSearchPerformed(query: 'foundation'));
+          await bloc.stream.firstWhere((s) => s is GlobalSearchLoadSuccess);
+          bloc.add(
+            const GlobalSearchScopeChanged(scope: SearchScope.estimation),
+          );
+          await bloc.stream.firstWhere((s) => s is GlobalSearchLoadSuccess);
+        },
+        verify: (bloc) {
+          final calls = searchCalls();
+          expect(calls, hasLength(2));
+          final params = calls.last['params'] as Map<String, dynamic>;
+          expect(params['scope'], 'estimation');
+        },
+      );
+
+      blocTest<GlobalSearchBloc, GlobalSearchState>(
+        'applying a date filter with no active search emits only the ready '
+        'state and performs no search',
+        setUp: seedOneProjectResult,
+        build: () => Modular.get<GlobalSearchBloc>(),
+        act: (bloc) => bloc.add(
+          GlobalSearchDateFilterApplied(
+            range: DateRange(
+              start: DateTime(2026, 1, 1),
+              end: DateTime(2026, 1, 5),
+            ),
+          ),
+        ),
+        expect: () => [isA<GlobalSearchReady>()],
+        verify: (bloc) {
+          expect(searchCalls(), isEmpty);
+        },
+      );
+
+      blocTest<GlobalSearchBloc, GlobalSearchState>(
+        're-runs the search when a filter is applied after the filter sheet '
+        'was opened (which emits the ready state)',
+        setUp: () {
+          seedOneProjectResult();
+          fakeSupabase.addTableData(DatabaseConstants.tagsTable, [
+            {
+              DatabaseConstants.idColumn: 'tag-Roofing',
+              DatabaseConstants.nameColumn: 'Roofing',
+            },
+          ]);
+        },
+        build: () => Modular.get<GlobalSearchBloc>(),
+        act: (bloc) async {
+          bloc.add(const GlobalSearchPerformed(query: 'foundation'));
+          await bloc.stream.firstWhere((s) => s is GlobalSearchLoadSuccess);
+          // Opening the tags sheet emits the ready state — this must not
+          // clear the active-search signal used by the re-run.
+          bloc.add(const GlobalSearchAvailableTagsRequested());
+          await bloc.stream.firstWhere((s) => s is GlobalSearchReady);
+          bloc.add(const GlobalSearchTagFiltersApplied(tags: {'Roofing'}));
+          await bloc.stream.firstWhere((s) => s is GlobalSearchLoadSuccess);
+        },
+        verify: (bloc) {
+          final calls = searchCalls();
+          expect(calls, hasLength(2));
+          final params = calls.last['params'] as Map<String, dynamic>;
+          expect(params['filter_by_tag'], 'Roofing');
+        },
+      );
+
+      blocTest<GlobalSearchBloc, GlobalSearchState>(
+        'editing the query back to suggestions stops filter changes from '
+        're-running the stale search',
+        setUp: () {
+          seedOneProjectResult();
+          fakeSupabase.setRpcResponse(
+            DatabaseConstants.searchSuggestionsRpcFunction,
+            <String>[],
+          );
+        },
+        build: () => Modular.get<GlobalSearchBloc>(),
+        act: (bloc) async {
+          bloc.add(const GlobalSearchPerformed(query: 'foundation'));
+          await bloc.stream.firstWhere((s) => s is GlobalSearchLoadSuccess);
+          bloc.add(const GlobalSearchQueryUpdated(query: 'found'));
+          await bloc.stream.firstWhere((s) => s is GlobalSearchReady);
+          bloc.add(
+            GlobalSearchDateFilterApplied(
+              range: DateRange(
+                start: DateTime(2026, 1, 1),
+                end: DateTime(2026, 1, 5),
+              ),
+            ),
+          );
+          await bloc.stream.firstWhere((s) => s is GlobalSearchReady);
+        },
+        verify: (bloc) {
+          // Only the original search ran; the filter change on the
+          // suggestions surface must not resurrect the dismissed results.
+          expect(searchCalls(), hasLength(1));
         },
       );
     });

--- a/test/features/global_search/units/blocs/global_search_bloc_test.dart
+++ b/test/features/global_search/units/blocs/global_search_bloc_test.dart
@@ -2820,6 +2820,20 @@ void main() {
           );
           await bloc.stream.firstWhere((s) => s is GlobalSearchLoadSuccess);
         },
+        // The interim ready state (carrying the new range) must be emitted
+        // before the re-run's loading state — pins the handler's
+        // emit-then-re-run ordering, not just the RPC call count.
+        expect: () => [
+          isA<GlobalSearchLoadInProgress>(),
+          isA<GlobalSearchLoadSuccess>(),
+          isA<GlobalSearchReady>().having(
+            (s) => s.selectedDateRange,
+            'selectedDateRange',
+            isNotNull,
+          ),
+          isA<GlobalSearchLoadInProgress>(),
+          isA<GlobalSearchLoadSuccess>(),
+        ],
         verify: (bloc) {
           final calls = searchCalls();
           expect(calls, hasLength(2));
@@ -2846,6 +2860,19 @@ void main() {
           bloc.add(const GlobalSearchTagFiltersApplied(tags: {'Roofing'}));
           await bloc.stream.firstWhere((s) => s is GlobalSearchLoadSuccess);
         },
+        // See the date-filter test above: the sequence pins the
+        // emit-then-re-run ordering.
+        expect: () => [
+          isA<GlobalSearchLoadInProgress>(),
+          isA<GlobalSearchLoadSuccess>(),
+          isA<GlobalSearchReady>().having(
+            (s) => s.selectedTags,
+            'selectedTags',
+            {'Roofing'},
+          ),
+          isA<GlobalSearchLoadInProgress>(),
+          isA<GlobalSearchLoadSuccess>(),
+        ],
         verify: (bloc) {
           final calls = searchCalls();
           expect(calls, hasLength(2));
@@ -2866,6 +2893,24 @@ void main() {
           bloc.add(const GlobalSearchTagFilterCleared(tag: 'Roofing'));
           await bloc.stream.firstWhere((s) => s is GlobalSearchLoadSuccess);
         },
+        // See the date-filter test above: the sequence pins the
+        // emit-then-re-run ordering.
+        expect: () => [
+          isA<GlobalSearchReady>().having(
+            (s) => s.selectedTags,
+            'selectedTags',
+            {'Roofing'},
+          ),
+          isA<GlobalSearchLoadInProgress>(),
+          isA<GlobalSearchLoadSuccess>(),
+          isA<GlobalSearchReady>().having(
+            (s) => s.selectedTags,
+            'selectedTags',
+            isEmpty,
+          ),
+          isA<GlobalSearchLoadInProgress>(),
+          isA<GlobalSearchLoadSuccess>(),
+        ],
         verify: (bloc) {
           final calls = searchCalls();
           expect(calls, hasLength(2));
@@ -2893,6 +2938,61 @@ void main() {
           final params = calls.last['params'] as Map<String, dynamic>;
           expect(params['scope'], 'estimation');
         },
+      );
+
+      blocTest<GlobalSearchBloc, GlobalSearchState>(
+        'a search dispatched while an older one is still in flight wins: '
+        'the older RPC resolving last cannot publish stale results',
+        setUp: seedOneProjectResult,
+        build: () => Modular.get<GlobalSearchBloc>(),
+        act: (bloc) async {
+          // Park the older search's RPC on a gate. Its loading state is
+          // emitted before the RPC await, so once that state is observed the
+          // older search is parked.
+          fakeSupabase.shouldDelayOperations = true;
+          fakeSupabase.completer = Completer<void>();
+          final olderSearchGate = fakeSupabase.completer!;
+          bloc.add(const GlobalSearchPerformed(query: 'foundation'));
+          await bloc.stream.firstWhere(
+            (s) => s is GlobalSearchLoadInProgress && s.query == 'foundation',
+          );
+          // The newer search runs ungated and publishes first.
+          fakeSupabase.shouldDelayOperations = false;
+          bloc.add(const GlobalSearchPerformed(query: 'girder'));
+          await bloc.stream.firstWhere((s) => s is GlobalSearchLoadSuccess);
+          // Swap the RPC response to empty before releasing the older
+          // search: if its late completion ever published, it would emit a
+          // LoadEmpty distinct from the newer LoadSuccess (an identical
+          // LoadSuccess would be deduplicated by Equatable and hide the
+          // regression).
+          fakeSupabase.setRpcResponse(
+            DatabaseConstants.globalSearchRpcFunction,
+            {
+              'projects': <Map<String, dynamic>>[],
+              'estimations': <Map<String, dynamic>>[],
+              'members': <Map<String, dynamic>>[],
+            },
+          );
+          // Release the disowned older search; its generation-guarded
+          // continuation runs to completion during bloc.close() without
+          // emitting.
+          olderSearchGate.complete();
+        },
+        // Exactly three emissions: the older search's late completion must
+        // not publish a stale state over the newer results.
+        expect: () => [
+          isA<GlobalSearchLoadInProgress>().having(
+            (s) => s.query,
+            'query',
+            'foundation',
+          ),
+          isA<GlobalSearchLoadInProgress>().having(
+            (s) => s.query,
+            'query',
+            'girder',
+          ),
+          isA<GlobalSearchLoadSuccess>(),
+        ],
       );
 
       blocTest<GlobalSearchBloc, GlobalSearchState>(

--- a/test/features/global_search/units/blocs/global_search_bloc_test.dart
+++ b/test/features/global_search/units/blocs/global_search_bloc_test.dart
@@ -2932,6 +2932,41 @@ void main() {
           );
           await bloc.stream.firstWhere((s) => s is GlobalSearchLoadSuccess);
         },
+        // Pins the emit-then-re-run ordering: the eager scope emit, the
+        // re-run's loading state, the per-scope recents reload landing
+        // mid-flight, then the re-run's results.
+        expect: () => [
+          isA<GlobalSearchLoadInProgress>().having(
+            (s) => s.query,
+            'query',
+            'foundation',
+          ),
+          isA<GlobalSearchLoadSuccess>(),
+          isA<GlobalSearchReady>()
+              .having(
+                (s) => s.selectedScope,
+                'selectedScope',
+                SearchScope.estimation,
+              )
+              .having(
+                (s) => s.recentSearches,
+                'recentSearches',
+                ['foundation'],
+              ),
+          isA<GlobalSearchLoadInProgress>().having(
+            (s) => s.query,
+            'query',
+            'foundation',
+          ),
+          isA<GlobalSearchReady>()
+              .having(
+                (s) => s.selectedScope,
+                'selectedScope',
+                SearchScope.estimation,
+              )
+              .having((s) => s.recentSearches, 'recentSearches', isEmpty),
+          isA<GlobalSearchLoadSuccess>(),
+        ],
         verify: (bloc) {
           final calls = searchCalls();
           expect(calls, hasLength(2));
@@ -2996,6 +3031,44 @@ void main() {
       );
 
       blocTest<GlobalSearchBloc, GlobalSearchState>(
+        'editing the query back while a search is in flight disowns it: the '
+        'late RPC completion cannot publish stale results over the '
+        'suggestions surface',
+        setUp: seedOneProjectResult,
+        build: () => Modular.get<GlobalSearchBloc>(),
+        act: (bloc) async {
+          // Park the search's RPC on a gate. Its loading state is emitted
+          // before the RPC await, so once that state is observed the search
+          // is parked.
+          fakeSupabase.shouldDelayOperations = true;
+          fakeSupabase.completer = Completer<void>();
+          final searchGate = fakeSupabase.completer!;
+          bloc.add(const GlobalSearchPerformed(query: 'foundation'));
+          await bloc.stream.firstWhere(
+            (s) => s is GlobalSearchLoadInProgress && s.query == 'foundation',
+          );
+          // Clearing the query navigates back to the suggestions surface
+          // while the search RPC is still parked; the edit must disown it.
+          fakeSupabase.shouldDelayOperations = false;
+          bloc.add(const GlobalSearchQueryUpdated(query: ''));
+          await bloc.stream.firstWhere((s) => s is GlobalSearchReady);
+          // Release the disowned search; its generation-guarded continuation
+          // runs to completion during bloc.close() without emitting.
+          searchGate.complete();
+        },
+        // Exactly two emissions: the disowned search's late completion must
+        // not publish a stale LoadSuccess over the suggestions surface.
+        expect: () => [
+          isA<GlobalSearchLoadInProgress>().having(
+            (s) => s.query,
+            'query',
+            'foundation',
+          ),
+          isA<GlobalSearchReady>(),
+        ],
+      );
+
+      blocTest<GlobalSearchBloc, GlobalSearchState>(
         'applying a date filter with no active search emits only the ready '
         'state and performs no search',
         setUp: seedOneProjectResult,
@@ -3037,6 +3110,39 @@ void main() {
           bloc.add(const GlobalSearchTagFiltersApplied(tags: {'Roofing'}));
           await bloc.stream.firstWhere((s) => s is GlobalSearchLoadSuccess);
         },
+        // Pins the emit-then-re-run ordering: results, sheet-open ready
+        // (loading then loaded), filter-applied ready, then the re-run pair.
+        expect: () => [
+          isA<GlobalSearchLoadInProgress>().having(
+            (s) => s.query,
+            'query',
+            'foundation',
+          ),
+          isA<GlobalSearchLoadSuccess>(),
+          isA<GlobalSearchReady>().having(
+            (s) => s.availableTagsLoading,
+            'availableTagsLoading',
+            true,
+          ),
+          isA<GlobalSearchReady>()
+              .having(
+                (s) => s.availableTagsLoading,
+                'availableTagsLoading',
+                false,
+              )
+              .having((s) => s.selectedTags, 'selectedTags', isEmpty),
+          isA<GlobalSearchReady>().having(
+            (s) => s.selectedTags,
+            'selectedTags',
+            {'Roofing'},
+          ),
+          isA<GlobalSearchLoadInProgress>().having(
+            (s) => s.query,
+            'query',
+            'foundation',
+          ),
+          isA<GlobalSearchLoadSuccess>(),
+        ],
         verify: (bloc) {
           final calls = searchCalls();
           expect(calls, hasLength(2));


### PR DESCRIPTION
## Summary

[CA-901](https://ripplearc.youtrack.cloud/issue/CA-901) — every filter handler in both search blocs only stored the new filter and emitted the idle/ready state, so applying or clearing a filter after a search left the visible results stale until the user manually resubmitted (verified live during the E2E pass).

Stacked on #485 (CA-904) — now that results render, this makes the filters actually affect them.

## Changes

Both `GlobalSearchBloc` and `ProjectSearchBloc`:
- Track `_lastPerformedQuery` (set when a search executes, cleared on the page-reset handler) and a durable `_searchIsActive` flag.
- `_searchIsActive` is set true when a search executes and cleared when the query is edited back to the suggestions surface (or on reset). It is a **durable flag, not derived from the current state** — opening a filter sheet emits the idle/ready state (to render the sheet's option list), which would otherwise wipe a state-derived signal before the user taps Apply. (This exact bug was caught in the E2E pass: the owner pill went active but the results blanked because the re-run never fired.)
- Tag apply+clear, owner apply+clear, date apply+clear (and scope-change in global) re-dispatch the performed search with the updated filters when a search is active.
- No-ops when there's no active query, and once the user edits the query back the stale search is not resurrected.

## Tests

- 7 new `GlobalSearchBloc` tests: date/tag/scope re-run with the new param asserted on the RPC payload; tag-clear drops the param; **filter-applied-after-sheet-open re-runs** (the durable-flag regression); no-active-search performs no RPC; editing-query-back guard. Plus the existing empty-query test updated to reflect the post-empty re-run.
- 5 new `ProjectSearchBloc` tests: date/owner re-run, **owner-applied-after-sheet-open re-run**, tag-clear, no-active-search guard.
- In-flight safety: R1 (37f6285) adds a `_searchExecutionGeneration` guard around the performed-search execution in both blocs (the pre-existing guards only covered the suggestions/tags/owners fetches), so two overlapping re-run dispatches can no longer resolve out of order; page resets disown an in-flight search. Full search suites green, analyze clean, custom_lint only the pre-existing `fake_router.dart` hit.

## Notes
- Multi-tag still truncates to the first tag (CA-846, backend array) and multi-owner is widened to the full set in the next PR (CA-913) — this PR re-runs with whatever the current filter path sends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
