### PR TITLE
CA-913: fix(search): send all selected owners to the project search filter_by_owners param

### DIFF
--- a/lib/features/dashboard/presentation/bloc/project_search_bloc/project_search_bloc.dart
+++ b/lib/features/dashboard/presentation/bloc/project_search_bloc/project_search_bloc.dart
@@ -372,19 +372,13 @@ class ProjectSearchBloc extends Bloc<ProjectSearchEvent, ProjectSearchState> {
     final generation = ++_searchExecutionGeneration;
     emit(ProjectSearchLoading(query: query));
 
-    // The RPC accepts a single tag/owner, so a multi-selection is silently
-    // truncated to the alphabetically-first value; log it until the RPC
-    // supports multi-value filters.
+    // The RPC accepts a single tag, so a multi-selection is silently
+    // truncated to the alphabetically-first value; log it until CA-846
+    // extends the tag param to an array.
     if (_selectedTags.length > 1) {
       _logger.warning(
         'Tag filter truncated: ${_selectedTags.length} tags selected, only '
         'the alphabetically-first is sent to the RPC',
-      );
-    }
-    if (_selectedOwnerIds.length > 1) {
-      _logger.warning(
-        'Owner filter truncated: ${_selectedOwnerIds.length} owners selected, '
-        'only the alphabetically-first is sent to the RPC',
       );
     }
 
@@ -392,15 +386,14 @@ class ProjectSearchBloc extends Bloc<ProjectSearchEvent, ProjectSearchState> {
       userId: userId,
       query: query,
       // The repository accepts a single tag; sort for deterministic selection
-      // until the RPC is extended to support multi-tag filtering.
+      // until CA-846 extends the RPC to support multi-tag filtering.
       filterByTag: _selectedTags.isEmpty
           ? null
           : (_selectedTags.toList()..sort()).first,
-      // The repository accepts a single owner; sort for deterministic
-      // selection until the RPC is extended to support multi-owner filtering.
-      filterByOwner: _selectedOwnerIds.isEmpty
+      // Sorted so equal selections always produce the same RPC payload.
+      filterByOwners: _selectedOwnerIds.isEmpty
           ? null
-          : (_selectedOwnerIds.toList()..sort()).first,
+          : (_selectedOwnerIds.toList()..sort()),
       // The RPC's date filter is an inclusive modification-date range;
       // thread both bounds, mirroring GlobalSearchBloc.
       filterByDateFrom: _selectedDateRange?.start,

--- a/lib/libraries/project/data/data_source/interfaces/project_search_data_source.dart
+++ b/lib/libraries/project/data/data_source/interfaces/project_search_data_source.dart
@@ -21,7 +21,7 @@ abstract class ProjectSearchDataSource {
     DateTime? filterByDateFrom,
     DateTime? filterByDateTo,
     String? filterByTag,
-    String? filterByOwner,
+    List<String>? filterByOwners,
   });
 
   /// Persists [searchTerm] as a recent project-search entry for [userId].

--- a/lib/libraries/project/data/data_source/remote_project_search_data_source.dart
+++ b/lib/libraries/project/data/data_source/remote_project_search_data_source.dart
@@ -28,7 +28,7 @@ class RemoteProjectSearchDataSource implements ProjectSearchDataSource {
     DateTime? filterByDateFrom,
     DateTime? filterByDateTo,
     String? filterByTag,
-    String? filterByOwner,
+    List<String>? filterByOwners,
   }) async {
     if (query.trim().isEmpty || userId.trim().isEmpty) {
       _logger.debug('Empty query or userId — skipping RPC call');
@@ -45,10 +45,9 @@ class RemoteProjectSearchDataSource implements ProjectSearchDataSource {
           'filter_by_tag': filterByTag,
           'filter_by_date_from': filterByDateFrom?.toIso8601String(),
           'filter_by_date_to': filterByDateTo?.toIso8601String(),
-          // The RPC takes an owner-id array; this data source still exposes a
-          // single-owner filter, so wrap it. Widening this interface to
-          // multiple owners is tracked in CA-771.
-          'filter_by_owners': filterByOwner == null ? null : [filterByOwner],
+          'filter_by_owners': (filterByOwners == null || filterByOwners.isEmpty)
+              ? null
+              : filterByOwners,
           'scope': DatabaseConstants.globalSearchDashboardScope,
           // Only the projects domain is consumed here; the RPC's other
           // per-domain offsets keep their defaults.

--- a/lib/libraries/project/data/repositories/project_search_repository_impl.dart
+++ b/lib/libraries/project/data/repositories/project_search_repository_impl.dart
@@ -89,7 +89,7 @@ class ProjectSearchRepositoryImpl implements ProjectSearchRepository {
     DateTime? filterByDateFrom,
     DateTime? filterByDateTo,
     String? filterByTag,
-    String? filterByOwner,
+    List<String>? filterByOwners,
   }) async {
     if (query.trim().isEmpty || userId.trim().isEmpty) {
       return Right([]);
@@ -103,7 +103,7 @@ class ProjectSearchRepositoryImpl implements ProjectSearchRepository {
         filterByDateFrom: filterByDateFrom,
         filterByDateTo: filterByDateTo,
         filterByTag: filterByTag,
-        filterByOwner: filterByOwner,
+        filterByOwners: filterByOwners,
       );
       _logger.debug('Search completed: ${dtos.length} projects found');
       return Right(dtos.map((dto) => dto.toDomain()).toList());

--- a/lib/libraries/project/domain/repositories/project_search_repository.dart
+++ b/lib/libraries/project/domain/repositories/project_search_repository.dart
@@ -13,7 +13,7 @@ abstract class ProjectSearchRepository {
   /// - [filterByDateFrom]/[filterByDateTo]: inclusive modification-date
   ///   range; either bound may be omitted for an open-ended range.
   /// - [filterByTag]: only projects tagged with this value.
-  /// - [filterByOwner]: only projects owned by this user id.
+  /// - [filterByOwners]: only projects owned by one of these user ids.
   ///
   /// Returns an empty list when [query] or [userId] is empty.
   Future<Either<Failure, List<Project>>> searchProjects({
@@ -22,7 +22,7 @@ abstract class ProjectSearchRepository {
     DateTime? filterByDateFrom,
     DateTime? filterByDateTo,
     String? filterByTag,
-    String? filterByOwner,
+    List<String>? filterByOwners,
   });
 
   /// Persists [searchTerm] as a recent project-search entry for [userId].

--- a/lib/libraries/project/testing/fake_project_search_repository.dart
+++ b/lib/libraries/project/testing/fake_project_search_repository.dart
@@ -73,7 +73,7 @@ class FakeProjectSearchRepository implements ProjectSearchRepository {
     DateTime? filterByDateFrom,
     DateTime? filterByDateTo,
     String? filterByTag,
-    String? filterByOwner,
+    List<String>? filterByOwners,
   }) async {
     if (shouldDelayOperations) {
       await completer?.future;
@@ -86,7 +86,7 @@ class FakeProjectSearchRepository implements ProjectSearchRepository {
       'filterByDateFrom': filterByDateFrom,
       'filterByDateTo': filterByDateTo,
       'filterByTag': filterByTag,
-      'filterByOwner': filterByOwner,
+      'filterByOwners': filterByOwners,
     });
 
     if (query.trim().isEmpty || userId.trim().isEmpty) {

--- a/test/features/dashboard/units/blocs/project_search_bloc_test.dart
+++ b/test/features/dashboard/units/blocs/project_search_bloc_test.dart
@@ -1660,7 +1660,7 @@ void main() {
       );
 
       blocTest<ProjectSearchBloc, ProjectSearchState>(
-        'threads the selected owner into the search RPC',
+        'threads all selected owners into the search RPC (sorted)',
         setUp: () {
           fakeSupabase.setRpcResponse(
             DatabaseConstants.globalSearchRpcFunction,
@@ -1681,9 +1681,12 @@ void main() {
           await bloc.stream.firstWhere((s) => s is ProjectSearchResultsLoaded);
         },
         verify: (_) {
-          // The RPC takes an owner-id array; the single-owner selection is
-          // wrapped, and sorted for determinism → 'owner-1' wins.
-          expect(lastSearchRpcParams()['filter_by_owners'], ['owner-1']);
+          // The RPC takes an owner-id array; every selected owner is sent,
+          // sorted for a deterministic payload.
+          expect(
+            lastSearchRpcParams()['filter_by_owners'],
+            ['owner-1', 'owner-2'],
+          );
         },
       );
     });

--- a/test/libraries/project/units/data/data_source/remote_project_search_data_source_test.dart
+++ b/test/libraries/project/units/data/data_source/remote_project_search_data_source_test.dart
@@ -248,7 +248,7 @@ void main() {
         },
       );
 
-      test('passes filterByTag and filterByOwner in RPC params', () async {
+      test('passes filterByTag and filterByOwners in RPC params', () async {
         supabaseWrapper.setRpcResponse(
           DatabaseConstants.globalSearchRpcFunction,
           {'projects': [], 'estimations': [], 'members': []},
@@ -258,7 +258,7 @@ void main() {
           userId: 'user-1',
           query: 'wall',
           filterByTag: 'structural',
-          filterByOwner: 'owner-42',
+          filterByOwners: const ['owner-42', 'owner-7'],
         );
 
         final params = supabaseWrapper.getMethodCallsFor('rpc').first['params']
@@ -266,9 +266,26 @@ void main() {
         expect(params!['filter_by_tag'], equals('structural'));
         expect(
           params['filter_by_owners'],
-          equals(['owner-42']),
-          reason: 'a single owner must be wrapped in the RPC owner-id array',
+          equals(['owner-42', 'owner-7']),
+          reason: 'all selected owners must reach the RPC owner-id array',
         );
+      });
+
+      test('sends a null owner array when no owners are selected', () async {
+        supabaseWrapper.setRpcResponse(
+          DatabaseConstants.globalSearchRpcFunction,
+          {'projects': [], 'estimations': [], 'members': []},
+        );
+
+        await dataSource.fetchProjectsBySearchQuery(
+          userId: 'user-1',
+          query: 'wall',
+          filterByOwners: const [],
+        );
+
+        final params = supabaseWrapper.getMethodCallsFor('rpc').first['params']
+            as Map<String, dynamic>?;
+        expect(params!['filter_by_owners'], isNull);
       });
 
       test('ignores estimations and members in RPC response', () async {

--- a/test/libraries/project/units/data/repositories/project_search_repository_impl_test.dart
+++ b/test/libraries/project/units/data/repositories/project_search_repository_impl_test.dart
@@ -212,7 +212,7 @@ void main() {
           filterByDateFrom: filterFrom,
           filterByDateTo: filterTo,
           filterByTag: 'structural',
-          filterByOwner: 'owner-42',
+          filterByOwners: const ['owner-42', 'owner-7'],
         );
 
         final rpcCalls = fakeSupabaseWrapper.getMethodCallsFor('rpc');
@@ -231,8 +231,8 @@ void main() {
         expect(params['filter_by_tag'], equals('structural'));
         expect(
           params['filter_by_owners'],
-          equals(['owner-42']),
-          reason: 'a single owner must be wrapped in the RPC owner-id array',
+          equals(['owner-42', 'owner-7']),
+          reason: 'all selected owners must reach the RPC owner-id array',
         );
         expect(params['scope'], equals('dashboard'));
       });


### PR DESCRIPTION
## Summary

[CA-913](https://ripplearc.youtrack.cloud/issue/CA-913) — the project-search Owner sheet is multi-select and the `global_search` RPC already accepts `filter_by_owners uuid[]`, but `ProjectSearchBloc` truncated the selection to the alphabetically-first owner and the datasource wrapped that single value in a list. This widens the app-side contract so every selected owner reaches the RPC. App-only — no backend change (contrast CA-846, the tag param, which needs a backend signature migration).

Stacked on #486 (CA-901). Replaces the never-refiled contract-widening half of the superseded CA-771.

## Changes

`filterByOwner: String?` → `filterByOwners: List<String>?` through the full chain:
- `ProjectSearchRepository` (interface + impl), `ProjectSearchDataSource` (interface + `RemoteProjectSearchDataSource`), `FakeProjectSearchRepository`.
- `RemoteProjectSearchDataSource` sends the list directly (null when empty) instead of `[singleOwner]`.
- `ProjectSearchBloc._executeSearch` sends `_selectedOwnerIds` sorted (deterministic payload); the owner-truncation warning and CA-771 comments are removed. Tag truncation stays (CA-846) with its comment repointed.

## Tests

- Datasource test: asserts all owners reach `filter_by_owners`, plus a new empty-selection → `null` case.
- Repository-impl test: multi-owner array passthrough.
- Bloc test "threads all selected owners into the search RPC (sorted)" updated from the old truncation assertion; the CA-901 single-owner re-run test still asserts `['owner-1']`.
- analyze clean; custom_lint only the pre-existing `fake_router.dart` hit.

## Notes
- The unbound dead dashboard `RemoteProjectSearchDataSource` keeps the old `filterByOwner` signature — it's slated for deletion in CA-845 and has no live callers, so it's left untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)