### PR TITLE
CA-939: Add posthog_flutter, platform config, and POSTHOG_* environment keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,8 +158,11 @@ API_URL=http://localhost:8000/api
 SUPABASE_URL=http://localhost:54321
 SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
 DEBUG_MODE=true
-ANALYTICS_ENABLED=false
+ANALYTICS_ENABLED=true
 SENTRY_DSN=
+POSTHOG_API_KEY=
+POSTHOG_HOST=
+POSTHOG_DEBUG=true
 ```
 
 **Environment Variable Details:**
@@ -172,8 +175,11 @@ SENTRY_DSN=
 | `SUPABASE_URL` | Supabase API URL | `http://localhost:54321` (from `supabase start` output) |
 | `SUPABASE_ANON_KEY` | Supabase anonymous key | Copy the ` Publishable key` from `supabase start` output |
 | `DEBUG_MODE` | Enable debug logging | `true` for development, `false` for production |
-| `ANALYTICS_ENABLED` | Enable analytics | `false` for local development |
+| `ANALYTICS_ENABLED` | Enable analytics (single kill switch, currently gates PostHog) | `true` for local development, `false` for qa/prod |
 | `SENTRY_DSN` | Sentry error tracking DSN | Leave empty for local dev |
+| `POSTHOG_API_KEY` | PostHog project API key (dev only for now) | Leave empty for local dev, or use your PostHog project key |
+| `POSTHOG_HOST` | PostHog ingestion host (dev only for now) | Leave empty for local dev, or use your PostHog instance URL |
+| `POSTHOG_DEBUG` | Enable PostHog debug logging | `true` for local development, `false` for qa/prod |
 
 #### Important: Emulator Network Configuration
 

--- a/assets/env/.env.template
+++ b/assets/env/.env.template
@@ -5,7 +5,10 @@ SUPABASE_URL=http://localhost:54321
 SUPABASE_ANON_KEY=fake-key
 POWERSYNC_URL=http://localhost:8080
 DEBUG_MODE=true
-ANALYTICS_ENABLED=false
+ANALYTICS_ENABLED=true
 SENTRY_DSN=
+POSTHOG_API_KEY=
+POSTHOG_HOST=
+POSTHOG_DEBUG=true
 
 # Create copies for .env.dev, .env.qa, .env.prod

--- a/docs/Testing/CI-Scripts.md
+++ b/docs/Testing/CI-Scripts.md
@@ -303,7 +303,9 @@ SENTRY_DSN=           (empty - Sentry disabled in dev)
 API_URL=http://localhost:8000/api
 SUPABASE_URL=http://localhost:54321
 DEBUG_MODE=true
-ANALYTICS_ENABLED=false
+ANALYTICS_ENABLED=true
+POSTHOG_API_KEY=...   (dev only for now)
+POSTHOG_HOST=...      (dev only for now)
 ```
 
 Example variables in `construculator_qa`:
@@ -314,8 +316,12 @@ SENTRY_DSN=https://...@sentry.io/...
 API_URL=https://qa-api.construculator.com/api
 SUPABASE_URL=https://qa-project.supabase.co
 DEBUG_MODE=false
-ANALYTICS_ENABLED=true
+ANALYTICS_ENABLED=false
+POSTHOG_API_KEY=      (empty - PostHog is dev-only for now)
+POSTHOG_HOST=         (empty - PostHog is dev-only for now)
 ```
+
+`ANALYTICS_ENABLED` is the single kill switch for analytics — it currently gates PostHog and is reused rather than adding a parallel `POSTHOG_ENABLED` flag. `POSTHOG_DEBUG` follows `DEBUG_MODE` per environment (`true` in dev, `false` in qa/prod) and doesn't need to be set explicitly in Codemagic; the script defaults it per `ENVIRONMENT`.
 
 ### Common environment variables
 

--- a/lib/libraries/config/env_constants.dart
+++ b/lib/libraries/config/env_constants.dart
@@ -12,6 +12,10 @@ const String prodAlias = '';
 
 const String sentryDsnKey = 'SENTRY_DSN';
 
+const String posthogApiKeyKey = 'POSTHOG_API_KEY';
+const String posthogHostKey = 'POSTHOG_HOST';
+const String posthogDebugKey = 'POSTHOG_DEBUG';
+
 enum Environment { dev, qa, prod }
 
 const Duration debounceTime = Duration(milliseconds: 300);

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -877,6 +877,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.8.0"
+  posthog_flutter:
+    dependency: "direct main"
+    description:
+      name: posthog_flutter
+      sha256: "41a7d3c7329d58c6b438b28346e62b06d063b9740960d750df431203a714708a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.35.1"
   powersync:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -32,6 +32,7 @@ dependencies:
   intl: 0.20.2
   sentry_flutter: 9.24.0
   powersync: 1.18.0
+  posthog_flutter: 5.35.1
 
 dev_dependencies:
   flutter_test:

--- a/scripts/ci/generate_env_file.sh
+++ b/scripts/ci/generate_env_file.sh
@@ -31,6 +31,14 @@ if [ -z "${SENTRY_DSN:-}" ]; then
   echo "⚠️  WARNING: SENTRY_DSN is not set (Sentry will be disabled)"
 fi
 
+if [ -z "${POSTHOG_API_KEY:-}" ]; then
+  echo "⚠️  WARNING: POSTHOG_API_KEY is not set (PostHog will be disabled)"
+fi
+
+if [ -z "${POSTHOG_HOST:-}" ]; then
+  echo "⚠️  WARNING: POSTHOG_HOST is not set (PostHog will be disabled)"
+fi
+
 # Set default values for optional variables
 APP_NAME="${APP_NAME:-Construculator}"
 API_URL="${API_URL:-}"

--- a/scripts/ci/generate_env_file.sh
+++ b/scripts/ci/generate_env_file.sh
@@ -11,6 +11,8 @@
 #   - SUPABASE_URL: The Supabase project URL
 #   - SUPABASE_ANON_KEY: The Supabase anonymous/public key
 #   - API_URL: The API base URL
+#   - POSTHOG_API_KEY: The PostHog project API key (dev only for now)
+#   - POSTHOG_HOST: The PostHog ingestion host (dev only for now)
 #
 # Usage:
 #   This script is automatically run by Codemagic before the build.
@@ -37,23 +39,29 @@ SUPABASE_ANON_KEY="${SUPABASE_ANON_KEY:-}"
 DEBUG_MODE="${DEBUG_MODE:-false}"
 ANALYTICS_ENABLED="${ANALYTICS_ENABLED:-false}"
 SENTRY_DSN="${SENTRY_DSN:-}"
+POSTHOG_API_KEY="${POSTHOG_API_KEY:-}"
+POSTHOG_HOST="${POSTHOG_HOST:-}"
+POSTHOG_DEBUG="${POSTHOG_DEBUG:-false}"
 
 # Determine environment-specific values
 case "${ENVIRONMENT}" in
   dev)
     ENV_FILE="assets/env/.env.dev"
     DEBUG_MODE="true"
-    ANALYTICS_ENABLED="false"
+    ANALYTICS_ENABLED="true"
+    POSTHOG_DEBUG="true"
     ;;
   qa)
     ENV_FILE="assets/env/.env.qa"
     DEBUG_MODE="false"
-    ANALYTICS_ENABLED="true"
+    ANALYTICS_ENABLED="false"
+    POSTHOG_DEBUG="false"
     ;;
   prod)
     ENV_FILE="assets/env/.env.prod"
     DEBUG_MODE="false"
-    ANALYTICS_ENABLED="true"
+    ANALYTICS_ENABLED="false"
+    POSTHOG_DEBUG="false"
     ;;
   *)
     echo "❌ ERROR: Invalid ENVIRONMENT value: ${ENVIRONMENT}"
@@ -77,6 +85,9 @@ SUPABASE_ANON_KEY="${SUPABASE_ANON_KEY}"
 DEBUG_MODE="${DEBUG_MODE}"
 ANALYTICS_ENABLED="${ANALYTICS_ENABLED}"
 SENTRY_DSN="${SENTRY_DSN}"
+POSTHOG_API_KEY="${POSTHOG_API_KEY}"
+POSTHOG_HOST="${POSTHOG_HOST}"
+POSTHOG_DEBUG="${POSTHOG_DEBUG}"
 EOF
 
 echo "✅ Environment file created successfully: ${ENV_FILE}"
@@ -86,6 +97,7 @@ echo "   Environment: ${ENVIRONMENT}"
 echo "   Debug Mode: ${DEBUG_MODE}"
 echo "   Analytics: ${ANALYTICS_ENABLED}"
 echo "   Sentry: $([ -n "${SENTRY_DSN}" ] && echo "Enabled" || echo "Disabled")"
+echo "   PostHog: $([ -n "${POSTHOG_API_KEY}" ] && echo "Enabled" || echo "Disabled")"
 echo ""
 
 # Verify the file was created


### PR DESCRIPTION
### 1. PR SUMMARY
First implementation step for PostHog analytics (CA-937). Adds the `posthog_flutter` dependency, wires `POSTHOG_API_KEY`/`POSTHOG_HOST`/`POSTHOG_DEBUG` into `scripts/ci/generate_env_file.sh` (no `POSTHOG_ENABLED` — reuses the existing `ANALYTICS_ENABLED` kill switch per the ticket's resolved comment thread), flips `ANALYTICS_ENABLED`'s per-environment defaults (dev=true, qa/prod=false) to match the one-project rollout, and adds the corresponding key constants to `env_constants.dart` following the `sentryDsnKey` pattern. Nothing is captured and no user is identified by this ticket.

`POSTHOG_DEBUG` is defaulted per-environment (true for dev, false for qa/prod) in the script itself, mirroring how `DEBUG_MODE` is already handled — it isn't sourced from Codemagic since the ticket only lists `POSTHOG_API_KEY`/`POSTHOG_HOST` for the `construculator_dev` environment group.

**Not included in this PR (external/manual step):** Adding real `POSTHOG_API_KEY`/`POSTHOG_HOST` values to the `construculator_dev` Codemagic environment group is a dashboard action outside source control — needs to be done separately by whoever has Codemagic access.

### 2. REVIEW SUMMARY TABLE
No issues found.

## Test plan
- [x] `fvm flutter pub get` — resolves cleanly, `posthog_flutter: 5.35.1` added
- [x] `fvm dart run custom_lint` — clean (1 pre-existing unrelated failure on `main` in `fake_router.dart`, confirmed via `git stash`)
- [x] `fvm flutter test` — all 3169 tests pass
- [x] Ran `generate_env_file.sh` locally for `dev`/`qa`/`prod` — correct `POSTHOG_*` values and flipped `ANALYTICS_ENABLED` defaults land in each generated file
- [x] `fvm flutter build apk --debug --flavor fishfood` — builds successfully with the new dependency (Android verified; iOS build requires a macOS toolchain, not available in this environment)
- [ ] Add `POSTHOG_API_KEY`/`POSTHOG_HOST` to the `construculator_dev` Codemagic environment group (manual, outside this PR)