### PR TITLE
CA-941 (1/6): add analytics domain contracts

### DIFF
--- a/lib/libraries/analytics/domain/entities/analytics_event.dart
+++ b/lib/libraries/analytics/domain/entities/analytics_event.dart
@@ -1,0 +1,19 @@
+import 'package:equatable/equatable.dart';
+
+/// A single trackable analytics event.
+class AnalyticsEvent extends Equatable {
+  /// Creates an [AnalyticsEvent] with the given [name] and optional [properties].
+  const AnalyticsEvent({required this.name, this.properties = const {}});
+
+  /// The event name, e.g. `estimation_created`. Use `snake_case`.
+  final String name;
+
+  /// Event properties sent alongside the event.
+  ///
+  /// Must never contain PII or sensitive values — use user properties via
+  /// `identify()` for user-level data instead.
+  final Map<String, dynamic> properties;
+
+  @override
+  List<Object?> get props => [name, properties];
+}

--- a/lib/libraries/analytics/domain/entities/analytics_event.dart
+++ b/lib/libraries/analytics/domain/entities/analytics_event.dart
@@ -7,7 +7,9 @@ class AnalyticsEvent extends Equatable {
   const AnalyticsEvent({
     required this.name,
     Map<String, dynamic> properties = const {},
-  }) : _properties = properties;
+  })
+    // ignore: prefer_initializing_formals
+    : _properties = properties;
 
   /// The event name, e.g. `estimation_created`. Use `snake_case`.
   final String name;

--- a/lib/libraries/analytics/domain/entities/analytics_event.dart
+++ b/lib/libraries/analytics/domain/entities/analytics_event.dart
@@ -1,19 +1,25 @@
+import 'package:construculator/libraries/analytics/domain/utils/unmodifiable_map_view.dart';
 import 'package:equatable/equatable.dart';
 
 /// A single trackable analytics event.
 class AnalyticsEvent extends Equatable {
   /// Creates an [AnalyticsEvent] with the given [name] and optional [properties].
-  const AnalyticsEvent({required this.name, this.properties = const {}});
+  const AnalyticsEvent({
+    required this.name,
+    Map<String, dynamic> properties = const {},
+  }) : _properties = properties;
 
   /// The event name, e.g. `estimation_created`. Use `snake_case`.
   final String name;
+
+  final Map<String, dynamic> _properties;
 
   /// Event properties sent alongside the event.
   ///
   /// Must never contain PII or sensitive values — use user properties via
   /// `identify()` for user-level data instead.
-  final Map<String, dynamic> properties;
+  Map<String, dynamic> get properties => _properties.unmodifiableView;
 
   @override
-  List<Object?> get props => [name, properties];
+  List<Object?> get props => [name, _properties];
 }

--- a/lib/libraries/analytics/domain/entities/analytics_user_properties.dart
+++ b/lib/libraries/analytics/domain/entities/analytics_user_properties.dart
@@ -10,6 +10,7 @@ class AnalyticsUserProperties extends Equatable {
     this.name,
     this.role,
     Map<String, dynamic> custom = const {},
+    // ignore: prefer_initializing_formals
   }) : _custom = custom;
 
   /// The user's email address.

--- a/lib/libraries/analytics/domain/entities/analytics_user_properties.dart
+++ b/lib/libraries/analytics/domain/entities/analytics_user_properties.dart
@@ -1,3 +1,4 @@
+import 'package:construculator/libraries/analytics/domain/utils/unmodifiable_map_view.dart';
 import 'package:equatable/equatable.dart';
 
 /// Person properties set on the current user via `identify()` or
@@ -8,8 +9,8 @@ class AnalyticsUserProperties extends Equatable {
     this.email,
     this.name,
     this.role,
-    this.custom = const {},
-  });
+    Map<String, dynamic> custom = const {},
+  }) : _custom = custom;
 
   /// The user's email address.
   final String? email;
@@ -20,8 +21,10 @@ class AnalyticsUserProperties extends Equatable {
   /// The user's role.
   final String? role;
 
+  final Map<String, dynamic> _custom;
+
   /// Additional properties not covered by the named fields above.
-  final Map<String, dynamic> custom;
+  Map<String, dynamic> get custom => _custom.unmodifiableView;
 
   /// Flattens the named fields and [custom] into a single map, omitting
   /// unset named fields.
@@ -29,9 +32,9 @@ class AnalyticsUserProperties extends Equatable {
     if (email != null) 'email': email,
     if (name != null) 'name': name,
     if (role != null) 'role': role,
-    ...custom,
+    ..._custom,
   };
 
   @override
-  List<Object?> get props => [email, name, role, custom];
+  List<Object?> get props => [email, name, role, _custom];
 }

--- a/lib/libraries/analytics/domain/entities/analytics_user_properties.dart
+++ b/lib/libraries/analytics/domain/entities/analytics_user_properties.dart
@@ -1,0 +1,37 @@
+import 'package:equatable/equatable.dart';
+
+/// Person properties set on the current user via `identify()` or
+/// `setUserProperties()`.
+class AnalyticsUserProperties extends Equatable {
+  /// Creates [AnalyticsUserProperties].
+  const AnalyticsUserProperties({
+    this.email,
+    this.name,
+    this.role,
+    this.custom = const {},
+  });
+
+  /// The user's email address.
+  final String? email;
+
+  /// The user's display name.
+  final String? name;
+
+  /// The user's role.
+  final String? role;
+
+  /// Additional properties not covered by the named fields above.
+  final Map<String, dynamic> custom;
+
+  /// Flattens the named fields and [custom] into a single map, omitting
+  /// unset named fields.
+  Map<String, dynamic> toMap() => {
+    if (email != null) 'email': email,
+    if (name != null) 'name': name,
+    if (role != null) 'role': role,
+    ...custom,
+  };
+
+  @override
+  List<Object?> get props => [email, name, role, custom];
+}

--- a/lib/libraries/analytics/domain/repositories/analytics_repository.dart
+++ b/lib/libraries/analytics/domain/repositories/analytics_repository.dart
@@ -1,0 +1,44 @@
+import 'package:construculator/libraries/analytics/domain/entities/analytics_event.dart';
+import 'package:construculator/libraries/analytics/domain/entities/analytics_user_properties.dart';
+import 'package:construculator/libraries/either/interfaces/either.dart';
+import 'package:construculator/libraries/errors/failures.dart';
+
+/// Abstract contract for product analytics.
+///
+/// SDK lifecycle methods (initialize, flush) are infrastructure concerns
+/// handled by the implementation and app bootstrap, not part of this
+/// domain-only contract.
+///
+/// Details can be found in the design doc: docs/Logging/Posthog-Integration.md
+abstract class AnalyticsRepository {
+  /// Tracks [event].
+  Future<Either<Failure, void>> track(AnalyticsEvent event);
+
+  /// Associates subsequent events with [userId] and sets [properties] on
+  /// their person profile.
+  Future<Either<Failure, void>> identify({
+    required String userId,
+    required AnalyticsUserProperties properties,
+  });
+
+  /// Clears the current user's identity, reverting to an anonymous session.
+  ///
+  /// Call on logout.
+  Future<Either<Failure, void>> reset();
+
+  /// Updates the current user's person properties without changing identity.
+  Future<Either<Failure, void>> setUserProperties(
+    AnalyticsUserProperties properties,
+  );
+
+  /// Associates the current user with a group of type [groupType] identified
+  /// by [groupKey], optionally setting group [properties].
+  ///
+  /// Call once per group type — a user may belong to several group types
+  /// simultaneously (e.g. both `project` and `company`).
+  Future<Either<Failure, void>> group({
+    required String groupType,
+    required String groupKey,
+    Map<String, dynamic>? properties,
+  });
+}

--- a/lib/libraries/analytics/domain/repositories/analytics_repository.dart
+++ b/lib/libraries/analytics/domain/repositories/analytics_repository.dart
@@ -1,3 +1,4 @@
+// coverage:ignore-file
 import 'package:construculator/libraries/analytics/domain/entities/analytics_event.dart';
 import 'package:construculator/libraries/analytics/domain/entities/analytics_user_properties.dart';
 import 'package:construculator/libraries/either/interfaces/either.dart';

--- a/lib/libraries/analytics/domain/types/analytics_error_type.dart
+++ b/lib/libraries/analytics/domain/types/analytics_error_type.dart
@@ -1,0 +1,7 @@
+// coverage:ignore-file
+
+/// Error type for analytics operations.
+///
+/// - [timeoutError]: the PostHog capture request timed out
+/// - [connectionError]: network connectivity issues reaching PostHog
+enum AnalyticsErrorType { timeoutError, connectionError }

--- a/lib/libraries/analytics/domain/utils/unmodifiable_map_view.dart
+++ b/lib/libraries/analytics/domain/utils/unmodifiable_map_view.dart
@@ -1,0 +1,7 @@
+/// Defensive-copy helper for entities that expose a `Map` field publicly.
+extension UnmodifiableMapView<K, V> on Map<K, V> {
+  /// Returns an unmodifiable view of this map, so callers holding a
+  /// reference to an entity cannot mutate its internal state after
+  /// construction.
+  Map<K, V> get unmodifiableView => Map.unmodifiable(this);
+}

--- a/lib/libraries/errors/failures.dart
+++ b/lib/libraries/errors/failures.dart
@@ -1,3 +1,4 @@
+import 'package:construculator/libraries/analytics/domain/types/analytics_error_type.dart';
 import 'package:construculator/libraries/auth/domain/types/auth_types.dart';
 import 'package:construculator/libraries/estimation/domain/estimation_error_type.dart';
 import 'package:construculator/libraries/global_search/domain/search_error_type.dart';
@@ -84,6 +85,18 @@ class ProjectFailure extends Failure {
 
   /// Creates a [ProjectFailure] with the given [errorType].
   const ProjectFailure({required this.errorType});
+
+  @override
+  List<Object?> get props => [errorType];
+}
+
+/// Failure thrown when an analytics operation fails.
+class AnalyticsFailure extends Failure {
+  /// The type of analytics error that occurred.
+  final AnalyticsErrorType errorType;
+
+  /// Creates an [AnalyticsFailure] with the given [errorType].
+  const AnalyticsFailure({required this.errorType});
 
   @override
   List<Object?> get props => [errorType];

--- a/test/libraries/analytics/units/domain/entities/analytics_event_test.dart
+++ b/test/libraries/analytics/units/domain/entities/analytics_event_test.dart
@@ -1,0 +1,38 @@
+import 'package:construculator/libraries/analytics/domain/entities/analytics_event.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('AnalyticsEvent', () {
+    test('defaults properties to an empty map', () {
+      const event = AnalyticsEvent(name: 'user_logged_in');
+
+      expect(event.properties, isEmpty);
+    });
+
+    test('two events with the same name and properties are equal', () {
+      const first = AnalyticsEvent(
+        name: 'estimation_created',
+        properties: {'estimation_id': 'est-1'},
+      );
+      const second = AnalyticsEvent(
+        name: 'estimation_created',
+        properties: {'estimation_id': 'est-1'},
+      );
+
+      expect(first, second);
+    });
+
+    test('events with different properties are not equal', () {
+      const first = AnalyticsEvent(
+        name: 'estimation_created',
+        properties: {'estimation_id': 'est-1'},
+      );
+      const second = AnalyticsEvent(
+        name: 'estimation_created',
+        properties: {'estimation_id': 'est-2'},
+      );
+
+      expect(first, isNot(second));
+    });
+  });
+}

--- a/test/libraries/analytics/units/domain/entities/analytics_event_test.dart
+++ b/test/libraries/analytics/units/domain/entities/analytics_event_test.dart
@@ -34,5 +34,17 @@ void main() {
 
       expect(first, isNot(second));
     });
+
+    test('properties getter returns an unmodifiable map', () {
+      const event = AnalyticsEvent(
+        name: 'estimation_created',
+        properties: {'estimation_id': 'est-1'},
+      );
+
+      expect(
+        () => event.properties['estimation_id'] = 'est-2',
+        throwsUnsupportedError,
+      );
+    });
   });
 }

--- a/test/libraries/analytics/units/domain/entities/analytics_user_properties_test.dart
+++ b/test/libraries/analytics/units/domain/entities/analytics_user_properties_test.dart
@@ -49,5 +49,16 @@ void main() {
 
       expect(first, second);
     });
+
+    test('custom getter returns an unmodifiable map', () {
+      const properties = AnalyticsUserProperties(
+        custom: {'company_id': 'company-1'},
+      );
+
+      expect(
+        () => properties.custom['company_id'] = 'company-2',
+        throwsUnsupportedError,
+      );
+    });
   });
 }

--- a/test/libraries/analytics/units/domain/entities/analytics_user_properties_test.dart
+++ b/test/libraries/analytics/units/domain/entities/analytics_user_properties_test.dart
@@ -1,0 +1,53 @@
+import 'package:construculator/libraries/analytics/domain/entities/analytics_user_properties.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('AnalyticsUserProperties', () {
+    group('toMap', () {
+      test('omits unset named fields', () {
+        const properties = AnalyticsUserProperties(email: 'a@example.com');
+
+        expect(properties.toMap(), {'email': 'a@example.com'});
+      });
+
+      test('includes all named fields when set', () {
+        const properties = AnalyticsUserProperties(
+          email: 'a@example.com',
+          name: 'Jane Doe',
+          role: 'Project Manager',
+        );
+
+        expect(properties.toMap(), {
+          'email': 'a@example.com',
+          'name': 'Jane Doe',
+          'role': 'Project Manager',
+        });
+      });
+
+      test('merges custom properties alongside named fields', () {
+        const properties = AnalyticsUserProperties(
+          email: 'a@example.com',
+          custom: {'company_id': 'company-1'},
+        );
+
+        expect(properties.toMap(), {
+          'email': 'a@example.com',
+          'company_id': 'company-1',
+        });
+      });
+
+      test('returns an empty map when nothing is set', () {
+        const properties = AnalyticsUserProperties();
+
+        expect(properties.toMap(), isEmpty);
+      });
+    });
+
+    test('two instances with the same fields are equal', () {
+      const first = AnalyticsUserProperties(email: 'a@example.com');
+      const second = AnalyticsUserProperties(email: 'a@example.com');
+
+      expect(first, second);
+    });
+  });
+}


### PR DESCRIPTION
### 1. PR SUMMARY
First slice of the analytics library (CA-941): domain-only contracts. Adds `AnalyticsRepository` (track/identify/reset/setUserProperties/group, all returning `Either<Failure, void>`), `AnalyticsEvent` and `AnalyticsUserProperties` entities, `AnalyticsErrorType`, and `AnalyticsFailure`. No PostHog/SDK import anywhere in this PR — domain stays pure. `FeatureFlagRepository` is intentionally excluded per the ticket (Phase 4 scope, nothing implements or consumes it yet).

Stacked on CA-939 (adds `posthog_flutter` + `POSTHOG_*` env keys, still open) since this ticket needs that dependency. First of 4 PRs for CA-941:
1. Domain contracts (this PR)
2. PostHog SDK boundary (`interfaces/posthog_sdk.dart` + impl + fake)
3. PostHog wrapper with the single enable/consent gate
4. `AnalyticsRepositoryImpl`

### 2. REVIEW SUMMARY TABLE
No issues found.

## Test plan
- [x] `fvm flutter test test/libraries/analytics/` — all pass
- [x] `fvm flutter analyze` — clean on changed files
- [x] `fvm dart run custom_lint` — no new issues (pre-existing `fake_router.dart` violation unrelated, confirmed present on parent branch)