### PR TITLE
CA-941 (2/6): add PostHog SDK boundary

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -60,6 +60,7 @@ custom_lint:
         - 'SentryUser'
         - 'CrudEntry'
         - 'PowerSyncCredentials'
+        - 'Posthog'
 
 linter:
   # The lint rules applied to this project can be customized in the

--- a/lib/libraries/analytics/interfaces/posthog_sdk.dart
+++ b/lib/libraries/analytics/interfaces/posthog_sdk.dart
@@ -1,3 +1,4 @@
+// coverage:ignore-file
 import 'package:posthog_flutter/posthog_flutter.dart';
 
 /// Thin boundary over the static PostHog SDK entry points.
@@ -7,12 +8,20 @@ import 'package:posthog_flutter/posthog_flutter.dart';
 /// against a fake boundary.
 abstract class PosthogSdk {
   /// Initializes the PostHog SDK; mirrors `Posthog().setup`.
+  ///
+  /// [config] the PostHog configuration to initialize the SDK with.
   Future<void> setup(PostHogConfig config);
 
   /// Captures a custom event; mirrors `Posthog().capture`.
+  ///
+  /// [eventName] identifies the event, and [properties] are optional
+  /// key/value pairs attached to it.
   Future<void> capture({required String eventName, Map<String, dynamic>? properties});
 
   /// Associates events with a user; mirrors `Posthog().identify`.
+  ///
+  /// [userId] identifies the user, and [userProperties] are optional
+  /// key/value pairs set on that user.
   Future<void> identify({
     required String userId,
     Map<String, dynamic>? userProperties,
@@ -23,9 +32,16 @@ abstract class PosthogSdk {
 
   /// Sets person properties without changing identity; mirrors
   /// `Posthog().setPersonProperties`.
+  ///
+  /// [userPropertiesToSet] are the key/value pairs to set on the current
+  /// user.
   Future<void> setPersonProperties({Map<String, dynamic>? userPropertiesToSet});
 
   /// Associates the current user with a group; mirrors `Posthog().group`.
+  ///
+  /// [groupType] the kind of group (e.g. `company`), [groupKey] identifies
+  /// the specific group, and [groupProperties] are optional key/value pairs
+  /// set on that group.
   Future<void> group({
     required String groupType,
     required String groupKey,

--- a/lib/libraries/analytics/interfaces/posthog_sdk.dart
+++ b/lib/libraries/analytics/interfaces/posthog_sdk.dart
@@ -1,0 +1,34 @@
+import 'package:posthog_flutter/posthog_flutter.dart';
+
+/// Thin boundary over the static PostHog SDK entry points.
+///
+/// `PosthogWrapperImpl` talks to this interface instead of the `Posthog()`
+/// singleton directly so its gate logic and lifecycle can be unit-tested
+/// against a fake boundary.
+abstract class PosthogSdk {
+  /// Initializes the PostHog SDK; mirrors `Posthog().setup`.
+  Future<void> setup(PostHogConfig config);
+
+  /// Captures a custom event; mirrors `Posthog().capture`.
+  Future<void> capture({required String eventName, Map<String, dynamic>? properties});
+
+  /// Associates events with a user; mirrors `Posthog().identify`.
+  Future<void> identify({
+    required String userId,
+    Map<String, dynamic>? userProperties,
+  });
+
+  /// Resets all cached identity; mirrors `Posthog().reset`.
+  Future<void> reset();
+
+  /// Sets person properties without changing identity; mirrors
+  /// `Posthog().setPersonProperties`.
+  Future<void> setPersonProperties({Map<String, dynamic>? userPropertiesToSet});
+
+  /// Associates the current user with a group; mirrors `Posthog().group`.
+  Future<void> group({
+    required String groupType,
+    required String groupKey,
+    Map<String, dynamic>? groupProperties,
+  });
+}

--- a/lib/libraries/analytics/posthog_sdk_impl.dart
+++ b/lib/libraries/analytics/posthog_sdk_impl.dart
@@ -1,0 +1,67 @@
+// coverage:ignore-file
+// Thin pass-through to the static PostHog SDK entry points, which rely on
+// native platform channels and a running host app and therefore cannot be
+// exercised in unit tests.
+
+import 'package:construculator/libraries/analytics/interfaces/posthog_sdk.dart';
+import 'package:posthog_flutter/posthog_flutter.dart';
+
+/// Production [PosthogSdk] that delegates to the `Posthog()` singleton.
+class PosthogSdkImpl implements PosthogSdk {
+  @override
+  Future<void> setup(PostHogConfig config) {
+    return Posthog().setup(config);
+  }
+
+  @override
+  Future<void> capture({
+    required String eventName,
+    Map<String, dynamic>? properties,
+  }) {
+    return Posthog().capture(
+      eventName: eventName,
+      properties: properties?.cast<String, Object>(),
+    );
+  }
+
+  @override
+  Future<void> identify({
+    required String userId,
+    Map<String, dynamic>? userProperties,
+  }) {
+    return Posthog().identify(
+      userId: userId,
+      userProperties: userProperties?.cast<String, Object>(),
+    );
+  }
+
+  @override
+  Future<void> reset() {
+    return Posthog().reset();
+  }
+
+  @override
+  Future<void> setPersonProperties({
+    Map<String, dynamic>? userPropertiesToSet,
+  }) {
+    return Posthog().setPersonProperties(
+      userPropertiesToSet: userPropertiesToSet?.cast<String, Object>(),
+    );
+  }
+
+  @override
+  Future<void> group({
+    required String groupType,
+    required String groupKey,
+    Map<String, dynamic>? groupProperties,
+  }) {
+    // False positive: the lint's test-block detector matches any call named
+    // `group`, including this SDK method of the same name.
+    return Posthog().group(
+      groupType: groupType,
+      groupKey: groupKey,
+      // ignore: no_optional_operators_in_tests
+      groupProperties: groupProperties?.cast<String, Object>(),
+    );
+  }
+}


### PR DESCRIPTION
### 1. PR SUMMARY
Second slice of CA-941: the thin SDK boundary. `interfaces/posthog_sdk.dart` wraps the `Posthog()` singleton's entry points (setup/capture/identify/reset/setPersonProperties/group), mirroring `SentrySdk`. `posthog_sdk_impl.dart` is a `coverage:ignore-file` pass-through — it talks to native platform channels and can't be exercised in unit tests, same as `SentrySdkImpl`, so it has no direct test of its own; it's exercised indirectly once `PosthogWrapperImpl` is added.

Also allowlists `Posthog` in `no_direct_instantiation`'s `ast_type_prefixes`, matching the existing exemptions for `SentryFlutterOptions`/`SentryId`/`SentryUser`/`PowerSyncCredentials` — third-party SDK boundary types that legitimately need direct construction.

One inline `no_optional_operators_in_tests` suppression: that lint's test-block detector matches any method invocation literally named `group` (to catch `package:test`'s `group()`), which false-positives on PostHog's own `group()` API method of the same name.

Split from the original PR — bundling interface + impl + fake would have been 246 production lines, over the 200-line ceiling. The batch has since grown to 6 slices total; this is 2/6, and the fake ships separately as 3/6.

### 2. REVIEW SUMMARY TABLE
No issues found.

## Test plan
- [x] `fvm flutter analyze lib/libraries/analytics/` — clean
- [x] `fvm dart run custom_lint lib/libraries/analytics/` — no new issues (pre-existing `fake_router.dart` violation unrelated)
- [x] No behavior to unit test at this layer — pure pass-through, matches `SentrySdkImpl` precedent
