### PR TITLE
CA-941 (3/6): add FakePosthogSdk

### DIFF
--- a/lib/libraries/analytics/testing/fake_posthog_sdk.dart
+++ b/lib/libraries/analytics/testing/fake_posthog_sdk.dart
@@ -1,0 +1,145 @@
+import 'package:construculator/libraries/analytics/interfaces/posthog_sdk.dart';
+import 'package:equatable/equatable.dart';
+import 'package:posthog_flutter/posthog_flutter.dart';
+
+/// Fake [PosthogSdk] boundary that records calls for unit tests.
+class FakePosthogSdk implements PosthogSdk {
+  /// Number of times [setup] was called.
+  int setupCallCount = 0;
+
+  /// The config passed to the last [setup] call.
+  PostHogConfig? lastConfig;
+
+  /// Recorded calls to [capture].
+  final List<CaptureCall> capturedEvents = [];
+
+  /// Recorded calls to [identify].
+  final List<IdentifyCall> identifyCalls = [];
+
+  /// Number of times [reset] was called.
+  int resetCallCount = 0;
+
+  /// Recorded calls to [setPersonProperties].
+  final List<Map<String, dynamic>?> setPersonPropertiesCalls = [];
+
+  /// Recorded calls to [group].
+  final List<GroupCall> groupCalls = [];
+
+  /// Restores the fake to its initial state.
+  ///
+  /// Named to avoid colliding with [reset], the interface method under test.
+  void resetFake() {
+    setupCallCount = 0;
+    lastConfig = null;
+    capturedEvents.clear();
+    identifyCalls.clear();
+    resetCallCount = 0;
+    setPersonPropertiesCalls.clear();
+    groupCalls.clear();
+  }
+
+  @override
+  Future<void> setup(PostHogConfig config) async {
+    setupCallCount++;
+    lastConfig = config;
+  }
+
+  @override
+  Future<void> capture({
+    required String eventName,
+    Map<String, dynamic>? properties,
+  }) async {
+    capturedEvents.add(
+      CaptureCall(eventName: eventName, properties: properties),
+    );
+  }
+
+  @override
+  Future<void> identify({
+    required String userId,
+    Map<String, dynamic>? userProperties,
+  }) async {
+    identifyCalls.add(
+      IdentifyCall(userId: userId, userProperties: userProperties),
+    );
+  }
+
+  @override
+  Future<void> reset() async {
+    resetCallCount++;
+  }
+
+  @override
+  Future<void> setPersonProperties({
+    Map<String, dynamic>? userPropertiesToSet,
+  }) async {
+    setPersonPropertiesCalls.add(userPropertiesToSet);
+  }
+
+  @override
+  Future<void> group({
+    required String groupType,
+    required String groupKey,
+    Map<String, dynamic>? groupProperties,
+  }) async {
+    groupCalls.add(
+      GroupCall(
+        groupType: groupType,
+        groupKey: groupKey,
+        groupProperties: groupProperties,
+      ),
+    );
+  }
+}
+
+/// Represents a call to [FakePosthogSdk.capture].
+class CaptureCall extends Equatable {
+  /// Creates a recorded capture call.
+  const CaptureCall({required this.eventName, this.properties});
+
+  /// Captured event name.
+  final String eventName;
+
+  /// Optional event properties.
+  final Map<String, dynamic>? properties;
+
+  @override
+  List<Object?> get props => [eventName, properties];
+}
+
+/// Represents a call to [FakePosthogSdk.identify].
+class IdentifyCall extends Equatable {
+  /// Creates a recorded identify call.
+  const IdentifyCall({required this.userId, this.userProperties});
+
+  /// Identified user id.
+  final String userId;
+
+  /// Optional user properties.
+  final Map<String, dynamic>? userProperties;
+
+  @override
+  List<Object?> get props => [userId, userProperties];
+}
+
+/// Represents a call to [FakePosthogSdk.group].
+class GroupCall extends Equatable {
+  /// Creates a recorded group call.
+  const GroupCall({
+    required this.groupType,
+    required this.groupKey,
+    this.groupProperties,
+  });
+
+  /// Group type, e.g. `project`.
+  final String groupType;
+
+  /// Group key.
+  final String groupKey;
+
+  /// Optional group properties.
+  final Map<String, dynamic>? groupProperties;
+
+  @override
+  List<Object?> get props => [groupType, groupKey, groupProperties];
+}

--- a/lib/libraries/analytics/testing/fake_posthog_sdk.dart
+++ b/lib/libraries/analytics/testing/fake_posthog_sdk.dart
@@ -20,7 +20,7 @@ class FakePosthogSdk implements PosthogSdk {
   int resetCallCount = 0;
 
   /// Recorded calls to [setPersonProperties].
-  final List<Map<String, dynamic>?> setPersonPropertiesCalls = [];
+  final List<SetPersonPropertiesCall> setPersonPropertiesCalls = [];
 
   /// Recorded calls to [group].
   final List<GroupCall> groupCalls = [];
@@ -73,7 +73,9 @@ class FakePosthogSdk implements PosthogSdk {
   Future<void> setPersonProperties({
     Map<String, dynamic>? userPropertiesToSet,
   }) async {
-    setPersonPropertiesCalls.add(userPropertiesToSet);
+    setPersonPropertiesCalls.add(
+      SetPersonPropertiesCall(userPropertiesToSet: userPropertiesToSet),
+    );
   }
 
   @override
@@ -120,6 +122,18 @@ class IdentifyCall extends Equatable {
 
   @override
   List<Object?> get props => [userId, userProperties];
+}
+
+/// Represents a call to [FakePosthogSdk.setPersonProperties].
+class SetPersonPropertiesCall extends Equatable {
+  /// Creates a recorded setPersonProperties call.
+  const SetPersonPropertiesCall({this.userPropertiesToSet});
+
+  /// Optional user properties to set.
+  final Map<String, dynamic>? userPropertiesToSet;
+
+  @override
+  List<Object?> get props => [userPropertiesToSet];
 }
 
 /// Represents a call to [FakePosthogSdk.group].

--- a/lib/libraries/analytics/testing/fake_posthog_sdk.dart
+++ b/lib/libraries/analytics/testing/fake_posthog_sdk.dart
@@ -1,3 +1,5 @@
+// coverage:ignore-file
+
 import 'package:construculator/libraries/analytics/interfaces/posthog_sdk.dart';
 import 'package:equatable/equatable.dart';
 import 'package:posthog_flutter/posthog_flutter.dart';


### PR DESCRIPTION
### 1. PR SUMMARY
Third slice of CA-941: `testing/fake_posthog_sdk.dart`, the fake for the SDK-boundary interface added in PR 2/5. Records `setup`/`capture`/`identify`/`reset`/`setPersonProperties`/`group` calls via typed `Equatable` records (`CaptureCall`, `IdentifyCall`, `GroupCall`) so consumer tests can assert on captured events by value.

No direct test of its own — it's exercised by `PosthogWrapperImpl`'s tests in the next PR, same as `FakeSentrySdk` has no direct test and is only exercised via `sentry_wrapper_impl_test.dart`.

### 2. REVIEW SUMMARY TABLE
No issues found.

## Test plan
- [x] `fvm flutter analyze lib/libraries/analytics/` — clean
- [x] `fvm dart run custom_lint lib/libraries/analytics/testing/fake_posthog_sdk.dart` — no new issues