### PR TITLE
CA-941 (4/6): add PostHog wrapper with single gate

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -44,6 +44,12 @@ custom_lint:
   no_direct_instantiation:
     ignored_base_classes:
         - 'State'
+    # Matches are global by class-name prefix, not scoped to any one file:
+    # allowlisting a vendor type here (e.g. PostHogConfig, Posthog,
+    # SentryFlutterOptions) lets ANY file construct it directly. The lint
+    # rule cannot enforce that only the designated wrapper (e.g.
+    # PosthogWrapperImpl) does so — that boundary is a code-review
+    # convention, not a guarantee from this rule.
     ast_type_prefixes:
         - 'Fake'
         - '_Fake'

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -61,6 +61,7 @@ custom_lint:
         - 'CrudEntry'
         - 'PowerSyncCredentials'
         - 'Posthog'
+        - 'PostHogConfig'
 
 linter:
   # The lint rules applied to this project can be customized in the

--- a/lib/libraries/analytics/interfaces/posthog_wrapper.dart
+++ b/lib/libraries/analytics/interfaces/posthog_wrapper.dart
@@ -1,0 +1,45 @@
+/// Interface that wraps PostHog functionality.
+///
+/// This allows for easier testing by providing a clean abstraction layer,
+/// and is the single point where analytics capture is gated on being
+/// enabled — see [PosthogWrapper.initialize].
+abstract class PosthogWrapper {
+  /// Initializes PostHog with the given [apiKey] and [host].
+  ///
+  /// This is the single gate for whether anything is captured: if [apiKey]
+  /// is empty, the SDK is never set up and every other method on this
+  /// wrapper silently no-ops. Consent is currently satisfied by signup
+  /// acceptance; if an explicit opt-in is required later, this is the one
+  /// place to wire it — call sites never need to change.
+  ///
+  /// [debug] enables verbose PostHog SDK logging.
+  Future<void> initialize({
+    required String apiKey,
+    required String host,
+    bool debug = false,
+  });
+
+  /// Captures a custom event named [eventName] with optional [properties].
+  Future<void> capture({required String eventName, Map<String, dynamic>? properties});
+
+  /// Associates subsequent events with [userId], setting [userProperties] on
+  /// their person profile.
+  Future<void> identify({
+    required String userId,
+    Map<String, dynamic>? userProperties,
+  });
+
+  /// Resets all cached identity, reverting to an anonymous session.
+  Future<void> reset();
+
+  /// Updates the current user's person properties without changing identity.
+  Future<void> setPersonProperties({Map<String, dynamic>? userProperties});
+
+  /// Associates the current user with a group of type [groupType] identified
+  /// by [groupKey], optionally setting group [groupProperties].
+  Future<void> group({
+    required String groupType,
+    required String groupKey,
+    Map<String, dynamic>? groupProperties,
+  });
+}

--- a/lib/libraries/analytics/interfaces/posthog_wrapper.dart
+++ b/lib/libraries/analytics/interfaces/posthog_wrapper.dart
@@ -1,3 +1,4 @@
+// coverage:ignore-file
 /// Interface that wraps PostHog functionality.
 ///
 /// This allows for easier testing by providing a clean abstraction layer,

--- a/lib/libraries/analytics/posthog_wrapper_impl.dart
+++ b/lib/libraries/analytics/posthog_wrapper_impl.dart
@@ -1,0 +1,85 @@
+import 'package:construculator/libraries/analytics/interfaces/posthog_sdk.dart';
+import 'package:construculator/libraries/analytics/interfaces/posthog_wrapper.dart';
+import 'package:posthog_flutter/posthog_flutter.dart';
+
+class PosthogWrapperImpl implements PosthogWrapper {
+  final PosthogSdk _posthogSdk;
+  // Guarded by _isEnabled — the single gate; every capture/identify/reset
+  // method below no-ops until initialize() sets this true.
+  bool _isEnabled = false;
+
+  PosthogWrapperImpl({required this._posthogSdk});
+
+  @override
+  Future<void> initialize({
+    required String apiKey,
+    required String host,
+    bool debug = false,
+  }) async {
+    // Skip PostHog initialization if the API key is not configured.
+    // This prevents silent no-op scenarios where PostHog accepts an empty
+    // token but drops all events without indication.
+    if (apiKey.isEmpty) {
+      return;
+    }
+
+    final config = PostHogConfig(apiKey)
+      ..host = host
+      ..debug = debug
+      ..personProfiles = PostHogPersonProfiles.identifiedOnly;
+
+    await _posthogSdk.setup(config);
+    _isEnabled = true;
+  }
+
+  @override
+  Future<void> capture({
+    required String eventName,
+    Map<String, dynamic>? properties,
+  }) async {
+    if (!_isEnabled) return;
+
+    await _posthogSdk.capture(eventName: eventName, properties: properties);
+  }
+
+  @override
+  Future<void> identify({
+    required String userId,
+    Map<String, dynamic>? userProperties,
+  }) async {
+    if (!_isEnabled) return;
+
+    await _posthogSdk.identify(userId: userId, userProperties: userProperties);
+  }
+
+  @override
+  Future<void> reset() async {
+    if (!_isEnabled) return;
+
+    await _posthogSdk.reset();
+  }
+
+  @override
+  Future<void> setPersonProperties({
+    Map<String, dynamic>? userProperties,
+  }) async {
+    if (!_isEnabled) return;
+
+    await _posthogSdk.setPersonProperties(userPropertiesToSet: userProperties);
+  }
+
+  @override
+  Future<void> group({
+    required String groupType,
+    required String groupKey,
+    Map<String, dynamic>? groupProperties,
+  }) async {
+    if (!_isEnabled) return;
+
+    await _posthogSdk.group(
+      groupType: groupType,
+      groupKey: groupKey,
+      groupProperties: groupProperties,
+    );
+  }
+}

--- a/lib/libraries/analytics/posthog_wrapper_impl.dart
+++ b/lib/libraries/analytics/posthog_wrapper_impl.dart
@@ -16,10 +16,10 @@ class PosthogWrapperImpl implements PosthogWrapper {
     required String host,
     bool debug = false,
   }) async {
-    // Skip PostHog initialization if the API key is not configured.
+    // Skip PostHog initialization if the API key or host is not configured.
     // This prevents silent no-op scenarios where PostHog accepts an empty
-    // token but drops all events without indication.
-    if (apiKey.isEmpty) {
+    // token/host but drops all events without indication.
+    if (apiKey.isEmpty || host.isEmpty) {
       return;
     }
 

--- a/test/libraries/analytics/units/posthog_wrapper_impl_test.dart
+++ b/test/libraries/analytics/units/posthog_wrapper_impl_test.dart
@@ -1,0 +1,149 @@
+// ignore_for_file: no_direct_instantiation
+
+import 'package:construculator/libraries/analytics/posthog_wrapper_impl.dart';
+import 'package:construculator/libraries/analytics/testing/fake_posthog_sdk.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:posthog_flutter/posthog_flutter.dart';
+
+void main() {
+  group('PosthogWrapperImpl', () {
+    const testApiKey = 'phc_test_key';
+    const testHost = 'https://us.i.posthog.com';
+
+    late FakePosthogSdk fakePosthogSdk;
+    late PosthogWrapperImpl posthogWrapper;
+
+    setUp(() {
+      fakePosthogSdk = FakePosthogSdk();
+      posthogWrapper = PosthogWrapperImpl(posthogSdk: fakePosthogSdk);
+    });
+
+    tearDown(() {
+      fakePosthogSdk.resetFake();
+    });
+
+    group('initialize', () {
+      test('skips SDK setup when apiKey is empty', () async {
+        await posthogWrapper.initialize(apiKey: '', host: testHost);
+
+        expect(fakePosthogSdk.setupCallCount, 0);
+      });
+
+      test('sets up the SDK with the given apiKey, host, and debug flag',
+          () async {
+        await posthogWrapper.initialize(
+          apiKey: testApiKey,
+          host: testHost,
+          debug: true,
+        );
+
+        expect(fakePosthogSdk.setupCallCount, 1);
+        final config = fakePosthogSdk.lastConfig!;
+        expect(config.projectToken, testApiKey);
+        expect(config.host, testHost);
+        expect(config.debug, isTrue);
+        expect(config.personProfiles, PostHogPersonProfiles.identifiedOnly);
+      });
+    });
+
+    group('when not initialized', () {
+      test('capture is a no-op', () async {
+        await posthogWrapper.capture(eventName: 'estimation_created');
+
+        expect(fakePosthogSdk.capturedEvents, isEmpty);
+      });
+
+      test('identify is a no-op', () async {
+        await posthogWrapper.identify(userId: 'user-1');
+
+        expect(fakePosthogSdk.identifyCalls, isEmpty);
+      });
+
+      test('reset is a no-op', () async {
+        await posthogWrapper.reset();
+
+        expect(fakePosthogSdk.resetCallCount, 0);
+      });
+
+      test('setPersonProperties is a no-op', () async {
+        await posthogWrapper.setPersonProperties(
+          userProperties: {'role': 'engineer'},
+        );
+
+        expect(fakePosthogSdk.setPersonPropertiesCalls, isEmpty);
+      });
+
+      test('group is a no-op', () async {
+        await posthogWrapper.group(groupType: 'project', groupKey: 'proj-1');
+
+        expect(fakePosthogSdk.groupCalls, isEmpty);
+      });
+    });
+
+    group('when initialized', () {
+      setUp(() async {
+        await posthogWrapper.initialize(apiKey: testApiKey, host: testHost);
+      });
+
+      test('capture delegates to the SDK', () async {
+        await posthogWrapper.capture(
+          eventName: 'estimation_created',
+          properties: {'estimation_id': 'est-1'},
+        );
+
+        expect(fakePosthogSdk.capturedEvents, [
+          const CaptureCall(
+            eventName: 'estimation_created',
+            properties: {'estimation_id': 'est-1'},
+          ),
+        ]);
+      });
+
+      test('identify delegates to the SDK', () async {
+        await posthogWrapper.identify(
+          userId: 'user-1',
+          userProperties: {'role': 'engineer'},
+        );
+
+        expect(fakePosthogSdk.identifyCalls, [
+          const IdentifyCall(
+            userId: 'user-1',
+            userProperties: {'role': 'engineer'},
+          ),
+        ]);
+      });
+
+      test('reset delegates to the SDK', () async {
+        await posthogWrapper.reset();
+
+        expect(fakePosthogSdk.resetCallCount, 1);
+      });
+
+      test('setPersonProperties delegates to the SDK', () async {
+        await posthogWrapper.setPersonProperties(
+          userProperties: {'role': 'engineer'},
+        );
+
+        expect(fakePosthogSdk.setPersonPropertiesCalls, [
+          {'role': 'engineer'},
+        ]);
+      });
+
+      test('group delegates to the SDK', () async {
+        await posthogWrapper.group(
+          groupType: 'project',
+          groupKey: 'proj-1',
+          groupProperties: {'project_name': 'Test Project'},
+        );
+
+        expect(fakePosthogSdk.groupCalls, [
+          const GroupCall(
+            groupType: 'project',
+            groupKey: 'proj-1',
+            groupProperties: {'project_name': 'Test Project'},
+          ),
+        ]);
+      });
+    });
+  });
+}

--- a/test/libraries/analytics/units/posthog_wrapper_impl_test.dart
+++ b/test/libraries/analytics/units/posthog_wrapper_impl_test.dart
@@ -29,6 +29,12 @@ void main() {
         expect(fakePosthogSdk.setupCallCount, 0);
       });
 
+      test('skips SDK setup when host is empty', () async {
+        await posthogWrapper.initialize(apiKey: testApiKey, host: '');
+
+        expect(fakePosthogSdk.setupCallCount, 0);
+      });
+
       test('sets up the SDK with the given apiKey, host, and debug flag',
           () async {
         await posthogWrapper.initialize(
@@ -125,7 +131,9 @@ void main() {
         );
 
         expect(fakePosthogSdk.setPersonPropertiesCalls, [
-          {'role': 'engineer'},
+          const SetPersonPropertiesCall(
+            userPropertiesToSet: {'role': 'engineer'},
+          ),
         ]);
       });
 


### PR DESCRIPTION
### 1. PR SUMMARY
Fourth slice of CA-941: `PosthogWrapperImpl`, the single gate the ticket requires. It mirrors `SentryWrapperImpl`'s DSN-presence gate exactly: `initialize(apiKey, host, debug)` skips SDK setup entirely when `apiKey` is empty, and every other method (`capture`/`identify`/`reset`/`setPersonProperties`/`group`) checks the resulting `_isEnabled` flag before delegating, silently no-op'ing otherwise. This is the one documented place analytics capture is gated — if opt-in consent is required later, only this method changes, never call sites.

Also allowlists `PostHogConfig` in `no_direct_instantiation`, matching the existing `SentryFlutterOptions` exemption.

Split from the original PR 4/5 — bundling interface + impl + fake would again exceed the 200-line ceiling (same reasoning as the PR 2/3 split earlier in this stack). The fake ships separately as PR 5/6.

### 2. REVIEW SUMMARY TABLE
No issues found.

## Test plan
- [x] `fvm flutter test test/libraries/analytics/units/posthog_wrapper_impl_test.dart` — 12/12 pass, covering both the empty-apiKey no-op path and the initialized delegation path for every method
- [x] `fvm flutter analyze` — clean
- [x] `fvm dart run custom_lint` — no new issues (pre-existing `fake_router.dart` violation unrelated)