### PR TITLE
CA-942 (1/2): add NoOpAnalyticsRepository

### DIFF
--- a/lib/libraries/analytics/data/repositories/no_op_analytics_repository.dart
+++ b/lib/libraries/analytics/data/repositories/no_op_analytics_repository.dart
@@ -1,0 +1,47 @@
+import 'package:construculator/libraries/analytics/domain/entities/analytics_event.dart';
+import 'package:construculator/libraries/analytics/domain/entities/analytics_user_properties.dart';
+import 'package:construculator/libraries/analytics/domain/repositories/analytics_repository.dart';
+import 'package:construculator/libraries/either/either.dart';
+import 'package:construculator/libraries/errors/failures.dart';
+
+/// Production no-op used when `POSTHOG_ENABLED=false`.
+///
+/// Not a test double — for tests, inject `FakePosthogWrapper` into
+/// [AnalyticsRepositoryImpl] instead.
+class NoOpAnalyticsRepository implements AnalyticsRepository {
+  const NoOpAnalyticsRepository();
+
+  @override
+  Future<Either<Failure, void>> track(AnalyticsEvent event) async {
+    return const Right(null);
+  }
+
+  @override
+  Future<Either<Failure, void>> identify({
+    required String userId,
+    required AnalyticsUserProperties properties,
+  }) async {
+    return const Right(null);
+  }
+
+  @override
+  Future<Either<Failure, void>> reset() async {
+    return const Right(null);
+  }
+
+  @override
+  Future<Either<Failure, void>> setUserProperties(
+    AnalyticsUserProperties properties,
+  ) async {
+    return const Right(null);
+  }
+
+  @override
+  Future<Either<Failure, void>> group({
+    required String groupType,
+    required String groupKey,
+    Map<String, dynamic>? properties,
+  }) async {
+    return const Right(null);
+  }
+}

--- a/test/libraries/analytics/units/data/repositories/no_op_analytics_repository_test.dart
+++ b/test/libraries/analytics/units/data/repositories/no_op_analytics_repository_test.dart
@@ -1,0 +1,59 @@
+// ignore_for_file: no_direct_instantiation
+
+import 'package:construculator/libraries/analytics/data/repositories/no_op_analytics_repository.dart';
+import 'package:construculator/libraries/analytics/domain/entities/analytics_event.dart';
+import 'package:construculator/libraries/analytics/domain/entities/analytics_user_properties.dart';
+import 'package:construculator/libraries/either/either.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+void _expectRight<L, R>(Either<L, R> result, void Function(R value) assertions) {
+  result.fold((_) => fail('Expected Right but got Left'), assertions);
+}
+
+void main() {
+  group('NoOpAnalyticsRepository', () {
+    const repository = NoOpAnalyticsRepository();
+
+    test('track returns Right(null)', () async {
+      final result = await repository.track(const AnalyticsEvent(name: 'event'));
+
+      _expectRight(result, (_) {});
+    });
+
+    test('identify returns Right(null)', () async {
+      final result = await repository.identify(
+        userId: 'user-1',
+        properties: const AnalyticsUserProperties(),
+      );
+
+      _expectRight(result, (_) {});
+    });
+
+    test('reset returns Right(null)', () async {
+      final result = await repository.reset();
+
+      _expectRight(result, (_) {});
+    });
+
+    test('setUserProperties returns Right(null)', () async {
+      final result = await repository.setUserProperties(
+        const AnalyticsUserProperties(),
+      );
+
+      _expectRight(result, (_) {});
+    });
+
+    test('group returns Right(null)', () async {
+      final result = await repository.group(
+        groupType: 'project',
+        groupKey: 'project-1',
+      );
+
+      _expectRight(result, (_) {});
+    });
+  });
+}


### PR DESCRIPTION
### 1. PR SUMMARY
Adds `NoOpAnalyticsRepository`, the production no-op `AnalyticsRepository` implementation used when `POSTHOG_ENABLED=false`. All five contract methods (`track`, `identify`, `reset`, `setUserProperties`, `group`) return `Right(null)` immediately with no I/O and no state. Not a test double — for tests, `FakePosthogWrapper` is injected into the real `AnalyticsRepositoryImpl` instead. Part 1 of 2 for CA-942 (module wiring + bootstrap selection lands in part 2, stacked on this branch).

### 2. REVIEW SUMMARY TABLE
No issues found.

## Test plan
- [x] `fvm dart run custom_lint` clean (pre-existing unrelated issue in `fake_router.dart` present on base branch)
- [x] `fvm flutter test` green (3200 tests)