### PR TITLE
CA-942 (2/2): wire AnalyticsModule and bootstrap selection

### DIFF
--- a/assets/env/.env.template
+++ b/assets/env/.env.template
@@ -10,5 +10,6 @@ SENTRY_DSN=
 POSTHOG_API_KEY=
 POSTHOG_HOST=
 POSTHOG_DEBUG=true
+POSTHOG_ENABLED=false
 
 # Create copies for .env.dev, .env.qa, .env.prod

--- a/assets/env/.env.template
+++ b/assets/env/.env.template
@@ -10,6 +10,5 @@ SENTRY_DSN=
 POSTHOG_API_KEY=
 POSTHOG_HOST=
 POSTHOG_DEBUG=true
-POSTHOG_ENABLED=false
 
 # Create copies for .env.dev, .env.qa, .env.prod

--- a/lib/app/app_bootstrap.dart
+++ b/lib/app/app_bootstrap.dart
@@ -1,4 +1,5 @@
 // coverage:ignore-file
+import 'package:construculator/libraries/analytics/domain/repositories/analytics_repository.dart';
 import 'package:construculator/libraries/config/interfaces/config.dart';
 import 'package:construculator/libraries/config/interfaces/env_loader.dart';
 import 'package:construculator/libraries/sentry/interfaces/sentry_wrapper.dart';
@@ -95,10 +96,16 @@ class AppBootstrap {
   /// Its [initialize] method must be called with the app runner to enable error tracking.
   final SentryWrapper sentryWrapper;
 
+  /// The analytics repository, resolved to either the real PostHog-backed
+  /// implementation or `NoOpAnalyticsRepository` based on `POSTHOG_ENABLED`.
+  /// Must be fully initialized (if real) before passing to the app module.
+  final AnalyticsRepository analyticsRepository;
+
   AppBootstrap({
     required this.envLoader,
     required this.config,
     required this.supabaseWrapper,
     required this.sentryWrapper,
+    required this.analyticsRepository,
   });
 }

--- a/lib/app/app_bootstrap.dart
+++ b/lib/app/app_bootstrap.dart
@@ -97,7 +97,7 @@ class AppBootstrap {
   final SentryWrapper sentryWrapper;
 
   /// The analytics repository, resolved to either the real PostHog-backed
-  /// implementation or `NoOpAnalyticsRepository` based on `POSTHOG_ENABLED`.
+  /// implementation or `NoOpAnalyticsRepository` based on `ANALYTICS_ENABLED`.
   /// Must be fully initialized (if real) before passing to the app module.
   final AnalyticsRepository analyticsRepository;
 

--- a/lib/app/app_module.dart
+++ b/lib/app/app_module.dart
@@ -3,6 +3,7 @@ import 'package:construculator/app/app_bootstrap.dart';
 import 'package:construculator/app/shell/shell_module.dart';
 import 'package:construculator/features/auth/auth_module.dart';
 import 'package:construculator/features/project/project_module.dart';
+import 'package:construculator/libraries/analytics/analytics_module.dart';
 import 'package:construculator/libraries/auth/auth_library_module.dart';
 import 'package:construculator/libraries/config/config_module.dart';
 import 'package:construculator/libraries/router/router_module.dart';
@@ -18,6 +19,7 @@ class AppModule extends Module {
     RouterModule(),
     ConfigModule(appBootstrap),
     SupabaseModule(appBootstrap),
+    AnalyticsModule(appBootstrap),
     AuthLibraryModule(appBootstrap),
     ProjectModule(appBootstrap),
   ];

--- a/lib/features/auth/testing/auth_test_module.dart
+++ b/lib/features/auth/testing/auth_test_module.dart
@@ -15,6 +15,7 @@ import 'package:construculator/features/auth/presentation/bloc/login_with_email_
 import 'package:construculator/features/auth/presentation/bloc/otp_verification_bloc/otp_verification_bloc.dart';
 import 'package:construculator/features/auth/presentation/bloc/register_with_email_bloc/register_with_email_bloc.dart';
 import 'package:construculator/features/auth/presentation/bloc/set_new_password_bloc/set_new_password_bloc.dart';
+import 'package:construculator/libraries/analytics/data/repositories/no_op_analytics_repository.dart';
 import 'package:construculator/libraries/auth/auth_library_module.dart';
 import 'package:construculator/libraries/auth/interfaces/auth_notifier.dart';
 import 'package:construculator/libraries/auth/interfaces/auth_notifier_controller.dart';
@@ -41,6 +42,7 @@ class AuthTestModule extends Module {
         config: FakeAppConfig(),
         supabaseWrapper: FakeSupabaseWrapper(clock: FakeClockImpl()),
         sentryWrapper: FakeSentryWrapper(),
+        analyticsRepository: const NoOpAnalyticsRepository(),
       ),
     ),
     RouterTestModule(),

--- a/lib/libraries/analytics/analytics_module.dart
+++ b/lib/libraries/analytics/analytics_module.dart
@@ -1,0 +1,12 @@
+import 'package:construculator/app/app_bootstrap.dart';
+import 'package:construculator/libraries/analytics/domain/repositories/analytics_repository.dart';
+import 'package:flutter_modular/flutter_modular.dart';
+
+class AnalyticsModule extends Module {
+  final AppBootstrap appBootstrap;
+  AnalyticsModule(this.appBootstrap);
+  @override
+  void exportedBinds(Injector i) {
+    i.addLazySingleton<AnalyticsRepository>(() => appBootstrap.analyticsRepository);
+  }
+}

--- a/lib/libraries/analytics/analytics_repository_factory.dart
+++ b/lib/libraries/analytics/analytics_repository_factory.dart
@@ -1,0 +1,37 @@
+import 'package:construculator/libraries/analytics/data/repositories/analytics_repository_impl.dart';
+import 'package:construculator/libraries/analytics/data/repositories/no_op_analytics_repository.dart';
+import 'package:construculator/libraries/analytics/domain/repositories/analytics_repository.dart';
+import 'package:construculator/libraries/analytics/interfaces/posthog_wrapper.dart';
+import 'package:construculator/libraries/config/env_constants.dart';
+import 'package:construculator/libraries/config/interfaces/env_loader.dart';
+
+/// Builds the [PosthogWrapper] backing [AnalyticsRepositoryImpl].
+///
+/// Deferred so the PostHog SDK is never touched when analytics is disabled.
+typedef PosthogWrapperBuilder = PosthogWrapper Function();
+
+/// Resolves the [AnalyticsRepository] used for the lifetime of the app.
+///
+/// Returns [NoOpAnalyticsRepository] unless `ANALYTICS_ENABLED` is exactly
+/// `'true'`; otherwise builds an [AnalyticsRepositoryImpl] and initializes it
+/// before handing it to the caller.
+///
+/// Split out of `main.dart` so the selection is unit-testable; it remains
+/// composition-root code and must only be called from bootstrap.
+Future<AnalyticsRepository> createAnalyticsRepository({
+  required EnvLoader envLoader,
+  required PosthogWrapperBuilder buildPosthogWrapper,
+}) async {
+  if (envLoader.get(analyticsEnabledKey) != 'true') {
+    return const NoOpAnalyticsRepository();
+  }
+  // The lint exempts main.dart as the composition root; this function is that
+  // same bootstrap step, only extracted to make it testable.
+  // ignore: no_direct_instantiation
+  final repository = AnalyticsRepositoryImpl(
+    envLoader: envLoader,
+    posthogWrapper: buildPosthogWrapper(),
+  );
+  await repository.initialize();
+  return repository;
+}

--- a/lib/libraries/analytics/data/repositories/no_op_analytics_repository.dart
+++ b/lib/libraries/analytics/data/repositories/no_op_analytics_repository.dart
@@ -4,7 +4,7 @@ import 'package:construculator/libraries/analytics/domain/repositories/analytics
 import 'package:construculator/libraries/either/either.dart';
 import 'package:construculator/libraries/errors/failures.dart';
 
-/// Production no-op used when `POSTHOG_ENABLED=false`.
+/// Production no-op used when `ANALYTICS_ENABLED=false`.
 ///
 /// Not a test double — for tests, inject `FakePosthogWrapper` into
 /// [AnalyticsRepositoryImpl] instead.

--- a/lib/libraries/config/env_constants.dart
+++ b/lib/libraries/config/env_constants.dart
@@ -15,6 +15,7 @@ const String sentryDsnKey = 'SENTRY_DSN';
 const String posthogApiKeyKey = 'POSTHOG_API_KEY';
 const String posthogHostKey = 'POSTHOG_HOST';
 const String posthogDebugKey = 'POSTHOG_DEBUG';
+const String posthogEnabledKey = 'POSTHOG_ENABLED';
 
 enum Environment { dev, qa, prod }
 

--- a/lib/libraries/config/env_constants.dart
+++ b/lib/libraries/config/env_constants.dart
@@ -15,7 +15,7 @@ const String sentryDsnKey = 'SENTRY_DSN';
 const String posthogApiKeyKey = 'POSTHOG_API_KEY';
 const String posthogHostKey = 'POSTHOG_HOST';
 const String posthogDebugKey = 'POSTHOG_DEBUG';
-const String posthogEnabledKey = 'POSTHOG_ENABLED';
+const String analyticsEnabledKey = 'ANALYTICS_ENABLED';
 
 enum Environment { dev, qa, prod }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -62,7 +62,7 @@ Future<AppBootstrap> _initializeApp() async {
 Future<AnalyticsRepository> _initializeAnalyticsRepository(
   EnvLoader envLoader,
 ) async {
-  if (envLoader.get(posthogEnabledKey) != 'true') {
+  if (envLoader.get(analyticsEnabledKey) != 'true') {
     return const NoOpAnalyticsRepository();
   }
   final repository = AnalyticsRepositoryImpl(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,15 +1,12 @@
 import 'package:construculator/app/app.dart';
 import 'package:construculator/app/app_bootstrap.dart';
 import 'package:construculator/app/app_module.dart';
-import 'package:construculator/libraries/analytics/data/repositories/analytics_repository_impl.dart';
-import 'package:construculator/libraries/analytics/data/repositories/no_op_analytics_repository.dart';
-import 'package:construculator/libraries/analytics/domain/repositories/analytics_repository.dart';
+import 'package:construculator/libraries/analytics/analytics_repository_factory.dart';
 import 'package:construculator/libraries/analytics/posthog_sdk_impl.dart';
 import 'package:construculator/libraries/analytics/posthog_wrapper_impl.dart';
 import 'package:construculator/libraries/config/app_config_impl.dart';
 import 'package:construculator/libraries/config/env_constants.dart';
 import 'package:construculator/libraries/config/env_loader_impl.dart';
-import 'package:construculator/libraries/config/interfaces/env_loader.dart';
 import 'package:construculator/libraries/logging/app_logger.dart';
 import 'package:construculator/libraries/sentry/sentry_sdk_impl.dart';
 import 'package:construculator/libraries/sentry/sentry_wrapper_impl.dart';
@@ -49,7 +46,10 @@ Future<AppBootstrap> _initializeApp() async {
     config: config,
     sentrySdk: SentrySdkImpl(),
   );
-  final analyticsRepository = await _initializeAnalyticsRepository(envLoader);
+  final analyticsRepository = await createAnalyticsRepository(
+    envLoader: envLoader,
+    buildPosthogWrapper: () => PosthogWrapperImpl(posthogSdk: PosthogSdkImpl()),
+  );
   return AppBootstrap(
     config: config,
     envLoader: envLoader,
@@ -57,20 +57,6 @@ Future<AppBootstrap> _initializeApp() async {
     sentryWrapper: sentryWrapper,
     analyticsRepository: analyticsRepository,
   );
-}
-
-Future<AnalyticsRepository> _initializeAnalyticsRepository(
-  EnvLoader envLoader,
-) async {
-  if (envLoader.get(analyticsEnabledKey) != 'true') {
-    return const NoOpAnalyticsRepository();
-  }
-  final repository = AnalyticsRepositoryImpl(
-    envLoader: envLoader,
-    posthogWrapper: PosthogWrapperImpl(posthogSdk: PosthogSdkImpl()),
-  );
-  await repository.initialize();
-  return repository;
 }
 
 Environment _getEnvironmentFromString(String? envName) {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,9 +1,15 @@
 import 'package:construculator/app/app.dart';
 import 'package:construculator/app/app_bootstrap.dart';
 import 'package:construculator/app/app_module.dart';
+import 'package:construculator/libraries/analytics/data/repositories/analytics_repository_impl.dart';
+import 'package:construculator/libraries/analytics/data/repositories/no_op_analytics_repository.dart';
+import 'package:construculator/libraries/analytics/domain/repositories/analytics_repository.dart';
+import 'package:construculator/libraries/analytics/posthog_sdk_impl.dart';
+import 'package:construculator/libraries/analytics/posthog_wrapper_impl.dart';
 import 'package:construculator/libraries/config/app_config_impl.dart';
 import 'package:construculator/libraries/config/env_constants.dart';
 import 'package:construculator/libraries/config/env_loader_impl.dart';
+import 'package:construculator/libraries/config/interfaces/env_loader.dart';
 import 'package:construculator/libraries/logging/app_logger.dart';
 import 'package:construculator/libraries/sentry/sentry_sdk_impl.dart';
 import 'package:construculator/libraries/sentry/sentry_wrapper_impl.dart';
@@ -43,12 +49,28 @@ Future<AppBootstrap> _initializeApp() async {
     config: config,
     sentrySdk: SentrySdkImpl(),
   );
+  final analyticsRepository = await _initializeAnalyticsRepository(envLoader);
   return AppBootstrap(
     config: config,
     envLoader: envLoader,
     supabaseWrapper: wrapper,
     sentryWrapper: sentryWrapper,
+    analyticsRepository: analyticsRepository,
   );
+}
+
+Future<AnalyticsRepository> _initializeAnalyticsRepository(
+  EnvLoader envLoader,
+) async {
+  if (envLoader.get(posthogEnabledKey) != 'true') {
+    return const NoOpAnalyticsRepository();
+  }
+  final repository = AnalyticsRepositoryImpl(
+    envLoader: envLoader,
+    posthogWrapper: PosthogWrapperImpl(posthogSdk: PosthogSdkImpl()),
+  );
+  await repository.initialize();
+  return repository;
 }
 
 Environment _getEnvironmentFromString(String? envName) {

--- a/test/app/shell/tab_module_manager_test.dart
+++ b/test/app/shell/tab_module_manager_test.dart
@@ -2,6 +2,7 @@ import 'package:construculator/app/app_bootstrap.dart';
 import 'package:construculator/app/shell/module_model.dart';
 import 'package:construculator/app/shell/shell_module.dart';
 import 'package:construculator/app/shell/tab_module_manager.dart';
+import 'package:construculator/libraries/analytics/data/repositories/no_op_analytics_repository.dart';
 import 'package:construculator/libraries/config/testing/fake_app_config.dart';
 import 'package:construculator/libraries/config/testing/fake_env_loader.dart';
 import 'package:construculator/libraries/sentry/fake_sentry_wrapper.dart';
@@ -21,6 +22,7 @@ void main() {
           envLoader: FakeEnvLoader(),
           sentryWrapper: FakeSentryWrapper(),
           supabaseWrapper: FakeSupabaseWrapper(clock: FakeClockImpl()),
+          analyticsRepository: const NoOpAnalyticsRepository(),
         );
         Modular.init(ShellModule(appBootstrap));
         manager = Modular.get<TabModuleManager>();
@@ -63,6 +65,7 @@ void main() {
           envLoader: FakeEnvLoader(),
           sentryWrapper: FakeSentryWrapper(),
           supabaseWrapper: FakeSupabaseWrapper(clock: FakeClockImpl()),
+          analyticsRepository: const NoOpAnalyticsRepository(),
         );
         Modular.init(_TestShellModule(appBootstrap));
         customManager = Modular.get<TabModuleManager>();

--- a/test/libraries/analytics/units/analytics_module_test.dart
+++ b/test/libraries/analytics/units/analytics_module_test.dart
@@ -1,0 +1,35 @@
+import 'package:construculator/app/app_bootstrap.dart';
+import 'package:construculator/libraries/analytics/analytics_module.dart';
+import 'package:construculator/libraries/analytics/data/repositories/no_op_analytics_repository.dart';
+import 'package:construculator/libraries/analytics/domain/repositories/analytics_repository.dart';
+import 'package:flutter_modular/flutter_modular.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../../../utils/fake_app_bootstrap_factory.dart';
+
+class _AnalyticsModuleTestHarness extends Module {
+  final AppBootstrap appBootstrap;
+  _AnalyticsModuleTestHarness(this.appBootstrap);
+
+  @override
+  List<Module> get imports => [AnalyticsModule(appBootstrap)];
+}
+
+void main() {
+  group('AnalyticsModule', () {
+    tearDown(() {
+      Modular.destroy();
+    });
+
+    test('registers the AnalyticsRepository from AppBootstrap', () {
+      const repository = NoOpAnalyticsRepository();
+      final bootstrap = FakeAppBootstrapFactory.create(
+        analyticsRepository: repository,
+      );
+
+      Modular.init(_AnalyticsModuleTestHarness(bootstrap));
+
+      expect(Modular.get<AnalyticsRepository>(), same(repository));
+    });
+  });
+}

--- a/test/libraries/analytics/units/analytics_repository_factory_test.dart
+++ b/test/libraries/analytics/units/analytics_repository_factory_test.dart
@@ -1,0 +1,113 @@
+import 'package:construculator/libraries/analytics/analytics_repository_factory.dart';
+import 'package:construculator/libraries/analytics/data/repositories/analytics_repository_impl.dart';
+import 'package:construculator/libraries/analytics/data/repositories/no_op_analytics_repository.dart';
+import 'package:construculator/libraries/analytics/testing/fake_posthog_wrapper.dart';
+import 'package:construculator/libraries/config/env_constants.dart';
+import 'package:construculator/libraries/config/testing/fake_env_loader.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('createAnalyticsRepository', () {
+    late FakeEnvLoader fakeEnvLoader;
+    late FakePosthogWrapper fakePosthogWrapper;
+    late int buildPosthogWrapperCallCount;
+
+    setUp(() {
+      fakeEnvLoader = FakeEnvLoader();
+      fakePosthogWrapper = FakePosthogWrapper();
+      buildPosthogWrapperCallCount = 0;
+    });
+
+    tearDown(() {
+      fakeEnvLoader.clearEnvVars();
+      fakePosthogWrapper.resetFake();
+    });
+
+    Future<Object> create() {
+      return createAnalyticsRepository(
+        envLoader: fakeEnvLoader,
+        buildPosthogWrapper: () {
+          buildPosthogWrapperCallCount++;
+          return fakePosthogWrapper;
+        },
+      );
+    }
+
+    test(
+      'returns AnalyticsRepositoryImpl when ANALYTICS_ENABLED is true',
+      () async {
+        fakeEnvLoader.setEnvVar(analyticsEnabledKey, 'true');
+
+        final repository = await create();
+
+        expect(repository, isA<AnalyticsRepositoryImpl>());
+      },
+    );
+
+    test(
+      'initializes the repository with the PostHog config from env',
+      () async {
+        fakeEnvLoader.setEnvVar(analyticsEnabledKey, 'true');
+        fakeEnvLoader.setEnvVar(posthogApiKeyKey, 'phc_test_key');
+        fakeEnvLoader.setEnvVar(posthogHostKey, 'https://us.i.posthog.com');
+        fakeEnvLoader.setEnvVar(posthogDebugKey, 'true');
+
+        await create();
+
+        expect(fakePosthogWrapper.initializeCalls, [
+          const InitializeCall(
+            apiKey: 'phc_test_key',
+            host: 'https://us.i.posthog.com',
+            debug: true,
+          ),
+        ]);
+      },
+    );
+
+    test(
+      'returns NoOpAnalyticsRepository when ANALYTICS_ENABLED is unset',
+      () async {
+        final repository = await create();
+
+        expect(repository, isA<NoOpAnalyticsRepository>());
+      },
+    );
+
+    test(
+      'returns NoOpAnalyticsRepository when ANALYTICS_ENABLED is false',
+      () async {
+        fakeEnvLoader.setEnvVar(analyticsEnabledKey, 'false');
+
+        final repository = await create();
+
+        expect(repository, isA<NoOpAnalyticsRepository>());
+      },
+    );
+
+    test(
+      'treats any value other than the exact string true as disabled',
+      () async {
+        for (final value in ['True', 'TRUE', '1', 'yes', '']) {
+          fakeEnvLoader.setEnvVar(analyticsEnabledKey, value);
+
+          expect(
+            await create(),
+            isA<NoOpAnalyticsRepository>(),
+            reason: 'ANALYTICS_ENABLED="$value" should disable analytics',
+          );
+        }
+      },
+    );
+
+    test(
+      'never builds the PostHog wrapper when analytics is disabled',
+      () async {
+        fakeEnvLoader.setEnvVar(analyticsEnabledKey, 'false');
+
+        await create();
+
+        expect(buildPosthogWrapperCallCount, 0);
+      },
+    );
+  });
+}

--- a/test/utils/fake_app_bootstrap_factory.dart
+++ b/test/utils/fake_app_bootstrap_factory.dart
@@ -1,4 +1,6 @@
 import 'package:construculator/app/app_bootstrap.dart';
+import 'package:construculator/libraries/analytics/data/repositories/no_op_analytics_repository.dart';
+import 'package:construculator/libraries/analytics/domain/repositories/analytics_repository.dart';
 import 'package:construculator/libraries/config/interfaces/config.dart';
 import 'package:construculator/libraries/config/interfaces/env_loader.dart';
 import 'package:construculator/libraries/config/testing/fake_app_config.dart';
@@ -19,6 +21,8 @@ class FakeAppBootstrapFactory {
   ///   database state and assertions
   /// - [config]: Provide custom app configuration for the test
   /// - [envLoader]: Provide custom environment loading behavior
+  /// - [analyticsRepository]: Provide a specific AnalyticsRepository; defaults
+  ///   to the production no-op
   ///
   /// When parameters are omitted, sensible test defaults are provided.
   ///
@@ -37,6 +41,7 @@ class FakeAppBootstrapFactory {
     FakeSupabaseWrapper? supabaseWrapper,
     Config? config,
     EnvLoader? envLoader,
+    AnalyticsRepository? analyticsRepository,
   }) {
     return AppBootstrap(
       supabaseWrapper:
@@ -44,6 +49,7 @@ class FakeAppBootstrapFactory {
       config: config ?? FakeAppConfig(),
       envLoader: envLoader ?? FakeEnvLoader(),
       sentryWrapper: FakeSentryWrapper(),
+      analyticsRepository: analyticsRepository ?? const NoOpAnalyticsRepository(),
     );
   }
 }


### PR DESCRIPTION
### 1. PR SUMMARY
Wires analytics into the running app with capture off by default. Adds `POSTHOG_ENABLED` env flag, an `AnalyticsModule` (following the `SupabaseModule`/`ConfigModule` pattern — reads a pre-built instance off `AppBootstrap`, no `Modular.get` involved), and bootstrap selection logic in `main.dart`: when `POSTHOG_ENABLED=true`, constructs and initializes the real `AnalyticsRepositoryImpl`; otherwise uses `NoOpAnalyticsRepository` directly without constructing `PosthogWrapperImpl` at all, so disabled analytics makes zero network calls. `AppBootstrap` gains a required `analyticsRepository` field, and `AnalyticsModule` is registered in `AppModule.imports`. Existing `AppBootstrap(...)` call sites and `FakeAppBootstrapFactory` are updated accordingly. Part 2 of 2 for CA-942, stacked on #503.

### 2. REVIEW SUMMARY TABLE
No issues found.

## Test plan
- [x] `fvm dart run custom_lint` clean (pre-existing unrelated issue in `fake_router.dart` present on base branch)
- [x] `fvm flutter test` green (3201 tests)
- [x] `AnalyticsModule` resolves `AppBootstrap.analyticsRepository` via Modular DI (new `analytics_module_test.dart`)
- [x] Reasoned through `POSTHOG_ENABLED=false`/unset path: no-op selected, no `PosthogWrapperImpl` constructed, no network call (AC3)