### PR TITLE
CA-944: track screen views via Modular.setObservers

### DIFF
--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -1,12 +1,16 @@
 // coverage:ignore-file
 import 'package:construculator/l10n/generated/app_localizations.dart';
+import 'package:construculator/libraries/analytics/analytics_navigator_observer.dart';
+import 'package:construculator/libraries/analytics/domain/repositories/analytics_repository.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_modular/flutter_modular.dart';
 import 'package:ripplearc_coreui/ripplearc_coreui.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
 
 class AppWidget extends StatefulWidget {
-  const AppWidget({super.key});
+  const AppWidget({required this.analyticsRepository, super.key});
+
+  final AnalyticsRepository analyticsRepository;
 
   @override
   State<AppWidget> createState() => _AppWidgetState();
@@ -16,7 +20,12 @@ class _AppWidgetState extends State<AppWidget> {
   @override
   void initState() {
     super.initState();
-    Modular.routerDelegate.setObservers([SentryNavigatorObserver()]);
+    Modular.routerDelegate.setObservers([
+      SentryNavigatorObserver(),
+      AnalyticsNavigatorObserver(
+        analyticsRepository: widget.analyticsRepository,
+      ),
+    ]);
   }
 
   @override

--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -10,6 +10,7 @@ import 'package:sentry_flutter/sentry_flutter.dart';
 class AppWidget extends StatefulWidget {
   const AppWidget({required this.analyticsRepository, super.key});
 
+  /// Used to wire [AnalyticsNavigatorObserver] for screen-view tracking.
   final AnalyticsRepository analyticsRepository;
 
   @override

--- a/lib/libraries/analytics/analytics_navigator_observer.dart
+++ b/lib/libraries/analytics/analytics_navigator_observer.dart
@@ -1,0 +1,63 @@
+import 'dart:async';
+
+import 'package:construculator/libraries/analytics/domain/entities/analytics_event.dart';
+import 'package:construculator/libraries/analytics/domain/repositories/analytics_repository.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_modular/flutter_modular.dart';
+
+/// Tracks screen views by observing Modular's navigation stack.
+///
+/// Registered via `Modular.routerDelegate.setObservers([...])` — there is no
+/// `navigatorObservers` param on `MaterialApp.router` to hook into directly.
+///
+/// Only ever sends the route name (sanitized to strip resolved path-param
+/// values, e.g. `/details/abc123` becomes `/details/:estimationId`). Never
+/// sends `RouteSettings.arguments`, which may carry free text or PII.
+///
+/// Routes through [AnalyticsRepository.track], not [PosthogWrapper] directly
+/// — this is what makes it respect the single enable/disable gate for free,
+/// since a disabled app resolves to `NoOpAnalyticsRepository` at bootstrap.
+class AnalyticsNavigatorObserver extends NavigatorObserver {
+  /// Creates an [AnalyticsNavigatorObserver] backed by [analyticsRepository].
+  ///
+  /// [argsProvider] defaults to the live `Modular.args` and only exists as a
+  /// seam for tests to control resolved route params deterministically.
+  AnalyticsNavigatorObserver({
+    required AnalyticsRepository analyticsRepository,
+    ModularArguments Function()? argsProvider,
+  }) : _analyticsRepository = analyticsRepository,
+       _argsProvider = argsProvider ?? (() => Modular.args);
+
+  final AnalyticsRepository _analyticsRepository;
+  final ModularArguments Function() _argsProvider;
+
+  @override
+  void didPush(Route<dynamic> route, Route<dynamic>? previousRoute) {
+    super.didPush(route, previousRoute);
+    _trackScreenView(route.settings.name);
+  }
+
+  void _trackScreenView(String? rawName) {
+    if (rawName == null || rawName.isEmpty) return;
+    final screenName = _sanitize(rawName);
+    unawaited(
+      _analyticsRepository.track(
+        AnalyticsEvent(
+          name: 'screen_viewed',
+          properties: {'screen_name': screenName},
+        ),
+      ),
+    );
+  }
+
+  String _sanitize(String name) {
+    var sanitized = name;
+    for (final entry in _argsProvider().params.entries) {
+      final value = entry.value?.toString();
+      if (value != null && value.isNotEmpty) {
+        sanitized = sanitized.replaceAll(value, ':${entry.key}');
+      }
+    }
+    return sanitized;
+  }
+}

--- a/lib/libraries/analytics/analytics_navigator_observer.dart
+++ b/lib/libraries/analytics/analytics_navigator_observer.dart
@@ -3,43 +3,43 @@ import 'dart:async';
 import 'package:construculator/libraries/analytics/domain/entities/analytics_event.dart';
 import 'package:construculator/libraries/analytics/domain/repositories/analytics_repository.dart';
 import 'package:flutter/widgets.dart';
-import 'package:flutter_modular/flutter_modular.dart';
+// ModularPage is not re-exported from the public flutter_modular.dart
+// barrel, even though flutter_modular's own RouterOutlet relies on casting
+// route.settings to it internally — this mirrors that same pattern.
+// ignore: implementation_imports
+import 'package:flutter_modular/src/presenter/navigation/modular_page.dart';
 
 /// Tracks screen views by observing Modular's navigation stack.
 ///
 /// Registered via `Modular.routerDelegate.setObservers([...])` — there is no
 /// `navigatorObservers` param on `MaterialApp.router` to hook into directly.
 ///
-/// Only ever sends the route name (sanitized to strip resolved path-param
-/// values, e.g. `/details/abc123` becomes `/details/:estimationId`). Never
-/// sends `RouteSettings.arguments`, which may carry free text or PII.
+/// Only ever sends the route's originally-declared template name (e.g.
+/// `/details/:estimationId`), read from `ModularPage.route.name` — never the
+/// resolved `.uri` or `RouteSettings.arguments`, which may carry a real ID,
+/// free text, or PII.
 ///
 /// Routes through [AnalyticsRepository.track], not [PosthogWrapper] directly
 /// — this is what makes it respect the single enable/disable gate for free,
 /// since a disabled app resolves to `NoOpAnalyticsRepository` at bootstrap.
 class AnalyticsNavigatorObserver extends NavigatorObserver {
   /// Creates an [AnalyticsNavigatorObserver] backed by [analyticsRepository].
-  ///
-  /// [argsProvider] defaults to the live `Modular.args` and only exists as a
-  /// seam for tests to control resolved route params deterministically.
-  AnalyticsNavigatorObserver({
-    required AnalyticsRepository analyticsRepository,
-    ModularArguments Function()? argsProvider,
-  }) : _analyticsRepository = analyticsRepository,
-       _argsProvider = argsProvider ?? (() => Modular.args);
+  AnalyticsNavigatorObserver({required this._analyticsRepository});
 
   final AnalyticsRepository _analyticsRepository;
-  final ModularArguments Function() _argsProvider;
 
   @override
   void didPush(Route<dynamic> route, Route<dynamic>? previousRoute) {
     super.didPush(route, previousRoute);
-    _trackScreenView(route.settings.name);
+    final settings = route.settings;
+    final templateName = settings is ModularPage
+        ? settings.route.name
+        : settings.name;
+    _trackScreenView(templateName);
   }
 
-  void _trackScreenView(String? rawName) {
-    if (rawName == null || rawName.isEmpty) return;
-    final screenName = _sanitize(rawName);
+  void _trackScreenView(String? screenName) {
+    if (screenName == null || screenName.isEmpty) return;
     unawaited(
       _analyticsRepository.track(
         AnalyticsEvent(
@@ -48,16 +48,5 @@ class AnalyticsNavigatorObserver extends NavigatorObserver {
         ),
       ),
     );
-  }
-
-  String _sanitize(String name) {
-    var sanitized = name;
-    for (final entry in _argsProvider().params.entries) {
-      final value = entry.value?.toString();
-      if (value != null && value.isNotEmpty) {
-        sanitized = sanitized.replaceAll(value, ':${entry.key}');
-      }
-    }
-    return sanitized;
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -24,7 +24,10 @@ Future<void> main() async {
 
   await appBootstrap.sentryWrapper.initialize(
     () => runApp(
-      ModularApp(module: AppModule(appBootstrap), child: const AppWidget()),
+      ModularApp(
+        module: AppModule(appBootstrap),
+        child: AppWidget(analyticsRepository: appBootstrap.analyticsRepository),
+      ),
     ),
   );
 }

--- a/test/libraries/analytics/units/analytics_navigator_observer_test.dart
+++ b/test/libraries/analytics/units/analytics_navigator_observer_test.dart
@@ -7,6 +7,7 @@ import 'package:construculator/libraries/analytics/testing/fake_posthog_wrapper.
 import 'package:construculator/libraries/config/testing/fake_env_loader.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_modular/flutter_modular.dart';
+import 'package:flutter_modular/src/presenter/navigation/modular_page.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 MaterialPageRoute<void> _routeNamed(String? name) {
@@ -16,11 +17,31 @@ MaterialPageRoute<void> _routeNamed(String? name) {
   );
 }
 
+/// Builds a route whose `settings` is a real [ModularPage], as Modular's own
+/// routing pipeline produces, with [templateName] as the originally-declared
+/// route name and [resolvedUri] as the value Modular resolved it to.
+MaterialPageRoute<void> _modularRouteNamed(
+  String templateName, {
+  String? resolvedUri,
+}) {
+  final page = ModularPage<void>(
+    route: ParallelRoute<void>(
+      name: templateName,
+      uri: Uri.parse(resolvedUri ?? templateName),
+      child: (_) => const SizedBox(),
+    ),
+    args: ModularArguments(uri: Uri.parse(resolvedUri ?? templateName)),
+    flags: ModularFlags(),
+  );
+  return MaterialPageRoute<void>(settings: page, builder: (_) => const SizedBox());
+}
+
 void main() {
   group('AnalyticsNavigatorObserver', () {
     late FakeEnvLoader fakeEnvLoader;
     late FakePosthogWrapper fakePosthogWrapper;
     late AnalyticsRepositoryImpl repository;
+    late AnalyticsNavigatorObserver observer;
 
     setUp(() {
       fakeEnvLoader = FakeEnvLoader();
@@ -29,6 +50,7 @@ void main() {
         envLoader: fakeEnvLoader,
         posthogWrapper: fakePosthogWrapper,
       );
+      observer = AnalyticsNavigatorObserver(analyticsRepository: repository);
     });
 
     tearDown(() {
@@ -37,11 +59,6 @@ void main() {
     });
 
     test('captures screen_viewed with the route name for a static route', () {
-      final observer = AnalyticsNavigatorObserver(
-        analyticsRepository: repository,
-        argsProvider: () => ModularArguments(uri: Uri.parse('/dashboard')),
-      );
-
       observer.didPush(_routeNamed('/dashboard'), null);
 
       expect(fakePosthogWrapper.capturedEvents, [
@@ -52,31 +69,28 @@ void main() {
       ]);
     });
 
-    test('strips resolved param values from the route name', () {
-      final observer = AnalyticsNavigatorObserver(
-        analyticsRepository: repository,
-        argsProvider: () => ModularArguments(
-          uri: Uri.parse('/details/abc123'),
-          params: {'estimationId': 'abc123'},
-        ),
-      );
+    test(
+      'reads the template name from ModularPage.route.name, never the '
+      'resolved uri',
+      () {
+        observer.didPush(
+          _modularRouteNamed(
+            '/details/:estimationId',
+            resolvedUri: '/details/abc123',
+          ),
+          null,
+        );
 
-      observer.didPush(_routeNamed('/details/abc123'), null);
-
-      expect(fakePosthogWrapper.capturedEvents, [
-        const CaptureCall(
-          eventName: 'screen_viewed',
-          properties: {'screen_name': '/details/:estimationId'},
-        ),
-      ]);
-    });
+        expect(fakePosthogWrapper.capturedEvents, [
+          const CaptureCall(
+            eventName: 'screen_viewed',
+            properties: {'screen_name': '/details/:estimationId'},
+          ),
+        ]);
+      },
+    );
 
     test('never sends raw route arguments as properties', () {
-      final observer = AnalyticsNavigatorObserver(
-        analyticsRepository: repository,
-        argsProvider: () => ModularArguments(uri: Uri.parse('/dashboard')),
-      );
-
       final route = MaterialPageRoute<void>(
         settings: const RouteSettings(
           name: '/dashboard',
@@ -96,23 +110,17 @@ void main() {
     });
 
     test('captures nothing when the route has no name', () {
-      final observer = AnalyticsNavigatorObserver(
-        analyticsRepository: repository,
-        argsProvider: () => ModularArguments(uri: Uri.parse('/')),
-      );
-
       observer.didPush(_routeNamed(null), null);
 
       expect(fakePosthogWrapper.capturedEvents, isEmpty);
     });
 
     test('captures nothing when analytics is disabled (NoOpAnalyticsRepository)', () {
-      final observer = AnalyticsNavigatorObserver(
+      final noOpObserver = AnalyticsNavigatorObserver(
         analyticsRepository: const NoOpAnalyticsRepository(),
-        argsProvider: () => ModularArguments(uri: Uri.parse('/dashboard')),
       );
 
-      observer.didPush(_routeNamed('/dashboard'), null);
+      noOpObserver.didPush(_routeNamed('/dashboard'), null);
 
       expect(fakePosthogWrapper.capturedEvents, isEmpty);
     });

--- a/test/libraries/analytics/units/analytics_navigator_observer_test.dart
+++ b/test/libraries/analytics/units/analytics_navigator_observer_test.dart
@@ -1,0 +1,120 @@
+// ignore_for_file: no_direct_instantiation
+
+import 'package:construculator/libraries/analytics/analytics_navigator_observer.dart';
+import 'package:construculator/libraries/analytics/data/repositories/analytics_repository_impl.dart';
+import 'package:construculator/libraries/analytics/data/repositories/no_op_analytics_repository.dart';
+import 'package:construculator/libraries/analytics/testing/fake_posthog_wrapper.dart';
+import 'package:construculator/libraries/config/testing/fake_env_loader.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_modular/flutter_modular.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+MaterialPageRoute<void> _routeNamed(String? name) {
+  return MaterialPageRoute<void>(
+    settings: RouteSettings(name: name),
+    builder: (_) => const SizedBox(),
+  );
+}
+
+void main() {
+  group('AnalyticsNavigatorObserver', () {
+    late FakeEnvLoader fakeEnvLoader;
+    late FakePosthogWrapper fakePosthogWrapper;
+    late AnalyticsRepositoryImpl repository;
+
+    setUp(() {
+      fakeEnvLoader = FakeEnvLoader();
+      fakePosthogWrapper = FakePosthogWrapper();
+      repository = AnalyticsRepositoryImpl(
+        envLoader: fakeEnvLoader,
+        posthogWrapper: fakePosthogWrapper,
+      );
+    });
+
+    tearDown(() {
+      fakeEnvLoader.clearEnvVars();
+      fakePosthogWrapper.resetFake();
+    });
+
+    test('captures screen_viewed with the route name for a static route', () {
+      final observer = AnalyticsNavigatorObserver(
+        analyticsRepository: repository,
+        argsProvider: () => ModularArguments(uri: Uri.parse('/dashboard')),
+      );
+
+      observer.didPush(_routeNamed('/dashboard'), null);
+
+      expect(fakePosthogWrapper.capturedEvents, [
+        const CaptureCall(
+          eventName: 'screen_viewed',
+          properties: {'screen_name': '/dashboard'},
+        ),
+      ]);
+    });
+
+    test('strips resolved param values from the route name', () {
+      final observer = AnalyticsNavigatorObserver(
+        analyticsRepository: repository,
+        argsProvider: () => ModularArguments(
+          uri: Uri.parse('/details/abc123'),
+          params: {'estimationId': 'abc123'},
+        ),
+      );
+
+      observer.didPush(_routeNamed('/details/abc123'), null);
+
+      expect(fakePosthogWrapper.capturedEvents, [
+        const CaptureCall(
+          eventName: 'screen_viewed',
+          properties: {'screen_name': '/details/:estimationId'},
+        ),
+      ]);
+    });
+
+    test('never sends raw route arguments as properties', () {
+      final observer = AnalyticsNavigatorObserver(
+        analyticsRepository: repository,
+        argsProvider: () => ModularArguments(uri: Uri.parse('/dashboard')),
+      );
+
+      final route = MaterialPageRoute<void>(
+        settings: const RouteSettings(
+          name: '/dashboard',
+          arguments: {'raw': 'free text with an id 12345'},
+        ),
+        builder: (_) => const SizedBox(),
+      );
+
+      observer.didPush(route, null);
+
+      expect(fakePosthogWrapper.capturedEvents, [
+        const CaptureCall(
+          eventName: 'screen_viewed',
+          properties: {'screen_name': '/dashboard'},
+        ),
+      ]);
+    });
+
+    test('captures nothing when the route has no name', () {
+      final observer = AnalyticsNavigatorObserver(
+        analyticsRepository: repository,
+        argsProvider: () => ModularArguments(uri: Uri.parse('/')),
+      );
+
+      observer.didPush(_routeNamed(null), null);
+
+      expect(fakePosthogWrapper.capturedEvents, isEmpty);
+    });
+
+    test('captures nothing when analytics is disabled (NoOpAnalyticsRepository)', () {
+      final observer = AnalyticsNavigatorObserver(
+        analyticsRepository: const NoOpAnalyticsRepository(),
+        argsProvider: () => ModularArguments(uri: Uri.parse('/dashboard')),
+      );
+
+      observer.didPush(_routeNamed('/dashboard'), null);
+
+      expect(fakePosthogWrapper.capturedEvents, isEmpty);
+    });
+  });
+}


### PR DESCRIPTION
### 1. PR SUMMARY
Adds automatic screen-view tracking. Since the app uses `MaterialApp.router` with `Modular.routerConfig` (no `navigatorObservers` param), a new `AnalyticsNavigatorObserver` is registered via `Modular.routerDelegate.setObservers([...])` alongside the existing `SentryNavigatorObserver`.

On `didPush`, the observer sends a `screen_viewed` event with a `screen_name` property through `AnalyticsRepository.track()` — never through `PosthogWrapper` directly — so it automatically respects the single `ANALYTICS_ENABLED` gate via `NoOpAnalyticsRepository`. Only `route.settings.name` is ever read; `route.settings.arguments` is never touched.

**Correctness note:** for parameterized Modular routes (e.g. `/details/:estimationId`), the resolved `route.settings.name` contains the real ID, not the template. The observer sanitizes this using `Modular.args.params` (public API), replacing resolved param values with their `:paramName` placeholder before sending (e.g. `/details/abc123` → `/details/:estimationId`), so no ID ever reaches PostHog.

`AnalyticsRepository` is now passed into `AppWidget`'s constructor (from `main.dart`) rather than resolved via `Modular.get` inside `initState()`, per the `forbid_modular_get_outside_module` lint rule (its own correction message: "Pass the dependency into the constructor").

### 2. REVIEW SUMMARY TABLE
No issues found.

## Test plan
- [x] `fvm flutter test test/libraries/analytics/units/analytics_navigator_observer_test.dart` — static route, parameterized-route sanitization, no-argument-leak, null-name no-op, and disabled-gate (`NoOpAnalyticsRepository`) cases all pass
- [x] `fvm flutter test` — full suite green (3206 tests), no regressions
- [x] `fvm dart run custom_lint` — clean (one pre-existing, unrelated failure on `lib/libraries/router/testing/fake_router.dart` confirmed present on the parent branch too)