### PR TITLE
CA-945: call identify() on login and reset() on logout

### DIFF
--- a/lib/libraries/analytics/testing/fake_analytics_repository.dart
+++ b/lib/libraries/analytics/testing/fake_analytics_repository.dart
@@ -1,0 +1,117 @@
+import 'package:construculator/libraries/analytics/domain/entities/analytics_event.dart';
+import 'package:construculator/libraries/analytics/domain/entities/analytics_user_properties.dart';
+import 'package:construculator/libraries/analytics/domain/repositories/analytics_repository.dart';
+import 'package:construculator/libraries/either/either.dart';
+import 'package:construculator/libraries/errors/failures.dart';
+import 'package:equatable/equatable.dart';
+
+/// Fake implementation of [AnalyticsRepository] for testing purposes.
+///
+/// Tracks all method calls and their parameters so tests can verify
+/// that the correct methods are called with the expected arguments,
+/// without going through the PostHog SDK boundary.
+class FakeAnalyticsRepository implements AnalyticsRepository {
+  /// Recorded calls to [track].
+  final List<AnalyticsEvent> trackedEvents = [];
+
+  /// Recorded calls to [identify].
+  final List<IdentifyCall> identifyCalls = [];
+
+  /// Number of times [reset] was called.
+  int resetCallCount = 0;
+
+  /// Recorded calls to [setUserProperties].
+  final List<AnalyticsUserProperties> setUserPropertiesCalls = [];
+
+  /// Recorded calls to [group].
+  final List<GroupCall> groupCalls = [];
+
+  @override
+  Future<Either<Failure, void>> track(AnalyticsEvent event) async {
+    trackedEvents.add(event);
+    return const Right(null);
+  }
+
+  @override
+  Future<Either<Failure, void>> identify({
+    required String userId,
+    required AnalyticsUserProperties properties,
+  }) async {
+    identifyCalls.add(IdentifyCall(userId: userId, properties: properties));
+    return const Right(null);
+  }
+
+  @override
+  Future<Either<Failure, void>> reset() async {
+    resetCallCount++;
+    return const Right(null);
+  }
+
+  @override
+  Future<Either<Failure, void>> setUserProperties(
+    AnalyticsUserProperties properties,
+  ) async {
+    setUserPropertiesCalls.add(properties);
+    return const Right(null);
+  }
+
+  @override
+  Future<Either<Failure, void>> group({
+    required String groupType,
+    required String groupKey,
+    Map<String, dynamic>? properties,
+  }) async {
+    groupCalls.add(
+      GroupCall(groupType: groupType, groupKey: groupKey, properties: properties),
+    );
+    return const Right(null);
+  }
+
+  /// Clears all recorded calls.
+  ///
+  /// Named to avoid colliding with [reset], the interface method under test.
+  void resetFake() {
+    trackedEvents.clear();
+    identifyCalls.clear();
+    resetCallCount = 0;
+    setUserPropertiesCalls.clear();
+    groupCalls.clear();
+  }
+}
+
+/// Represents a call to [FakeAnalyticsRepository.identify].
+class IdentifyCall extends Equatable {
+  /// Creates a recorded identify call.
+  const IdentifyCall({required this.userId, required this.properties});
+
+  /// Identified user id.
+  final String userId;
+
+  /// User properties passed alongside identification.
+  final AnalyticsUserProperties properties;
+
+  @override
+  List<Object?> get props => [userId, properties];
+}
+
+/// Represents a call to [FakeAnalyticsRepository.group].
+class GroupCall extends Equatable {
+  /// Creates a recorded group call.
+  const GroupCall({
+    required this.groupType,
+    required this.groupKey,
+    this.properties,
+  });
+
+  /// Group type, e.g. `project`.
+  final String groupType;
+
+  /// Group key.
+  final String groupKey;
+
+  /// Optional group properties.
+  final Map<String, dynamic>? properties;
+
+  @override
+  List<Object?> get props => [groupType, groupKey, properties];
+}

--- a/lib/libraries/analytics/testing/fake_analytics_repository.dart
+++ b/lib/libraries/analytics/testing/fake_analytics_repository.dart
@@ -62,7 +62,11 @@ class FakeAnalyticsRepository implements AnalyticsRepository {
     Map<String, dynamic>? properties,
   }) async {
     groupCalls.add(
-      GroupCall(groupType: groupType, groupKey: groupKey, properties: properties),
+      GroupCall(
+        groupType: groupType,
+        groupKey: groupKey,
+        properties: properties,
+      ),
     );
     return const Right(null);
   }

--- a/lib/libraries/auth/auth_library_module.dart
+++ b/lib/libraries/auth/auth_library_module.dart
@@ -32,6 +32,7 @@ class AuthLibraryModule extends Module {
         authRepository: i(),
         authNotifier: i(),
         sentryWrapper: appBootstrap.sentryWrapper,
+        analyticsRepository: appBootstrap.analyticsRepository,
       ),
     );
   }

--- a/lib/libraries/auth/auth_manager_impl.dart
+++ b/lib/libraries/auth/auth_manager_impl.dart
@@ -166,6 +166,9 @@ class AuthManagerImpl implements AuthManager {
       }
 
       await _sentryWrapper.setUser(user.id);
+      // TODO: [CA-961] Gate identify() on recorded analytics consent once
+      // the server-driven consent flow lands; currently relies on the
+      // signup terms & privacy acceptance covering analytics consent.
       await _analyticsRepository.identify(
         userId: user.id,
         properties: const AnalyticsUserProperties(),
@@ -206,6 +209,9 @@ class AuthManagerImpl implements AuthManager {
       }
 
       await _sentryWrapper.setUser(user.id);
+      // TODO: [CA-961] Gate identify() on recorded analytics consent once
+      // the server-driven consent flow lands; currently relies on the
+      // signup terms & privacy acceptance covering analytics consent.
       await _analyticsRepository.identify(
         userId: user.id,
         properties: const AnalyticsUserProperties(),
@@ -282,6 +288,9 @@ class AuthManagerImpl implements AuthManager {
       }
 
       await _sentryWrapper.setUser(user.id);
+      // TODO: [CA-961] Gate identify() on recorded analytics consent once
+      // the server-driven consent flow lands; currently relies on the
+      // signup terms & privacy acceptance covering analytics consent.
       await _analyticsRepository.identify(
         userId: user.id,
         properties: const AnalyticsUserProperties(),

--- a/lib/libraries/auth/auth_manager_impl.dart
+++ b/lib/libraries/auth/auth_manager_impl.dart
@@ -1,4 +1,6 @@
 import 'dart:async';
+import 'package:construculator/libraries/analytics/domain/entities/analytics_user_properties.dart';
+import 'package:construculator/libraries/analytics/domain/repositories/analytics_repository.dart';
 import 'package:construculator/libraries/auth/data/models/auth_credential.dart';
 import 'package:construculator/libraries/auth/data/models/auth_state.dart';
 import 'package:construculator/libraries/auth/data/models/auth_user.dart';
@@ -19,6 +21,7 @@ class AuthManagerImpl implements AuthManager {
   final AuthNotifierController _authNotifier;
   final AuthRepository _authRepository;
   final SentryWrapper _sentryWrapper;
+  final AnalyticsRepository _analyticsRepository;
   final _logger = AppLogger().tag('AuthManagerImpl');
 
   AuthManagerImpl({
@@ -26,6 +29,7 @@ class AuthManagerImpl implements AuthManager {
     required this._authRepository,
     required this._authNotifier,
     required this._sentryWrapper,
+    required this._analyticsRepository,
   }) {
     _initAuthListener();
   }
@@ -162,6 +166,10 @@ class AuthManagerImpl implements AuthManager {
       }
 
       await _sentryWrapper.setUser(user.id);
+      await _analyticsRepository.identify(
+        userId: user.id,
+        properties: const AnalyticsUserProperties(),
+      );
 
       _logger.info('Login successful for user: $email');
       return AuthResult.success(_mapSupabaseUserToCredential(user));
@@ -198,6 +206,10 @@ class AuthManagerImpl implements AuthManager {
       }
 
       await _sentryWrapper.setUser(user.id);
+      await _analyticsRepository.identify(
+        userId: user.id,
+        properties: const AnalyticsUserProperties(),
+      );
 
       _logger.info('Registration successful for user: $email');
       return AuthResult.success(_mapSupabaseUserToCredential(user));
@@ -270,6 +282,10 @@ class AuthManagerImpl implements AuthManager {
       }
 
       await _sentryWrapper.setUser(user.id);
+      await _analyticsRepository.identify(
+        userId: user.id,
+        properties: const AnalyticsUserProperties(),
+      );
 
       _logger.info('OTP verification successful for: $address');
       return AuthResult.success(_mapSupabaseUserToCredential(user));
@@ -326,6 +342,7 @@ class AuthManagerImpl implements AuthManager {
       await _wrapper.signOut();
 
       await _sentryWrapper.setUser(null);
+      await _analyticsRepository.reset();
 
       _logger.info('Logout successful');
       return AuthResult.success(null);

--- a/lib/libraries/auth/testing/auth_test_module.dart
+++ b/lib/libraries/auth/testing/auth_test_module.dart
@@ -1,11 +1,11 @@
 // coverage:ignore-file
+import 'package:construculator/libraries/analytics/testing/fake_analytics_repository.dart';
 import 'package:construculator/libraries/auth/auth_manager_impl.dart';
 import 'package:construculator/libraries/auth/auth_notifier_impl.dart';
 import 'package:construculator/libraries/auth/interfaces/auth_manager.dart';
 import 'package:construculator/libraries/auth/interfaces/auth_notifier.dart';
 import 'package:construculator/libraries/auth/interfaces/auth_repository.dart';
 import 'package:construculator/libraries/auth/repositories/supabase_repository_impl.dart';
-import 'package:construculator/libraries/analytics/testing/fake_analytics_repository.dart';
 import 'package:construculator/libraries/auth/testing/fake_auth_notifier.dart';
 import 'package:construculator/libraries/auth/testing/fake_auth_repository.dart';
 import 'package:construculator/libraries/sentry/fake_sentry_wrapper.dart';

--- a/lib/libraries/auth/testing/auth_test_module.dart
+++ b/lib/libraries/auth/testing/auth_test_module.dart
@@ -5,6 +5,7 @@ import 'package:construculator/libraries/auth/interfaces/auth_manager.dart';
 import 'package:construculator/libraries/auth/interfaces/auth_notifier.dart';
 import 'package:construculator/libraries/auth/interfaces/auth_repository.dart';
 import 'package:construculator/libraries/auth/repositories/supabase_repository_impl.dart';
+import 'package:construculator/libraries/analytics/testing/fake_analytics_repository.dart';
 import 'package:construculator/libraries/auth/testing/fake_auth_notifier.dart';
 import 'package:construculator/libraries/auth/testing/fake_auth_repository.dart';
 import 'package:construculator/libraries/sentry/fake_sentry_wrapper.dart';
@@ -33,6 +34,7 @@ class AuthTestModule extends Module {
         authRepository: i(),
         authNotifier: i(),
         sentryWrapper: FakeSentryWrapper(),
+        analyticsRepository: FakeAnalyticsRepository(),
       ),
       key: 'authManagerWithFakeDep',
     );

--- a/test/libraries/auth/units/auth_manager_test.dart
+++ b/test/libraries/auth/units/auth_manager_test.dart
@@ -1,3 +1,6 @@
+import 'package:construculator/libraries/analytics/domain/entities/analytics_user_properties.dart';
+import 'package:construculator/libraries/analytics/domain/repositories/analytics_repository.dart';
+import 'package:construculator/libraries/analytics/testing/fake_analytics_repository.dart';
 import 'package:construculator/libraries/auth/auth_manager_impl.dart';
 import 'package:construculator/libraries/auth/data/models/auth_credential.dart';
 import 'package:construculator/libraries/auth/data/models/auth_state.dart';
@@ -25,6 +28,7 @@ void main() {
   late FakeAuthRepository authRepository;
   late FakeSupabaseWrapper supabaseWrapper;
   late FakeSentryWrapper sentryWrapper;
+  late FakeAnalyticsRepository analyticsRepository;
   late AuthManager authManager;
   late Clock clock;
   const testEmail = 'test@example.com';
@@ -51,12 +55,15 @@ void main() {
     authRepository = Modular.get<AuthRepository>() as FakeAuthRepository;
     supabaseWrapper = Modular.get<SupabaseWrapper>() as FakeSupabaseWrapper;
     sentryWrapper = Modular.get<SentryWrapper>() as FakeSentryWrapper;
+    analyticsRepository =
+        Modular.get<AnalyticsRepository>() as FakeAnalyticsRepository;
     authManager = Modular.get<AuthManager>();
     clock = Modular.get<Clock>();
   });
 
   tearDown(() {
     sentryWrapper.reset();
+    analyticsRepository.resetFake();
     Modular.destroy();
   });
 
@@ -1048,6 +1055,129 @@ void main() {
         expect(sentryWrapper.userId, userId);
       });
     });
+
+    group('Analytics Integration', () {
+      test(
+        'loginWithEmail should call identify with user ID on success',
+        () async {
+          final result = await authManager.loginWithEmail(
+            testEmail,
+            testPassword,
+          );
+
+          expect(result.isSuccess, true);
+          expect(analyticsRepository.identifyCalls, hasLength(1));
+          expect(
+            analyticsRepository.identifyCalls.single.userId,
+            result.data!.id,
+          );
+          expect(
+            analyticsRepository.identifyCalls.single.properties,
+            const AnalyticsUserProperties(),
+          );
+        },
+      );
+
+      test('loginWithEmail should not call identify on failure', () async {
+        supabaseWrapper.shouldThrowOnSignIn = true;
+        supabaseWrapper.signInErrorMessage = 'Invalid credentials';
+        supabaseWrapper.authErrorCode =
+            SupabaseAuthErrorCode.invalidCredentials;
+
+        final result = await authManager.loginWithEmail(
+          testEmail,
+          testPassword,
+        );
+
+        expect(result.isSuccess, false);
+        expect(analyticsRepository.identifyCalls, isEmpty);
+      });
+
+      test(
+        'registerWithEmail should call identify with user ID on success',
+        () async {
+          final result = await authManager.registerWithEmail(
+            testEmail,
+            testPassword,
+          );
+
+          expect(result.isSuccess, true);
+          expect(analyticsRepository.identifyCalls, hasLength(1));
+          expect(
+            analyticsRepository.identifyCalls.single.userId,
+            result.data!.id,
+          );
+        },
+      );
+
+      test('registerWithEmail should not call identify on failure', () async {
+        supabaseWrapper.shouldThrowOnSignUp = true;
+        supabaseWrapper.signUpErrorMessage = 'Registration failed';
+        supabaseWrapper.authErrorCode =
+            SupabaseAuthErrorCode.registrationFailure;
+
+        final result = await authManager.registerWithEmail(
+          testEmail,
+          testPassword,
+        );
+
+        expect(result.isSuccess, false);
+        expect(analyticsRepository.identifyCalls, isEmpty);
+      });
+
+      test('verifyOtp should call identify with user ID on success', () async {
+        final result = await authManager.verifyOtp(
+          testEmail,
+          '123456',
+          OtpReceiver.email,
+        );
+
+        expect(result.isSuccess, true);
+        expect(analyticsRepository.identifyCalls, hasLength(1));
+        expect(
+          analyticsRepository.identifyCalls.single.userId,
+          result.data!.id,
+        );
+      });
+
+      test('verifyOtp should not call identify on failure', () async {
+        supabaseWrapper.shouldThrowOnVerifyOtp = true;
+        supabaseWrapper.verifyOtpErrorMessage = 'Invalid OTP';
+        supabaseWrapper.authErrorCode =
+            SupabaseAuthErrorCode.invalidCredentials;
+
+        final result = await authManager.verifyOtp(
+          testEmail,
+          '123456',
+          OtpReceiver.email,
+        );
+
+        expect(result.isSuccess, false);
+        expect(analyticsRepository.identifyCalls, isEmpty);
+      });
+
+      test('logout should call reset on success', () async {
+        await authManager.loginWithEmail(testEmail, testPassword);
+        expect(analyticsRepository.identifyCalls, isNotEmpty);
+
+        final result = await authManager.logout();
+
+        expect(result.isSuccess, true);
+        expect(analyticsRepository.resetCallCount, 1);
+      });
+
+      test('logout should not call reset on failure', () async {
+        await authManager.loginWithEmail(testEmail, testPassword);
+
+        supabaseWrapper.shouldThrowOnSignOut = true;
+        supabaseWrapper.signOutErrorMessage = 'Logout failed';
+
+        final result = await authManager.logout();
+
+        expect(result.isSuccess, false);
+        expect(analyticsRepository.resetCallCount, 0);
+      });
+    });
   });
 }
 
@@ -1060,12 +1190,14 @@ class _TestAppModule extends Module {
     i.addSingleton<AuthRepository>(() => FakeAuthRepository(clock: i()));
     i.addSingleton<SupabaseWrapper>(() => FakeSupabaseWrapper(clock: i()));
     i.addSingleton<SentryWrapper>(() => FakeSentryWrapper());
+    i.addSingleton<AnalyticsRepository>(() => FakeAnalyticsRepository());
     i.add<AuthManager>(
       () => AuthManagerImpl(
         wrapper: i(),
         authRepository: i(),
         authNotifier: i(),
         sentryWrapper: i<SentryWrapper>(),
+        analyticsRepository: i<AnalyticsRepository>(),
       ),
     );
   }


### PR DESCRIPTION
### 1. PR SUMMARY
Ties PostHog analytics events to the authenticated Supabase user. `AuthManagerImpl` now calls `AnalyticsRepository.identify(userId: user.id, properties: const AnalyticsUserProperties())` alongside its existing `SentryWrapper.setUser(user.id)` call in every path where Supabase issues an authenticated session (`loginWithEmail`, `registerWithEmail`, `verifyOtp`), and `AnalyticsRepository.reset()` alongside `SentryWrapper.setUser(null)` in `logout()`.

No email/name is sent — only the Supabase UUID — per the ticket's PII constraint (T&P copy still being finalized). `identify()`/`reset()` already existed end-to-end in `AnalyticsRepositoryImpl`/`NoOpAnalyticsRepository`/`PosthogWrapper` from CA-941/942; this PR only wires the call sites, following the same integration point and pattern already established for Sentry.

Adds `FakeAnalyticsRepository` (mirrors `FakeSentryWrapper`'s recording-fake shape) for use in `AuthManagerImpl`/auth test wiring, and a new `Analytics Integration` test group in `auth_manager_test.dart` mirroring the existing `Sentry Integration` group.

### 2. REVIEW SUMMARY TABLE
No issues found.

## Test plan
- [x] `fvm flutter test test/libraries/auth/units/auth_manager_test.dart` — new Analytics Integration group green (72/72 passing)
- [x] `fvm flutter test` (full suite) — 3214/3214 passing
- [x] `fvm dart run custom_lint` — clean (pre-existing unrelated issue in `fake_router.dart` confirmed present on base branch)
- [ ] Manual: run with `POSTHOG_DEBUG=true`, log in, confirm person profile appears in PostHog Live Events with only the UUID as identity (no email); log out and confirm a fresh anonymous distinct ID follows