### PR TITLE
CA-946: track SignUp/SignIn/logout analytics events

### DIFF
--- a/docs/Logging/PostHog-Event-Tracking.md
+++ b/docs/Logging/PostHog-Event-Tracking.md
@@ -17,7 +17,9 @@
 
 ### Authentication
 - `user_registered`
+- `user_registration_failed` — properties: `reason` (typed, see Data Safety Rules; derived from `AuthErrorType`, never the raw exception)
 - `user_logged_in`
+- `user_login_failed` — properties: `reason` (typed, see Data Safety Rules; derived from `AuthErrorType`, never the raw exception)
 - `user_logged_out`
 - `user_password_reset`
 - `otp_verified`

--- a/docs/Logging/PostHog-Event-Tracking.md
+++ b/docs/Logging/PostHog-Event-Tracking.md
@@ -79,15 +79,20 @@ Keep event cardinality bounded — avoid unbounded strings in properties used as
 
 ## Standard Properties
 
-Include in every event:
+Attached automatically to every event by `AnalyticsRepositoryImpl.track()` — callers never set these themselves:
 
 ```dart
 {
-  'app_version': '1.0.0',
-  'platform': Platform.isIOS ? 'ios' : 'android',
-  'screen_name': '/estimation/details',
+  'app_version': '1.0.0',      // resolved once at bootstrap via package_info_plus
+  'platform': 'ios',           // derived from defaultTargetPlatform
+  'screen_name': '/estimation/details', // from the shared CurrentScreenTracker,
+                                         // updated by AnalyticsNavigatorObserver
+                                         // on every navigation; null before the
+                                         // first navigation
 }
 ```
+
+Event-specific properties passed to `track()` take precedence over these on key collision.
 
 > Do **not** include a client-side `timestamp`. PostHog assigns server-side timestamps — injecting `DateTime.now()` causes clock-skew bugs and inconsistent analytics across timezones.
 

--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -1,6 +1,7 @@
 // coverage:ignore-file
 import 'package:construculator/l10n/generated/app_localizations.dart';
 import 'package:construculator/libraries/analytics/analytics_navigator_observer.dart';
+import 'package:construculator/libraries/analytics/current_screen_tracker.dart';
 import 'package:construculator/libraries/analytics/domain/repositories/analytics_repository.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_modular/flutter_modular.dart';
@@ -8,10 +9,15 @@ import 'package:ripplearc_coreui/ripplearc_coreui.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
 
 class AppWidget extends StatefulWidget {
-  const AppWidget({required this.analyticsRepository, super.key});
+  const AppWidget({
+    required this.analyticsRepository,
+    required this.currentScreenTracker,
+    super.key,
+  });
 
   /// Used to wire [AnalyticsNavigatorObserver] for screen-view tracking.
   final AnalyticsRepository analyticsRepository;
+  final CurrentScreenTracker currentScreenTracker;
 
   @override
   State<AppWidget> createState() => _AppWidgetState();
@@ -25,6 +31,7 @@ class _AppWidgetState extends State<AppWidget> {
       SentryNavigatorObserver(),
       AnalyticsNavigatorObserver(
         analyticsRepository: widget.analyticsRepository,
+        currentScreenTracker: widget.currentScreenTracker,
       ),
     ]);
   }

--- a/lib/app/app_bootstrap.dart
+++ b/lib/app/app_bootstrap.dart
@@ -1,4 +1,5 @@
 // coverage:ignore-file
+import 'package:construculator/libraries/analytics/current_screen_tracker.dart';
 import 'package:construculator/libraries/analytics/domain/repositories/analytics_repository.dart';
 import 'package:construculator/libraries/analytics/domain/repositories/feature_flag_repository.dart';
 import 'package:construculator/libraries/config/interfaces/config.dart';
@@ -117,6 +118,13 @@ class AppBootstrap {
   /// to the app module.
   final FeatureFlagRepository featureFlagRepository;
 
+  /// Shared holder of the currently active screen's template name.
+  ///
+  /// Must be passed to both `AnalyticsRepositoryImpl` (which reads it to
+  /// enrich every tracked event) and `AnalyticsNavigatorObserver` (which
+  /// writes it on every navigation) — the same instance to both.
+  final CurrentScreenTracker currentScreenTracker;
+
   AppBootstrap({
     required this.envLoader,
     required this.config,
@@ -125,5 +133,6 @@ class AppBootstrap {
     required this.analyticsRepository,
     required this.powerSyncDatabase,
     required this.featureFlagRepository,
+    required this.currentScreenTracker,
   });
 }

--- a/lib/features/auth/auth_module.dart
+++ b/lib/features/auth/auth_module.dart
@@ -48,7 +48,7 @@ class AuthModule extends Module {
   void routes(RouteManager r) => _registerRoutes(r);
 
   @override
-  void binds(Injector i) => _registerDependencies(i);
+  void binds(Injector i) => _registerDependencies(i, appBootstrap);
 }
 
 void _registerRoutes(RouteManager r) {
@@ -143,7 +143,7 @@ void _registerRoutes(RouteManager r) {
   );
 }
 
-void _registerDependencies(Injector i) {
+void _registerDependencies(Injector i, AppBootstrap appBootstrap) {
   i.addLazySingleton<ResetPasswordUseCase>(() => ResetPasswordUseCase(i()));
   i.addLazySingleton<GetProfessionalRolesUseCase>(
     () => GetProfessionalRolesUseCase(i()),
@@ -175,12 +175,18 @@ void _registerDependencies(Injector i) {
       createAccountUseCase: i(),
       getProfessionalRolesUseCase: i(),
       sendOtpUseCase: i(),
+      analyticsRepository: appBootstrap.analyticsRepository,
     ),
   );
   i.add<LoginWithEmailBloc>(
     () => LoginWithEmailBloc(checkEmailAvailabilityUseCase: i()),
   );
-  i.add<EnterPasswordBloc>(() => EnterPasswordBloc(loginUseCase: i()));
+  i.add<EnterPasswordBloc>(
+    () => EnterPasswordBloc(
+      loginUseCase: i(),
+      analyticsRepository: appBootstrap.analyticsRepository,
+    ),
+  );
   i.add<ForgotPasswordBloc>(
     () => ForgotPasswordBloc(resetPasswordUseCase: i()),
   );

--- a/lib/features/auth/presentation/bloc/create_account_bloc/create_account_bloc.dart
+++ b/lib/features/auth/presentation/bloc/create_account_bloc/create_account_bloc.dart
@@ -6,6 +6,7 @@ import 'package:construculator/features/auth/domain/usecases/params/create_accou
 import 'package:construculator/features/auth/domain/usecases/send_otp_usecase.dart';
 import 'package:construculator/libraries/analytics/domain/entities/analytics_event.dart';
 import 'package:construculator/libraries/analytics/domain/repositories/analytics_repository.dart';
+import 'package:construculator/libraries/analytics/domain/utils/failure_analytics_reason.dart';
 import 'package:construculator/libraries/auth/data/models/professional_role.dart';
 import 'package:construculator/libraries/auth/domain/types/auth_types.dart';
 import 'package:construculator/libraries/auth/domain/validation/auth_validation.dart';
@@ -220,7 +221,7 @@ class CreateAccountBloc extends Bloc<CreateAccountEvent, CreateAccountState> {
           _analyticsRepository.track(
             AnalyticsEvent(
               name: 'user_registration_failed',
-              properties: {'reason': _failureReason(failure)},
+              properties: {'reason': failure.analyticsReason},
             ),
           ),
         );
@@ -236,7 +237,4 @@ class CreateAccountBloc extends Bloc<CreateAccountEvent, CreateAccountState> {
       },
     );
   }
-
-  String _failureReason(Failure failure) =>
-      failure is AuthFailure ? failure.errorType.name : 'unexpected';
 }

--- a/lib/features/auth/presentation/bloc/create_account_bloc/create_account_bloc.dart
+++ b/lib/features/auth/presentation/bloc/create_account_bloc/create_account_bloc.dart
@@ -1,7 +1,11 @@
+import 'dart:async';
+
 import 'package:construculator/features/auth/domain/usecases/create_account_usecase.dart';
 import 'package:construculator/features/auth/domain/usecases/get_professional_roles_usecase.dart';
 import 'package:construculator/features/auth/domain/usecases/params/create_account_usecase_params.dart';
 import 'package:construculator/features/auth/domain/usecases/send_otp_usecase.dart';
+import 'package:construculator/libraries/analytics/domain/entities/analytics_event.dart';
+import 'package:construculator/libraries/analytics/domain/repositories/analytics_repository.dart';
 import 'package:construculator/libraries/auth/data/models/professional_role.dart';
 import 'package:construculator/libraries/auth/domain/types/auth_types.dart';
 import 'package:construculator/libraries/auth/domain/validation/auth_validation.dart';
@@ -20,11 +24,13 @@ class CreateAccountBloc extends Bloc<CreateAccountEvent, CreateAccountState> {
   final CreateAccountUseCase _createAccountUseCase;
   final GetProfessionalRolesUseCase _getProfessionalRolesUseCase;
   final SendOtpUseCase _sendOtpUseCase;
+  final AnalyticsRepository _analyticsRepository;
 
   CreateAccountBloc({
     required this._createAccountUseCase,
     required this._getProfessionalRolesUseCase,
     required this._sendOtpUseCase,
+    required this._analyticsRepository,
   }) : super(CreateAccountInitial()) {
     on<CreateAccountSubmitted>(_onSubmitted);
     on<CreateAccountGetProfessionalRolesRequested>(_onLoadProfessionalRoles);
@@ -209,8 +215,28 @@ class CreateAccountBloc extends Bloc<CreateAccountEvent, CreateAccountState> {
       ),
     );
     result.fold(
-      (failure) => emit(CreateAccountFailure(failure: failure)),
-      (roles) => emit(CreateAccountSuccess()),
+      (failure) {
+        unawaited(
+          _analyticsRepository.track(
+            AnalyticsEvent(
+              name: 'user_registration_failed',
+              properties: {'reason': _failureReason(failure)},
+            ),
+          ),
+        );
+        emit(CreateAccountFailure(failure: failure));
+      },
+      (roles) {
+        unawaited(
+          _analyticsRepository.track(
+            const AnalyticsEvent(name: 'user_registered'),
+          ),
+        );
+        emit(CreateAccountSuccess());
+      },
     );
   }
+
+  String _failureReason(Failure failure) =>
+      failure is AuthFailure ? failure.errorType.name : 'unexpected';
 }

--- a/lib/features/auth/presentation/bloc/enter_password_bloc/enter_password_bloc.dart
+++ b/lib/features/auth/presentation/bloc/enter_password_bloc/enter_password_bloc.dart
@@ -1,4 +1,8 @@
+import 'dart:async';
+
 import 'package:construculator/features/auth/domain/usecases/login_usecase.dart';
+import 'package:construculator/libraries/analytics/domain/entities/analytics_event.dart';
+import 'package:construculator/libraries/analytics/domain/repositories/analytics_repository.dart';
 import 'package:construculator/libraries/errors/failures.dart';
 import 'package:equatable/equatable.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -9,9 +13,12 @@ part 'enter_password_state.dart';
 /// Bloc for entering a password, submits the password to the server and logs the user in
 class EnterPasswordBloc extends Bloc<EnterPasswordEvent, EnterPasswordState> {
   final LoginUseCase _loginUseCase;
+  final AnalyticsRepository _analyticsRepository;
 
-  EnterPasswordBloc({required this._loginUseCase})
-    : super(EnterPasswordInitial()) {
+  EnterPasswordBloc({
+    required this._loginUseCase,
+    required this._analyticsRepository,
+  }) : super(EnterPasswordInitial()) {
     on<EnterPasswordSubmitted>(_onSubmitted);
   }
 
@@ -22,8 +29,28 @@ class EnterPasswordBloc extends Bloc<EnterPasswordEvent, EnterPasswordState> {
     emit(EnterPasswordSubmitLoading());
     final result = await _loginUseCase(event.email, event.password);
     result.fold(
-      (failure) => emit(EnterPasswordSubmitFailure(failure: failure)),
-      (credential) => emit(EnterPasswordSubmitSuccess()),
+      (failure) {
+        unawaited(
+          _analyticsRepository.track(
+            AnalyticsEvent(
+              name: 'user_login_failed',
+              properties: {'reason': _failureReason(failure)},
+            ),
+          ),
+        );
+        emit(EnterPasswordSubmitFailure(failure: failure));
+      },
+      (credential) {
+        unawaited(
+          _analyticsRepository.track(
+            const AnalyticsEvent(name: 'user_logged_in'),
+          ),
+        );
+        emit(EnterPasswordSubmitSuccess());
+      },
     );
   }
+
+  String _failureReason(Failure failure) =>
+      failure is AuthFailure ? failure.errorType.name : 'unexpected';
 }

--- a/lib/features/auth/presentation/bloc/enter_password_bloc/enter_password_bloc.dart
+++ b/lib/features/auth/presentation/bloc/enter_password_bloc/enter_password_bloc.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:construculator/features/auth/domain/usecases/login_usecase.dart';
 import 'package:construculator/libraries/analytics/domain/entities/analytics_event.dart';
 import 'package:construculator/libraries/analytics/domain/repositories/analytics_repository.dart';
+import 'package:construculator/libraries/analytics/domain/utils/failure_analytics_reason.dart';
 import 'package:construculator/libraries/errors/failures.dart';
 import 'package:equatable/equatable.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -34,7 +35,7 @@ class EnterPasswordBloc extends Bloc<EnterPasswordEvent, EnterPasswordState> {
           _analyticsRepository.track(
             AnalyticsEvent(
               name: 'user_login_failed',
-              properties: {'reason': _failureReason(failure)},
+              properties: {'reason': failure.analyticsReason},
             ),
           ),
         );
@@ -50,7 +51,4 @@ class EnterPasswordBloc extends Bloc<EnterPasswordEvent, EnterPasswordState> {
       },
     );
   }
-
-  String _failureReason(Failure failure) =>
-      failure is AuthFailure ? failure.errorType.name : 'unexpected';
 }

--- a/lib/features/auth/testing/auth_test_module.dart
+++ b/lib/features/auth/testing/auth_test_module.dart
@@ -16,7 +16,6 @@ import 'package:construculator/features/auth/presentation/bloc/otp_verification_
 import 'package:construculator/features/auth/presentation/bloc/register_with_email_bloc/register_with_email_bloc.dart';
 import 'package:construculator/features/auth/presentation/bloc/set_new_password_bloc/set_new_password_bloc.dart';
 import 'package:construculator/libraries/analytics/current_screen_tracker.dart';
-import 'package:construculator/libraries/analytics/data/repositories/no_op_analytics_repository.dart';
 import 'package:construculator/libraries/analytics/domain/repositories/analytics_repository.dart';
 import 'package:construculator/libraries/analytics/testing/fake_analytics_repository.dart';
 import 'package:construculator/libraries/analytics/testing/fake_feature_flag_repository.dart';
@@ -38,21 +37,21 @@ import 'package:construculator/libraries/time/testing/fake_clock_impl.dart';
 import 'package:flutter_modular/flutter_modular.dart';
 
 class AuthTestModule extends Module {
+  final AppBootstrap appBootstrap = AppBootstrap(
+    envLoader: FakeEnvLoader(),
+    config: FakeAppConfig(),
+    supabaseWrapper: FakeSupabaseWrapper(clock: FakeClockImpl()),
+    sentryWrapper: FakeSentryWrapper(),
+    analyticsRepository: FakeAnalyticsRepository(),
+    powerSyncDatabase: FakePowerSyncDatabase(),
+    featureFlagRepository: FakeFeatureFlagRepository(),
+    currentScreenTracker: CurrentScreenTracker(),
+  );
+
   @override
   List<Module> get imports => [
     ClockTestModule(),
-    AuthLibraryModule(
-      AppBootstrap(
-        envLoader: FakeEnvLoader(),
-        config: FakeAppConfig(),
-        supabaseWrapper: FakeSupabaseWrapper(clock: FakeClockImpl()),
-        sentryWrapper: FakeSentryWrapper(),
-        analyticsRepository: const NoOpAnalyticsRepository(),
-        powerSyncDatabase: FakePowerSyncDatabase(),
-        featureFlagRepository: FakeFeatureFlagRepository(),
-        currentScreenTracker: CurrentScreenTracker(),
-      ),
-    ),
+    AuthLibraryModule(appBootstrap),
     RouterTestModule(),
   ];
 
@@ -63,7 +62,7 @@ class AuthTestModule extends Module {
       () => i<AuthNotifierController>() as AuthNotifier,
     );
     i.addSingleton<AuthRepository>(() => FakeAuthRepository(clock: i<Clock>()));
-    i.addSingleton<AnalyticsRepository>(() => FakeAnalyticsRepository());
+    i.addSingleton<AnalyticsRepository>(() => appBootstrap.analyticsRepository);
 
     i.add<ResetPasswordUseCase>(() => ResetPasswordUseCase(i()));
     i.add<GetProfessionalRolesUseCase>(() => GetProfessionalRolesUseCase(i()));
@@ -89,14 +88,17 @@ class AuthTestModule extends Module {
         createAccountUseCase: i(),
         getProfessionalRolesUseCase: i(),
         sendOtpUseCase: i(),
-        analyticsRepository: i(),
+        analyticsRepository: appBootstrap.analyticsRepository,
       ),
     );
     i.add<LoginWithEmailBloc>(
       () => LoginWithEmailBloc(checkEmailAvailabilityUseCase: i()),
     );
     i.add<EnterPasswordBloc>(
-      () => EnterPasswordBloc(loginUseCase: i(), analyticsRepository: i()),
+      () => EnterPasswordBloc(
+        loginUseCase: i(),
+        analyticsRepository: appBootstrap.analyticsRepository,
+      ),
     );
     i.add<ForgotPasswordBloc>(
       () => ForgotPasswordBloc(resetPasswordUseCase: i()),

--- a/lib/features/auth/testing/auth_test_module.dart
+++ b/lib/features/auth/testing/auth_test_module.dart
@@ -16,6 +16,8 @@ import 'package:construculator/features/auth/presentation/bloc/otp_verification_
 import 'package:construculator/features/auth/presentation/bloc/register_with_email_bloc/register_with_email_bloc.dart';
 import 'package:construculator/features/auth/presentation/bloc/set_new_password_bloc/set_new_password_bloc.dart';
 import 'package:construculator/libraries/analytics/data/repositories/no_op_analytics_repository.dart';
+import 'package:construculator/libraries/analytics/domain/repositories/analytics_repository.dart';
+import 'package:construculator/libraries/analytics/testing/fake_analytics_repository.dart';
 import 'package:construculator/libraries/analytics/testing/fake_feature_flag_repository.dart';
 import 'package:construculator/libraries/auth/auth_library_module.dart';
 import 'package:construculator/libraries/auth/interfaces/auth_notifier.dart';
@@ -59,6 +61,7 @@ class AuthTestModule extends Module {
       () => i<AuthNotifierController>() as AuthNotifier,
     );
     i.addSingleton<AuthRepository>(() => FakeAuthRepository(clock: i<Clock>()));
+    i.addSingleton<AnalyticsRepository>(() => FakeAnalyticsRepository());
 
     i.add<ResetPasswordUseCase>(() => ResetPasswordUseCase(i()));
     i.add<GetProfessionalRolesUseCase>(() => GetProfessionalRolesUseCase(i()));
@@ -84,12 +87,15 @@ class AuthTestModule extends Module {
         createAccountUseCase: i(),
         getProfessionalRolesUseCase: i(),
         sendOtpUseCase: i(),
+        analyticsRepository: i(),
       ),
     );
     i.add<LoginWithEmailBloc>(
       () => LoginWithEmailBloc(checkEmailAvailabilityUseCase: i()),
     );
-    i.add<EnterPasswordBloc>(() => EnterPasswordBloc(loginUseCase: i()));
+    i.add<EnterPasswordBloc>(
+      () => EnterPasswordBloc(loginUseCase: i(), analyticsRepository: i()),
+    );
     i.add<ForgotPasswordBloc>(
       () => ForgotPasswordBloc(resetPasswordUseCase: i()),
     );

--- a/lib/features/auth/testing/auth_test_module.dart
+++ b/lib/features/auth/testing/auth_test_module.dart
@@ -15,6 +15,7 @@ import 'package:construculator/features/auth/presentation/bloc/login_with_email_
 import 'package:construculator/features/auth/presentation/bloc/otp_verification_bloc/otp_verification_bloc.dart';
 import 'package:construculator/features/auth/presentation/bloc/register_with_email_bloc/register_with_email_bloc.dart';
 import 'package:construculator/features/auth/presentation/bloc/set_new_password_bloc/set_new_password_bloc.dart';
+import 'package:construculator/libraries/analytics/current_screen_tracker.dart';
 import 'package:construculator/libraries/analytics/data/repositories/no_op_analytics_repository.dart';
 import 'package:construculator/libraries/analytics/domain/repositories/analytics_repository.dart';
 import 'package:construculator/libraries/analytics/testing/fake_analytics_repository.dart';
@@ -49,6 +50,7 @@ class AuthTestModule extends Module {
         analyticsRepository: const NoOpAnalyticsRepository(),
         powerSyncDatabase: FakePowerSyncDatabase(),
         featureFlagRepository: FakeFeatureFlagRepository(),
+        currentScreenTracker: CurrentScreenTracker(),
       ),
     ),
     RouterTestModule(),

--- a/lib/libraries/analytics/analytics_navigator_observer.dart
+++ b/lib/libraries/analytics/analytics_navigator_observer.dart
@@ -40,14 +40,44 @@ class AnalyticsNavigatorObserver extends NavigatorObserver {
   @override
   void didPush(Route<dynamic> route, Route<dynamic>? previousRoute) {
     super.didPush(route, previousRoute);
+    final templateName = _templateNameOf(route);
+    _syncScreenName(templateName);
+    _trackScreenView(templateName);
+  }
+
+  @override
+  void didPop(Route<dynamic> route, Route<dynamic>? previousRoute) {
+    super.didPop(route, previousRoute);
+    if (previousRoute != null) {
+      _syncScreenName(_templateNameOf(previousRoute));
+    }
+  }
+
+  @override
+  void didRemove(Route<dynamic> route, Route<dynamic>? previousRoute) {
+    super.didRemove(route, previousRoute);
+    if (previousRoute != null) {
+      _syncScreenName(_templateNameOf(previousRoute));
+    }
+  }
+
+  @override
+  void didReplace({Route<dynamic>? newRoute, Route<dynamic>? oldRoute}) {
+    super.didReplace(newRoute: newRoute, oldRoute: oldRoute);
+    if (newRoute != null) {
+      _syncScreenName(_templateNameOf(newRoute));
+    }
+  }
+
+  String? _templateNameOf(Route<dynamic> route) {
     final settings = route.settings;
-    final templateName = settings is ModularPage
-        ? settings.route.name
-        : settings.name;
+    return settings is ModularPage ? settings.route.name : settings.name;
+  }
+
+  void _syncScreenName(String? templateName) {
     if (templateName != null && templateName.isNotEmpty) {
       _currentScreenTracker.screenName = templateName;
     }
-    _trackScreenView(templateName);
   }
 
   void _trackScreenView(String? screenName) {

--- a/lib/libraries/analytics/analytics_navigator_observer.dart
+++ b/lib/libraries/analytics/analytics_navigator_observer.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:construculator/libraries/analytics/current_screen_tracker.dart';
 import 'package:construculator/libraries/analytics/domain/entities/analytics_event.dart';
 import 'package:construculator/libraries/analytics/domain/repositories/analytics_repository.dart';
 import 'package:flutter/widgets.dart';
@@ -24,9 +25,17 @@ import 'package:flutter_modular/src/presenter/navigation/modular_page.dart';
 /// since a disabled app resolves to `NoOpAnalyticsRepository` at bootstrap.
 class AnalyticsNavigatorObserver extends NavigatorObserver {
   /// Creates an [AnalyticsNavigatorObserver] backed by [analyticsRepository].
-  AnalyticsNavigatorObserver({required this._analyticsRepository});
+  ///
+  /// [currentScreenTracker] must be the same instance given to
+  /// `AnalyticsRepositoryImpl` so every tracked event, not just
+  /// `screen_viewed`, carries the currently active screen.
+  AnalyticsNavigatorObserver({
+    required this._analyticsRepository,
+    required this._currentScreenTracker,
+  });
 
   final AnalyticsRepository _analyticsRepository;
+  final CurrentScreenTracker _currentScreenTracker;
 
   @override
   void didPush(Route<dynamic> route, Route<dynamic>? previousRoute) {
@@ -35,6 +44,9 @@ class AnalyticsNavigatorObserver extends NavigatorObserver {
     final templateName = settings is ModularPage
         ? settings.route.name
         : settings.name;
+    if (templateName != null && templateName.isNotEmpty) {
+      _currentScreenTracker.screenName = templateName;
+    }
     _trackScreenView(templateName);
   }
 

--- a/lib/libraries/analytics/analytics_repository_factory.dart
+++ b/lib/libraries/analytics/analytics_repository_factory.dart
@@ -1,3 +1,4 @@
+import 'package:construculator/libraries/analytics/current_screen_tracker.dart';
 import 'package:construculator/libraries/analytics/data/repositories/analytics_repository_impl.dart';
 import 'package:construculator/libraries/analytics/data/repositories/no_op_analytics_repository.dart';
 import 'package:construculator/libraries/analytics/domain/repositories/analytics_repository.dart';
@@ -21,6 +22,8 @@ typedef PosthogWrapperBuilder = PosthogWrapper Function();
 Future<AnalyticsRepository> createAnalyticsRepository({
   required EnvLoader envLoader,
   required PosthogWrapperBuilder buildPosthogWrapper,
+  required CurrentScreenTracker currentScreenTracker,
+  required String appVersion,
 }) async {
   if (envLoader.get(analyticsEnabledKey) != 'true') {
     return const NoOpAnalyticsRepository();
@@ -31,6 +34,8 @@ Future<AnalyticsRepository> createAnalyticsRepository({
   final repository = AnalyticsRepositoryImpl(
     envLoader: envLoader,
     posthogWrapper: buildPosthogWrapper(),
+    currentScreenTracker: currentScreenTracker,
+    appVersion: appVersion,
   );
   await repository.initialize();
   return repository;

--- a/lib/libraries/analytics/current_screen_tracker.dart
+++ b/lib/libraries/analytics/current_screen_tracker.dart
@@ -1,0 +1,12 @@
+/// Shared, mutable holder of the currently active screen's sanitized
+/// template name (e.g. `/details/:estimationId`).
+///
+/// [AnalyticsNavigatorObserver] updates [screenName] on every navigation;
+/// [AnalyticsRepositoryImpl] reads it to attach `screen_name` to every
+/// tracked event, not just navigation events. A single instance must be
+/// shared between both — see `AppBootstrap.currentScreenTracker`.
+class CurrentScreenTracker {
+  /// The sanitized template name of the currently active screen, or `null`
+  /// before the first navigation.
+  String? screenName;
+}

--- a/lib/libraries/analytics/data/repositories/analytics_repository_impl.dart
+++ b/lib/libraries/analytics/data/repositories/analytics_repository_impl.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:construculator/libraries/analytics/current_screen_tracker.dart';
 import 'package:construculator/libraries/analytics/domain/entities/analytics_event.dart';
 import 'package:construculator/libraries/analytics/domain/entities/analytics_user_properties.dart';
 import 'package:construculator/libraries/analytics/domain/repositories/analytics_repository.dart';
@@ -11,6 +12,7 @@ import 'package:construculator/libraries/config/interfaces/env_loader.dart';
 import 'package:construculator/libraries/either/either.dart';
 import 'package:construculator/libraries/errors/failures.dart';
 import 'package:construculator/libraries/logging/app_logger.dart';
+import 'package:flutter/foundation.dart';
 
 /// PostHog-backed implementation of [AnalyticsRepository].
 ///
@@ -19,11 +21,49 @@ import 'package:construculator/libraries/logging/app_logger.dart';
 class AnalyticsRepositoryImpl implements AnalyticsRepository {
   final EnvLoader _envLoader;
   final PosthogWrapper _posthogWrapper;
+  final CurrentScreenTracker _currentScreenTracker;
+  final String _appVersion;
   static final _logger = AppLogger().tag('AnalyticsRepositoryImpl');
 
-  /// Creates an [AnalyticsRepositoryImpl] with the given [_envLoader] and
-  /// [_posthogWrapper].
-  AnalyticsRepositoryImpl({required this._envLoader, required this._posthogWrapper});
+  /// Creates an [AnalyticsRepositoryImpl].
+  ///
+  /// [currentScreenTracker] must be the same instance given to
+  /// `AnalyticsNavigatorObserver` so `track()` can attach the currently
+  /// active screen to every event. [appVersion] is resolved once at
+  /// bootstrap (e.g. via `package_info_plus`) since it never changes at
+  /// runtime.
+  AnalyticsRepositoryImpl({
+    required this._envLoader,
+    required this._posthogWrapper,
+    required this._currentScreenTracker,
+    required this._appVersion,
+  });
+
+  /// Standard properties attached to every [track]ed event, per
+  /// `docs/Logging/PostHog-Event-Tracking.md`'s "Standard Properties"
+  /// contract.
+  Map<String, dynamic> get _standardProperties => {
+    'app_version': _appVersion,
+    'platform': _platformName,
+    'screen_name': _currentScreenTracker.screenName,
+  };
+
+  String get _platformName {
+    switch (defaultTargetPlatform) {
+      case TargetPlatform.iOS:
+        return 'ios';
+      case TargetPlatform.android:
+        return 'android';
+      case TargetPlatform.macOS:
+        return 'macos';
+      case TargetPlatform.windows:
+        return 'windows';
+      case TargetPlatform.linux:
+        return 'linux';
+      case TargetPlatform.fuchsia:
+        return 'fuchsia';
+    }
+  }
 
   /// Reads PostHog configuration from [_envLoader] and initializes the
   /// underlying wrapper.
@@ -68,7 +108,7 @@ class AnalyticsRepositoryImpl implements AnalyticsRepository {
     try {
       await _posthogWrapper.capture(
         eventName: event.name,
-        properties: event.properties,
+        properties: {..._standardProperties, ...event.properties},
       );
       return const Right(null);
     } catch (e) {

--- a/lib/libraries/analytics/domain/utils/failure_analytics_reason.dart
+++ b/lib/libraries/analytics/domain/utils/failure_analytics_reason.dart
@@ -1,0 +1,9 @@
+import 'package:construculator/libraries/errors/failures.dart';
+
+/// Maps a [Failure] to a typed, PII-free reason string for analytics
+/// failure events.
+extension FailureAnalyticsReason on Failure {
+  /// The reason to attach to an analytics failure event's `reason` property.
+  String get analyticsReason =>
+      this is AuthFailure ? (this as AuthFailure).errorType.name : 'unexpected';
+}

--- a/lib/libraries/analytics/testing/fake_analytics_repository.dart
+++ b/lib/libraries/analytics/testing/fake_analytics_repository.dart
@@ -26,8 +26,13 @@ class FakeAnalyticsRepository implements AnalyticsRepository {
   /// Recorded calls to [group].
   final List<GroupCall> groupCalls = [];
 
+  /// Method names in call order, e.g. `['track', 'reset']` — lets tests
+  /// assert ordering between methods, not just that each was called.
+  final List<String> callSequence = [];
+
   @override
   Future<Either<Failure, void>> track(AnalyticsEvent event) async {
+    callSequence.add('track');
     trackedEvents.add(event);
     return const Right(null);
   }
@@ -37,12 +42,14 @@ class FakeAnalyticsRepository implements AnalyticsRepository {
     required String userId,
     required AnalyticsUserProperties properties,
   }) async {
+    callSequence.add('identify');
     identifyCalls.add(IdentifyCall(userId: userId, properties: properties));
     return const Right(null);
   }
 
   @override
   Future<Either<Failure, void>> reset() async {
+    callSequence.add('reset');
     resetCallCount++;
     return const Right(null);
   }
@@ -80,6 +87,7 @@ class FakeAnalyticsRepository implements AnalyticsRepository {
     resetCallCount = 0;
     setUserPropertiesCalls.clear();
     groupCalls.clear();
+    callSequence.clear();
   }
 }
 

--- a/lib/libraries/auth/auth_manager_impl.dart
+++ b/lib/libraries/auth/auth_manager_impl.dart
@@ -352,12 +352,12 @@ class AuthManagerImpl implements AuthManager {
       await _wrapper.signOut();
 
       await _sentryWrapper.setUser(null);
-      await _analyticsRepository.reset();
       unawaited(
         _analyticsRepository.track(
           const AnalyticsEvent(name: 'user_logged_out'),
         ),
       );
+      await _analyticsRepository.reset();
 
       _logger.info('Logout successful');
       return AuthResult.success(null);

--- a/lib/libraries/auth/auth_manager_impl.dart
+++ b/lib/libraries/auth/auth_manager_impl.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'package:construculator/libraries/analytics/domain/entities/analytics_event.dart';
 import 'package:construculator/libraries/analytics/domain/entities/analytics_user_properties.dart';
 import 'package:construculator/libraries/analytics/domain/repositories/analytics_repository.dart';
 import 'package:construculator/libraries/auth/data/models/auth_credential.dart';
@@ -352,6 +353,11 @@ class AuthManagerImpl implements AuthManager {
 
       await _sentryWrapper.setUser(null);
       await _analyticsRepository.reset();
+      unawaited(
+        _analyticsRepository.track(
+          const AnalyticsEvent(name: 'user_logged_out'),
+        ),
+      );
 
       _logger.info('Logout successful');
       return AuthResult.success(null);

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,6 +2,7 @@ import 'package:construculator/app/app.dart';
 import 'package:construculator/app/app_bootstrap.dart';
 import 'package:construculator/app/app_module.dart';
 import 'package:construculator/libraries/analytics/analytics_repository_factory.dart';
+import 'package:construculator/libraries/analytics/current_screen_tracker.dart';
 import 'package:construculator/libraries/analytics/data/repositories/feature_flag_repository_impl.dart';
 import 'package:construculator/libraries/analytics/data/repositories/no_op_feature_flag_repository.dart';
 import 'package:construculator/libraries/analytics/domain/repositories/feature_flag_repository.dart';
@@ -18,6 +19,7 @@ import 'package:construculator/libraries/sentry/sentry_wrapper_impl.dart';
 import 'package:construculator/libraries/supabase/supabase_wrapper_impl.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_modular/flutter_modular.dart';
+import 'package:package_info_plus/package_info_plus.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -31,7 +33,10 @@ Future<void> main() async {
     () => runApp(
       ModularApp(
         module: AppModule(appBootstrap),
-        child: AppWidget(analyticsRepository: appBootstrap.analyticsRepository),
+        child: AppWidget(
+          analyticsRepository: appBootstrap.analyticsRepository,
+          currentScreenTracker: appBootstrap.currentScreenTracker,
+        ),
       ),
     ),
   );
@@ -55,9 +60,13 @@ Future<AppBootstrap> _initializeApp() async {
     sentrySdk: SentrySdkImpl(),
   );
   final powerSyncDatabase = await openPowerSyncDatabase();
+  final currentScreenTracker = CurrentScreenTracker();
+  final packageInfo = await PackageInfo.fromPlatform();
   final analyticsRepository = await createAnalyticsRepository(
     envLoader: envLoader,
     buildPosthogWrapper: () => PosthogWrapperImpl(posthogSdk: PosthogSdkImpl()),
+    currentScreenTracker: currentScreenTracker,
+    appVersion: packageInfo.version,
   );
   final featureFlagRepository = await _initializeFeatureFlagRepository(
     envLoader,
@@ -70,6 +79,7 @@ Future<AppBootstrap> _initializeApp() async {
     analyticsRepository: analyticsRepository,
     powerSyncDatabase: powerSyncDatabase,
     featureFlagRepository: featureFlagRepository,
+    currentScreenTracker: currentScreenTracker,
   );
 }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -797,7 +797,7 @@ packages:
     source: hosted
     version: "2.2.0"
   package_info_plus:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: package_info_plus
       sha256: "127e1751e37ffb2ff4658beeaca77bad0c27bf5f932bd3a501c2296926d4b481"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -35,6 +35,7 @@ dependencies:
   posthog_flutter: 5.35.1
   path_provider: 2.1.6
   path: 1.9.1
+  package_info_plus: 10.2.1
 
 dev_dependencies:
   flutter_test:

--- a/test/app/shell/tab_module_manager_test.dart
+++ b/test/app/shell/tab_module_manager_test.dart
@@ -2,6 +2,7 @@ import 'package:construculator/app/app_bootstrap.dart';
 import 'package:construculator/app/shell/module_model.dart';
 import 'package:construculator/app/shell/shell_module.dart';
 import 'package:construculator/app/shell/tab_module_manager.dart';
+import 'package:construculator/libraries/analytics/current_screen_tracker.dart';
 import 'package:construculator/libraries/analytics/data/repositories/no_op_analytics_repository.dart';
 import 'package:construculator/libraries/analytics/testing/fake_feature_flag_repository.dart';
 import 'package:construculator/libraries/config/testing/fake_app_config.dart';
@@ -27,6 +28,7 @@ void main() {
           analyticsRepository: const NoOpAnalyticsRepository(),
           powerSyncDatabase: FakePowerSyncDatabase(),
           featureFlagRepository: FakeFeatureFlagRepository(),
+          currentScreenTracker: CurrentScreenTracker(),
         );
         Modular.init(ShellModule(appBootstrap));
         manager = Modular.get<TabModuleManager>();
@@ -72,6 +74,7 @@ void main() {
           analyticsRepository: const NoOpAnalyticsRepository(),
           powerSyncDatabase: FakePowerSyncDatabase(),
           featureFlagRepository: FakeFeatureFlagRepository(),
+          currentScreenTracker: CurrentScreenTracker(),
         );
         Modular.init(_TestShellModule(appBootstrap));
         customManager = Modular.get<TabModuleManager>();

--- a/test/features/auth/units/blocs/create_account_bloc_test.dart
+++ b/test/features/auth/units/blocs/create_account_bloc_test.dart
@@ -655,21 +655,19 @@ void main() {
         ),
       ],
       verify: (_) {
-        expect(fakeAnalytics.trackedEvents, hasLength(1));
-        expect(
-          fakeAnalytics.trackedEvents.single.name,
-          'user_registration_failed',
-        );
-        expect(
-          fakeAnalytics.trackedEvents.single.properties['reason'],
-          isNotEmpty,
-        );
+        expect(fakeAnalytics.trackedEvents, [
+          const AnalyticsEvent(
+            name: 'user_registration_failed',
+            properties: {'reason': 'serverError'},
+          ),
+        ]);
       },
     );
 
     blocTest<CreateAccountBloc, CreateAccountState>(
       'emits [Loading, Failure] when user profile creation fails',
       build: () {
+        fakeSupabase.setCurrentUser(createFakeUser('fail-insert@example.com'));
         fakeSupabase.shouldThrowOnInsert = true;
         return bloc;
       },
@@ -694,15 +692,12 @@ void main() {
         ),
       ],
       verify: (_) {
-        expect(fakeAnalytics.trackedEvents, hasLength(1));
-        expect(
-          fakeAnalytics.trackedEvents.single.name,
-          'user_registration_failed',
-        );
-        expect(
-          fakeAnalytics.trackedEvents.single.properties['reason'],
-          isNotEmpty,
-        );
+        expect(fakeAnalytics.trackedEvents, [
+          const AnalyticsEvent(
+            name: 'user_registration_failed',
+            properties: {'reason': 'serverError'},
+          ),
+        ]);
       },
     );
   });

--- a/test/features/auth/units/blocs/create_account_bloc_test.dart
+++ b/test/features/auth/units/blocs/create_account_bloc_test.dart
@@ -1,6 +1,9 @@
 import 'package:bloc_test/bloc_test.dart';
 import 'package:construculator/features/auth/presentation/bloc/create_account_bloc/create_account_bloc.dart';
 import 'package:construculator/features/auth/testing/auth_test_module.dart';
+import 'package:construculator/libraries/analytics/domain/entities/analytics_event.dart';
+import 'package:construculator/libraries/analytics/domain/repositories/analytics_repository.dart';
+import 'package:construculator/libraries/analytics/testing/fake_analytics_repository.dart';
 import 'package:construculator/libraries/auth/domain/types/auth_types.dart';
 import 'package:construculator/libraries/errors/failures.dart';
 import 'package:construculator/libraries/supabase/interfaces/supabase_wrapper.dart';
@@ -12,6 +15,7 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   late FakeSupabaseWrapper fakeSupabase;
+  late FakeAnalyticsRepository fakeAnalytics;
   late Clock clock;
   late CreateAccountBloc bloc;
   const testPhone = '+12019292918';
@@ -28,12 +32,15 @@ void main() {
   setUp(() {
     Modular.init(AuthTestModule());
     fakeSupabase = Modular.get<SupabaseWrapper>() as FakeSupabaseWrapper;
+    fakeAnalytics =
+        Modular.get<AnalyticsRepository>() as FakeAnalyticsRepository;
     clock = Modular.get<Clock>();
     bloc = Modular.get<CreateAccountBloc>();
   });
 
   tearDown(() {
     fakeSupabase.reset();
+    fakeAnalytics.resetFake();
     Modular.destroy();
   });
 
@@ -614,6 +621,11 @@ void main() {
         ),
       ),
       expect: () => [isA<CreateAccountLoading>(), isA<CreateAccountSuccess>()],
+      verify: (_) {
+        expect(fakeAnalytics.trackedEvents, [
+          const AnalyticsEvent(name: 'user_registered'),
+        ]);
+      },
     );
 
     blocTest<CreateAccountBloc, CreateAccountState>(
@@ -642,6 +654,17 @@ void main() {
           isA<AuthFailure>(),
         ),
       ],
+      verify: (_) {
+        expect(fakeAnalytics.trackedEvents, hasLength(1));
+        expect(
+          fakeAnalytics.trackedEvents.single.name,
+          'user_registration_failed',
+        );
+        expect(
+          fakeAnalytics.trackedEvents.single.properties['reason'],
+          isNotEmpty,
+        );
+      },
     );
 
     blocTest<CreateAccountBloc, CreateAccountState>(
@@ -670,6 +693,17 @@ void main() {
           isA<AuthFailure>(),
         ),
       ],
+      verify: (_) {
+        expect(fakeAnalytics.trackedEvents, hasLength(1));
+        expect(
+          fakeAnalytics.trackedEvents.single.name,
+          'user_registration_failed',
+        );
+        expect(
+          fakeAnalytics.trackedEvents.single.properties['reason'],
+          isNotEmpty,
+        );
+      },
     );
   });
 }

--- a/test/features/auth/units/blocs/enter_password_bloc_test.dart
+++ b/test/features/auth/units/blocs/enter_password_bloc_test.dart
@@ -75,7 +75,7 @@ void main() {
         act: (bloc) => bloc.add(
           EnterPasswordSubmitted(
             email: 'test@example.com',
-            password: 'wrongpassword',
+            password: '@Password123!',
           ),
         ),
         expect: () => [
@@ -83,12 +83,12 @@ void main() {
           isA<EnterPasswordSubmitFailure>(),
         ],
         verify: (_) {
-          expect(fakeAnalytics.trackedEvents, hasLength(1));
-          expect(fakeAnalytics.trackedEvents.single.name, 'user_login_failed');
-          expect(
-            fakeAnalytics.trackedEvents.single.properties['reason'],
-            isNotEmpty,
-          );
+          expect(fakeAnalytics.trackedEvents, [
+            const AnalyticsEvent(
+              name: 'user_login_failed',
+              properties: {'reason': 'unknownError'},
+            ),
+          ]);
         },
       );
     });

--- a/test/features/auth/units/blocs/enter_password_bloc_test.dart
+++ b/test/features/auth/units/blocs/enter_password_bloc_test.dart
@@ -4,6 +4,7 @@ import 'package:construculator/features/auth/testing/auth_test_module.dart';
 import 'package:construculator/libraries/analytics/domain/entities/analytics_event.dart';
 import 'package:construculator/libraries/analytics/domain/repositories/analytics_repository.dart';
 import 'package:construculator/libraries/analytics/testing/fake_analytics_repository.dart';
+import 'package:construculator/libraries/supabase/data/supabase_types.dart';
 import 'package:construculator/libraries/supabase/interfaces/supabase_wrapper.dart';
 import 'package:construculator/libraries/supabase/testing/fake_supabase_user.dart';
 import 'package:construculator/libraries/supabase/testing/fake_supabase_wrapper.dart';
@@ -67,7 +68,7 @@ void main() {
       );
 
       blocTest<EnterPasswordBloc, EnterPasswordState>(
-        'emits [EnterPasswordSubmitLoading, EnterPasswordSubmitFailure] when invalid credentials',
+        'emits [EnterPasswordSubmitLoading, EnterPasswordSubmitFailure] on an unrecognized sign-in error',
         build: () {
           fakeSupabase.shouldThrowOnSignIn = true;
           return bloc;
@@ -87,6 +88,33 @@ void main() {
             const AnalyticsEvent(
               name: 'user_login_failed',
               properties: {'reason': 'unknownError'},
+            ),
+          ]);
+        },
+      );
+
+      blocTest<EnterPasswordBloc, EnterPasswordState>(
+        'emits [EnterPasswordSubmitLoading, EnterPasswordSubmitFailure] when invalid credentials',
+        build: () {
+          fakeSupabase.shouldThrowOnSignIn = true;
+          fakeSupabase.authErrorCode = SupabaseAuthErrorCode.invalidCredentials;
+          return bloc;
+        },
+        act: (bloc) => bloc.add(
+          EnterPasswordSubmitted(
+            email: 'test@example.com',
+            password: '@Password123!',
+          ),
+        ),
+        expect: () => [
+          EnterPasswordSubmitLoading(),
+          isA<EnterPasswordSubmitFailure>(),
+        ],
+        verify: (_) {
+          expect(fakeAnalytics.trackedEvents, [
+            const AnalyticsEvent(
+              name: 'user_login_failed',
+              properties: {'reason': 'invalidCredentials'},
             ),
           ]);
         },

--- a/test/features/auth/units/blocs/enter_password_bloc_test.dart
+++ b/test/features/auth/units/blocs/enter_password_bloc_test.dart
@@ -1,6 +1,9 @@
 import 'package:bloc_test/bloc_test.dart';
 import 'package:construculator/features/auth/presentation/bloc/enter_password_bloc/enter_password_bloc.dart';
 import 'package:construculator/features/auth/testing/auth_test_module.dart';
+import 'package:construculator/libraries/analytics/domain/entities/analytics_event.dart';
+import 'package:construculator/libraries/analytics/domain/repositories/analytics_repository.dart';
+import 'package:construculator/libraries/analytics/testing/fake_analytics_repository.dart';
 import 'package:construculator/libraries/supabase/interfaces/supabase_wrapper.dart';
 import 'package:construculator/libraries/supabase/testing/fake_supabase_user.dart';
 import 'package:construculator/libraries/supabase/testing/fake_supabase_wrapper.dart';
@@ -10,6 +13,7 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   late FakeSupabaseWrapper fakeSupabase;
+  late FakeAnalyticsRepository fakeAnalytics;
   late Clock clock;
   late EnterPasswordBloc bloc;
 
@@ -24,12 +28,15 @@ void main() {
   setUp(() {
     Modular.init(AuthTestModule());
     fakeSupabase = Modular.get<SupabaseWrapper>() as FakeSupabaseWrapper;
+    fakeAnalytics =
+        Modular.get<AnalyticsRepository>() as FakeAnalyticsRepository;
     clock = Modular.get<Clock>();
     bloc = Modular.get<EnterPasswordBloc>();
   });
 
   tearDown(() {
     fakeSupabase.reset();
+    fakeAnalytics.resetFake();
     bloc.close();
     Modular.destroy();
   });
@@ -52,6 +59,11 @@ void main() {
           EnterPasswordSubmitLoading(),
           EnterPasswordSubmitSuccess(),
         ],
+        verify: (_) {
+          expect(fakeAnalytics.trackedEvents, [
+            const AnalyticsEvent(name: 'user_logged_in'),
+          ]);
+        },
       );
 
       blocTest<EnterPasswordBloc, EnterPasswordState>(
@@ -70,6 +82,14 @@ void main() {
           EnterPasswordSubmitLoading(),
           isA<EnterPasswordSubmitFailure>(),
         ],
+        verify: (_) {
+          expect(fakeAnalytics.trackedEvents, hasLength(1));
+          expect(fakeAnalytics.trackedEvents.single.name, 'user_login_failed');
+          expect(
+            fakeAnalytics.trackedEvents.single.properties['reason'],
+            isNotEmpty,
+          );
+        },
       );
     });
     group('Multiple Login Attempts', () {

--- a/test/features/auth/units/sign_up_sign_in_event_catalog_test.dart
+++ b/test/features/auth/units/sign_up_sign_in_event_catalog_test.dart
@@ -1,0 +1,147 @@
+import 'package:construculator/features/auth/presentation/bloc/create_account_bloc/create_account_bloc.dart';
+import 'package:construculator/features/auth/presentation/bloc/enter_password_bloc/enter_password_bloc.dart';
+import 'package:construculator/features/auth/testing/auth_test_module.dart';
+import 'package:construculator/libraries/analytics/domain/entities/analytics_event.dart';
+import 'package:construculator/libraries/analytics/domain/repositories/analytics_repository.dart';
+import 'package:construculator/libraries/analytics/testing/fake_analytics_repository.dart';
+import 'package:construculator/libraries/auth/interfaces/auth_manager.dart';
+import 'package:construculator/libraries/supabase/interfaces/supabase_wrapper.dart';
+import 'package:construculator/libraries/supabase/testing/fake_supabase_user.dart';
+import 'package:construculator/libraries/supabase/testing/fake_supabase_wrapper.dart';
+import 'package:construculator/libraries/time/interfaces/clock.dart';
+import 'package:flutter_modular/flutter_modular.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Pins the SignUp/SignIn/logout analytics event catalog (event name +
+/// sorted property keys) against every real trigger path, so a typo'd
+/// event name or a property rename shows up as an explicit, reviewable
+/// diff here instead of shipping silently. See the analytics event
+/// catalog doc linked on PR #508 for the source-of-truth property list.
+void main() {
+  late FakeSupabaseWrapper fakeSupabase;
+  late FakeAnalyticsRepository fakeAnalytics;
+  late Clock clock;
+
+  FakeUser createFakeUser(String email) {
+    return FakeUser(
+      id: 'fake-user-${email.hashCode}',
+      email: email,
+      createdAt: clock.now().toIso8601String(),
+    );
+  }
+
+  String catalogEntry(AnalyticsEvent event) {
+    final sortedKeys = event.properties.keys.toList()..sort();
+    return '${event.name}: $sortedKeys';
+  }
+
+  setUp(() {
+    Modular.init(AuthTestModule());
+    fakeSupabase = Modular.get<SupabaseWrapper>() as FakeSupabaseWrapper;
+    fakeAnalytics =
+        Modular.get<AnalyticsRepository>() as FakeAnalyticsRepository;
+    clock = Modular.get<Clock>();
+  });
+
+  tearDown(() {
+    fakeSupabase.reset();
+    fakeAnalytics.resetFake();
+    Modular.destroy();
+  });
+
+  test('SignUp/SignIn/logout analytics event catalog is unchanged', () async {
+    final catalog = <String>[];
+
+    // user_registered
+    final createAccountBloc = Modular.get<CreateAccountBloc>();
+    fakeSupabase.setCurrentUser(
+      createFakeUser('catalog-register@example.com'),
+    );
+    createAccountBloc.add(
+      const CreateAccountSubmitted(
+        email: 'catalog-register@example.com',
+        firstName: 'Cat',
+        lastName: 'Alog',
+        mobileNumber: '1234567890',
+        password: 'securePassword',
+        confirmPassword: 'securePassword',
+        role: 'engineer',
+        phonePrefix: '+1',
+      ),
+    );
+    await createAccountBloc.stream.firstWhere(
+      (s) => s is CreateAccountSuccess || s is CreateAccountFailure,
+    );
+    catalog.addAll(fakeAnalytics.trackedEvents.map(catalogEntry));
+    fakeAnalytics.resetFake();
+
+    // user_registration_failed
+    fakeSupabase.shouldThrowOnUpdate = true;
+    createAccountBloc.add(
+      const CreateAccountSubmitted(
+        email: 'catalog-register-fail@example.com',
+        firstName: 'Cat',
+        lastName: 'Alog',
+        mobileNumber: '1234567890',
+        password: 'securePassword',
+        confirmPassword: 'securePassword',
+        role: 'engineer',
+        phonePrefix: '+1',
+      ),
+    );
+    await createAccountBloc.stream.firstWhere(
+      (s) => s is CreateAccountSuccess || s is CreateAccountFailure,
+    );
+    catalog.addAll(fakeAnalytics.trackedEvents.map(catalogEntry));
+    fakeAnalytics.resetFake();
+    fakeSupabase.shouldThrowOnUpdate = false;
+
+    // user_logged_in
+    final enterPasswordBloc = Modular.get<EnterPasswordBloc>();
+    fakeSupabase.setCurrentUser(createFakeUser('catalog-login@example.com'));
+    enterPasswordBloc.add(
+      const EnterPasswordSubmitted(
+        email: 'catalog-login@example.com',
+        password: '@Password123!',
+      ),
+    );
+    await enterPasswordBloc.stream.firstWhere(
+      (s) => s is EnterPasswordSubmitSuccess || s is EnterPasswordSubmitFailure,
+    );
+    catalog.addAll(fakeAnalytics.trackedEvents.map(catalogEntry));
+    fakeAnalytics.resetFake();
+
+    // user_login_failed
+    fakeSupabase.shouldThrowOnSignIn = true;
+    enterPasswordBloc.add(
+      const EnterPasswordSubmitted(
+        email: 'catalog-login-fail@example.com',
+        password: '@Password123!',
+      ),
+    );
+    await enterPasswordBloc.stream.firstWhere(
+      (s) => s is EnterPasswordSubmitSuccess || s is EnterPasswordSubmitFailure,
+    );
+    catalog.addAll(fakeAnalytics.trackedEvents.map(catalogEntry));
+    fakeAnalytics.resetFake();
+    fakeSupabase.shouldThrowOnSignIn = false;
+
+    // user_logged_out
+    final authManager = Modular.get<AuthManager>();
+    await authManager.loginWithEmail(
+      'catalog-logout@example.com',
+      '@Password123!',
+    );
+    fakeAnalytics.resetFake();
+    await authManager.logout();
+    catalog.addAll(fakeAnalytics.trackedEvents.map(catalogEntry));
+
+    expect(catalog..sort(), [
+      'user_logged_in: []',
+      'user_logged_out: []',
+      'user_login_failed: [reason]',
+      'user_registered: []',
+      'user_registration_failed: [reason]',
+    ]);
+  });
+}

--- a/test/libraries/analytics/units/analytics_navigator_observer_test.dart
+++ b/test/libraries/analytics/units/analytics_navigator_observer_test.dart
@@ -131,6 +131,53 @@ void main() {
       expect(fakePosthogWrapper.capturedEvents, isEmpty);
     });
 
+    test('didPop syncs screenName to the previous route without tracking', () {
+      observer.didPop(_routeNamed('/details'), _routeNamed('/dashboard'));
+
+      expect(currentScreenTracker.screenName, '/dashboard');
+      expect(fakePosthogWrapper.capturedEvents, isEmpty);
+    });
+
+    test('didRemove syncs screenName to the previous route without tracking', () {
+      observer.didRemove(_routeNamed('/details'), _routeNamed('/dashboard'));
+
+      expect(currentScreenTracker.screenName, '/dashboard');
+      expect(fakePosthogWrapper.capturedEvents, isEmpty);
+    });
+
+    test('didReplace syncs screenName to the new route without tracking', () {
+      observer.didReplace(
+        newRoute: _routeNamed('/dashboard'),
+        oldRoute: _routeNamed('/details'),
+      );
+
+      expect(currentScreenTracker.screenName, '/dashboard');
+      expect(fakePosthogWrapper.capturedEvents, isEmpty);
+    });
+
+    test(
+      'leaves screenName unchanged when popping/removing/replacing to a '
+      'route with no name',
+      () {
+        observer.didPush(_routeNamed('/dashboard'), null);
+        fakePosthogWrapper.resetFake();
+
+        observer.didPop(_routeNamed('/details'), _routeNamed(null));
+        expect(currentScreenTracker.screenName, '/dashboard');
+
+        observer.didRemove(_routeNamed('/details'), _routeNamed(null));
+        expect(currentScreenTracker.screenName, '/dashboard');
+
+        observer.didReplace(
+          newRoute: _routeNamed(null),
+          oldRoute: _routeNamed('/details'),
+        );
+        expect(currentScreenTracker.screenName, '/dashboard');
+
+        expect(fakePosthogWrapper.capturedEvents, isEmpty);
+      },
+    );
+
     test('captures nothing when analytics is disabled (NoOpAnalyticsRepository)', () {
       final noOpObserver = AnalyticsNavigatorObserver(
         analyticsRepository: const NoOpAnalyticsRepository(),

--- a/test/libraries/analytics/units/analytics_navigator_observer_test.dart
+++ b/test/libraries/analytics/units/analytics_navigator_observer_test.dart
@@ -1,6 +1,7 @@
 // ignore_for_file: no_direct_instantiation
 
 import 'package:construculator/libraries/analytics/analytics_navigator_observer.dart';
+import 'package:construculator/libraries/analytics/current_screen_tracker.dart';
 import 'package:construculator/libraries/analytics/data/repositories/analytics_repository_impl.dart';
 import 'package:construculator/libraries/analytics/data/repositories/no_op_analytics_repository.dart';
 import 'package:construculator/libraries/analytics/testing/fake_posthog_wrapper.dart';
@@ -38,19 +39,34 @@ MaterialPageRoute<void> _modularRouteNamed(
 
 void main() {
   group('AnalyticsNavigatorObserver', () {
+    const testAppVersion = '1.2.3';
+
     late FakeEnvLoader fakeEnvLoader;
     late FakePosthogWrapper fakePosthogWrapper;
+    late CurrentScreenTracker currentScreenTracker;
     late AnalyticsRepositoryImpl repository;
     late AnalyticsNavigatorObserver observer;
+
+    Map<String, dynamic> standardProperties({String? screenName}) => {
+      'app_version': testAppVersion,
+      'platform': 'android',
+      'screen_name': screenName,
+    };
 
     setUp(() {
       fakeEnvLoader = FakeEnvLoader();
       fakePosthogWrapper = FakePosthogWrapper();
+      currentScreenTracker = CurrentScreenTracker();
       repository = AnalyticsRepositoryImpl(
         envLoader: fakeEnvLoader,
         posthogWrapper: fakePosthogWrapper,
+        currentScreenTracker: currentScreenTracker,
+        appVersion: testAppVersion,
       );
-      observer = AnalyticsNavigatorObserver(analyticsRepository: repository);
+      observer = AnalyticsNavigatorObserver(
+        analyticsRepository: repository,
+        currentScreenTracker: currentScreenTracker,
+      );
     });
 
     tearDown(() {
@@ -62,9 +78,9 @@ void main() {
       observer.didPush(_routeNamed('/dashboard'), null);
 
       expect(fakePosthogWrapper.capturedEvents, [
-        const CaptureCall(
+        CaptureCall(
           eventName: 'screen_viewed',
-          properties: {'screen_name': '/dashboard'},
+          properties: standardProperties(screenName: '/dashboard'),
         ),
       ]);
     });
@@ -82,9 +98,9 @@ void main() {
         );
 
         expect(fakePosthogWrapper.capturedEvents, [
-          const CaptureCall(
+          CaptureCall(
             eventName: 'screen_viewed',
-            properties: {'screen_name': '/details/:estimationId'},
+            properties: standardProperties(screenName: '/details/:estimationId'),
           ),
         ]);
       },
@@ -102,9 +118,9 @@ void main() {
       observer.didPush(route, null);
 
       expect(fakePosthogWrapper.capturedEvents, [
-        const CaptureCall(
+        CaptureCall(
           eventName: 'screen_viewed',
-          properties: {'screen_name': '/dashboard'},
+          properties: standardProperties(screenName: '/dashboard'),
         ),
       ]);
     });
@@ -118,6 +134,7 @@ void main() {
     test('captures nothing when analytics is disabled (NoOpAnalyticsRepository)', () {
       final noOpObserver = AnalyticsNavigatorObserver(
         analyticsRepository: const NoOpAnalyticsRepository(),
+        currentScreenTracker: currentScreenTracker,
       );
 
       noOpObserver.didPush(_routeNamed('/dashboard'), null);

--- a/test/libraries/analytics/units/analytics_repository_factory_test.dart
+++ b/test/libraries/analytics/units/analytics_repository_factory_test.dart
@@ -1,4 +1,7 @@
+// ignore_for_file: no_direct_instantiation
+
 import 'package:construculator/libraries/analytics/analytics_repository_factory.dart';
+import 'package:construculator/libraries/analytics/current_screen_tracker.dart';
 import 'package:construculator/libraries/analytics/data/repositories/analytics_repository_impl.dart';
 import 'package:construculator/libraries/analytics/data/repositories/no_op_analytics_repository.dart';
 import 'package:construculator/libraries/analytics/testing/fake_posthog_wrapper.dart';
@@ -30,6 +33,8 @@ void main() {
           buildPosthogWrapperCallCount++;
           return fakePosthogWrapper;
         },
+        currentScreenTracker: CurrentScreenTracker(),
+        appVersion: '1.2.3',
       );
     }
 

--- a/test/libraries/analytics/units/data/repositories/analytics_repository_impl_test.dart
+++ b/test/libraries/analytics/units/data/repositories/analytics_repository_impl_test.dart
@@ -3,6 +3,7 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:construculator/libraries/analytics/current_screen_tracker.dart';
 import 'package:construculator/libraries/analytics/data/repositories/analytics_repository_impl.dart';
 import 'package:construculator/libraries/analytics/domain/entities/analytics_event.dart';
 import 'package:construculator/libraries/analytics/domain/entities/analytics_user_properties.dart';
@@ -28,16 +29,28 @@ void _expectLeft<L, R>(Either<L, R> result, void Function(L error) assertions) {
 
 void main() {
   group('AnalyticsRepositoryImpl', () {
+    const testAppVersion = '1.2.3';
+
     late FakeEnvLoader fakeEnvLoader;
     late FakePosthogWrapper fakePosthogWrapper;
+    late CurrentScreenTracker currentScreenTracker;
     late AnalyticsRepositoryImpl repository;
+
+    Map<String, dynamic> standardProperties({String? screenName}) => {
+      'app_version': testAppVersion,
+      'platform': 'android',
+      'screen_name': screenName,
+    };
 
     setUp(() {
       fakeEnvLoader = FakeEnvLoader();
       fakePosthogWrapper = FakePosthogWrapper();
+      currentScreenTracker = CurrentScreenTracker();
       repository = AnalyticsRepositoryImpl(
         envLoader: fakeEnvLoader,
         posthogWrapper: fakePosthogWrapper,
+        currentScreenTracker: currentScreenTracker,
+        appVersion: testAppVersion,
       );
     });
 
@@ -108,11 +121,54 @@ void main() {
 
         _expectRight(result, (_) {
           expect(fakePosthogWrapper.capturedEvents, [
-            const CaptureCall(
+            CaptureCall(
               eventName: 'estimation_created',
-              properties: {'estimation_id': 'est-1'},
+              properties: {
+                ...standardProperties(),
+                'estimation_id': 'est-1',
+              },
             ),
           ]);
+        });
+      });
+
+      test(
+        'attaches app_version, platform, and the current screen name to '
+        'every event',
+        () async {
+          currentScreenTracker.screenName = '/details/:estimationId';
+
+          final result = await repository.track(
+            const AnalyticsEvent(name: 'estimation_created'),
+          );
+
+          _expectRight(result, (_) {
+            expect(fakePosthogWrapper.capturedEvents, [
+              CaptureCall(
+                eventName: 'estimation_created',
+                properties: standardProperties(
+                  screenName: '/details/:estimationId',
+                ),
+              ),
+            ]);
+          });
+        },
+      );
+
+      test('event properties override standard properties on key collision',
+          () async {
+        final result = await repository.track(
+          const AnalyticsEvent(
+            name: 'estimation_created',
+            properties: {'app_version': 'overridden'},
+          ),
+        );
+
+        _expectRight(result, (_) {
+          expect(
+            fakePosthogWrapper.capturedEvents.single.properties?['app_version'],
+            'overridden',
+          );
         });
       });
 

--- a/test/libraries/analytics/units/data/repositories/analytics_repository_impl_test.dart
+++ b/test/libraries/analytics/units/data/repositories/analytics_repository_impl_test.dart
@@ -166,7 +166,7 @@ void main() {
 
         _expectRight(result, (_) {
           expect(
-            fakePosthogWrapper.capturedEvents.single.properties?['app_version'],
+            fakePosthogWrapper.capturedEvents.single.properties!['app_version'],
             'overridden',
           );
         });

--- a/test/libraries/analytics/units/domain/utils/failure_analytics_reason_test.dart
+++ b/test/libraries/analytics/units/domain/utils/failure_analytics_reason_test.dart
@@ -1,0 +1,20 @@
+import 'package:construculator/libraries/analytics/domain/utils/failure_analytics_reason.dart';
+import 'package:construculator/libraries/auth/domain/types/auth_types.dart';
+import 'package:construculator/libraries/errors/failures.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('FailureAnalyticsReason', () {
+    test('returns the AuthErrorType name for an AuthFailure', () {
+      const failure = AuthFailure(errorType: AuthErrorType.invalidCredentials);
+
+      expect(failure.analyticsReason, 'invalidCredentials');
+    });
+
+    test('falls back to "unexpected" for a non-AuthFailure', () {
+      final failure = UnexpectedFailure();
+
+      expect(failure.analyticsReason, 'unexpected');
+    });
+  });
+}

--- a/test/libraries/auth/units/auth_manager_test.dart
+++ b/test/libraries/auth/units/auth_manager_test.dart
@@ -1164,6 +1164,7 @@ void main() {
       test('logout should call reset on success', () async {
         await authManager.loginWithEmail(testEmail, testPassword);
         expect(analyticsRepository.identifyCalls, isNotEmpty);
+        analyticsRepository.callSequence.clear();
 
         final result = await authManager.logout();
 
@@ -1173,6 +1174,7 @@ void main() {
           analyticsRepository.trackedEvents,
           contains(const AnalyticsEvent(name: 'user_logged_out')),
         );
+        expect(analyticsRepository.callSequence, ['track', 'reset']);
       });
 
       test('logout should not call reset on failure', () async {

--- a/test/libraries/auth/units/auth_manager_test.dart
+++ b/test/libraries/auth/units/auth_manager_test.dart
@@ -1,3 +1,4 @@
+import 'package:construculator/libraries/analytics/domain/entities/analytics_event.dart';
 import 'package:construculator/libraries/analytics/domain/entities/analytics_user_properties.dart';
 import 'package:construculator/libraries/analytics/domain/repositories/analytics_repository.dart';
 import 'package:construculator/libraries/analytics/testing/fake_analytics_repository.dart';
@@ -1168,6 +1169,10 @@ void main() {
 
         expect(result.isSuccess, true);
         expect(analyticsRepository.resetCallCount, 1);
+        expect(
+          analyticsRepository.trackedEvents,
+          contains(const AnalyticsEvent(name: 'user_logged_out')),
+        );
       });
 
       test('logout should not call reset on failure', () async {

--- a/test/utils/fake_app_bootstrap_factory.dart
+++ b/test/utils/fake_app_bootstrap_factory.dart
@@ -1,4 +1,5 @@
 import 'package:construculator/app/app_bootstrap.dart';
+import 'package:construculator/libraries/analytics/current_screen_tracker.dart';
 import 'package:construculator/libraries/analytics/data/repositories/no_op_analytics_repository.dart';
 import 'package:construculator/libraries/analytics/domain/repositories/analytics_repository.dart';
 import 'package:construculator/libraries/analytics/domain/repositories/feature_flag_repository.dart';
@@ -64,6 +65,7 @@ class FakeAppBootstrapFactory {
       powerSyncDatabase: powerSyncDatabase ?? FakePowerSyncDatabase(),
       featureFlagRepository:
           featureFlagRepository ?? FakeFeatureFlagRepository(),
+      currentScreenTracker: CurrentScreenTracker(),
     );
   }
 }


### PR DESCRIPTION
### 1. PR SUMMARY

Instruments the SignUp and SignIn flows with real PostHog events, the first feature-level analytics instrumentation in the app (CA-943 only proved the transport with a synthetic event). `EnterPasswordBloc` and `CreateAccountBloc` now constructor-inject `AnalyticsRepository` and fire `user_logged_in` / `user_registered` on success and `user_login_failed` / `user_registration_failed` (with a typed `reason` derived from `AuthErrorType`, never the raw exception) on failure. `AuthManagerImpl.logout()` fires `user_logged_out` alongside the existing `reset()` call from CA-945. All `track()` calls are fire-and-forget via `unawaited(...)`, matching the existing `AnalyticsNavigatorObserver` pattern, so analytics can never block or change the auth flow.

Event names follow the taxonomy doc's existing `user_*` object (not the ticket's own `account_created`/`login_succeeded` examples, which would have fragmented the taxonomy across two objects for the same entity) — `docs/Logging/PostHog-Event-Tracking.md` is updated with the two new failure variants, which weren't previously documented.

Scope is SignUp + SignIn + logout only, per the ticket's own examples and Suyang's explicit nomination in the ticket comments. Password reset and OTP verification are left uninstrumented (no ticket exists yet for them).

**Analytics event catalog:** https://docs.google.com/document/d/15FmeqPPKpnnnASVB9hsClPHJKzMlFolq/edit?usp=sharing&ouid=100193797480827154438&rtpof=true&sd=true — catalogs this PR's 5 events (`user_logged_in`, `user_registered`, `user_login_failed`, `user_registration_failed`, `user_logged_out`) + properties, per the round-1 review's blocking ask. Will be expanded per-CUJ going forward as more analytics tracking is added.

### 2. REVIEW SUMMARY TABLE
No issues found.

## Test plan
- [x] `fvm flutter test` — full suite green (3246 tests)
- [x] `fvm dart run custom_lint` — clean (pre-existing, unrelated findings only)
- [x] New `verify` assertions in `enter_password_bloc_test.dart` / `create_account_bloc_test.dart` confirm the correct event + typed `reason` fire on success/failure
- [x] `auth_manager_test.dart` asserts `user_logged_out` fires on successful logout, before `reset()`
- [x] `test/features/auth/units/sign_up_sign_in_event_catalog_test.dart` pins the full SignUp/SignIn/logout event catalog (name + sorted property keys) against real trigger paths — verified it fails on a mutated event name
- [ ] Manual: exercise login success/failure, signup success/failure, and logout with `ANALYTICS_ENABLED=true` against a debug PostHog project and confirm all five events land with no PII
