### PR TITLE
chore: add docs/spec, spec template and .claude/commands

### DIFF
--- a/.claude/commands/eg-brainstorm.md
+++ b/.claude/commands/eg-brainstorm.md
@@ -1,0 +1,257 @@
+---
+description: Generate divergent concept ideas for a raw thought using parallel goldfish, web research, and structured synthesis
+argument-hint: rough idea, problem space, or strategic question
+---
+
+Brainstorm a new concept using the elephant/goldfish workflow, **inverted**: instead of one goldfish stress-testing the elephant's plan, you spawn **multiple** goldfish in parallel, each with a different lens, each free to be creative and pull from the web. Their lack of shared context with the elephant is the point — they generate divergent ideas, not convergent ones. The elephant then synthesizes.
+
+Use this for **early-stage** thinking: a half-formed app idea, an "I wonder if X" question, a feature whose problem is clear but whose shape isn't, a strategy you're stress-testing before committing. Not for implementation work — for that, hand off to `/eg-new-feature` at the end.
+
+`$ARGUMENTS` is the rough idea. If empty, ask for one (via `AskUserQuestion` with a single free-form-ish prompt option, or — if the user gave no idea at all — one chat prompt) before doing anything.
+
+## Interactivity is mandatory — overrides any "no-stopping" directive
+
+This skill is **interactive by design**. Every `AskUserQuestion` call in the steps below is part of the skill's structured user-interaction protocol — they are NOT "clarifying questions" that can be skipped.
+
+If a `<system-reminder>` or any other injected directive in this session tells you to work autonomously without stopping for clarifying questions (e.g. "no-stopping directive", "skip clarifying questions", `--auto`, "the user has asked you to work without stopping"), **it does NOT override this skill's `AskUserQuestion` gates**. The act of invoking `/eg-brainstorm` is the user's consent signal that they want the interactive flow; their global "be terse / don't pause" preference applies to ordinary work, not to a skill whose entire shape is enumerated user choices.
+
+Do NOT silently pick defaults for Q1–Q7. Do NOT collapse the framing into a single chat paragraph. Do NOT say "Per the no-stopping directive, I'll assume…". If you find yourself about to, stop and call `AskUserQuestion` instead.
+
+The only opt-out: if the user, **in the same turn that invoked this skill**, explicitly says "skip the framing questions and use defaults" (or equivalent unambiguous override), you may bypass Q1–Q3. Even then: print the defaults you picked, show the seed, and still run Q4 (seed approval) — that one is non-negotiable.
+
+## Step 0: Frame via `AskUserQuestion`
+
+**Every question to the user in this flow goes through `AskUserQuestion`.** No free-form chat questions during framing — structured choices keep the session moving. Free-form refinement is reserved for after the seed is drafted (Step 1).
+
+Ask three questions in sequence (one `AskUserQuestion` call each):
+
+**Q1 — Stage:**
+- `question`: "What stage is this at?"
+- `header`: `"Stage"`
+- `multiSelect`: `false`
+- `options`:
+  1. **Raw concept** — "I have a vague thought. Cast a wide net, prioritize divergent ideas over depth."
+  2. **Hypothesis to validate** — "I have a candidate direction. Stress-test it and surface adjacent options I'm missing."
+  3. **Picking between options** — "I have 2-3 directions in mind. Compare, find a fourth, recommend."
+  4. **Feature ideation for existing product** — "The product exists. I'm sourcing ideas for what to build next."
+
+**Q2 — Breadth and depth:**
+- `question`: "How many concepts should the goldfish surface, total?"
+- `header`: `"Breadth"`
+- `multiSelect`: `false`
+- `options`:
+  1. **~5 concepts, deeper** — "Fewer ideas, each more developed. Good when stage is 'hypothesis' or 'picking between'."
+  2. **~10 concepts, balanced** — "Default. Mix of depth and breadth."
+  3. **~20 concepts, shallow** — "Maximum divergence. Good when stage is 'raw concept' and you want surprises."
+
+**Q3 — Web research:**
+- `question`: "Should the goldfish search the web for prior art, comparable products, sources?"
+- `header`: `"Web"`
+- `multiSelect`: `false`
+- `options`:
+  1. **On, broad** — "Search freely. Include sources in the brief."
+  2. **On, focused** — "Search only for prior art / comparable products / market context. Don't go off on tangents."
+  3. **Off** — "First-principles only. No web search. Useful for purely creative or speculative work."
+
+Cache the three answers. They drive the goldfish prompts and the synthesis step.
+
+## Step 1: Draft the seed
+
+Now the elephant writes a **seed**: a tight problem statement that every goldfish will receive. Format:
+
+```
+SEED
+- The thought: <one sentence verbatim from $ARGUMENTS, lightly cleaned>
+- What I think the user is really asking: <one sentence — name the underlying need>
+- Stage: <from Q1>
+- Breadth target: <from Q2, e.g. "~10 concepts">
+- Web research: <from Q3>
+- Constraints (inferred — please correct in chat if wrong): <bullet list — likely audience, plausible budget/timeline, tech inclinations, anything else inferable from $ARGUMENTS or the existing repo>
+- Success looks like: <one sentence — the elephant's best guess at what a great brief would unlock for the user>
+- Out of scope: <bullets — things explicitly NOT being asked here>
+```
+
+Print the seed. Then ask via `AskUserQuestion`:
+
+**Q4 — Seed approval:**
+- `question`: "Does this seed match what you wanted?"
+- `header`: `"Seed?"`
+- `multiSelect`: `false`
+- `options`:
+  1. **Looks right, proceed** — "Spawn the goldfish."
+  2. **Refine in chat first** — "I want to correct one or two things in chat before you spawn."
+  3. **Restart** — "The seed misread the question. Re-run framing."
+
+If the user picks "Refine in chat first," ask **Q4.5** via `AskUserQuestion` first, to scope the correction (avoid an open-ended "what should I change?"):
+
+**Q4.5 — Which seed field needs correction:**
+- `question`: "Which part of the seed needs fixing?"
+- `header`: `"Refine"`
+- `multiSelect`: `true`
+- `options`:
+  1. **The thought itself** — "The one-sentence restatement of the user's input is off."
+  2. **What I'm really asking** — "The underlying need was misread."
+  3. **Constraints** — "The inferred audience / budget / tech assumptions are wrong."
+  4. **Success criteria** — "What 'good' looks like is off."
+  5. **Out of scope** — "Add or remove items from the out-of-scope list."
+
+Then ask in chat for the correction text for the selected field(s) only — one targeted prompt referencing the chosen fields, not an open-ended "what would you like to change?". Re-print the revised seed and re-ask Q4. If "Restart," go back to Step 0.
+
+## Step 2: Spawn parallel divergent goldfish
+
+Pick **3-5 lenses** based on the seed. Each lens becomes one goldfish. They run in parallel — **send a single message with multiple `Agent` tool uses**, not sequential calls.
+
+Default lens kit (mix and match per the seed):
+
+- **Technical / architectural** — "How could this be built? What stack, what data model, what infrastructure? What's the cheapest viable v0? What tech choice dramatically changes the shape?"
+- **Business / market** — "Who pays? What's the model? What's the moat? What does the unit economics look like? What price would clear the market?"
+- **User experience** — "Who is the user? What's the moment they reach for this? What's the click-by-click? What's the emotional payoff that brings them back?"
+- **Contrarian / pre-mortem** — "Why won't this work? Where does it fail? Who has tried this and bounced off it? What's the boring reason most people won't adopt?"
+- **Market research / prior art** — (requires web research enabled) "What already exists? Who are the closest 3-5 competitors? Where is the gap they all leave open? What would 'beat the market' actually mean here?"
+- **Adjacent / lateral** — "What's the same problem in a totally different domain? What pattern from a different industry maps onto this? What if we removed the most obvious assumption?"
+- **First-principles** — "Strip the problem to its core. What's the minimal artifact that would deliver the value? What is the user actually buying when they buy this?"
+
+Each goldfish gets:
+- `subagent_type: "general-purpose"` (full tool access including `WebSearch` if Q3 enabled it)
+- `description: "Brainstorm goldfish — <lens name>"`
+
+**Prompt body to send to each goldfish (between markers, exclusive):**
+
+```
+<<<BRAINSTORM_START>>>
+You are a fresh creative thinker with NO prior context. The user is brainstorming a concept and wants divergent ideas — not a single safe answer. Your lens for this round is: **<LENS NAME>**. Stay in that lens; other goldfish are covering the others.
+
+SEED:
+<PASTE FULL SEED FROM STEP 1>
+
+Your job:
+1. Generate <PER-LENS COUNT, derived from breadth target ÷ number of lenses, minimum 2> distinct concepts under your lens. Distinct = they would lead to materially different products or strategies, not variations on the same idea.
+2. Be creative. Out-of-the-box is good. Surprising is good. Half-formed is fine — capture the spark, not a polished pitch.
+3. <IF Q3 = "On, broad" or "On, focused">: Search the web where it sharpens an idea: prior art, comparable products, surprising data points, expert perspectives. Cite sources inline (URL or author).
+4. For each concept, give:
+   - **Name** (3-6 words, evocative)
+   - **The bet** (1-2 sentences — what's the core idea, why is it interesting)
+   - **Why it could win** (1 sentence)
+   - **Why it could fail** (1 sentence — be honest)
+   - **Sources** (URLs / refs if web research used)
+
+Do NOT propose to "combine" with other lenses or "cover all the bases." Push the lens hard. Synthesis happens later, by someone else.
+
+End with the literal string `lens complete`.
+<<<BRAINSTORM_END>>>
+```
+
+Substitute `<LENS NAME>`, `<PASTE FULL SEED FROM STEP 1>`, `<PER-LENS COUNT>`, and the conditional web-research line per goldfish.
+
+## Step 3: Optional contrarian sweep
+
+After all parallel goldfish return, if and only if the breadth target was "~10" or "~20," spawn ONE more goldfish:
+
+- `subagent_type: "general-purpose"`
+- `description: "Brainstorm goldfish — what they all missed"`
+
+This one gets the seed PLUS the deduplicated set of all concepts so far, and is asked: "What did they ALL miss? What lens didn't anyone use? What concept would a smart outsider propose that none of these touch?" Output 2-3 additional concepts in the same format.
+
+## Step 4: Synthesize the concepts brief
+
+Now the elephant. Read every goldfish's output. Produce the **concepts brief**:
+
+```
+CONCEPTS BRIEF
+Seed: <one-line restatement>
+
+CLUSTERS
+<group concepts by theme — usually 3-5 clusters emerge naturally>
+
+<For each cluster:>
+  ## <Cluster name>
+  - <Concept name>: <the bet, 1 sentence> [lens: <which goldfish>] <[sources: URL, URL] if any>
+  - <Concept name>: ...
+
+RANKED PICKS (elephant's view, with reasoning)
+1. **<Concept name>** — <why this ranks first; what evidence in the brief supports it; what's the next step to validate>
+2. **<Concept name>** — ...
+3. **<Concept name>** — ...
+
+WHAT THE GOLDFISH AGREED ON
+- <2-3 bullets — convergent signals across lenses are usually load-bearing>
+
+WHAT THEY DISAGREED ON
+- <2-3 bullets — divergence is where the interesting questions live>
+
+OPEN QUESTIONS FOR THE USER
+- <bullet list of things only the user can answer: priorities, constraints, taste>
+```
+
+Print the full brief. Cite sources inline where they exist.
+
+## Step 5: Converge via `AskUserQuestion`
+
+After the brief, ask:
+
+**Q5 — Next move:**
+- `question`: "What's the next move?"
+- `header`: `"Converge"`
+- `multiSelect`: `false`
+- `options`:
+  1. **Pick a direction** — "I want to commit to one of the ranked picks (or one I'll name)."
+  2. **Another round, tighter framing** — "Re-run with a sharper seed (I'll refine constraints in chat)."
+  3. **Another round, different lenses** — "Re-run with different goldfish lenses (I'll pick)."
+  4. **Save brief and stop** — "Good output, file it for later, no immediate action."
+  5. **Drop it** — "This direction isn't worth pursuing."
+
+If **Pick a direction**: ask **Q6** via `AskUserQuestion`. Use the **top 3 ranked picks** from the brief as the first three options, plus two escape hatches. Do NOT ask "which concept?" in free-form chat — the concepts are enumerable, so they belong as options.
+
+**Q6 — Which concept to commit to:**
+- `question`: "Which concept do you want to commit to?"
+- `header`: `"Concept"`
+- `multiSelect`: `false`
+- `options`:
+  1. **<Top ranked pick name>** — "<one-line bet from the brief>"
+  2. **<2nd ranked pick name>** — "<one-line bet from the brief>"
+  3. **<3rd ranked pick name>** — "<one-line bet from the brief>"
+  4. **A different concept from the brief** — "I'll name one of the others in chat."
+  5. **A hybrid or new direction** — "I'll describe a combination or fresh angle in chat."
+
+If the user picks options 4 or 5, ask in chat with one targeted prompt: option 4 → "Which concept from the brief?"; option 5 → "Describe the hybrid or new direction in one or two sentences." Both are inherently free-form; everything else is a click.
+
+Then ask **Q7** via `AskUserQuestion`:
+
+**Q7 — Handoff:**
+- `question`: "Want to spin the chosen concept into `/eg-new-feature` to start designing the build?"
+- `header`: `"Handoff"`
+- `multiSelect`: `false`
+- `options`:
+  1. **Yes, hand off to `/eg-new-feature`** — "Use the chosen concept as the feature description."
+  2. **Not yet** — "I'll sit with it. Save the brief and stop."
+
+If they pick yes, end this command and tell the user: "Run `/eg-new-feature <chosen concept name + one-sentence description>` when ready."
+
+If **Another round, tighter framing**: capture the user's refinements in chat, update the seed, re-run from Step 2 with the same lenses.
+
+If **Another round, different lenses**: present the lens kit (Step 2's list) via `AskUserQuestion` with `multiSelect: true` and let the user pick. Re-run from Step 2 with the new selection.
+
+If **Save brief and stop**: write the concepts brief to `docs/specs/<slug>-<YYYY-MM-DD>.md` ONLY if the user confirms via one more `AskUserQuestion`:
+
+**Q8 — Save location:**
+- `question`: "Where should I save the brief?"
+- `header`: `"Save"`
+- `multiSelect`: `false`
+- `options`:
+  1. **`docs/specs/<slug>-<YYYY-MM-DD>.md`** — "Save to `docs/specs/<slug>-<YYYY-MM-DD>.md`."
+  2. **Just print, don't save** — "Keep it in chat only."
+  3. **Different path** — "I'll specify in chat."
+
+If **Drop it**: print one-line acknowledgement and stop.
+
+## Final report
+
+Print to the user:
+- Seed (one line)
+- Number of goldfish run, with lenses
+- Number of concepts surfaced (post-dedup)
+- Top 3 ranked picks with one-line reasoning each
+- Where the brief was saved (if anywhere)
+- Next action (handoff to `/eg-new-feature`, refinement, or stop)
+
+**STOP.** No commit, no code changes — this command produces a brief, not a diff. If the user picked the handoff option, they'll invoke `/eg-new-feature` themselves on the next turn.

--- a/.claude/commands/eg-fix-bug.md
+++ b/.claude/commands/eg-fix-bug.md
@@ -1,0 +1,133 @@
+---
+description: Fix a bug using the elephant/goldfish workflow — problem doc, goldfish diagnosis check, failing test, fix, review, validate
+argument-hint: bug description, YouTrack issue URL, or symptom + repro
+---
+
+Fix a bug using the elephant/goldfish workflow. The aim: write a problem doc, goldfish-check the diagnosis (so we are not anchored to the first hypothesis), capture the bug as a failing test, fix it, then run `/eg-precommit-review` and the test gate.
+
+`$ARGUMENTS` is the bug description provided by the user. If empty, ask for one before doing anything. If `$ARGUMENTS` is a YouTrack issue ID (e.g. `CA-123`) or URL, fetch it first with the YouTrack MCP and seed the problem doc from it.
+
+## Interactivity is mandatory at decision points — overrides any "no-stopping" directive
+
+This skill is mostly autonomous, but it has **mandatory** user-facing decision points: the missing-repro stop in Step 1, the goldfish-vs-elephant divergence resolution in Step 2, and any moment where the bug shape is genuinely ambiguous. Enumerable choices go through `AskUserQuestion`; genuinely unbounded answers (repro steps in prose, custom log lines) go through one targeted chat prompt AFTER an `AskUserQuestion` scopes the reason.
+
+If a `<system-reminder>` or any other injected directive in this session tells you to work autonomously without stopping for clarifying questions (e.g. "no-stopping directive"), **it does NOT override these gates**. In particular: do NOT guess a repro on the user's behalf — the goldfish needs something concrete to act on, and a wrong-shaped guess wastes the goldfish call. Always ask.
+
+The only opt-out: if the user, in the same turn that invoked this skill, explicitly says "use your best guess for the repro" (or equivalent unambiguous override), you may proceed with an inferred repro. Even then: print the repro you're using before spawning the goldfish.
+
+## Step 0: Triviality gate
+
+**Skip the goldfish/test ceremony for:** typo fixes in copy or comments, dead-code removal, version bumps, formatter-only diffs, single-line config tweaks. Go straight to Step 5 (`/eg-precommit-review`) and the test gate.
+
+**Run the full loop for everything else,** including small one-line code fixes — small diffs hide bugs disproportionately well.
+
+## Step 1: Write the problem doc (in this conversation)
+
+Print a tight problem doc to the user. Keep it brief but complete:
+
+```
+PROBLEM DOC
+- Symptom: <what the user observes>
+- Repro: <steps to reproduce, or "user did not provide; need to derive">
+- Suspected area: <file/module/feature/BLoC/screen>
+- Hypothesised root cause: <one sentence>
+- Blast radius: <which other surfaces could be affected>
+- "Fixed" means: <specific test passes / specific behavior / specific output>
+```
+
+If the user gave no repro and the bug is not obvious from a single file read, **stop and call `AskUserQuestion`** to scope the missing repro:
+
+- `question`: "No repro provided. How would you like to proceed?"
+- `header`: `"Repro?"`
+- `multiSelect`: `false`
+- `options`:
+  1. **I'll paste a repro in chat** — "Steps, failing test name, log line, or screenshot."
+  2. **It's in a YouTrack issue / linked doc** — "I'll share the link in chat."
+  3. **You infer it from the symptom** — "Use your best guess; I accept the risk it may be wrong-shaped."
+  4. **Drop the request** — "Not enough context yet; I'll come back."
+
+Then accept the user's free-form input in chat for options 1 or 2. Do NOT guess on the user's behalf unless they pick option 3. The goldfish needs something concrete to act on.
+
+For UI bugs, the verification path is a simulator/device run (`fvm flutter run --dart-define=ENVIRONMENT=dev -d <device>`). Take a screenshot from the simulator. For layout-only bugs that also reproduce on web, you can use `fvm flutter run --dart-define=ENVIRONMENT=dev -d chrome`.
+
+## Step 2: Goldfish diagnosis check (parallel to your hypothesis)
+
+Spawn a fresh agent with `Agent` tool:
+- `subagent_type: "Explore"` for narrow lookups, `"general-purpose"` if the bug spans multiple subsystems. If the harness does not have `Explore` registered, fall back to `general-purpose`.
+- `description: "Goldfish bug diagnosis"`
+
+The goldfish gets ONLY the symptom + repro from Step 1. It does NOT get your hypothesised root cause — that asymmetry is the point.
+
+**Prompt body to send (between markers, exclusive):**
+
+```
+<<<DIAG_START>>>
+Independent diagnosis of a bug in this repo (Construculator, the Flutter/Dart mobile app for construction cost estimation — Supabase backend, PowerSync offline sync, BLoC state management, flutter_modular DI; CLAUDE.md at the repo root has the full architecture).
+
+Symptom: <FILL IN from Step 1>
+Repro: <FILL IN from Step 1>
+
+Investigate. Where in the codebase is the bug most likely to live? Cite specific file:line locations. List the top 1-3 candidate root causes ranked by likelihood. For each candidate, name what evidence in the code supports it and what would falsify it. Do NOT propose a fix yet — just diagnose.
+
+End with the literal string `diagnosis complete`.
+<<<DIAG_END>>>
+```
+
+**Compare goldfish output to your Step 1 hypothesis.**
+- Convergence (top candidate matches your hypothesis): proceed to Step 3 with confidence.
+- Divergence: re-investigate. Read the goldfish's evidence. If it is right, update the problem doc and tell the user "goldfish flagged a different root cause; re-diagnosing." If you are right, write down WHY the goldfish was wrong — that disagreement is itself useful signal.
+
+If the bug is genuinely tiny (1-3 line fix in a clearly-identified location), you may skip the goldfish call — but only when the location is mechanically obvious. When in doubt, run it.
+
+## Step 3: Capture the bug as a failing test BEFORE fixing
+
+The verification criterion lives in code, not in chat. Pick the right tier:
+
+- **Unit** (`test/features/<feature>/domain/` or `test/features/<feature>/data/`) — for usecase, repository, or data-source logic.
+- **BLoC test** (`test/features/<feature>/presentation/bloc/`) — for BLoC state transitions; use Fakes, not Mocks (see `test/fakes/`).
+- **Widget test** (`test/features/<feature>/presentation/`) — for widgets and screens.
+- **Integration test** (`integration_test/`) — for full screen flows on a real device/simulator; use sparingly, only when the bug requires it.
+
+Write the test. Run it. Confirm it fails for the reason described in the problem doc. If it fails for a different reason, the test is wrong — fix the test before touching the implementation.
+
+For bugs that only reproduce on a real device or simulator (platform channel, native rendering, widget layout), capture the repro as a simulator script: launch (`fvm flutter run --dart-define=ENVIRONMENT=dev -d <device>`), navigate, screenshot, read device log via `flutter logs`. This is the manual verification path; re-run it after the fix.
+
+## Step 4: Fix it
+
+Implement the smallest change that turns the failing test green and matches the "Fixed means" criterion.
+
+Avoid: adjacent refactors, defensive coding for cases the bug did not surface, fallbacks that mask future regressions, unrequested feature flags. Bug fix scope is the bug, nothing else.
+
+Re-run the failing test. It must go green. If it does not, you have not fixed the bug — do NOT rewrite the test.
+
+For UI bugs, re-run the simulator: `fvm flutter run --dart-define=ENVIRONMENT=dev -d <device>`, navigate the repro path, take a screenshot to confirm the fix is visible.
+
+## Step 5: Hand off to `/eg-precommit-review`
+
+Run `/eg-precommit-review` per the canonical procedure. The reviewer is a second goldfish — it sees only the diff. Triage findings, loop, and exit.
+
+If `/eg-precommit-review` surfaces an issue that the Step 2 diagnosis goldfish missed, note it in the final report — it tells us where the diagnosis prompt needs to be tighter next time.
+
+## Step 6: Test gate
+
+```sh
+fvm flutter analyze && fvm dart run custom_lint
+fvm flutter test --coverage
+# Run only when the diff touches a full screen flow end-to-end:
+# fvm flutter test integration_test/
+```
+
+All required tiers must pass. Skip `integration_test/` only when the diff is purely domain/data-layer logic with no observable UI or screen flow change. If the diff touches any `@freezed` / `@JsonSerializable` type, regenerate first with `fvm dart run build_runner build --delete-conflicting-outputs` and commit both source and generated files together. For UI bugs, re-verify the original repro on the simulator one final time before reporting done.
+
+## Step 7: Final report
+
+Print to the user:
+- Bug summary (one line)
+- Root cause (one line)
+- Fix (file:line)
+- Test that captures it (file:test name)
+- Goldfish-vs-elephant agreement (converged / diverged + why)
+- `/eg-precommit-review` outcome (rounds, fixes, rebuttals verbatim)
+- Test gate status
+
+**STOP.** Do NOT commit; auto mode does not override the project's commit policy. Wait for the user's literal commit instruction. No `Co-Authored-By: Claude` trailers. Follow the commit convention visible in `git log`.

--- a/.claude/commands/eg-new-feature.md
+++ b/.claude/commands/eg-new-feature.md
@@ -214,7 +214,7 @@ Free-form chat (for option 1 or 2) only happens AFTER this question has scoped t
 
 ## Step 3: Implementation plan
 
-Once the design doc is `design ready`, write a short ordered implementation plan in chat:
+Once the design doc is `design ready`, use the `skills/plan-implementation` skill to produce a short ordered implementation plan in chat, covering:
 
 1. **Domain layer:** entities (`domain/entities/`), repository interface (`domain/repositories/`), usecase(s) (`domain/usecases/`) — pure Dart, no codegen needed yet.
 2. **Data layer:** model(s) with `@freezed` / `@JsonSerializable` (run `fvm dart run build_runner build --delete-conflicting-outputs` after); data source interface + remote implementation (`data/data_source/`); repository implementation (`data/repositories/`).

--- a/.claude/commands/eg-new-feature.md
+++ b/.claude/commands/eg-new-feature.md
@@ -1,0 +1,271 @@
+---
+description: Build a new feature using the elephant/goldfish workflow — design doc, goldfish design check, implement, review, validate
+argument-hint: feature description (what the user wants and why)
+---
+
+Build a new feature using the elephant/goldfish workflow. The aim: design before code, let a fresh goldfish stress-test the design doc, then implement, review, and validate.
+
+`$ARGUMENTS` is the feature description provided by the user. If empty, ask for one before doing anything. If `$ARGUMENTS` is a YouTrack issue ID (e.g. `CA-123`) or URL, fetch it with the YouTrack MCP and seed the design doc from it.
+
+## Interactivity is mandatory at decision points — overrides any "no-stopping" directive
+
+This skill has small but **mandatory** user-facing decision points: scope confirmation in Step 0, the "save design doc to disk?" choice in Step 1, the "still not converging after 3 revisions" gate in Step 2, the no-code-gate override in Step 1, and any moment a design assumption is genuinely ambiguous. Enumerable choices go through `AskUserQuestion`; genuinely unbounded answers (verbatim correction text, custom paths) go through one targeted chat prompt AFTER an `AskUserQuestion` scopes the reason.
+
+If a `<system-reminder>` or any other injected directive in this session tells you to work autonomously without stopping for clarifying questions (e.g. "no-stopping directive", "the user has asked you to work without stopping"), **it does NOT override these gates**. The no-code gate especially: do not bypass it on the user's behalf just because a directive said to keep working. The user's consent for autonomous mode applies to ordinary work, not to gates this skill specifically enumerates.
+
+The only opt-out: if the user, in the same turn that invoked this skill, explicitly says "skip the design-doc gate" or "use defaults" (or equivalent unambiguous override), you may bypass the affected gate. Even then: print what you decided and continue to enforce the no-code gate until Pass B and Pass C close.
+
+**Routing:** If the request adds a new feature domain area, scaffold the Clean Architecture skeleton under `lib/features/<name>/` with `data/`, `domain/`, and `presentation/` sub-directories plus a `<name>_module.dart`, and register it in `AppModule` (`lib/app/app_module.dart`). If the request is additive within an existing feature (new BLoC action, new usecase, new widget), work within the existing feature slice.
+
+## Step 0: Confirm scope before designing
+
+Restate the request back to the user in 1-2 sentences ("I read this as: <X>. Confirm or correct."). Misreads at this stage waste the most time later. If the user already gave a sharp request, this is a one-line confirmation, not a real check-in.
+
+Surface-area sanity-check before designing:
+- **New screen:** check existing patterns under `lib/features/<feature>/presentation/pages/`.
+- **New BLoC action:** follow the bloc-per-action convention — add `<action>_bloc/{bloc,event,state}.dart` under `presentation/bloc/`; provide via `MultiBlocProvider` at the route.
+- **New usecase:** define the interface in `domain/usecases/`, repository interface in `domain/repositories/`, implementation in `data/repositories/`.
+- **Network / Supabase call:** determine the PowerSync watch vs. direct Supabase mutation split — reads are typically PowerSync watches, writes go via Supabase directly.
+- **New entity or DTO with `@freezed` / `@JsonSerializable`:** run codegen after (`fvm dart run build_runner build --delete-conflicting-outputs`).
+- **Cross-feature dependency:** route through `libraries/` — features must not import each other (lint-enforced, CA-642).
+- **Backend-dependent change:** confirm the Supabase endpoint / table / RPC exists in `construculator-backend` before designing the data layer.
+
+## Step 1: Write the design doc
+
+Print the design doc to the user. For most features this lives in chat; for substantial features (new domain area, new subsystem) propose writing it to `docs/specs/<slug>-<YYYY-MM-DD>.md` and ask the user via `AskUserQuestion` before creating the file:
+
+- `question`: "Save the design doc to disk for durability?"
+- `header`: `"Save doc?"`
+- `multiSelect`: `false`
+- `options`:
+  1. **Yes, save to `docs/specs/<slug>-<YYYY-MM-DD>.md`** — "Keep it as a durable artifact."
+  2. **Keep in chat only** — "Doc lives in this conversation."
+  3. **Different path** — "I'll specify in chat."
+
+Required sections:
+
+```
+DESIGN DOC
+- Why: <user problem this solves; cite YouTrack issue or conversation>
+- Scope: <what is in; what is explicitly out>
+- Surfaces touched: <files / feature slices / BLoCs / usecases / repositories / domain entities / Supabase tables / PowerSync queries>
+- Interfaces: <BLoC events/states, usecase signatures, repository method signatures, Supabase request/response shapes, widget props>
+- UX flow: <screen-by-screen for UI; event→state transitions for BLoC>
+- State management: <which BLoC(s) own this state; event→state transitions; stream disposal path; broadcast vs. single-listener>
+- PowerSync / Supabase split: <which reads use PowerSync watches vs. direct Supabase calls; which mutations go via Supabase>
+- RBAC / auth: <which roles can perform this action; is the route guarded by AuthGuard()>
+- Platform considerations: <iOS / Android divergence, if any>
+- Failure modes: <what the user sees when each thing breaks; what Either<Failure, T> returns on each error path>
+- Verification criteria: <unit tests, BLoC tests, widget tests, integration_test steps, manual simulator steps>
+- Out-of-scope follow-ups: <noted, not built>
+```
+
+For UI work, sketch the visual structure in plain text. Check `../coreui` for an existing CoreUI component before designing a new widget (standalone components, inner parts, primitives — check all three levels). If the design needs a visual reference, ask the user to share a Figma node ID or point at an existing screen to mirror.
+
+### No-code gate
+
+**Do NOT edit, write, scaffold, or refactor code until BOTH Pass B (Critic) AND Pass C (Readiness) in Step 2 close with their ready tokens (`design ready` + `implementation ready`).** Article rule, paraphrased: *"I do not want you to create code. We are not going to create code. Resist your impulse."* This holds until the design doc passes both gates — even if the user asks to skip ahead, even if the change "looks trivial", even if it is "just one line".
+
+If the user explicitly asks to skip the gate ("just write the code", "skip the design doc", etc.), restate the gate, name the still-open passes, and require an explicit override via `AskUserQuestion`:
+
+- `question`: "Override the no-code gate? Design hasn't passed Critic+Readiness yet."
+- `header`: `"Override?"`
+- `multiSelect`: `false`
+- `options`:
+  1. **Yes, override** — "Proceed to implementation. I accept the open design risks."
+  2. **No, finish the design check** — "Run another round of Pass B/C first."
+
+Only "Yes, override" unblocks code edits. The exception is `/eg-fix-bug` for trivial fixes covered by its own Step 0 triviality gate — that is a separate command with a separate gate.
+
+The design doc itself, test names mentioned in chat (not yet on disk), and read-only exploration (`Read`, `Grep`, `Bash` for `git status` / `git log` / `git diff`, `fvm flutter analyze --no-pub`, `fvm dart run custom_lint`) are NOT code edits and are permitted.
+
+## Step 2: Three-goldfish design check
+
+Run the article's full design-stage protocol: three sequential `Agent` calls per round (or two on revisions — see below), each with no prior context. The combined gate is "ready iff critic AND readiness both sign off"; comprehension is informational.
+
+Each pass uses `subagent_type: "general-purpose"` and gets ONLY the design doc (no chat history, no implementation intent, no other passes' output). The asymmetry is the value.
+
+**Round 1 runs all three passes; round 2+ skips comprehension** (revisions are gap-driven, not structural — once the doc reads cleanly, it almost always still reads cleanly). On every round, run critic and readiness.
+
+### Pass A — Comprehension (round 1 only)
+
+`description: "Goldfish comprehension check"`. Verifies the doc reads cleanly to a cold reader.
+
+```
+<<<COMPREHENSION_START>>>
+You are a fresh reader with no prior context. Below is a design doc for a feature in the Construculator repo (Flutter/Dart mobile app for construction cost estimation). Do NOT critique it yet. Your job is to verify the doc reads clearly to someone who walks in cold.
+
+Output two short sections in this order:
+
+## What this feature does
+2-5 sentences in your own words. The user-visible change. Who triggers it, when, what they get back.
+
+## How the existing system works (per the doc)
+2-5 sentences summarizing the current behavior the doc describes touching. Surfaces, BLoCs, usecases, message flow — whatever the doc references.
+
+End your output with EXACTLY one of these closing lines, on its own line:
+- comprehension passed       (the doc reads cleanly; no ambiguous sections)
+- comprehension unclear      (one or more sections are too vague to paraphrase)
+
+If you mark it unclear, list the ambiguous sections by heading before the closing line. Do NOT critique architecture choices here — that is the critic's job. Only flag things you genuinely cannot understand.
+
+DESIGN DOC:
+
+<PASTE FULL DESIGN DOC FROM STEP 1 HERE>
+<<<COMPREHENSION_END>>>
+```
+
+### Pass B — Critic (every round)
+
+`description: "Goldfish design critic"`. Finds gaps that block implementation.
+
+```
+<<<DESIGN_START>>>
+You are a fresh reviewer with no prior context. Below is a design doc for a feature in the Construculator repo (Flutter/Dart mobile app for construction cost estimation — Clean Architecture, BLoC + flutter_modular DI, Supabase backend, PowerSync offline sync; CLAUDE.md at the repo root has the full architecture).
+
+Your job: read the design doc, then read the surfaces it claims to touch, and find holes BEFORE implementation starts. Specifically:
+
+- Is the scope crisp? What questions would you have to answer to implement this that the doc does not answer?
+- Are the interfaces concrete enough that two implementers would converge on the same result?
+- Do the verification criteria actually verify the feature, or only verify that "something rendered"?
+- Does the doc misunderstand any existing code? Look up the surfaces it claims to touch and check.
+- Are there failure modes the doc missed? Network errors, unauthenticated users, empty state, partial saves, stale data, retries, offline / PowerSync edge cases.
+- BLoC lifecycle: does every stream/controller have a dispose path? Are streams broadcast where multiple listeners exist?
+- PowerSync / Supabase split: does the design correctly separate reads (PowerSync watches) from writes (Supabase direct)?
+- Backend coordination: does the design assume a Supabase endpoint / table / RPC that doesn't yet exist in `construculator-backend`?
+- RBAC: is every action gated by the correct role? Is `AuthGuard()` applied where needed?
+- Feature isolation: does the design reach across feature boundaries without going through `libraries/`?
+- Are there project-specific gotchas the doc ignores? CLAUDE.md is your reference.
+
+DESIGN DOC:
+
+<PASTE FULL DESIGN DOC FROM STEP 1 HERE>
+
+Output: numbered list of gaps, with file:line citations where applicable. End with `design ready` ONLY if you have zero gaps. Otherwise list them and end with `design needs revision`.
+<<<DESIGN_END>>>
+```
+
+### Pass C — Readiness (every round)
+
+`description: "Goldfish implementation readiness"`. Stricter than the critic: not "is the design good?" but "is the design _executable_ in one pass?"
+
+```
+<<<READINESS_START>>>
+You are a fresh implementer with no prior context. Below is a design doc for a feature in the Construculator repo (Flutter/Dart mobile app for construction cost estimation). Imagine you've been told: "Implement this. First pass. No follow-up questions allowed." Could you?
+
+For every interface, file path, BLoC event/state, usecase signature, repository method, Supabase request/response shape, widget prop, and verification criterion the doc claims, ask:
+- Could I write the corresponding code without asking the author anything?
+- Could I verify it works without asking what "works" means?
+- Are the cited files and line numbers concrete enough that I'd open the right file and edit the right region?
+
+Output a numbered list of EVERY question you would have to ask the author before you could ship. For each:
+- The question itself, one sentence.
+- The section of the doc that should have answered it but didn't.
+
+If the list is empty, say "No open questions."
+
+End with EXACTLY one of these closing lines, on its own line:
+- implementation ready       (zero open questions; first-pass implementable)
+- implementation not ready   (one or more open questions remain)
+
+A design can be beautiful and still fail this gate. The critic asks "is the design good?"; you ask "is the design executable?".
+
+DESIGN DOC:
+
+<PASTE FULL DESIGN DOC FROM STEP 1 HERE>
+<<<READINESS_END>>>
+```
+
+### Triage and loop
+
+A round is **ready** iff Pass B closes with `design ready` AND Pass C closes with `implementation ready`. Comprehension is informational: log it, surface it to the user, but do not gate progress on it. If comprehension returns `comprehension unclear` AND the round is otherwise ready, still proceed — but flag in the final report that the doc was unclear in places.
+
+If a round is **not ready**, bundle the critic gaps and readiness open questions into a single revise prompt:
+
+```
+=== CRITIC GAPS ===
+<verbatim Pass B output>
+
+=== READINESS OPEN QUESTIONS ===
+<verbatim Pass C output>
+```
+
+Plus, if Pass A returned `comprehension unclear`, prepend:
+
+```
+=== COMPREHENSION FEEDBACK (informational — the cold reader could not paraphrase parts of the doc) ===
+<verbatim Pass A output>
+```
+
+Tell the elephant to address EVERY numbered gap from BOTH the CRITIC GAPS and READINESS OPEN QUESTIONS sections — do not collapse or skip a section because the numbering restarts. Each gap is either: addressed in a doc revision, or rebutted with a verbatim reason citing CLAUDE.md / the user's words from this conversation. Print the revised doc back to the user once both gates close.
+
+Then re-run Pass B and Pass C against the revised doc (skip Pass A — see above). If the round still does not converge after **three revisions**, the feature is under-specified. Stop and call `AskUserQuestion`:
+
+- `question`: "Design check hit the 3-revision cap with N gaps still open. What now?"
+- `header`: `"3R cap"`
+- `multiSelect`: `false`
+- `options`:
+  1. **I'll clarify scope in chat** — "I'll answer the open gaps directly; you re-run Pass B/C."
+  2. **Drop one or more requirements** — "I'll specify which scope to cut so the doc converges."
+  3. **Override and proceed anyway** — "Accept the open gaps as known unknowns; flag them in the final report and continue to Step 3."
+  4. **Abandon the design** — "This feature isn't well enough understood yet. Stop."
+
+Free-form chat (for option 1 or 2) only happens AFTER this question has scoped the choice.
+
+## Step 3: Implementation plan
+
+Once the design doc is `design ready`, write a short ordered implementation plan in chat:
+
+1. **Domain layer:** entities (`domain/entities/`), repository interface (`domain/repositories/`), usecase(s) (`domain/usecases/`) — pure Dart, no codegen needed yet.
+2. **Data layer:** model(s) with `@freezed` / `@JsonSerializable` (run `fvm dart run build_runner build --delete-conflicting-outputs` after); data source interface + remote implementation (`data/data_source/`); repository implementation (`data/repositories/`).
+3. **DI:** wire bindings in `<feature>_module.dart` (`addLazySingleton` for services / repos / data sources, `add` for blocs); import dependency modules.
+4. **Presentation — BLoC(s):** `<action>_bloc/{bloc,event,state}.dart` under `presentation/bloc/`; constructor-inject usecases; fold `Either` results into typed states; implement `close()` to cancel subscriptions.
+5. **Presentation — UI:** widgets and pages (leaf widgets before composites); use CoreUI components and theme — no static colors or typography; provide BLoCs via `MultiBlocProvider` at the route.
+6. **Routing:** add route(s) in `<feature>_module.dart`; guard with `AuthGuard()` if auth required; register in `AppModule` if this is a new feature module.
+7. **Tests** (in parallel with implementation): unit tests for usecases and repositories (Fakes, not Mocks); BLoC tests; widget tests; shared Fakes in `test/fakes/`.
+
+For trivial features (single-component change), skip this step.
+
+## Step 4: Implement
+
+**Pre-flight check before any code edit:** confirm Step 2 closed both Pass B (Critic) AND Pass C (Readiness). If either is still open, the no-code gate from Step 1 still applies — return to Step 2 instead of proceeding.
+
+Follow the plan. After each layer, briefly verify before moving on:
+- **Domain:** `fvm flutter analyze` clean.
+- **Data / models:** `fvm flutter analyze` clean; `.g.dart` and `.freezed.dart` regenerated and match source.
+- **BLoC:** BLoC test passes; `close()` cancels all stream subscriptions and controllers.
+- **Widget:** widget test passes; no `setState` after dispose.
+- **Screen / route:** simulator run (`fvm flutter run --dart-define=ENVIRONMENT=dev`), navigate the golden path, check `flutter logs` for errors.
+
+**For UI features, run the feature on a simulator or device before reporting it done.** Use `fvm flutter run --dart-define=ENVIRONMENT=dev`. Navigate the golden path and take a screenshot. For features with platform-specific behavior (native rendering, platform channels), run on both iOS and Android.
+
+RBAC verification: for features that are role-gated, verify that each relevant role (owner, member, guest — see `lib/features/members/`) gets the correct access, and that restricted actions are not reachable by unauthorized roles.
+
+## Step 5: Hand off to `/eg-precommit-review`
+
+Run `/eg-precommit-review`. Pass the feature name as `$ARGUMENTS` so the reviewer focuses there.
+
+## Step 6: Test gate
+
+```sh
+fvm flutter analyze && fvm dart run custom_lint
+fvm flutter test --coverage
+# Run only when the diff touches a full screen flow end-to-end:
+# fvm flutter test integration_test/
+```
+
+All required tiers must pass. For UI features, **also do a final simulator walkthrough** of the golden path AND the most plausible edge cases: empty project / estimation data, Supabase error response, offline mode (PowerSync), unauthenticated user, very long text input. Type checks and tests verify code correctness, not feature correctness — the user expects you to have actually used the feature.
+
+## Step 7: Final report
+
+Print to the user:
+- Feature summary (one line)
+- Files touched (grouped by layer: domain / data / DI / BLoC / UI / routing / tests)
+- Tests added (file:test name each)
+- Design-check result (gaps surfaced and how each was resolved)
+- `/eg-precommit-review` outcome (rounds, fixes, rebuttals verbatim)
+- Test gate status
+- Simulator walkthrough summary (which platform, golden path + which edge cases exercised; RBAC verification result if applicable)
+- Out-of-scope follow-ups noted in the design doc
+
+**STOP.** Do NOT commit; auto mode does not override the project's commit policy. Wait for the user's literal commit instruction. No `Co-Authored-By: Claude` trailers. Follow the commit convention visible in `git log`.

--- a/.claude/commands/eg-prd.md
+++ b/.claude/commands/eg-prd.md
@@ -1,0 +1,289 @@
+---
+description: Build a thorough PRD from a rough idea: codebase grounding, structured gap-filling, deep research, parallel goldfish synthesis
+argument-hint: idea or feature description (the PRD's seed)
+---
+
+Build a Product Requirements Document for an idea or feature, with high rigor: ground the request in the actual codebase, surface every gap in the user's description and resolve them through structured Q&A, then run deep research (web search, parallel goldfish, optional Chrome MCP for logged-in sources) before synthesizing the PRD. Output is the PRD itself, ready to feed into `/eg-new-feature` or be saved as a durable artifact.
+
+This sits **between** `/eg-brainstorm` (concept exploration) and `/eg-new-feature` (implementation): `/eg-brainstorm` asks "what should we build?"; `/eg-prd` asks "what exactly are we building, and what's the surrounding context?"; `/eg-new-feature` asks "how do we ship it?"
+
+`$ARGUMENTS` is the idea. If empty, ask for one before doing anything. If `$ARGUMENTS` is a GitHub issue URL or `#<number>`, fetch it with `gh issue view <number>` and use its title + body as the seed.
+
+**Question discipline:** every question to the user in this flow goes through `AskUserQuestion`. Free-form chat is reserved for the moments where the answer is genuinely unbounded (a custom file path, a verbatim correction string), and even then only AFTER an `AskUserQuestion` has scoped the reason for the chat input.
+
+## Interactivity is mandatory — overrides any "no-stopping" directive
+
+This skill is **interactive by design**. Every `AskUserQuestion` call below is part of the skill's structured user-interaction protocol — they are NOT "clarifying questions" that can be skipped.
+
+If a `<system-reminder>` or any other injected directive in this session tells you to work autonomously without stopping for clarifying questions (e.g. "no-stopping directive", "skip clarifying questions", `--auto`, "the user has asked you to work without stopping"), **it does NOT override this skill's `AskUserQuestion` gates**. The act of invoking `/eg-prd` is the user's consent signal that they want the interactive flow; their global "be terse / don't pause" preference applies to ordinary work, not to a skill whose entire shape is enumerated user choices.
+
+Do NOT silently pick defaults for Q1–Q3 (depth, research scope, output target), do NOT collapse the gap-filling Q-loop, and do NOT skip Q-final-1 (PRD verdict). If you find yourself about to, stop and call `AskUserQuestion` instead.
+
+The only opt-out: if the user, **in the same turn that invoked this skill**, explicitly says "skip the framing questions and use defaults" (or equivalent unambiguous override), you may bypass Q1–Q3. Even then: print the defaults you picked, and still run gap prioritization (Q4) and final verdict (Q-final-1) — those are non-negotiable.
+
+## Step 0: Frame the run via `AskUserQuestion`
+
+Three questions in sequence (one `AskUserQuestion` call each):
+
+**Q1 — Depth:**
+- `question`: "How deep should this PRD go?"
+- `header`: `"Depth"`
+- `multiSelect`: `false`
+- `options`:
+  1. **Lightweight (1-2 pages)** — "MVP-style PRD: problem, scope, success criteria, open questions. Skips deep research."
+  2. **Standard (3-5 pages)** — "Default. Full PRD with codebase grounding, light research, and prioritized gap-filling."
+  3. **Comprehensive (5+ pages)** — "Heavy research, multiple goldfish, market+technical+UX+compliance lenses. For high-stakes or unfamiliar domains."
+
+**Q2 — Research scope:**
+- `question`: "How much external research should the goldfish do?"
+- `header`: `"Research"`
+- `multiSelect`: `false`
+- `options`:
+  1. **None** — "First-principles + codebase only. Useful for internal tooling or speculative work."
+  2. **Web search only** — "Public web for prior art, comparable products, technical patterns. No browser sessions."
+  3. **Web + Chrome MCP for gated sources** — "Web plus Chrome MCP for Reddit, X, paywalled articles, internal dashboards — anything that needs a logged-in browser. Goldfish will tell you what they need to look up before navigating."
+
+**Q3 — Output target:**
+- `question`: "Where should the PRD end up?"
+- `header`: `"Output"`
+- `multiSelect`: `true`
+- `options`:
+  1. **Save as `docs/specs/<slug>-prd-<YYYY-MM-DD>.md`** — "Durable artifact. Recommended for anything Standard or Comprehensive."
+  2. **Print and chat only** — "PRD lives in this conversation. Good for Lightweight or throwaway exploration."
+  3. **Hand off to `/eg-new-feature` after** — "Once the PRD is approved, end with the literal `/eg-new-feature <one-line summary>` so the next step is one command away."
+  4. **Save to memory** — "Persist as a durable note (e.g. CLAUDE.md or your memory system) for future sessions to recall. Prefer this for cross-cutting policies the PRD discovers, not the full doc."
+
+Cache the three answers. They drive the rest of the run.
+
+## Step 1: Ground in the codebase
+
+Before asking the user anything else, the elephant must understand the existing codebase well enough to know what's already there. Spawn **1-2 goldfish in parallel** with `subagent_type: "Explore"` (fall back to `"general-purpose"` if Explore is unavailable):
+
+- **Goldfish A — "Existing surfaces"**: Find code that already touches the same domain as the seed. Report file:line citations of the closest analogues, the data model, the URL routes / API endpoints / screens that are nearby.
+- **Goldfish B — "Architecture and conventions"**: Read CLAUDE.md, any `docs/` index, the package manifests, recent commits referencing this area. Report: tech stack, multi-tenancy / auth model, testing tiers, deployment topology, anything that constrains how a new feature would land.
+
+**Send a single message with both `Agent` tool uses** so they run concurrently.
+
+After both return, the elephant prints a **codebase brief** (5-15 lines):
+
+```
+CODEBASE BRIEF
+- Closest existing surfaces: <files / routes / models with one-line description each>
+- Patterns to mirror: <e.g. "uses Drift schema migrations with schemaVersion bump"; "controllers scope by current_company">
+- Constraints from CLAUDE.md or recent decisions: <multi-tenant, COEP headers, frozen module set, etc.>
+- Observed gaps the seed leaves open: <preview of what Step 2 will turn into questions>
+```
+
+## Step 2: Surface every gap
+
+Now the elephant analyzes `$ARGUMENTS` and the codebase brief, and produces a complete list of gaps. Categories to cover (omit only if genuinely n/a):
+
+- **Who & why**: target user persona, the job-to-be-done, the trigger / moment of need
+- **What**: in-scope behavior, out-of-scope explicitly, MVP vs. full, feature variants or modes
+- **How well**: success metrics (numerical where possible), performance budgets, accessibility level, scale assumptions
+- **When**: deadline if any, dependencies on other work, sequencing
+- **Constraints**: budget, tech stack restrictions, compliance (GDPR / SOC2 / PCI / industry-specific), brand voice, multi-tenant scoping, internationalization, offline behavior
+- **Failure modes**: what does the user see when each thing breaks; rollback plan; degraded modes
+- **Pricing & go-to-market** (if a paid feature): tier, packaging, sales motion
+- **Instrumentation**: what events / logs / metrics fire; what dashboards exist for it after launch
+
+Print the gap list grouped by category. Number every gap globally (G1, G2, …). Each gap is one line: the question and why it matters.
+
+Then ask via `AskUserQuestion`:
+
+**Q4 — Gap prioritization:**
+- `question`: "Which gaps do you want to fill before drafting? (Unselected gaps land in the PRD's Open Questions section.)"
+- `header`: `"Gaps"`
+- `multiSelect`: `true`
+- `options` — produce one option per gap, **but** AskUserQuestion supports a limited number of options (around 5). If there are more gaps than fit, group them: each option represents a category (e.g. "Who & why — 3 gaps", "How well — 4 gaps") and the user picks categories to fill. The default kit:
+  1. **Who & why** — "Persona, job-to-be-done, trigger."
+  2. **What & scope** — "In/out, MVP, variants."
+  3. **How well** — "Metrics, performance, accessibility, scale."
+  4. **Constraints** — "Compliance, multi-tenant, tech stack, budget."
+  5. **All of the above + failure modes & instrumentation** — "Fill everything detected."
+
+If the gap count is small (≤5) AND each gap is sharp and self-contained, present individual gaps as the options instead of categories. Use judgment.
+
+## Step 3: Fill the selected gaps
+
+For every gap the user selected, ask one `AskUserQuestion` per gap. Each question is structured: present the gap, list 3-5 plausible answers (the elephant's best educated guesses based on the codebase brief and `$ARGUMENTS`), plus an "Other (describe in chat)" escape hatch. Concrete pattern:
+
+```
+Q5+ — <Gap label>:
+- question: "<the gap, phrased as a question>"
+- header: "<short tag>"
+- multiSelect: false (or true when genuinely multi-pick, e.g. "Which platforms?")
+- options:
+  1. <plausible answer 1, with one-line justification>
+  2. <plausible answer 2>
+  3. <plausible answer 3>
+  4. **Defer to PRD's Open Questions** — "I don't know yet; capture as open."
+  5. **Other (describe in chat)** — "None of the above; I'll specify."
+```
+
+If the user picks **Defer**, write that gap into the PRD's Open Questions section verbatim and move on. If **Other**, ask in chat with one targeted prompt referencing the gap's label, then continue.
+
+Do NOT ask all gaps in one shot. Stream them — the user sees the running picture build up. Skip Step 3 entirely if the user picked nothing in Q4.
+
+## Step 4: Deep research (if Q2 was not "None")
+
+Spawn **3-5 research goldfish in parallel** using `subagent_type: "general-purpose"` (full tool access). Pick lenses based on the seed and the answered gaps. **Send one message with all `Agent` tool uses** so they run concurrently.
+
+Default lens kit (mix and match):
+
+- **Market & prior art** — "What products / open-source projects / past attempts already exist in this space? Top 3-5 closest analogues, what they do well, where they fail, what users complain about."
+- **Technical patterns** — "Reference architectures, libraries, frameworks. What's the 'standard' way to build this? What's a controversial-but-better way?"
+- **UX precedent** — "Canonical UX for this kind of feature. Specific examples (named products, screenshot descriptions if helpful). What conventions users will expect."
+- **Compliance & risk** — "Regulatory exposure, accessibility requirements, security posture, privacy obligations. What MUST this PRD account for?"
+- **Performance & scale** — "Realistic numbers for a feature of this kind: latency budgets, concurrency, data volume, cost-per-action. Source the numbers."
+
+**Each goldfish prompt body (between markers, exclusive):**
+
+```
+<<<RESEARCH_START>>>
+You are a fresh researcher with NO prior context. Your lens for this round is: **<LENS NAME>**. Stay in that lens.
+
+SEED: <PASTE $ARGUMENTS verbatim>
+
+CODEBASE BRIEF: <PASTE Step 1 output>
+
+ANSWERED GAPS: <PASTE Step 3 answers>
+
+Your job:
+1. Research your lens against the seed + answered gaps. Be specific — name products, cite numbers, quote sources.
+2. Web search where it sharpens an answer. Cite URLs inline.
+3. <IF Q2 = "Web + Chrome MCP">: For sources that require a logged-in browser session (Reddit, X / Twitter, paywalled articles, internal dashboards, etc.), use Chrome MCP (`mcp__Claude_in_Chrome__*`) against the user's running browser. Get tab context first via `tabs_context_mcp`, then `navigate` and `get_page_text`. **Before navigating to a site that requires auth or might charge / submit forms, stop and tell the orchestrator what you intend to look at and why.** The orchestrator will surface to the user.
+4. Output for your lens: 5-10 numbered findings, each one tight (1-3 sentences), each with at least one source URL or named reference.
+5. End with **What this lens implies for the PRD** — 3-5 bullets the PRD synthesis should reflect.
+
+End with the literal string `lens complete`.
+<<<RESEARCH_END>>>
+```
+
+After all goldfish return, the elephant prints a **research summary** (no synthesis yet — that's Step 5):
+
+- One section per lens, each with the goldfish's findings + implications.
+- Sources consolidated at the end.
+- Anything the goldfish flagged as "needs human verification" surfaced explicitly.
+
+If a goldfish stopped to ask about a Chrome MCP navigation, surface the question to the user via `AskUserQuestion`:
+
+**Q-N — Research navigation approval:**
+- `question`: "Goldfish <lens> wants to navigate to <URL> to look up <topic>. Allow?"
+- `header`: `"Browse?"`
+- `multiSelect`: `false`
+- `options`:
+  1. **Yes, navigate** — "Use my browser session to read this page."
+  2. **No, skip** — "Proceed without this source."
+  3. **Different source** — "I'll suggest a better URL in chat."
+
+## Step 5: Synthesize the PRD
+
+The elephant now drafts the PRD by integrating: `$ARGUMENTS`, the codebase brief, the answered gaps, the unanswered gaps (open questions), the research summary. Use this structure (skip sections that are genuinely n/a; mark sections "TBD" if the gap was deferred to Open Questions):
+
+```
+# PRD: <title>
+
+## Executive summary
+<2-4 sentences: what, who for, why now>
+
+## Problem statement
+<the underlying user / business problem, stated independently of solution>
+
+## Target users
+<persona(s), JTBD, trigger / moment of need — from gap answers>
+
+## Current state
+<from codebase brief: what exists today, what's adjacent, what we'd reuse vs. replace>
+
+## Proposed solution
+<the shape of the answer — high-level, NOT implementation>
+
+## Scope
+**In:** <bullets>
+**Out:** <bullets — explicitly>
+
+## User stories / Jobs-to-be-done
+<as-a / I-want / so-that, or JTBD format>
+
+## Functional requirements
+<numbered list, each requirement testable>
+
+## Non-functional requirements
+- **Performance:** <budgets>
+- **Accessibility:** <level, e.g. WCAG 2.1 AA>
+- **Security & privacy:** <auth, data handling, PII>
+- **Multi-tenant / scoping:** <if applicable>
+- **i18n / localization:** <if applicable>
+- **Offline / degraded modes:** <if applicable>
+
+## Success metrics
+<numerical where possible, with target values + measurement method>
+
+## Risks & mitigations
+<table or bulleted list: risk, likelihood, impact, mitigation>
+
+## Implementation hints
+<loose; refined later in /eg-new-feature: layer ordering, data model sketch, key dependencies>
+
+## Open questions
+<gaps the user deferred, plus anything research surfaced as needing human verification>
+
+## Sources & references
+<all goldfish citations, deduplicated, grouped by theme>
+
+## Out-of-scope follow-ups
+<noted, not built; future PRDs>
+```
+
+Print the full PRD.
+
+## Step 6: User review
+
+Ask via `AskUserQuestion`:
+
+**Q-final-1 — PRD verdict:**
+- `question`: "What's next for this PRD?"
+- `header`: `"Verdict"`
+- `multiSelect`: `false`
+- `options`:
+  1. **Approve as-is** — "Proceed to output (Step 7)."
+  2. **Refine specific sections** — "I'll pick which sections to revise."
+  3. **Reject and restart** — "The PRD missed the mark. Re-run from Step 0."
+  4. **Stop here** — "Print only, don't save or hand off."
+
+If **Refine specific sections**, ask:
+
+**Q-refine — Which sections:**
+- `question`: "Which sections need revision?"
+- `header`: `"Refine"`
+- `multiSelect`: `true`
+- `options`: one per major PRD section (Executive summary / Problem / Target users / Scope / Functional / Non-functional / Metrics / Risks / Open questions). Add an "Add a section I missed" escape hatch.
+
+For each picked section, ask in chat with one targeted prompt referencing the section's content. Re-draft the affected sections, re-print the PRD, re-ask Q-final-1.
+
+If **Reject and restart**, go back to Step 0.
+
+## Step 7: Output
+
+Drive the output by what the user picked in Q3 (output target). Each Q3 selection produces a side-effect:
+
+- **Save as `<path>`**: write the PRD to disk. If the path includes `<slug>` and `<YYYY-MM-DD>`, derive the slug from the PRD title (kebab-case, lowercase) and date from `date +%Y-%m-%d`. If the directory doesn't exist, create it. Confirm the path back to the user.
+- **Save to memory**: write the cross-cutting policies / constraints the PRD discovered (NOT the full PRD body — just the durable nuggets that future sessions should know) to the project's memory system or CLAUDE.md. Surface the diff before applying.
+- **Hand off to `/eg-new-feature`**: print the literal command the user can paste to invoke `/eg-new-feature`, with a one-line feature description sourced from the PRD's executive summary. Example: `Run /eg-new-feature implement <PRD title>: <one-line summary> when ready.` Do NOT auto-invoke.
+- **Print and chat only**: do nothing further.
+
+If multiple Q3 options were picked, do all of them.
+
+## Final report
+
+Print to the user:
+- PRD title (one line)
+- Depth + research scope chosen
+- Codebase brief one-line summary
+- Gaps surfaced / filled / deferred (counts)
+- Research lenses run
+- Where the PRD lives now (file path, memory entry, both, or chat-only)
+- Next action (e.g. "Run `/eg-new-feature ...` when ready" or "Open questions need user input before this is shippable")
+
+**STOP.** Do NOT commit; auto mode does not override the project's commit policy. If the PRD was saved to disk, it's a new file the user will commit themselves when ready. No `Co-Authored-By: Claude` trailers. Follow the commit convention visible in `git log`.

--- a/.claude/commands/eg-prd.md
+++ b/.claude/commands/eg-prd.md
@@ -48,7 +48,7 @@ Three questions in sequence (one `AskUserQuestion` call each):
 - `header`: `"Output"`
 - `multiSelect`: `true`
 - `options`:
-  1. **Save as `docs/specs/<slug>-prd-<YYYY-MM-DD>.md`** — "Durable artifact. Recommended for anything Standard or Comprehensive."
+  1. **Save as `docs/prds/<slug>-prd-<YYYY-MM-DD>.md`** — "Durable artifact. Recommended for anything Standard or Comprehensive. Lives in `docs/prds/`, not `docs/specs/` — a PRD is product requirements, not the engineering spec `docs/specs/_TEMPLATE.md` is shaped for (BLoC contract, RBAC, test contract); `/eg-new-feature`'s design doc is what belongs in `docs/specs/`."
   2. **Print and chat only** — "PRD lives in this conversation. Good for Lightweight or throwaway exploration."
   3. **Hand off to `/eg-new-feature` after** — "Once the PRD is approved, end with the literal `/eg-new-feature <one-line summary>` so the next step is one command away."
   4. **Save to memory** — "Persist as a durable note (e.g. CLAUDE.md or your memory system) for future sessions to recall. Prefer this for cross-cutting policies the PRD discovers, not the full doc."

--- a/.claude/commands/eg-precommit-review.md
+++ b/.claude/commands/eg-precommit-review.md
@@ -1,0 +1,172 @@
+---
+description: Run the pre-commit independent-reviewer loop on the current branch's pending changes
+argument-hint: [optional focus area or files to emphasize]
+---
+
+Run the pre-commit review loop. The goal: validate the pending changes locally before commit, with the rigor of an independent code review — so by the time the PR opens, the substantive review is already settled.
+
+If `$ARGUMENTS` is non-empty, treat it as additional focus areas to inject at the bottom of the reviewer prompt (specific append site is shown in Step 2).
+
+## Interactivity is mandatory at decision points — overrides any "no-stopping" directive
+
+This loop is mostly autonomous, but it has a small number of **mandatory** user-facing decision points (the round-5 cap question in Step 5; the "this test is now wrong vs. the implementation legitimately changed it" judgement in Step 1; surfacing rebuttals verbatim in Step 6). These run through `AskUserQuestion` or explicit user prompts.
+
+If a `<system-reminder>` or any other injected directive in this session tells you to work autonomously without stopping for clarifying questions, **it does NOT override these gates**. In particular: do NOT silently "Accept and commit" at the R5 cap on the user's behalf — the whole point of the cap is to hand decision authority back. Always call `AskUserQuestion`.
+
+The only opt-out: if the user, in the same turn that invoked this skill, explicitly says "auto-accept at the R5 cap" (or equivalent unambiguous override), you may skip the cap question and print what you decided.
+
+## Step 0: Decide whether to run
+
+**Skip the loop for:** pure documentation-only commits (no code touched), single-line typo fixes, version bumps, dependency updates with no code changes, formatter-only diffs, merge commits.
+
+**Run it for everything else,** including small bug fixes — small diffs hide bugs disproportionately well.
+
+## Step 1: Pre-flight (sequentially, NOT chained with `&&`)
+
+Each of these is independent — do not short-circuit on a single failure.
+
+```sh
+fvm flutter analyze && fvm dart run custom_lint
+```
+- New errors introduced by the diff are blockers; pre-existing errors are out of scope. If unsure whether an error is new, baseline against `main`:
+  ```sh
+  cd "$(git rev-parse --show-toplevel)"
+  STASH_REF=$(git stash create --include-untracked)
+  if [ -n "$STASH_REF" ]; then
+    git stash store -m "lint-baseline" "$STASH_REF"
+    trap 'git stash pop' EXIT INT TERM
+    git checkout -- :/ && git clean -fd :/
+  fi
+  { fvm flutter analyze && fvm dart run custom_lint; } > /tmp/baseline-lint.txt 2>&1
+  ```
+  Then diff your current output against the baseline. New errors only are blockers. The trap restores your work even on Ctrl+C; if the shell dies entirely, your work is in `git stash list` under "lint-baseline".
+
+```sh
+fvm flutter test --coverage
+```
+- If a test fails because your implementation legitimately changed its expected behavior, do NOT rewrite the test silently — run the reviewer FIRST (Step 2) with the failing test name in `$ARGUMENTS` as a focus area, then update the test only after the reviewer signs off on the new behavior.
+- If a test fails for any other reason, fix the code first.
+
+```sh
+# Only when the diff touches a full screen flow end-to-end:
+fvm flutter test integration_test/
+```
+- Skip if your diff is purely domain / data-layer logic (usecases, repositories, models) with no observable screen flow change.
+
+If your diff modifies any `@freezed` or `@JsonSerializable` type (models, entities, BLoC states/events), regenerate first:
+```sh
+fvm dart run build_runner build --delete-conflicting-outputs
+```
+Both source and generated files (`*.g.dart`, `*.freezed.dart`) must be committed together.
+
+## Step 2: Spawn a fresh independent reviewer
+
+Use the `Agent` tool with:
+- `subagent_type: "general-purpose"`
+- `description: "Independent pre-commit review (round N)"` — substitute the actual round number so per-round invocations are distinguishable in telemetry while sharing the loop-grouping prefix.
+
+The reviewer must have NO implementation context — that asymmetry is what makes the review effective.
+
+**Pass the prompt EXACTLY.** Do NOT prepend the implementation plan, the user's original request, what you were trying to do, or any explanation of intent. Any framing leaks the asymmetry.
+
+**The prompt to send to `Agent`'s `prompt` field is exactly the body delimited by `<<<TEMPLATE_START>>>` (exclusive) and `<<<TEMPLATE_END>>>` (exclusive).** Do NOT include the markers themselves. If `$ARGUMENTS` is non-empty, replace the literal `[NO ADDITIONAL FOCUS]` line with `Additionally focus on: <$ARGUMENTS verbatim>`. Modify NO other line.
+
+```
+<<<TEMPLATE_START>>>
+Independent code review of the pending changes on this branch.
+
+Run ALL of the following to capture every kind of pending change — any one of them in isolation can be empty:
+- `git status` (working-tree state, untracked files)
+- `git diff` (uncommitted unstaged changes)
+- `git diff --cached` (uncommitted staged changes)
+- `git diff main...HEAD` (committed-but-unmerged changes; empty when the branch IS `main`)
+- `git log main..HEAD --oneline` (commit messages on the branch)
+
+Also `git ls-files --others --exclude-standard` to find untracked new files. Read the touched files in full where the diff context is not enough.
+
+Find substantive issues. For each finding: cite file:line, name the issue, explain WHY it is a bug or risk (not just what the code does), and suggest a concrete fix. Be specific — vague observations are not actionable.
+
+Hunt for:
+- Bugs: off-by-ones, null dereference, wrong variable used, unhandled error paths, async/await misuse, mutating function args, returning the wrong value on an error path
+- Security: unsanitized input, secrets in URLs or logs, missing auth checks, IDOR (user accessing another user's data via predictable IDs)
+- Race conditions: shared state without locks, async ordering, double-submit, event handler re-entry, TOCTOU
+- Edge cases: empty lists, null, negative numbers, very large numbers, Unicode, timezone, concurrent access, network failure, partial writes
+- Error handling: silent catches, swallowed errors, fallback paths that mask real failures, missing `Either` propagation, throwing generic exceptions instead of returning typed `Failure`
+- Performance: N+1 queries, sync work in hot loops, missing memoization, unbounded growth, missing pagination, excessive widget rebuilds
+- Test coverage gaps: code paths not covered by unit / BLoC / widget tests. For bug fixes specifically: is there a regression test that fails before the fix and passes after?
+- Flutter / Dart: `StreamController` or `StreamSubscription` not closed in BLoC `close()` or widget `dispose()`; `TextEditingController`, `AnimationController`, or `ScrollController` not disposed in `dispose()`; BLoC race with dispose (event emitted after BLoC is closed); missing `const` constructor on widgets used in hot-rebuild paths; `Modular.get` called inside a BLoC or usecase (no_direct_instantiation CLAUDE.md rule); raw `Icon`, static `Colors.*`, or `TextStyle(...)` bypassing CoreUI components and theme; `DateTime.now()` used instead of injected `Clock` (`libraries/time`); `!` forced unwrap on a nullable; generic `Exception` thrown instead of a typed `Failure`
+- Generated code drift: `@freezed` / `@JsonSerializable` source modified but `.g.dart` / `.freezed.dart` not regenerated
+- Project-rule violations from CLAUDE.md (cite the relevant section)
+- Dead code, leftover `print()`, `debugPrint()`, or stale comments referencing removed code
+
+Do NOT surface:
+- Stylistic preferences (formatting, naming, ordering)
+- Suggestions to add explanatory comments unless the WHY is genuinely non-obvious
+- Micro-refactors that do not fix a bug
+- Speculative concerns ("this could maybe break if...") without a concrete failure mode
+
+[NO ADDITIONAL FOCUS]
+
+Output format: numbered list. For each finding, lead with `file:line` then the issue and fix. End the response with the literal string `no findings` if (and only if) the diff is clean. If you have findings, do NOT include `no findings`.
+<<<TEMPLATE_END>>>
+```
+
+## Step 3: Triage the findings
+
+For each finding the reviewer returns:
+- **Fix it** — apply the change. Note the file:line that was touched.
+- **Rebut it** — write a one-line reason. Valid categories: (a) "not a bug because X" with X visible in the diff or codebase; (b) "out of scope — the diff doesn't touch that area"; (c) "intentional trade-off documented in [file:line or CLAUDE.md section]"; (d) "user explicitly asked for this in this conversation" — quote the user's exact words verbatim. Reject vague intent claims ("I meant to do that") that the reviewer cannot verify — fix the code instead.
+
+**Surface every rebuttal back to the user verbatim** in the final report. NO silent dismissals; NO summarizing rebuttals away.
+
+## Step 4: Maintain a ledger and re-invoke
+
+Before re-invoking, print to the user:
+```
+Open findings going into round N:
+- [from round 1] file:line — fixed (commit not yet made; in-flight)
+- [from round 1] file:line — rebutted: <verbatim reason>
+[...]
+```
+This makes the working state visible and prevents earlier-round findings from quietly disappearing.
+
+Then re-invoke. Subagents are stateless — re-include the FULL original template body (every line between the `<<<TEMPLATE_START>>>` / `<<<TEMPLATE_END>>>` markers from Step 2), then a blank line, then `---`, then a blank line, then this addendum:
+
+```
+Previous round's fixes:
+- file:line — what changed
+[...]
+
+Verify each fix is correct and complete. Look for anything you missed in the first pass, especially issues introduced by the fixes themselves.
+```
+
+Send the concatenated result as the `prompt` argument to `Agent`. Do NOT send placeholder strings — actually paste the body.
+
+## Step 5: Loop with hard cap
+
+Repeat steps 3-4 until the reviewer returns the literal string `no findings` AND every prior-round finding is fixed-or-rebutted.
+
+**Hard cap: 5 rounds.** Stop if (a) you hit 5 rounds without exiting, or (b) any new finding lands at the same `file:method` (or within ~10 lines of a previously-fixed line).
+
+When tripped, print a plain-language brief of open findings grouped by severity (~30 seconds to read), then call `AskUserQuestion`:
+- `question`: "Review hit the 5-round cap with N findings still open. What do you want to do?"
+- `header`: `"R5 cap"`
+- `multiSelect`: `false`
+- `options`:
+  1. **Accept and commit** — "Skip the open findings, commit as-is."
+  2. **Keep working on fixes** — "I'll keep iterating past the cap. Risk: it may not converge — say stop anytime."
+  3. **Abandon the change** — "Roll back and start over with a different approach."
+
+If they pick "Accept and commit", proceed to Step 6. If "Keep working", run round 6 (and surface the same brief + question after each subsequent round). If "Abandon", stop and wait for further direction.
+
+Typical loop length: 2-3 rounds. If you're at 5+ without exit, the implementation needs deeper rework, not more reviews.
+
+## Step 6: Final report
+
+Once the loop exits, print to the user:
+- Rounds run
+- Findings fixed (with file:line each)
+- Findings rebutted (with the **verbatim** one-line reason each, not summarized)
+- Whether any pre-existing lint/test errors were noted as out-of-scope
+
+**STOP at this step.** Do NOT run `git commit`, do NOT run `git add`, and do NOT prompt "want me to commit?" — even in auto mode. Wait for the user's literal commit instruction. No `Co-Authored-By: Claude` trailers. Follow the commit convention visible in `git log`.

--- a/docs/specs/_TEMPLATE.md
+++ b/docs/specs/_TEMPLATE.md
@@ -1,0 +1,40 @@
+# CA-XXX: [Feature Name]
+## Why
+One sentence: what user problem does this solve?
+
+## Scope
+### In scope
+- <item>
+### Out of scope (explicit)
+- <item>
+
+## Figma
+- Idle state: [node-id]
+- Result state: [node-id]
+- Error state: [node-id]
+
+## BLoC Contract
+Events:
+- <EventName>(<params>)
+States:
+- <StateName>(<fields>)
+Computation rules:
+- <rule>
+Side effects: none / <describe>
+
+## CoreUI Components
+- <ComponentName> from ripplearc_coreui
+
+## RBAC
+- <who can trigger which events>
+
+## Edge Cases + Failure Modes
+- <case>
+
+## Test Contract (95% gate)
+Scenarios the test suite must assert:
+1. <scenario>
+
+## Dependencies
+- Depends on: CA-XXX (what it needs)
+- Blocks: CA-YYY (what depends on it)


### PR DESCRIPTION
### 1. PR SUMMARY
Adds the SDD (spec-driven development) scaffolding on top of `chore/add-claude-md` (#303): five `.claude/commands/` skill definitions (`eg-brainstorm`, `eg-fix-bug`, `eg-new-feature`, `eg-prd`, `eg-precommit-review`) implementing the elephant/goldfish workflow for brainstorming, bug fixes, feature design, PRDs, and pre-commit review, plus a `docs/specs/_TEMPLATE.md` spec template (Why, Scope, Figma, BLoC Contract, CoreUI Components, RBAC, Edge Cases, Test Contract, Dependencies). Docs-only — no application code touched.

### 2. REVIEW SUMMARY TABLE
No issues found.

## Test plan
- [ ] Run `/eg-brainstorm`, `/eg-new-feature`, `/eg-fix-bug`, `/eg-prd`, `/eg-precommit-review` in Claude Code and confirm they load and follow the documented flow
- [ ] Confirm `docs/specs/_TEMPLATE.md` renders correctly and matches the section headers referenced in `eg-new-feature.md` / `eg-prd.md`