### PR TITLE
CA-955 (1/5): add FeatureFlagRepository domain contracts

### DIFF
--- a/lib/libraries/analytics/domain/repositories/feature_flag_repository.dart
+++ b/lib/libraries/analytics/domain/repositories/feature_flag_repository.dart
@@ -8,7 +8,9 @@ import 'package:construculator/libraries/errors/failures.dart';
 /// there is no per-call network round trip. Every method fails closed: a
 /// [Left] is never returned, and a `null` right-hand value (whether from a
 /// real evaluation failure or an unset flag) must be treated as "off" by
-/// callers.
+/// callers. This applies uniformly across every method on this contract,
+/// including [reloadFeatureFlags] — see its own doc comment for how that
+/// applies to a cache-refresh call specifically.
 ///
 /// Details can be found in the design doc: docs/Logging/PostHog-Feature-Flags.md
 abstract class FeatureFlagRepository {
@@ -16,10 +18,30 @@ abstract class FeatureFlagRepository {
   /// `null` if the flag is unset or evaluation failed.
   Future<Either<Failure, bool?>> isFeatureEnabled(String featureFlagKey);
 
+  /// Returns the variant key for a multivariate [featureFlagKey], or `null`
+  /// if the flag is unset, not multivariate, or evaluation failed.
+  Future<Either<Failure, String?>> getFeatureFlagVariant(
+    String featureFlagKey,
+  );
+
+  /// Returns the JSON payload associated with [featureFlagKey], or `null`
+  /// if the flag has no payload or evaluation failed.
+  Future<Either<Failure, Map<String, dynamic>?>> getFeatureFlagPayload(
+    String featureFlagKey,
+  );
+
   /// Refreshes the client-side flag cache against the current identity.
   ///
   /// Call after app start (post `PosthogWrapper.initialize`); the design
   /// doc also calls for refreshing after `identify()`/`reset()`, which is
   /// deferred to whoever implements that trigger.
+  ///
+  /// Fails closed like every other method on this contract: a SDK failure
+  /// while refreshing (e.g. timeout, connection error) is mapped to a
+  /// [FeatureFlagFailure] and logged internally by the implementation, but
+  /// is never returned as [Left] here — the cache simply keeps its
+  /// last-known state and the call still resolves `Right`. Callers cannot
+  /// distinguish "refreshed successfully" from "refresh failed, cache
+  /// unchanged" through the return value.
   Future<Either<Failure, void>> reloadFeatureFlags();
 }

--- a/lib/libraries/analytics/domain/repositories/feature_flag_repository.dart
+++ b/lib/libraries/analytics/domain/repositories/feature_flag_repository.dart
@@ -1,0 +1,25 @@
+// coverage:ignore-file
+import 'package:construculator/libraries/either/interfaces/either.dart';
+import 'package:construculator/libraries/errors/failures.dart';
+
+/// Abstract contract for PostHog Feature Flags.
+///
+/// Evaluation reads a client-side cache populated by [reloadFeatureFlags];
+/// there is no per-call network round trip. Every method fails closed: a
+/// [Left] is never returned, and a `null` right-hand value (whether from a
+/// real evaluation failure or an unset flag) must be treated as "off" by
+/// callers.
+///
+/// Details can be found in the design doc: docs/Logging/PostHog-Feature-Flags.md
+abstract class FeatureFlagRepository {
+  /// Returns whether [featureFlagKey] is enabled for the current user, or
+  /// `null` if the flag is unset or evaluation failed.
+  Future<Either<Failure, bool?>> isFeatureEnabled(String featureFlagKey);
+
+  /// Refreshes the client-side flag cache against the current identity.
+  ///
+  /// Call after app start (post `PosthogWrapper.initialize`); the design
+  /// doc also calls for refreshing after `identify()`/`reset()`, which is
+  /// deferred to whoever implements that trigger.
+  Future<Either<Failure, void>> reloadFeatureFlags();
+}

--- a/lib/libraries/analytics/domain/types/feature_flag_error_type.dart
+++ b/lib/libraries/analytics/domain/types/feature_flag_error_type.dart
@@ -1,0 +1,7 @@
+// coverage:ignore-file
+
+/// Error type for feature flag operations.
+///
+/// - [timeoutError]: the PostHog flag read/reload request timed out
+/// - [connectionError]: network connectivity issues reaching PostHog
+enum FeatureFlagErrorType { timeoutError, connectionError }

--- a/lib/libraries/errors/failures.dart
+++ b/lib/libraries/errors/failures.dart
@@ -1,4 +1,5 @@
 import 'package:construculator/libraries/analytics/domain/types/analytics_error_type.dart';
+import 'package:construculator/libraries/analytics/domain/types/feature_flag_error_type.dart';
 import 'package:construculator/libraries/auth/domain/types/auth_types.dart';
 import 'package:construculator/libraries/estimation/domain/estimation_error_type.dart';
 import 'package:construculator/libraries/global_search/domain/search_error_type.dart';
@@ -97,6 +98,18 @@ class AnalyticsFailure extends Failure {
 
   /// Creates an [AnalyticsFailure] with the given [errorType].
   const AnalyticsFailure({required this.errorType});
+
+  @override
+  List<Object?> get props => [errorType];
+}
+
+/// Failure thrown when a feature flag operation fails.
+class FeatureFlagFailure extends Failure {
+  /// The type of feature flag error that occurred.
+  final FeatureFlagErrorType errorType;
+
+  /// Creates a [FeatureFlagFailure] with the given [errorType].
+  const FeatureFlagFailure({required this.errorType});
 
   @override
   List<Object?> get props => [errorType];


### PR DESCRIPTION
### 1. PR SUMMARY
Adds the domain contract for PostHog Feature Flags, per the design in `docs/Logging/PostHog-Feature-Flags.md` (CA-954): `FeatureFlagRepository` abstract interface (`isFeatureEnabled`, `reloadFeatureFlags`), `FeatureFlagErrorType`, and `FeatureFlagFailure`. Mirrors `AnalyticsRepository`/`AnalyticsErrorType`/`AnalyticsFailure`'s existing shape exactly. No implementation yet — that's the next PR in this stack.

Part of the CA-955 stack ("Gate the Calculator module behind a PostHog feature flag"), based on `CA-941-feat/posthog-wrapper-fake` (open, unmerged) per the ticket's "coordinate directly on the open stack" option, since `main` doesn't yet have the `PosthogWrapper` this stack builds on.

### 2. REVIEW SUMMARY TABLE
No issues found.

## Test plan
- [x] `fvm dart run custom_lint` — clean (one pre-existing unrelated failure in `fake_router.dart`, confirmed present on the parent branch too)
- [x] `fvm flutter test` — all 3246 tests pass
- [ ] Reviewer sign-off