### PR TITLE
CA-955 (2/5): add feature-flag methods to PosthogWrapper + FakePosthogWrapper

### DIFF
--- a/lib/libraries/analytics/interfaces/posthog_sdk.dart
+++ b/lib/libraries/analytics/interfaces/posthog_sdk.dart
@@ -58,4 +58,17 @@ abstract class PosthogSdk {
   /// Reloads feature flags for the current user; mirrors
   /// `Posthog().reloadFeatureFlags`.
   Future<void> reloadFeatureFlags();
+
+  /// Returns the raw flag value; mirrors `Posthog().getFeatureFlag`.
+  ///
+  /// A `bool` means a simple on/off flag; a `String` means a multivariate
+  /// flag's variant key. Returns `null` if [key] is unset or evaluation
+  /// failed.
+  Future<Object?> getFeatureFlag(String key);
+
+  /// Returns the JSON payload for a feature flag; mirrors
+  /// `Posthog().getFeatureFlagPayload`.
+  ///
+  /// Returns `null` if [key] has no payload or evaluation failed.
+  Future<Object?> getFeatureFlagPayload(String key);
 }

--- a/lib/libraries/analytics/interfaces/posthog_sdk.dart
+++ b/lib/libraries/analytics/interfaces/posthog_sdk.dart
@@ -47,4 +47,15 @@ abstract class PosthogSdk {
     required String groupKey,
     Map<String, dynamic>? groupProperties,
   });
+
+  /// Returns whether a boolean feature flag is enabled; mirrors
+  /// `Posthog().isFeatureEnabled`.
+  ///
+  /// Returns `false` when [key] is disabled, missing, or not a boolean
+  /// flag — the underlying SDK has no null case.
+  Future<bool> isFeatureEnabled(String key);
+
+  /// Reloads feature flags for the current user; mirrors
+  /// `Posthog().reloadFeatureFlags`.
+  Future<void> reloadFeatureFlags();
 }

--- a/lib/libraries/analytics/interfaces/posthog_wrapper.dart
+++ b/lib/libraries/analytics/interfaces/posthog_wrapper.dart
@@ -43,4 +43,14 @@ abstract class PosthogWrapper {
     required String groupKey,
     Map<String, dynamic>? groupProperties,
   });
+
+  /// Returns whether [flagKey] is enabled for the current user, or `null`
+  /// if this wrapper isn't enabled (see [initialize]).
+  ///
+  /// Evaluated from the client-side cache populated by [reloadFeatureFlags],
+  /// not a live network call.
+  Future<bool?> isFeatureEnabled(String flagKey);
+
+  /// Refreshes the client-side feature flag cache for the current identity.
+  Future<void> reloadFeatureFlags();
 }

--- a/lib/libraries/analytics/interfaces/posthog_wrapper.dart
+++ b/lib/libraries/analytics/interfaces/posthog_wrapper.dart
@@ -57,4 +57,14 @@ abstract class PosthogWrapper {
   /// subsequent [isFeatureEnabled] call is not guaranteed to reflect it
   /// immediately.
   Future<void> reloadFeatureFlags();
+
+  /// Returns the variant key for a multivariate [flagKey], or `null` if the
+  /// flag is unset, a simple boolean flag (not multivariate), evaluation
+  /// failed, or this wrapper isn't enabled (see [initialize]).
+  Future<String?> getFeatureFlagVariant(String flagKey);
+
+  /// Returns the JSON payload for [flagKey], or `null` if the flag has no
+  /// payload, evaluation failed, or this wrapper isn't enabled (see
+  /// [initialize]).
+  Future<Map<String, dynamic>?> getFeatureFlagPayload(String flagKey);
 }

--- a/lib/libraries/analytics/interfaces/posthog_wrapper.dart
+++ b/lib/libraries/analytics/interfaces/posthog_wrapper.dart
@@ -51,6 +51,10 @@ abstract class PosthogWrapper {
   /// not a live network call.
   Future<bool?> isFeatureEnabled(String flagKey);
 
-  /// Refreshes the client-side feature flag cache for the current identity.
+  /// Requests a refresh of the client-side feature flag cache for the
+  /// current identity. The returned Future resolves once the refresh has
+  /// been queued — not once the cache is confirmed updated, so a
+  /// subsequent [isFeatureEnabled] call is not guaranteed to reflect it
+  /// immediately.
   Future<void> reloadFeatureFlags();
 }

--- a/lib/libraries/analytics/posthog_sdk_impl.dart
+++ b/lib/libraries/analytics/posthog_sdk_impl.dart
@@ -74,4 +74,15 @@ class PosthogSdkImpl implements PosthogSdk {
   Future<void> reloadFeatureFlags() {
     return Posthog().reloadFeatureFlags();
   }
+
+  @override
+  Future<Object?> getFeatureFlag(String key) {
+    return Posthog().getFeatureFlag(key);
+  }
+
+  @override
+  Future<Object?> getFeatureFlagPayload(String key) {
+    // ignore: deprecated_member_use
+    return Posthog().getFeatureFlagPayload(key);
+  }
 }

--- a/lib/libraries/analytics/posthog_sdk_impl.dart
+++ b/lib/libraries/analytics/posthog_sdk_impl.dart
@@ -64,4 +64,14 @@ class PosthogSdkImpl implements PosthogSdk {
       groupProperties: groupProperties?.cast<String, Object>(),
     );
   }
+
+  @override
+  Future<bool> isFeatureEnabled(String key) {
+    return Posthog().isFeatureEnabled(key);
+  }
+
+  @override
+  Future<void> reloadFeatureFlags() {
+    return Posthog().reloadFeatureFlags();
+  }
 }

--- a/lib/libraries/analytics/posthog_wrapper_impl.dart
+++ b/lib/libraries/analytics/posthog_wrapper_impl.dart
@@ -82,4 +82,18 @@ class PosthogWrapperImpl implements PosthogWrapper {
       groupProperties: groupProperties,
     );
   }
+
+  @override
+  Future<bool?> isFeatureEnabled(String flagKey) async {
+    if (!_isEnabled) return null;
+
+    return _posthogSdk.isFeatureEnabled(flagKey);
+  }
+
+  @override
+  Future<void> reloadFeatureFlags() async {
+    if (!_isEnabled) return;
+
+    await _posthogSdk.reloadFeatureFlags();
+  }
 }

--- a/lib/libraries/analytics/posthog_wrapper_impl.dart
+++ b/lib/libraries/analytics/posthog_wrapper_impl.dart
@@ -87,7 +87,7 @@ class PosthogWrapperImpl implements PosthogWrapper {
   Future<bool?> isFeatureEnabled(String flagKey) async {
     if (!_isEnabled) return null;
 
-    return _posthogSdk.isFeatureEnabled(flagKey);
+    return await _posthogSdk.isFeatureEnabled(flagKey);
   }
 
   @override

--- a/lib/libraries/analytics/posthog_wrapper_impl.dart
+++ b/lib/libraries/analytics/posthog_wrapper_impl.dart
@@ -96,4 +96,20 @@ class PosthogWrapperImpl implements PosthogWrapper {
 
     await _posthogSdk.reloadFeatureFlags();
   }
+
+  @override
+  Future<String?> getFeatureFlagVariant(String flagKey) async {
+    if (!_isEnabled) return null;
+
+    final result = await _posthogSdk.getFeatureFlag(flagKey);
+    return result is String ? result : null;
+  }
+
+  @override
+  Future<Map<String, dynamic>?> getFeatureFlagPayload(String flagKey) async {
+    if (!_isEnabled) return null;
+
+    final result = await _posthogSdk.getFeatureFlagPayload(flagKey);
+    return result is Map ? Map<String, dynamic>.from(result) : null;
+  }
 }

--- a/lib/libraries/analytics/testing/fake_posthog_sdk.dart
+++ b/lib/libraries/analytics/testing/fake_posthog_sdk.dart
@@ -36,6 +36,19 @@ class FakePosthogSdk implements PosthogSdk {
   /// Number of times [reloadFeatureFlags] was called.
   int reloadFeatureFlagsCallCount = 0;
 
+  /// Recorded calls to [getFeatureFlag], in order of the flag key passed.
+  final List<String> getFeatureFlagCalls = [];
+
+  /// Value returned by [getFeatureFlag].
+  Object? getFeatureFlagResult;
+
+  /// Recorded calls to [getFeatureFlagPayload], in order of the flag key
+  /// passed.
+  final List<String> getFeatureFlagPayloadCalls = [];
+
+  /// Value returned by [getFeatureFlagPayload].
+  Object? getFeatureFlagPayloadResult;
+
   /// Restores the fake to its initial state.
   ///
   /// Named to avoid colliding with [reset], the interface method under test.
@@ -50,6 +63,10 @@ class FakePosthogSdk implements PosthogSdk {
     isFeatureEnabledCalls.clear();
     isFeatureEnabledResult = false;
     reloadFeatureFlagsCallCount = 0;
+    getFeatureFlagCalls.clear();
+    getFeatureFlagResult = null;
+    getFeatureFlagPayloadCalls.clear();
+    getFeatureFlagPayloadResult = null;
   }
 
   @override
@@ -116,6 +133,18 @@ class FakePosthogSdk implements PosthogSdk {
   @override
   Future<void> reloadFeatureFlags() async {
     reloadFeatureFlagsCallCount++;
+  }
+
+  @override
+  Future<Object?> getFeatureFlag(String key) async {
+    getFeatureFlagCalls.add(key);
+    return getFeatureFlagResult;
+  }
+
+  @override
+  Future<Object?> getFeatureFlagPayload(String key) async {
+    getFeatureFlagPayloadCalls.add(key);
+    return getFeatureFlagPayloadResult;
   }
 }
 

--- a/lib/libraries/analytics/testing/fake_posthog_sdk.dart
+++ b/lib/libraries/analytics/testing/fake_posthog_sdk.dart
@@ -27,6 +27,15 @@ class FakePosthogSdk implements PosthogSdk {
   /// Recorded calls to [group].
   final List<GroupCall> groupCalls = [];
 
+  /// Recorded calls to [isFeatureEnabled], in order of the flag key passed.
+  final List<String> isFeatureEnabledCalls = [];
+
+  /// Value returned by [isFeatureEnabled].
+  bool isFeatureEnabledResult = false;
+
+  /// Number of times [reloadFeatureFlags] was called.
+  int reloadFeatureFlagsCallCount = 0;
+
   /// Restores the fake to its initial state.
   ///
   /// Named to avoid colliding with [reset], the interface method under test.
@@ -38,6 +47,9 @@ class FakePosthogSdk implements PosthogSdk {
     resetCallCount = 0;
     setPersonPropertiesCalls.clear();
     groupCalls.clear();
+    isFeatureEnabledCalls.clear();
+    isFeatureEnabledResult = false;
+    reloadFeatureFlagsCallCount = 0;
   }
 
   @override
@@ -93,6 +105,17 @@ class FakePosthogSdk implements PosthogSdk {
         groupProperties: groupProperties,
       ),
     );
+  }
+
+  @override
+  Future<bool> isFeatureEnabled(String key) async {
+    isFeatureEnabledCalls.add(key);
+    return isFeatureEnabledResult;
+  }
+
+  @override
+  Future<void> reloadFeatureFlags() async {
+    reloadFeatureFlagsCallCount++;
   }
 }
 

--- a/lib/libraries/analytics/testing/fake_posthog_wrapper.dart
+++ b/lib/libraries/analytics/testing/fake_posthog_wrapper.dart
@@ -37,8 +37,25 @@ class FakePosthogWrapper implements PosthogWrapper {
   /// Number of times [reloadFeatureFlags] was called.
   int reloadFeatureFlagsCallCount = 0;
 
+  /// Recorded calls to [getFeatureFlagVariant], in order of the flag key
+  /// passed.
+  final List<String> getFeatureFlagVariantCalls = [];
+
+  /// Per-key return values for [getFeatureFlagVariant]; a key absent from
+  /// this map behaves the same as an unset/non-multivariate flag (`null`).
+  final Map<String, String?> variantOverrides = {};
+
+  /// Recorded calls to [getFeatureFlagPayload], in order of the flag key
+  /// passed.
+  final List<String> getFeatureFlagPayloadCalls = [];
+
+  /// Per-key return values for [getFeatureFlagPayload]; a key absent from
+  /// this map behaves the same as a flag with no payload (`null`).
+  final Map<String, Map<String, dynamic>?> payloadOverrides = {};
+
   /// If set, [capture], [identify], [reset], [setPersonProperties],
-  /// [group], [isFeatureEnabled], and [reloadFeatureFlags] throw this
+  /// [group], [isFeatureEnabled], [reloadFeatureFlags],
+  /// [getFeatureFlagVariant], and [getFeatureFlagPayload] throw this
   /// instead of recording the call.
   Object? errorToThrow;
 
@@ -127,6 +144,22 @@ class FakePosthogWrapper implements PosthogWrapper {
     reloadFeatureFlagsCallCount++;
   }
 
+  @override
+  Future<String?> getFeatureFlagVariant(String flagKey) async {
+    final error = errorToThrow;
+    if (error != null) throw error;
+    getFeatureFlagVariantCalls.add(flagKey);
+    return variantOverrides[flagKey];
+  }
+
+  @override
+  Future<Map<String, dynamic>?> getFeatureFlagPayload(String flagKey) async {
+    final error = errorToThrow;
+    if (error != null) throw error;
+    getFeatureFlagPayloadCalls.add(flagKey);
+    return payloadOverrides[flagKey];
+  }
+
   /// Clears all recorded calls, flag overrides, and any configured error.
   ///
   /// Named to avoid colliding with [reset], the interface method under test.
@@ -140,6 +173,10 @@ class FakePosthogWrapper implements PosthogWrapper {
     isFeatureEnabledCalls.clear();
     flagOverrides.clear();
     reloadFeatureFlagsCallCount = 0;
+    getFeatureFlagVariantCalls.clear();
+    variantOverrides.clear();
+    getFeatureFlagPayloadCalls.clear();
+    payloadOverrides.clear();
     errorToThrow = null;
   }
 }

--- a/lib/libraries/analytics/testing/fake_posthog_wrapper.dart
+++ b/lib/libraries/analytics/testing/fake_posthog_wrapper.dart
@@ -27,8 +27,19 @@ class FakePosthogWrapper implements PosthogWrapper {
   /// Recorded calls to [group].
   final List<GroupCall> groupCalls = [];
 
-  /// If set, [capture], [identify], [reset], [setPersonProperties], and
-  /// [group] throw this instead of recording the call.
+  /// Recorded calls to [isFeatureEnabled], in order of the flag key passed.
+  final List<String> isFeatureEnabledCalls = [];
+
+  /// Per-key return values for [isFeatureEnabled]; a key absent from this
+  /// map behaves the same as an unset flag (`null`).
+  final Map<String, bool?> flagOverrides = {};
+
+  /// Number of times [reloadFeatureFlags] was called.
+  int reloadFeatureFlagsCallCount = 0;
+
+  /// If set, [capture], [identify], [reset], [setPersonProperties],
+  /// [group], [isFeatureEnabled], and [reloadFeatureFlags] throw this
+  /// instead of recording the call.
   Object? errorToThrow;
 
   @override
@@ -101,7 +112,22 @@ class FakePosthogWrapper implements PosthogWrapper {
     );
   }
 
-  /// Clears all recorded calls and any configured error.
+  @override
+  Future<bool?> isFeatureEnabled(String flagKey) async {
+    final error = errorToThrow;
+    if (error != null) throw error;
+    isFeatureEnabledCalls.add(flagKey);
+    return flagOverrides[flagKey];
+  }
+
+  @override
+  Future<void> reloadFeatureFlags() async {
+    final error = errorToThrow;
+    if (error != null) throw error;
+    reloadFeatureFlagsCallCount++;
+  }
+
+  /// Clears all recorded calls, flag overrides, and any configured error.
   ///
   /// Named to avoid colliding with [reset], the interface method under test.
   void resetFake() {
@@ -111,6 +137,9 @@ class FakePosthogWrapper implements PosthogWrapper {
     resetCallCount = 0;
     setPersonPropertiesCalls.clear();
     groupCalls.clear();
+    isFeatureEnabledCalls.clear();
+    flagOverrides.clear();
+    reloadFeatureFlagsCallCount = 0;
     errorToThrow = null;
   }
 }

--- a/test/libraries/analytics/units/posthog_wrapper_impl_test.dart
+++ b/test/libraries/analytics/units/posthog_wrapper_impl_test.dart
@@ -84,6 +84,22 @@ void main() {
 
         expect(fakePosthogSdk.groupCalls, isEmpty);
       });
+
+      test('isFeatureEnabled returns null without querying the SDK',
+          () async {
+        final result = await posthogWrapper.isFeatureEnabled(
+          'calculator-enabled',
+        );
+
+        expect(result, isNull);
+        expect(fakePosthogSdk.isFeatureEnabledCalls, isEmpty);
+      });
+
+      test('reloadFeatureFlags is a no-op', () async {
+        await posthogWrapper.reloadFeatureFlags();
+
+        expect(fakePosthogSdk.reloadFeatureFlagsCallCount, 0);
+      });
     });
 
     group('when initialized', () {
@@ -151,6 +167,23 @@ void main() {
             groupProperties: {'project_name': 'Test Project'},
           ),
         ]);
+      });
+
+      test('isFeatureEnabled delegates to the SDK', () async {
+        fakePosthogSdk.isFeatureEnabledResult = true;
+
+        final result = await posthogWrapper.isFeatureEnabled(
+          'calculator-enabled',
+        );
+
+        expect(result, isTrue);
+        expect(fakePosthogSdk.isFeatureEnabledCalls, ['calculator-enabled']);
+      });
+
+      test('reloadFeatureFlags delegates to the SDK', () async {
+        await posthogWrapper.reloadFeatureFlags();
+
+        expect(fakePosthogSdk.reloadFeatureFlagsCallCount, 1);
       });
     });
   });


### PR DESCRIPTION
### 1. PR SUMMARY
Extends `PosthogWrapper`/`PosthogWrapperImpl` and the `PosthogSdk` boundary with `isFeatureEnabled(String)`/`reloadFeatureFlags()`, gated on the wrapper's existing `_isEnabled` single gate (returns `null`/no-ops when disabled), per `docs/Logging/PostHog-Feature-Flags.md`. `FakePosthogSdk` and `FakePosthogWrapper` grow matching recordable methods in the same PR.

**Note on scope vs. the original plan:** this PR also updates `FakePosthogWrapper`, originally planned as a separate PR (mirroring how CA-941 split "real wrapper" (4/6) from "its fake" (5/6)). That split isn't possible here: this stack bases on `CA-941-feat/posthog-wrapper-fake`, where `FakePosthogWrapper` already exists as a concrete `PosthogWrapper` implementer. Extending the interface without updating its only fake would leave the tree non-compiling, so both had to land together.

Part of the CA-955 stack, stacked on #511.

### 2. REVIEW SUMMARY TABLE
No issues found.

## Test plan
- [x] `fvm flutter analyze` on changed files — clean
- [x] `fvm dart run custom_lint` — clean (same pre-existing unrelated `fake_router.dart` failure as the parent branch)
- [x] `fvm flutter test` — all 3250 tests pass (4 new: gate no-op + delegation for `isFeatureEnabled`/`reloadFeatureFlags`)
- [ ] Reviewer sign-off