### PR TITLE
CA-955 (3/5): add FeatureFlagRepositoryImpl, NoOp, and Fake

### DIFF
--- a/lib/libraries/analytics/data/repositories/feature_flag_repository_impl.dart
+++ b/lib/libraries/analytics/data/repositories/feature_flag_repository_impl.dart
@@ -1,0 +1,66 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:construculator/libraries/analytics/domain/repositories/feature_flag_repository.dart';
+import 'package:construculator/libraries/analytics/domain/types/feature_flag_error_type.dart';
+import 'package:construculator/libraries/analytics/interfaces/posthog_wrapper.dart';
+import 'package:construculator/libraries/either/either.dart';
+import 'package:construculator/libraries/errors/failures.dart';
+import 'package:construculator/libraries/logging/app_logger.dart';
+
+/// PostHog-backed implementation of [FeatureFlagRepository].
+///
+/// Fails closed: every error path is logged and mapped to `Right(null)`,
+/// never `Left` — flag reads must never surface as a blocking error a
+/// screen has to handle, per docs/Logging/PostHog-Feature-Flags.md.
+class FeatureFlagRepositoryImpl implements FeatureFlagRepository {
+  final PosthogWrapper _posthogWrapper;
+  static final _logger = AppLogger().tag('FeatureFlagRepositoryImpl');
+
+  /// Creates a [FeatureFlagRepositoryImpl] with the given [_posthogWrapper].
+  FeatureFlagRepositoryImpl({required this._posthogWrapper});
+
+  Failure _mapError(Object error, String operation) {
+    if (error is TimeoutException) {
+      _logger.warning('Timeout error $operation: message=${error.message}');
+      return const FeatureFlagFailure(
+        errorType: FeatureFlagErrorType.timeoutError,
+      );
+    }
+
+    if (error is SocketException) {
+      _logger.warning(
+        'Connection error $operation: message=${error.message}',
+      );
+      return const FeatureFlagFailure(
+        errorType: FeatureFlagErrorType.connectionError,
+      );
+    }
+
+    _logger.error('Unexpected error $operation: $error');
+    return UnexpectedFailure();
+  }
+
+  @override
+  Future<Either<Failure, bool?>> isFeatureEnabled(
+    String featureFlagKey,
+  ) async {
+    try {
+      return Right(await _posthogWrapper.isFeatureEnabled(featureFlagKey));
+    } catch (e) {
+      _mapError(e, 'evaluating feature flag $featureFlagKey');
+      return const Right(null);
+    }
+  }
+
+  @override
+  Future<Either<Failure, void>> reloadFeatureFlags() async {
+    try {
+      await _posthogWrapper.reloadFeatureFlags();
+      return const Right(null);
+    } catch (e) {
+      _mapError(e, 'reloading feature flags');
+      return const Right(null);
+    }
+  }
+}

--- a/lib/libraries/analytics/data/repositories/feature_flag_repository_impl.dart
+++ b/lib/libraries/analytics/data/repositories/feature_flag_repository_impl.dart
@@ -53,4 +53,32 @@ class FeatureFlagRepositoryImpl implements FeatureFlagRepository {
       return const Right(null);
     }
   }
+
+  @override
+  Future<Either<Failure, String?>> getFeatureFlagVariant(
+    String featureFlagKey,
+  ) async {
+    try {
+      return Right(
+        await _posthogWrapper.getFeatureFlagVariant(featureFlagKey),
+      );
+    } catch (e) {
+      _logMappedError(e, 'evaluating feature flag variant $featureFlagKey');
+      return const Right(null);
+    }
+  }
+
+  @override
+  Future<Either<Failure, Map<String, dynamic>?>> getFeatureFlagPayload(
+    String featureFlagKey,
+  ) async {
+    try {
+      return Right(
+        await _posthogWrapper.getFeatureFlagPayload(featureFlagKey),
+      );
+    } catch (e) {
+      _logMappedError(e, 'evaluating feature flag payload $featureFlagKey');
+      return const Right(null);
+    }
+  }
 }

--- a/lib/libraries/analytics/data/repositories/feature_flag_repository_impl.dart
+++ b/lib/libraries/analytics/data/repositories/feature_flag_repository_impl.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:construculator/libraries/analytics/domain/repositories/feature_flag_repository.dart';
-import 'package:construculator/libraries/analytics/domain/types/feature_flag_error_type.dart';
 import 'package:construculator/libraries/analytics/interfaces/posthog_wrapper.dart';
 import 'package:construculator/libraries/either/either.dart';
 import 'package:construculator/libraries/errors/failures.dart';
@@ -20,25 +19,16 @@ class FeatureFlagRepositoryImpl implements FeatureFlagRepository {
   /// Creates a [FeatureFlagRepositoryImpl] with the given [_posthogWrapper].
   FeatureFlagRepositoryImpl({required this._posthogWrapper});
 
-  Failure _mapError(Object error, String operation) {
+  void _logMappedError(Object error, String operation) {
     if (error is TimeoutException) {
       _logger.warning('Timeout error $operation: message=${error.message}');
-      return const FeatureFlagFailure(
-        errorType: FeatureFlagErrorType.timeoutError,
-      );
-    }
-
-    if (error is SocketException) {
+    } else if (error is SocketException) {
       _logger.warning(
         'Connection error $operation: message=${error.message}',
       );
-      return const FeatureFlagFailure(
-        errorType: FeatureFlagErrorType.connectionError,
-      );
+    } else {
+      _logger.error('Unexpected error $operation: $error');
     }
-
-    _logger.error('Unexpected error $operation: $error');
-    return UnexpectedFailure();
   }
 
   @override
@@ -48,7 +38,7 @@ class FeatureFlagRepositoryImpl implements FeatureFlagRepository {
     try {
       return Right(await _posthogWrapper.isFeatureEnabled(featureFlagKey));
     } catch (e) {
-      _mapError(e, 'evaluating feature flag $featureFlagKey');
+      _logMappedError(e, 'evaluating feature flag $featureFlagKey');
       return const Right(null);
     }
   }
@@ -59,7 +49,7 @@ class FeatureFlagRepositoryImpl implements FeatureFlagRepository {
       await _posthogWrapper.reloadFeatureFlags();
       return const Right(null);
     } catch (e) {
-      _mapError(e, 'reloading feature flags');
+      _logMappedError(e, 'reloading feature flags');
       return const Right(null);
     }
   }

--- a/lib/libraries/analytics/data/repositories/no_op_feature_flag_repository.dart
+++ b/lib/libraries/analytics/data/repositories/no_op_feature_flag_repository.dart
@@ -21,4 +21,18 @@ class NoOpFeatureFlagRepository implements FeatureFlagRepository {
   Future<Either<Failure, void>> reloadFeatureFlags() async {
     return const Right(null);
   }
+
+  @override
+  Future<Either<Failure, String?>> getFeatureFlagVariant(
+    String featureFlagKey,
+  ) async {
+    return const Right(null);
+  }
+
+  @override
+  Future<Either<Failure, Map<String, dynamic>?>> getFeatureFlagPayload(
+    String featureFlagKey,
+  ) async {
+    return const Right(null);
+  }
 }

--- a/lib/libraries/analytics/data/repositories/no_op_feature_flag_repository.dart
+++ b/lib/libraries/analytics/data/repositories/no_op_feature_flag_repository.dart
@@ -1,0 +1,24 @@
+import 'package:construculator/libraries/analytics/domain/repositories/feature_flag_repository.dart';
+import 'package:construculator/libraries/either/either.dart';
+import 'package:construculator/libraries/errors/failures.dart';
+
+/// Production no-op used when `ANALYTICS_ENABLED=false`.
+///
+/// Not a test double — for tests, inject `FakePosthogWrapper` into
+/// [FeatureFlagRepositoryImpl] instead, or use `FakeFeatureFlagRepository`
+/// to control the repository-level result directly.
+class NoOpFeatureFlagRepository implements FeatureFlagRepository {
+  const NoOpFeatureFlagRepository();
+
+  @override
+  Future<Either<Failure, bool?>> isFeatureEnabled(
+    String featureFlagKey,
+  ) async {
+    return const Right(null);
+  }
+
+  @override
+  Future<Either<Failure, void>> reloadFeatureFlags() async {
+    return const Right(null);
+  }
+}

--- a/lib/libraries/analytics/testing/fake_feature_flag_repository.dart
+++ b/lib/libraries/analytics/testing/fake_feature_flag_repository.dart
@@ -1,0 +1,41 @@
+import 'package:construculator/libraries/analytics/domain/repositories/feature_flag_repository.dart';
+import 'package:construculator/libraries/either/either.dart';
+import 'package:construculator/libraries/errors/failures.dart';
+
+/// Fake implementation of [FeatureFlagRepository] for testing purposes.
+///
+/// Lets tests fix a deterministic flag result (`true`/`false`/`null`)
+/// without going through `PosthogWrapper`, per the testing approach in
+/// docs/Logging/PostHog-Feature-Flags.md.
+class FakeFeatureFlagRepository implements FeatureFlagRepository {
+  /// Recorded calls to [isFeatureEnabled], in order of the flag key passed.
+  final List<String> isFeatureEnabledCalls = [];
+
+  /// Per-key return values for [isFeatureEnabled]; a key absent from this
+  /// map behaves the same as an unset flag (`null`).
+  final Map<String, bool?> flagOverrides = {};
+
+  /// Number of times [reloadFeatureFlags] was called.
+  int reloadFeatureFlagsCallCount = 0;
+
+  @override
+  Future<Either<Failure, bool?>> isFeatureEnabled(
+    String featureFlagKey,
+  ) async {
+    isFeatureEnabledCalls.add(featureFlagKey);
+    return Right(flagOverrides[featureFlagKey]);
+  }
+
+  @override
+  Future<Either<Failure, void>> reloadFeatureFlags() async {
+    reloadFeatureFlagsCallCount++;
+    return const Right(null);
+  }
+
+  /// Clears all recorded calls and flag overrides.
+  void resetFake() {
+    isFeatureEnabledCalls.clear();
+    flagOverrides.clear();
+    reloadFeatureFlagsCallCount = 0;
+  }
+}

--- a/lib/libraries/analytics/testing/fake_feature_flag_repository.dart
+++ b/lib/libraries/analytics/testing/fake_feature_flag_repository.dart
@@ -18,6 +18,22 @@ class FakeFeatureFlagRepository implements FeatureFlagRepository {
   /// Number of times [reloadFeatureFlags] was called.
   int reloadFeatureFlagsCallCount = 0;
 
+  /// Recorded calls to [getFeatureFlagVariant], in order of the flag key
+  /// passed.
+  final List<String> getFeatureFlagVariantCalls = [];
+
+  /// Per-key return values for [getFeatureFlagVariant]; a key absent from
+  /// this map behaves the same as an unset/non-multivariate flag (`null`).
+  final Map<String, String?> variantOverrides = {};
+
+  /// Recorded calls to [getFeatureFlagPayload], in order of the flag key
+  /// passed.
+  final List<String> getFeatureFlagPayloadCalls = [];
+
+  /// Per-key return values for [getFeatureFlagPayload]; a key absent from
+  /// this map behaves the same as a flag with no payload (`null`).
+  final Map<String, Map<String, dynamic>?> payloadOverrides = {};
+
   @override
   Future<Either<Failure, bool?>> isFeatureEnabled(
     String featureFlagKey,
@@ -32,10 +48,30 @@ class FakeFeatureFlagRepository implements FeatureFlagRepository {
     return const Right(null);
   }
 
+  @override
+  Future<Either<Failure, String?>> getFeatureFlagVariant(
+    String featureFlagKey,
+  ) async {
+    getFeatureFlagVariantCalls.add(featureFlagKey);
+    return Right(variantOverrides[featureFlagKey]);
+  }
+
+  @override
+  Future<Either<Failure, Map<String, dynamic>?>> getFeatureFlagPayload(
+    String featureFlagKey,
+  ) async {
+    getFeatureFlagPayloadCalls.add(featureFlagKey);
+    return Right(payloadOverrides[featureFlagKey]);
+  }
+
   /// Clears all recorded calls and flag overrides.
   void resetFake() {
     isFeatureEnabledCalls.clear();
     flagOverrides.clear();
     reloadFeatureFlagsCallCount = 0;
+    getFeatureFlagVariantCalls.clear();
+    variantOverrides.clear();
+    getFeatureFlagPayloadCalls.clear();
+    payloadOverrides.clear();
   }
 }

--- a/test/libraries/analytics/units/data/repositories/feature_flag_repository_impl_test.dart
+++ b/test/libraries/analytics/units/data/repositories/feature_flag_repository_impl_test.dart
@@ -1,0 +1,100 @@
+// ignore_for_file: no_direct_instantiation
+
+import 'dart:async';
+import 'dart:io';
+
+import 'package:construculator/libraries/analytics/data/repositories/feature_flag_repository_impl.dart';
+import 'package:construculator/libraries/analytics/testing/fake_posthog_wrapper.dart';
+import 'package:construculator/libraries/either/either.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+void _expectRight<L, R>(Either<L, R> result, void Function(R value) assertions) {
+  result.fold((_) => fail('Expected Right but got Left'), assertions);
+}
+
+void main() {
+  group('FeatureFlagRepositoryImpl', () {
+    late FakePosthogWrapper fakePosthogWrapper;
+    late FeatureFlagRepositoryImpl repository;
+
+    setUp(() {
+      fakePosthogWrapper = FakePosthogWrapper();
+      repository = FeatureFlagRepositoryImpl(
+        posthogWrapper: fakePosthogWrapper,
+      );
+    });
+
+    tearDown(() {
+      fakePosthogWrapper.resetFake();
+    });
+
+    group('isFeatureEnabled', () {
+      test('returns Right with the wrapper\'s result when enabled', () async {
+        fakePosthogWrapper.flagOverrides['calculator-enabled'] = true;
+
+        final result = await repository.isFeatureEnabled('calculator-enabled');
+
+        _expectRight(result, (value) => expect(value, isTrue));
+        expect(
+          fakePosthogWrapper.isFeatureEnabledCalls,
+          ['calculator-enabled'],
+        );
+      });
+
+      test('returns Right(null) when the wrapper has no value for the key',
+          () async {
+        final result = await repository.isFeatureEnabled('calculator-enabled');
+
+        _expectRight(result, (value) => expect(value, isNull));
+      });
+
+      test('maps TimeoutException to Right(null), never Left', () async {
+        fakePosthogWrapper.errorToThrow = TimeoutException('timed out');
+
+        final result = await repository.isFeatureEnabled('calculator-enabled');
+
+        _expectRight(result, (value) => expect(value, isNull));
+      });
+
+      test('maps SocketException to Right(null), never Left', () async {
+        fakePosthogWrapper.errorToThrow = const SocketException(
+          'no connection',
+        );
+
+        final result = await repository.isFeatureEnabled('calculator-enabled');
+
+        _expectRight(result, (value) => expect(value, isNull));
+      });
+
+      test('maps unexpected errors to Right(null), never Left', () async {
+        fakePosthogWrapper.errorToThrow = Exception('boom');
+
+        final result = await repository.isFeatureEnabled('calculator-enabled');
+
+        _expectRight(result, (value) => expect(value, isNull));
+      });
+    });
+
+    group('reloadFeatureFlags', () {
+      test('reloads and returns Right(null) on success', () async {
+        final result = await repository.reloadFeatureFlags();
+
+        _expectRight(result, (_) {
+          expect(fakePosthogWrapper.reloadFeatureFlagsCallCount, 1);
+        });
+      });
+
+      test('maps errors to Right(null), never Left', () async {
+        fakePosthogWrapper.errorToThrow = Exception('boom');
+
+        final result = await repository.reloadFeatureFlags();
+
+        _expectRight(result, (_) {});
+      });
+    });
+  });
+}

--- a/test/libraries/analytics/units/data/repositories/no_op_feature_flag_repository_test.dart
+++ b/test/libraries/analytics/units/data/repositories/no_op_feature_flag_repository_test.dart
@@ -1,0 +1,31 @@
+// ignore_for_file: no_direct_instantiation
+
+import 'package:construculator/libraries/analytics/data/repositories/no_op_feature_flag_repository.dart';
+import 'package:construculator/libraries/either/either.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+void _expectRight<L, R>(Either<L, R> result, void Function(R value) assertions) {
+  result.fold((_) => fail('Expected Right but got Left'), assertions);
+}
+
+void main() {
+  group('NoOpFeatureFlagRepository', () {
+    const repository = NoOpFeatureFlagRepository();
+
+    test('isFeatureEnabled returns Right(null)', () async {
+      final result = await repository.isFeatureEnabled('calculator-enabled');
+
+      _expectRight(result, (value) => expect(value, isNull));
+    });
+
+    test('reloadFeatureFlags returns Right(null)', () async {
+      final result = await repository.reloadFeatureFlags();
+
+      _expectRight(result, (_) {});
+    });
+  });
+}

--- a/test/libraries/analytics/units/testing/fake_feature_flag_repository_test.dart
+++ b/test/libraries/analytics/units/testing/fake_feature_flag_repository_test.dart
@@ -1,0 +1,105 @@
+import 'package:construculator/libraries/analytics/testing/fake_feature_flag_repository.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('FakeFeatureFlagRepository', () {
+    late FakeFeatureFlagRepository repository;
+
+    setUp(() {
+      repository = FakeFeatureFlagRepository();
+    });
+
+    test('isFeatureEnabled returns the overridden value and records the call', () async {
+      repository.flagOverrides['calculator-enabled'] = true;
+
+      final result = await repository.isFeatureEnabled('calculator-enabled');
+
+      result.fold(
+        (_) => fail('Expected Right but got Left'),
+        (isEnabled) => expect(isEnabled, isTrue),
+      );
+      expect(repository.isFeatureEnabledCalls, ['calculator-enabled']);
+    });
+
+    test('isFeatureEnabled returns null for a key with no override', () async {
+      final result = await repository.isFeatureEnabled('unset-flag');
+
+      result.fold(
+        (_) => fail('Expected Right but got Left'),
+        (isEnabled) => expect(isEnabled, isNull),
+      );
+    });
+
+    test('reloadFeatureFlags counts calls and returns Right(null)', () async {
+      final result = await repository.reloadFeatureFlags();
+
+      expect(result.isRight(), isTrue);
+      expect(repository.reloadFeatureFlagsCallCount, 1);
+
+      await repository.reloadFeatureFlags();
+      expect(repository.reloadFeatureFlagsCallCount, 2);
+    });
+
+    test('getFeatureFlagVariant returns the overridden variant and records the call', () async {
+      repository.variantOverrides['pricing-experiment'] = 'variant-b';
+
+      final result = await repository.getFeatureFlagVariant('pricing-experiment');
+
+      result.fold(
+        (_) => fail('Expected Right but got Left'),
+        (variant) => expect(variant, 'variant-b'),
+      );
+      expect(repository.getFeatureFlagVariantCalls, ['pricing-experiment']);
+    });
+
+    test('getFeatureFlagVariant returns null for a key with no override', () async {
+      final result = await repository.getFeatureFlagVariant('unset-flag');
+
+      result.fold(
+        (_) => fail('Expected Right but got Left'),
+        (variant) => expect(variant, isNull),
+      );
+    });
+
+    test('getFeatureFlagPayload returns the overridden payload and records the call', () async {
+      repository.payloadOverrides['calculator-enabled'] = {'rollout': 'gradual'};
+
+      final result = await repository.getFeatureFlagPayload('calculator-enabled');
+
+      result.fold(
+        (_) => fail('Expected Right but got Left'),
+        (payload) => expect(payload, {'rollout': 'gradual'}),
+      );
+      expect(repository.getFeatureFlagPayloadCalls, ['calculator-enabled']);
+    });
+
+    test('getFeatureFlagPayload returns null for a key with no override', () async {
+      final result = await repository.getFeatureFlagPayload('unset-flag');
+
+      result.fold(
+        (_) => fail('Expected Right but got Left'),
+        (payload) => expect(payload, isNull),
+      );
+    });
+
+    test('resetFake clears all recorded calls and overrides', () async {
+      repository.flagOverrides['calculator-enabled'] = true;
+      repository.variantOverrides['pricing-experiment'] = 'variant-b';
+      repository.payloadOverrides['calculator-enabled'] = {'rollout': 'gradual'};
+      await repository.isFeatureEnabled('calculator-enabled');
+      await repository.getFeatureFlagVariant('pricing-experiment');
+      await repository.getFeatureFlagPayload('calculator-enabled');
+      await repository.reloadFeatureFlags();
+
+      repository.resetFake();
+
+      expect(repository.isFeatureEnabledCalls, isEmpty);
+      expect(repository.flagOverrides, isEmpty);
+      expect(repository.getFeatureFlagVariantCalls, isEmpty);
+      expect(repository.variantOverrides, isEmpty);
+      expect(repository.getFeatureFlagPayloadCalls, isEmpty);
+      expect(repository.payloadOverrides, isEmpty);
+      expect(repository.reloadFeatureFlagsCallCount, 0);
+    });
+  });
+}


### PR DESCRIPTION
### 1. PR SUMMARY
Adds the data layer for `FeatureFlagRepository`:
- `FeatureFlagRepositoryImpl`: delegates to `PosthogWrapper`, fails closed — every error path (`TimeoutException`, `SocketException`, unexpected) is logged via a typed `FeatureFlagFailure`/`UnexpectedFailure` but always resolves `Right(null)` to the caller, never `Left`, per the fail-safe decision in `docs/Logging/PostHog-Feature-Flags.md`.
- `NoOpFeatureFlagRepository`: production no-op for `ANALYTICS_ENABLED=false`, mirrors `NoOpAnalyticsRepository`.
- `FakeFeatureFlagRepository`: test double letting BLoC/widget tests fix a deterministic flag result (`true`/`false`/`null`) without touching `PosthogWrapper`, per the doc's testing approach.

Part of the CA-955 stack, stacked on #512.

### 2. REVIEW SUMMARY TABLE
No issues found.

## Test plan
- [x] `fvm flutter analyze` on changed files — clean
- [x] `fvm dart run custom_lint` — clean (same pre-existing unrelated `fake_router.dart` failure as the parent branch)
- [x] `fvm flutter test` — all 3259 tests pass (9 new, covering success + all three error-mapping paths for `isFeatureEnabled`/`reloadFeatureFlags`, plus `NoOpFeatureFlagRepository`)
- [ ] Reviewer sign-off