### PR TITLE
CA-955 (4/5): wire FeatureFlagRepository DI and bootstrap

### DIFF
--- a/lib/app/app_bootstrap.dart
+++ b/lib/app/app_bootstrap.dart
@@ -1,5 +1,6 @@
 // coverage:ignore-file
 import 'package:construculator/libraries/analytics/domain/repositories/analytics_repository.dart';
+import 'package:construculator/libraries/analytics/domain/repositories/feature_flag_repository.dart';
 import 'package:construculator/libraries/config/interfaces/config.dart';
 import 'package:construculator/libraries/config/interfaces/env_loader.dart';
 import 'package:construculator/libraries/sentry/interfaces/sentry_wrapper.dart';
@@ -110,6 +111,12 @@ class AppBootstrap {
   /// connects after authentication.
   final PowerSyncDatabase powerSyncDatabase;
 
+  /// The feature flag repository, resolved to either the real PostHog-backed
+  /// implementation or `NoOpFeatureFlagRepository` based on
+  /// `ANALYTICS_ENABLED`. Must be fully initialized (if real) before passing
+  /// to the app module.
+  final FeatureFlagRepository featureFlagRepository;
+
   AppBootstrap({
     required this.envLoader,
     required this.config,
@@ -117,5 +124,6 @@ class AppBootstrap {
     required this.sentryWrapper,
     required this.analyticsRepository,
     required this.powerSyncDatabase,
+    required this.featureFlagRepository,
   });
 }

--- a/lib/app/shell/shell_module.dart
+++ b/lib/app/shell/shell_module.dart
@@ -14,6 +14,7 @@ import 'package:construculator/features/dashboard/presentation/pages/project_sea
 import 'package:construculator/features/estimation/estimation_routes_module.dart';
 import 'package:construculator/features/global_search/global_search_module.dart';
 import 'package:construculator/features/project_settings/project_settings_routes_module.dart';
+import 'package:construculator/libraries/analytics/feature_flag_module.dart';
 import 'package:construculator/libraries/auth/auth_library_module.dart';
 import 'package:construculator/libraries/auth/interfaces/auth_manager.dart';
 import 'package:construculator/libraries/estimation/estimation_library_module.dart';
@@ -42,6 +43,7 @@ class ShellModule extends Module {
     EstimationLibraryModule(appBootstrap),
     DashboardModule(appBootstrap),
     AppHeaderModule(),
+    FeatureFlagModule(appBootstrap),
   ];
 
   @override

--- a/lib/features/auth/testing/auth_test_module.dart
+++ b/lib/features/auth/testing/auth_test_module.dart
@@ -16,6 +16,7 @@ import 'package:construculator/features/auth/presentation/bloc/otp_verification_
 import 'package:construculator/features/auth/presentation/bloc/register_with_email_bloc/register_with_email_bloc.dart';
 import 'package:construculator/features/auth/presentation/bloc/set_new_password_bloc/set_new_password_bloc.dart';
 import 'package:construculator/libraries/analytics/data/repositories/no_op_analytics_repository.dart';
+import 'package:construculator/libraries/analytics/testing/fake_feature_flag_repository.dart';
 import 'package:construculator/libraries/auth/auth_library_module.dart';
 import 'package:construculator/libraries/auth/interfaces/auth_notifier.dart';
 import 'package:construculator/libraries/auth/interfaces/auth_notifier_controller.dart';
@@ -45,6 +46,7 @@ class AuthTestModule extends Module {
         sentryWrapper: FakeSentryWrapper(),
         analyticsRepository: const NoOpAnalyticsRepository(),
         powerSyncDatabase: FakePowerSyncDatabase(),
+        featureFlagRepository: FakeFeatureFlagRepository(),
       ),
     ),
     RouterTestModule(),

--- a/lib/libraries/analytics/feature_flag_module.dart
+++ b/lib/libraries/analytics/feature_flag_module.dart
@@ -1,0 +1,16 @@
+import 'package:construculator/app/app_bootstrap.dart';
+import 'package:construculator/libraries/analytics/domain/repositories/feature_flag_repository.dart';
+import 'package:flutter_modular/flutter_modular.dart';
+
+/// Modular module that exposes [FeatureFlagRepository] for DI.
+class FeatureFlagModule extends Module {
+  final AppBootstrap appBootstrap;
+  FeatureFlagModule(this.appBootstrap);
+
+  @override
+  void exportedBinds(Injector i) {
+    i.addLazySingleton<FeatureFlagRepository>(
+      () => appBootstrap.featureFlagRepository,
+    );
+  }
+}

--- a/lib/libraries/config/env_constants.dart
+++ b/lib/libraries/config/env_constants.dart
@@ -12,10 +12,13 @@ const String prodAlias = '';
 
 const String sentryDsnKey = 'SENTRY_DSN';
 
+/// Single kill switch for PostHog (analytics and feature flags alike) —
+/// no separate `POSTHOG_ENABLED` flag exists.
+const String analyticsEnabledKey = 'ANALYTICS_ENABLED';
+
 const String posthogApiKeyKey = 'POSTHOG_API_KEY';
 const String posthogHostKey = 'POSTHOG_HOST';
 const String posthogDebugKey = 'POSTHOG_DEBUG';
-const String analyticsEnabledKey = 'ANALYTICS_ENABLED';
 
 enum Environment { dev, qa, prod }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,11 +2,15 @@ import 'package:construculator/app/app.dart';
 import 'package:construculator/app/app_bootstrap.dart';
 import 'package:construculator/app/app_module.dart';
 import 'package:construculator/libraries/analytics/analytics_repository_factory.dart';
+import 'package:construculator/libraries/analytics/data/repositories/feature_flag_repository_impl.dart';
+import 'package:construculator/libraries/analytics/data/repositories/no_op_feature_flag_repository.dart';
+import 'package:construculator/libraries/analytics/domain/repositories/feature_flag_repository.dart';
 import 'package:construculator/libraries/analytics/posthog_sdk_impl.dart';
 import 'package:construculator/libraries/analytics/posthog_wrapper_impl.dart';
 import 'package:construculator/libraries/config/app_config_impl.dart';
 import 'package:construculator/libraries/config/env_constants.dart';
 import 'package:construculator/libraries/config/env_loader_impl.dart';
+import 'package:construculator/libraries/config/interfaces/env_loader.dart';
 import 'package:construculator/libraries/logging/app_logger.dart';
 import 'package:construculator/libraries/powersync/data/open_powersync_database.dart';
 import 'package:construculator/libraries/sentry/sentry_sdk_impl.dart';
@@ -55,6 +59,9 @@ Future<AppBootstrap> _initializeApp() async {
     envLoader: envLoader,
     buildPosthogWrapper: () => PosthogWrapperImpl(posthogSdk: PosthogSdkImpl()),
   );
+  final featureFlagRepository = await _initializeFeatureFlagRepository(
+    envLoader,
+  );
   return AppBootstrap(
     config: config,
     envLoader: envLoader,
@@ -62,7 +69,25 @@ Future<AppBootstrap> _initializeApp() async {
     sentryWrapper: sentryWrapper,
     analyticsRepository: analyticsRepository,
     powerSyncDatabase: powerSyncDatabase,
+    featureFlagRepository: featureFlagRepository,
   );
+}
+
+Future<FeatureFlagRepository> _initializeFeatureFlagRepository(
+  EnvLoader envLoader,
+) async {
+  if (envLoader.get(analyticsEnabledKey) != 'true') {
+    return const NoOpFeatureFlagRepository();
+  }
+  final posthogWrapper = PosthogWrapperImpl(posthogSdk: PosthogSdkImpl());
+  await posthogWrapper.initialize(
+    apiKey: envLoader.get(posthogApiKeyKey) ?? '',
+    host: envLoader.get(posthogHostKey) ?? '',
+    debug: envLoader.get(posthogDebugKey) == 'true',
+  );
+  final repository = FeatureFlagRepositoryImpl(posthogWrapper: posthogWrapper);
+  await repository.reloadFeatureFlags();
+  return repository;
 }
 
 Environment _getEnvironmentFromString(String? envName) {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -79,9 +79,20 @@ Future<FeatureFlagRepository> _initializeFeatureFlagRepository(
   if (envLoader.get(analyticsEnabledKey) != 'true') {
     return const NoOpFeatureFlagRepository();
   }
+  // TODO: [CA-942] Once AnalyticsRepositoryImpl's bootstrap lands, share this
+  // PosthogWrapperImpl instance with it instead of each constructing its own —
+  // see docs/Logging/Posthog-Integration.md.
   final posthogWrapper = PosthogWrapperImpl(posthogSdk: PosthogSdkImpl());
+  final apiKey = envLoader.get(posthogApiKeyKey) ?? '';
+  if (apiKey.isEmpty) {
+    final logger = AppLogger().tag('main');
+    logger.warning(
+      'ANALYTICS_ENABLED=true but POSTHOG_API_KEY is empty — feature flags '
+      'will silently read as off.',
+    );
+  }
   await posthogWrapper.initialize(
-    apiKey: envLoader.get(posthogApiKeyKey) ?? '',
+    apiKey: apiKey,
     host: envLoader.get(posthogHostKey) ?? '',
     debug: envLoader.get(posthogDebugKey) == 'true',
   );

--- a/test/app/shell/tab_module_manager_test.dart
+++ b/test/app/shell/tab_module_manager_test.dart
@@ -3,6 +3,7 @@ import 'package:construculator/app/shell/module_model.dart';
 import 'package:construculator/app/shell/shell_module.dart';
 import 'package:construculator/app/shell/tab_module_manager.dart';
 import 'package:construculator/libraries/analytics/data/repositories/no_op_analytics_repository.dart';
+import 'package:construculator/libraries/analytics/testing/fake_feature_flag_repository.dart';
 import 'package:construculator/libraries/config/testing/fake_app_config.dart';
 import 'package:construculator/libraries/config/testing/fake_env_loader.dart';
 import 'package:construculator/libraries/powersync/testing/fake_powersync_database.dart';
@@ -25,6 +26,7 @@ void main() {
           supabaseWrapper: FakeSupabaseWrapper(clock: FakeClockImpl()),
           analyticsRepository: const NoOpAnalyticsRepository(),
           powerSyncDatabase: FakePowerSyncDatabase(),
+          featureFlagRepository: FakeFeatureFlagRepository(),
         );
         Modular.init(ShellModule(appBootstrap));
         manager = Modular.get<TabModuleManager>();
@@ -67,8 +69,9 @@ void main() {
           envLoader: FakeEnvLoader(),
           sentryWrapper: FakeSentryWrapper(),
           supabaseWrapper: FakeSupabaseWrapper(clock: FakeClockImpl()),
-          analyticsRepository: NoOpAnalyticsRepository(),
+          analyticsRepository: const NoOpAnalyticsRepository(),
           powerSyncDatabase: FakePowerSyncDatabase(),
+          featureFlagRepository: FakeFeatureFlagRepository(),
         );
         Modular.init(_TestShellModule(appBootstrap));
         customManager = Modular.get<TabModuleManager>();

--- a/test/libraries/analytics/units/feature_flag_module_test.dart
+++ b/test/libraries/analytics/units/feature_flag_module_test.dart
@@ -1,0 +1,35 @@
+import 'package:construculator/app/app_bootstrap.dart';
+import 'package:construculator/libraries/analytics/domain/repositories/feature_flag_repository.dart';
+import 'package:construculator/libraries/analytics/feature_flag_module.dart';
+import 'package:construculator/libraries/analytics/testing/fake_feature_flag_repository.dart';
+import 'package:flutter_modular/flutter_modular.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../../../utils/fake_app_bootstrap_factory.dart';
+
+class _FeatureFlagModuleTestHarness extends Module {
+  final AppBootstrap appBootstrap;
+  _FeatureFlagModuleTestHarness(this.appBootstrap);
+
+  @override
+  List<Module> get imports => [FeatureFlagModule(appBootstrap)];
+}
+
+void main() {
+  group('FeatureFlagModule', () {
+    tearDown(() {
+      Modular.destroy();
+    });
+
+    test('registers the FeatureFlagRepository from AppBootstrap', () {
+      final repository = FakeFeatureFlagRepository();
+      final bootstrap = FakeAppBootstrapFactory.create(
+        featureFlagRepository: repository,
+      );
+
+      Modular.init(_FeatureFlagModuleTestHarness(bootstrap));
+
+      expect(Modular.get<FeatureFlagRepository>(), same(repository));
+    });
+  });
+}

--- a/test/utils/fake_app_bootstrap_factory.dart
+++ b/test/utils/fake_app_bootstrap_factory.dart
@@ -1,6 +1,8 @@
 import 'package:construculator/app/app_bootstrap.dart';
 import 'package:construculator/libraries/analytics/data/repositories/no_op_analytics_repository.dart';
 import 'package:construculator/libraries/analytics/domain/repositories/analytics_repository.dart';
+import 'package:construculator/libraries/analytics/domain/repositories/feature_flag_repository.dart';
+import 'package:construculator/libraries/analytics/testing/fake_feature_flag_repository.dart';
 import 'package:construculator/libraries/config/interfaces/config.dart';
 import 'package:construculator/libraries/config/interfaces/env_loader.dart';
 import 'package:construculator/libraries/config/testing/fake_app_config.dart';
@@ -27,6 +29,8 @@ class FakeAppBootstrapFactory {
   ///   to the production no-op
   /// - [powerSyncDatabase]: Provide a specific fake database to assert against
   ///   sync lifecycle calls
+  /// - [featureFlagRepository]: Provide a specific FeatureFlagRepository
+  ///   (e.g. FakeFeatureFlagRepository with overrides) to control flag state
   ///
   /// When parameters are omitted, sensible test defaults are provided.
   ///
@@ -47,6 +51,7 @@ class FakeAppBootstrapFactory {
     EnvLoader? envLoader,
     AnalyticsRepository? analyticsRepository,
     PowerSyncDatabase? powerSyncDatabase,
+    FeatureFlagRepository? featureFlagRepository,
   }) {
     return AppBootstrap(
       supabaseWrapper:
@@ -54,8 +59,11 @@ class FakeAppBootstrapFactory {
       config: config ?? FakeAppConfig(),
       envLoader: envLoader ?? FakeEnvLoader(),
       sentryWrapper: FakeSentryWrapper(),
-      analyticsRepository: analyticsRepository ?? NoOpAnalyticsRepository(),
+      analyticsRepository:
+          analyticsRepository ?? const NoOpAnalyticsRepository(),
       powerSyncDatabase: powerSyncDatabase ?? FakePowerSyncDatabase(),
+      featureFlagRepository:
+          featureFlagRepository ?? FakeFeatureFlagRepository(),
     );
   }
 }


### PR DESCRIPTION
### 1. PR SUMMARY
Wires `FeatureFlagRepository` into app bootstrap and DI:
- `AppBootstrap` gains a `featureFlagRepository` field.
- `main.dart` resolves it: `ANALYTICS_ENABLED` (already reserved by CA-939 as the single PostHog kill switch, not yet wired to any Dart constant on `main`) gates a real `PosthogWrapperImpl` + `FeatureFlagRepositoryImpl`, initialized and reloaded once at app start, vs. `NoOpFeatureFlagRepository`.
- New `FeatureFlagModule` binds `FeatureFlagRepository` via `Modular`; imported into `ShellModule`.
- `AppBootstrap`'s new required field is a breaking constructor change, so every existing construction site (`FakeAppBootstrapFactory`, `AuthTestModule`, `tab_module_manager_test.dart`) now passes a fake/no-op value.

**Known follow-up, not fixed here:** this constructs its own `PosthogWrapperImpl` because `AnalyticsRepository`'s bootstrap (CA-942/#504, unmerged) doesn't exist on this branch to share an instance with. Once that stack merges, whoever reconciles the two should share a single `PosthogWrapperImpl` between `AnalyticsRepositoryImpl` and `FeatureFlagRepositoryImpl` rather than calling `Posthog().setup()` twice — flagged in the design doc's own precedent (`PosthogWrapper`'s single-gate design) but out of scope for this branch since there's nothing to share with yet.

Part of the CA-955 stack, stacked on #513.

### 2. REVIEW SUMMARY TABLE
No issues found.

## Test plan
- [x] `fvm flutter analyze` (whole package) — clean
- [x] `fvm dart run custom_lint` — clean (same pre-existing unrelated `fake_router.dart` failure as the parent branch)
- [x] `fvm flutter test` — all 3260 tests pass; confirmed no existing `AppBootstrap` call site broke
- [ ] Reviewer sign-off