### PR TITLE
CA-914 (2/9): migrate auth screenshot tests to screenshotThemeGroups

### DIFF
--- a/test/features/auth/screenshots/auth_footer_screenshot_test.dart
+++ b/test/features/auth/screenshots/auth_footer_screenshot_test.dart
@@ -18,11 +18,11 @@ void main() {
     required WidgetTester tester,
     required String text,
     required String actionText,
-    ThemeData? theme,
+    required ThemeData theme,
   }) async {
     await tester.pumpWidget(
       MaterialApp(
-        theme: theme ?? createTestTheme(),
+        theme: theme,
         home: Builder(
           builder: (ctx) => Scaffold(
             backgroundColor: ctx.colorTheme.pageBackground,
@@ -38,7 +38,7 @@ void main() {
     await tester.pumpAndSettle();
   }
 
-  group('AuthFooter Screenshot Tests - Light', () {
+  screenshotThemeGroups('AuthFooter Screenshot Tests', (theme, suffix) {
     testWidgets('renders register footer correctly', (tester) async {
       tester.view.physicalSize = size;
       tester.view.devicePixelRatio = ratio;
@@ -47,12 +47,13 @@ void main() {
         tester: tester,
         text: "Don't have an account?",
         actionText: 'Register',
+        theme: theme,
       );
 
       await expectLater(
         find.byType(Scaffold),
         matchesGoldenFile(
-          'goldens/auth_footer/${size.width}x${size.height}/auth_footer_register.png',
+          'goldens/auth_footer/${size.width}x${size.height}/auth_footer_register$suffix.png',
         ),
       );
     });
@@ -65,52 +66,13 @@ void main() {
         tester: tester,
         text: 'Already have an account?',
         actionText: 'Login',
+        theme: theme,
       );
 
       await expectLater(
         find.byType(Scaffold),
         matchesGoldenFile(
-          'goldens/auth_footer/${size.width}x${size.height}/auth_footer_login.png',
-        ),
-      );
-    });
-  });
-
-  group('AuthFooter Screenshot Tests - Dark', () {
-    testWidgets('renders register footer correctly', (tester) async {
-      tester.view.physicalSize = size;
-      tester.view.devicePixelRatio = ratio;
-      addTearDown(tester.view.reset);
-      await pumpAuthFooter(
-        tester: tester,
-        text: "Don't have an account?",
-        actionText: 'Register',
-        theme: createTestThemeDark(),
-      );
-
-      await expectLater(
-        find.byType(Scaffold),
-        matchesGoldenFile(
-          'goldens/auth_footer/${size.width}x${size.height}/auth_footer_register_dark.png',
-        ),
-      );
-    });
-
-    testWidgets('renders login footer correctly', (tester) async {
-      tester.view.physicalSize = size;
-      tester.view.devicePixelRatio = ratio;
-      addTearDown(tester.view.reset);
-      await pumpAuthFooter(
-        tester: tester,
-        text: 'Already have an account?',
-        actionText: 'Login',
-        theme: createTestThemeDark(),
-      );
-
-      await expectLater(
-        find.byType(Scaffold),
-        matchesGoldenFile(
-          'goldens/auth_footer/${size.width}x${size.height}/auth_footer_login_dark.png',
+          'goldens/auth_footer/${size.width}x${size.height}/auth_footer_login$suffix.png',
         ),
       );
     });

--- a/test/features/auth/screenshots/auth_header_screenshot_test.dart
+++ b/test/features/auth/screenshots/auth_header_screenshot_test.dart
@@ -18,13 +18,13 @@ void main() {
     required WidgetTester tester,
     required String title,
     required String description,
+    required ThemeData theme,
     String? contact,
     VoidCallback? onContactPressed,
-    ThemeData? theme,
   }) async {
     await tester.pumpWidget(
       MaterialApp(
-        theme: theme ?? createTestTheme(),
+        theme: theme,
         home: Builder(
           builder: (ctx) => Scaffold(
             backgroundColor: ctx.colorTheme.pageBackground,
@@ -44,7 +44,7 @@ void main() {
     await tester.pumpAndSettle();
   }
 
-  group('AuthHeader Screenshot Tests - Light', () {
+  screenshotThemeGroups('AuthHeader Screenshot Tests', (theme, suffix) {
     testWidgets('renders auth header without contact correctly', (
       tester,
     ) async {
@@ -56,12 +56,13 @@ void main() {
         tester: tester,
         title: 'Welcome Back',
         description: 'Hey, Enter your details to log in to your account',
+        theme: theme,
       );
 
       await expectLater(
         find.byType(Scaffold),
         matchesGoldenFile(
-          'goldens/auth_header/${size.width}x${size.height}/auth_header_no_contact.png',
+          'goldens/auth_header/${size.width}x${size.height}/auth_header_no_contact$suffix.png',
         ),
       );
     });
@@ -77,58 +78,13 @@ void main() {
         description: 'Enter your password for this account. Your email id is ',
         contact: 'user@example.com',
         onContactPressed: () {},
+        theme: theme,
       );
 
       await expectLater(
         find.byType(Scaffold),
         matchesGoldenFile(
-          'goldens/auth_header/${size.width}x${size.height}/auth_header_with_contact.png',
-        ),
-      );
-    });
-  });
-
-  group('AuthHeader Screenshot Tests - Dark', () {
-    testWidgets('renders auth header without contact correctly', (
-      tester,
-    ) async {
-      tester.view.physicalSize = size;
-      tester.view.devicePixelRatio = ratio;
-      addTearDown(tester.view.reset);
-
-      await pumpAuthHeader(
-        tester: tester,
-        title: 'Welcome Back',
-        description: 'Hey, Enter your details to log in to your account',
-        theme: createTestThemeDark(),
-      );
-
-      await expectLater(
-        find.byType(Scaffold),
-        matchesGoldenFile(
-          'goldens/auth_header/${size.width}x${size.height}/auth_header_no_contact_dark.png',
-        ),
-      );
-    });
-
-    testWidgets('renders auth header with contact correctly', (tester) async {
-      tester.view.physicalSize = size;
-      tester.view.devicePixelRatio = ratio;
-      addTearDown(tester.view.reset);
-
-      await pumpAuthHeader(
-        tester: tester,
-        title: 'Enter your password',
-        description: 'Enter your password for this account. Your email id is ',
-        contact: 'user@example.com',
-        onContactPressed: () {},
-        theme: createTestThemeDark(),
-      );
-
-      await expectLater(
-        find.byType(Scaffold),
-        matchesGoldenFile(
-          'goldens/auth_header/${size.width}x${size.height}/auth_header_with_contact_dark.png',
+          'goldens/auth_header/${size.width}x${size.height}/auth_header_with_contact$suffix.png',
         ),
       );
     });

--- a/test/features/auth/screenshots/auth_provider_buttons_screenshot_test.dart
+++ b/test/features/auth/screenshots/auth_provider_buttons_screenshot_test.dart
@@ -18,11 +18,11 @@ void main() {
   Future<void> pumpAuthProviderButtons({
     required WidgetTester tester,
     required bool isEmailAuth,
-    ThemeData? theme,
+    required ThemeData theme,
   }) async {
     await tester.pumpWidget(
       MaterialApp(
-        theme: theme ?? createTestTheme(),
+        theme: theme,
         localizationsDelegates: AppLocalizations.localizationsDelegates,
         supportedLocales: AppLocalizations.supportedLocales,
         home: Builder(
@@ -42,37 +42,10 @@ void main() {
     await tester.pumpAndSettle();
   }
 
-  group('AuthProviderButtons Screenshot Tests - Light', () {
-    testWidgets('renders email auth mode correctly', (tester) async {
-      tester.view.physicalSize = size;
-      tester.view.devicePixelRatio = ratio;
-      addTearDown(tester.view.reset);
-      await pumpAuthProviderButtons(tester: tester, isEmailAuth: true);
-
-      await expectLater(
-        find.byType(Scaffold),
-        matchesGoldenFile(
-          'goldens/auth_provider_buttons/${size.width}x${size.height}/auth_provider_buttons_email_auth.png',
-        ),
-      );
-    });
-
-    testWidgets('renders phone auth mode correctly', (tester) async {
-      tester.view.physicalSize = size;
-      tester.view.devicePixelRatio = ratio;
-      addTearDown(tester.view.reset);
-      await pumpAuthProviderButtons(tester: tester, isEmailAuth: false);
-
-      await expectLater(
-        find.byType(Scaffold),
-        matchesGoldenFile(
-          'goldens/auth_provider_buttons/${size.width}x${size.height}/auth_provider_buttons_phone_auth.png',
-        ),
-      );
-    });
-  });
-
-  group('AuthProviderButtons Screenshot Tests - Dark', () {
+  screenshotThemeGroups('AuthProviderButtons Screenshot Tests', (
+    theme,
+    suffix,
+  ) {
     testWidgets('renders email auth mode correctly', (tester) async {
       tester.view.physicalSize = size;
       tester.view.devicePixelRatio = ratio;
@@ -80,13 +53,13 @@ void main() {
       await pumpAuthProviderButtons(
         tester: tester,
         isEmailAuth: true,
-        theme: createTestThemeDark(),
+        theme: theme,
       );
 
       await expectLater(
         find.byType(Scaffold),
         matchesGoldenFile(
-          'goldens/auth_provider_buttons/${size.width}x${size.height}/auth_provider_buttons_email_auth_dark.png',
+          'goldens/auth_provider_buttons/${size.width}x${size.height}/auth_provider_buttons_email_auth$suffix.png',
         ),
       );
     });
@@ -98,13 +71,13 @@ void main() {
       await pumpAuthProviderButtons(
         tester: tester,
         isEmailAuth: false,
-        theme: createTestThemeDark(),
+        theme: theme,
       );
 
       await expectLater(
         find.byType(Scaffold),
         matchesGoldenFile(
-          'goldens/auth_provider_buttons/${size.width}x${size.height}/auth_provider_buttons_phone_auth_dark.png',
+          'goldens/auth_provider_buttons/${size.width}x${size.height}/auth_provider_buttons_phone_auth$suffix.png',
         ),
       );
     });

--- a/test/features/auth/screenshots/error_widget_builder_screenshot_test.dart
+++ b/test/features/auth/screenshots/error_widget_builder_screenshot_test.dart
@@ -14,13 +14,13 @@ void main() {
 
   Future<void> pumpErrorWidget({
     required WidgetTester tester,
+    required ThemeData theme,
     String? error,
     String? link,
-    ThemeData? theme,
   }) async {
     await tester.pumpWidget(
       MaterialApp(
-        theme: theme ?? createTestTheme(),
+        theme: theme,
         home: Scaffold(
           body: Center(
             child: Builder(
@@ -40,7 +40,10 @@ void main() {
     await tester.pumpAndSettle();
   }
 
-  group('ErrorWidgetBuilder Screenshot Tests - Light', () {
+  screenshotThemeGroups('ErrorWidgetBuilder Screenshot Tests', (
+    theme,
+    suffix,
+  ) {
     testWidgets('renders error only correctly', (tester) async {
       tester.view.physicalSize = size;
       tester.view.devicePixelRatio = ratio;
@@ -49,12 +52,13 @@ void main() {
         tester: tester,
         error: 'Email not found. Please ',
         link: 'register',
+        theme: theme,
       );
 
       await expectLater(
         find.byType(Center),
         matchesGoldenFile(
-          'goldens/error_widget_builder/${size.width}x${size.height}/error_widget_builder_error_only.png',
+          'goldens/error_widget_builder/${size.width}x${size.height}/error_widget_builder_error_only$suffix.png',
         ),
       );
     });
@@ -67,52 +71,13 @@ void main() {
         tester: tester,
         error: 'Email ID already registered with us. Please ',
         link: 'login',
+        theme: theme,
       );
 
       await expectLater(
         find.byType(Center),
         matchesGoldenFile(
-          'goldens/error_widget_builder/${size.width}x${size.height}/error_widget_builder_error_with_link.png',
-        ),
-      );
-    });
-  });
-
-  group('ErrorWidgetBuilder Screenshot Tests - Dark', () {
-    testWidgets('renders error only correctly', (tester) async {
-      tester.view.physicalSize = size;
-      tester.view.devicePixelRatio = ratio;
-      addTearDown(tester.view.reset);
-      await pumpErrorWidget(
-        tester: tester,
-        error: 'Email not found. Please ',
-        link: 'register',
-        theme: createTestThemeDark(),
-      );
-
-      await expectLater(
-        find.byType(Center),
-        matchesGoldenFile(
-          'goldens/error_widget_builder/${size.width}x${size.height}/error_widget_builder_error_only_dark.png',
-        ),
-      );
-    });
-
-    testWidgets('renders error with link correctly', (tester) async {
-      tester.view.physicalSize = size;
-      tester.view.devicePixelRatio = ratio;
-      addTearDown(tester.view.reset);
-      await pumpErrorWidget(
-        tester: tester,
-        error: 'Email ID already registered with us. Please ',
-        link: 'login',
-        theme: createTestThemeDark(),
-      );
-
-      await expectLater(
-        find.byType(Center),
-        matchesGoldenFile(
-          'goldens/error_widget_builder/${size.width}x${size.height}/error_widget_builder_error_with_link_dark.png',
+          'goldens/error_widget_builder/${size.width}x${size.height}/error_widget_builder_error_with_link$suffix.png',
         ),
       );
     });

--- a/test/features/auth/screenshots/forgot_password_header_screenshot_test.dart
+++ b/test/features/auth/screenshots/forgot_password_header_screenshot_test.dart
@@ -18,11 +18,11 @@ void main() {
     required WidgetTester tester,
     required String title,
     required String description,
-    ThemeData? theme,
+    required ThemeData theme,
   }) async {
     await tester.pumpWidget(
       MaterialApp(
-        theme: theme ?? createTestTheme(),
+        theme: theme,
         home: Builder(
           builder: (ctx) => Scaffold(
             backgroundColor: ctx.colorTheme.pageBackground,
@@ -40,7 +40,10 @@ void main() {
     await tester.pumpAndSettle();
   }
 
-  group('ForgotPasswordHeader Screenshot Tests - Light', () {
+  screenshotThemeGroups('ForgotPasswordHeader Screenshot Tests', (
+    theme,
+    suffix,
+  ) {
     testWidgets('renders forgot password header correctly', (tester) async {
       tester.view.physicalSize = size;
       tester.view.devicePixelRatio = ratio;
@@ -51,35 +54,13 @@ void main() {
         title: 'Forgot Password?',
         description:
             'An OTP will be sent to your registered email ID to reset your password',
+        theme: theme,
       );
 
       await expectLater(
         find.byType(Scaffold),
         matchesGoldenFile(
-          'goldens/forgot_password_header/${size.width}x${size.height}/forgot_password_header.png',
-        ),
-      );
-    });
-  });
-
-  group('ForgotPasswordHeader Screenshot Tests - Dark', () {
-    testWidgets('renders forgot password header correctly', (tester) async {
-      tester.view.physicalSize = size;
-      tester.view.devicePixelRatio = ratio;
-      addTearDown(tester.view.reset);
-
-      await pumpForgotPasswordHeader(
-        tester: tester,
-        title: 'Forgot Password?',
-        description:
-            'An OTP will be sent to your registered email ID to reset your password',
-        theme: createTestThemeDark(),
-      );
-
-      await expectLater(
-        find.byType(Scaffold),
-        matchesGoldenFile(
-          'goldens/forgot_password_header/${size.width}x${size.height}/forgot_password_header_dark.png',
+          'goldens/forgot_password_header/${size.width}x${size.height}/forgot_password_header$suffix.png',
         ),
       );
     });

--- a/test/features/auth/screenshots/otp_verification_sheet_screenshot_test.dart
+++ b/test/features/auth/screenshots/otp_verification_sheet_screenshot_test.dart
@@ -52,7 +52,11 @@ void main() {
       tester.view.physicalSize = size;
       tester.view.devicePixelRatio = ratio;
       addTearDown(tester.view.reset);
-      await pumpOtpSheet(tester: tester, verifyButtonDisabled: true, theme: theme);
+      await pumpOtpSheet(
+        tester: tester,
+        verifyButtonDisabled: true,
+        theme: theme,
+      );
 
       await expectLater(
         find.byType(OtpVerificationQuickSheet),

--- a/test/features/auth/screenshots/otp_verification_sheet_screenshot_test.dart
+++ b/test/features/auth/screenshots/otp_verification_sheet_screenshot_test.dart
@@ -16,14 +16,14 @@ void main() {
 
   Future<void> pumpOtpSheet({
     required WidgetTester tester,
+    required ThemeData theme,
     bool verifyButtonDisabled = false,
     bool isVerifying = false,
     bool isResending = false,
-    ThemeData? theme,
   }) async {
     await tester.pumpWidget(
       MaterialApp(
-        theme: theme ?? createTestTheme(),
+        theme: theme,
         localizationsDelegates: AppLocalizations.localizationsDelegates,
         supportedLocales: AppLocalizations.supportedLocales,
         home: Scaffold(
@@ -44,17 +44,20 @@ void main() {
     await tester.pumpAndSettle();
   }
 
-  group('OtpVerificationQuickSheet Screenshot Tests - Light', () {
+  screenshotThemeGroups('OtpVerificationQuickSheet Screenshot Tests', (
+    theme,
+    suffix,
+  ) {
     testWidgets('renders with verify button disabled', (tester) async {
       tester.view.physicalSize = size;
       tester.view.devicePixelRatio = ratio;
       addTearDown(tester.view.reset);
-      await pumpOtpSheet(tester: tester, verifyButtonDisabled: true);
+      await pumpOtpSheet(tester: tester, verifyButtonDisabled: true, theme: theme);
 
       await expectLater(
         find.byType(OtpVerificationQuickSheet),
         matchesGoldenFile(
-          'goldens/otp_verification_sheet/${size.width}x${size.height}/otp_verification_sheet_verify_disabled.png',
+          'goldens/otp_verification_sheet/${size.width}x${size.height}/otp_verification_sheet_verify_disabled$suffix.png',
         ),
       );
     });
@@ -64,7 +67,7 @@ void main() {
       tester.view.devicePixelRatio = ratio;
       addTearDown(tester.view.reset);
 
-      await pumpOtpSheet(tester: tester);
+      await pumpOtpSheet(tester: tester, theme: theme);
 
       final pinInput = find.byKey(const Key('pin_input'));
       expect(pinInput, findsOneWidget);
@@ -74,7 +77,7 @@ void main() {
       await expectLater(
         find.byType(OtpVerificationQuickSheet),
         matchesGoldenFile(
-          'goldens/otp_verification_sheet/${size.width}x${size.height}/otp_verification_sheet_verify_enabled.png',
+          'goldens/otp_verification_sheet/${size.width}x${size.height}/otp_verification_sheet_verify_enabled$suffix.png',
         ),
       );
     });
@@ -87,12 +90,13 @@ void main() {
         tester: tester,
         isResending: true,
         verifyButtonDisabled: true,
+        theme: theme,
       );
 
       await expectLater(
         find.byType(OtpVerificationQuickSheet),
         matchesGoldenFile(
-          'goldens/otp_verification_sheet/${size.width}x${size.height}/otp_verification_sheet_resending.png',
+          'goldens/otp_verification_sheet/${size.width}x${size.height}/otp_verification_sheet_resending$suffix.png',
         ),
       );
     });
@@ -102,7 +106,7 @@ void main() {
       tester.view.devicePixelRatio = ratio;
       addTearDown(tester.view.reset);
 
-      await pumpOtpSheet(tester: tester);
+      await pumpOtpSheet(tester: tester, theme: theme);
 
       final pinInput = find.byKey(const Key('pin_input'));
       expect(pinInput, findsOneWidget);
@@ -113,98 +117,13 @@ void main() {
         tester: tester,
         isVerifying: true,
         verifyButtonDisabled: true,
+        theme: theme,
       );
 
       await expectLater(
         find.byType(OtpVerificationQuickSheet),
         matchesGoldenFile(
-          'goldens/otp_verification_sheet/${size.width}x${size.height}/otp_verification_sheet_verifying.png',
-        ),
-      );
-    });
-  });
-
-  group('OtpVerificationQuickSheet Screenshot Tests - Dark', () {
-    testWidgets('renders with verify button disabled', (tester) async {
-      tester.view.physicalSize = size;
-      tester.view.devicePixelRatio = ratio;
-      addTearDown(tester.view.reset);
-      await pumpOtpSheet(
-        tester: tester,
-        verifyButtonDisabled: true,
-        theme: createTestThemeDark(),
-      );
-
-      await expectLater(
-        find.byType(OtpVerificationQuickSheet),
-        matchesGoldenFile(
-          'goldens/otp_verification_sheet/${size.width}x${size.height}/otp_verification_sheet_verify_disabled_dark.png',
-        ),
-      );
-    });
-
-    testWidgets('renders with verify button enabled', (tester) async {
-      tester.view.physicalSize = size;
-      tester.view.devicePixelRatio = ratio;
-      addTearDown(tester.view.reset);
-
-      await pumpOtpSheet(tester: tester, theme: createTestThemeDark());
-
-      final pinInput = find.byKey(const Key('pin_input'));
-      expect(pinInput, findsOneWidget);
-      await tester.enterText(pinInput, '123456');
-      await tester.pumpAndSettle();
-
-      await expectLater(
-        find.byType(OtpVerificationQuickSheet),
-        matchesGoldenFile(
-          'goldens/otp_verification_sheet/${size.width}x${size.height}/otp_verification_sheet_verify_enabled_dark.png',
-        ),
-      );
-    });
-
-    testWidgets('renders with resending state', (tester) async {
-      tester.view.physicalSize = size;
-      tester.view.devicePixelRatio = ratio;
-      addTearDown(tester.view.reset);
-      await pumpOtpSheet(
-        tester: tester,
-        isResending: true,
-        verifyButtonDisabled: true,
-        theme: createTestThemeDark(),
-      );
-
-      await expectLater(
-        find.byType(OtpVerificationQuickSheet),
-        matchesGoldenFile(
-          'goldens/otp_verification_sheet/${size.width}x${size.height}/otp_verification_sheet_resending_dark.png',
-        ),
-      );
-    });
-
-    testWidgets('renders with verifying state', (tester) async {
-      tester.view.physicalSize = size;
-      tester.view.devicePixelRatio = ratio;
-      addTearDown(tester.view.reset);
-
-      await pumpOtpSheet(tester: tester, theme: createTestThemeDark());
-
-      final pinInput = find.byKey(const Key('pin_input'));
-      expect(pinInput, findsOneWidget);
-      await tester.enterText(pinInput, '123456');
-      await tester.pump();
-
-      await pumpOtpSheet(
-        tester: tester,
-        isVerifying: true,
-        verifyButtonDisabled: true,
-        theme: createTestThemeDark(),
-      );
-
-      await expectLater(
-        find.byType(OtpVerificationQuickSheet),
-        matchesGoldenFile(
-          'goldens/otp_verification_sheet/${size.width}x${size.height}/otp_verification_sheet_verifying_dark.png',
+          'goldens/otp_verification_sheet/${size.width}x${size.height}/otp_verification_sheet_verifying$suffix.png',
         ),
       );
     });

--- a/test/features/auth/screenshots/terms_and_conditions_section_screenshot_test.dart
+++ b/test/features/auth/screenshots/terms_and_conditions_section_screenshot_test.dart
@@ -20,11 +20,11 @@ void main() {
     required String termsAndServicesLink,
     required String privacyPolicyLink,
     required String andAcknowledge,
-    ThemeData? theme,
+    required ThemeData theme,
   }) async {
     await tester.pumpWidget(
       MaterialApp(
-        theme: theme ?? createTestTheme(),
+        theme: theme,
         home: Builder(
           builder: (ctx) => Scaffold(
             backgroundColor: ctx.colorTheme.pageBackground,
@@ -46,7 +46,10 @@ void main() {
     await tester.pumpAndSettle();
   }
 
-  group('TermsAndConditions Screenshot Tests - Light', () {
+  screenshotThemeGroups('TermsAndConditions Screenshot Tests', (
+    theme,
+    suffix,
+  ) {
     testWidgets('renders terms and conditions correctly', (tester) async {
       tester.view.physicalSize = size;
       tester.view.devicePixelRatio = ratio;
@@ -59,37 +62,13 @@ void main() {
         termsAndServicesLink: 'terms & services',
         privacyPolicyLink: 'privacy policy',
         andAcknowledge: 'and acknowledge ',
+        theme: theme,
       );
 
       await expectLater(
         find.byType(Scaffold),
         matchesGoldenFile(
-          'goldens/terms_and_conditions/${size.width}x${size.height}/terms_and_conditions_agreement.png',
-        ),
-      );
-    });
-  });
-
-  group('TermsAndConditions Screenshot Tests - Dark', () {
-    testWidgets('renders terms and conditions correctly', (tester) async {
-      tester.view.physicalSize = size;
-      tester.view.devicePixelRatio = ratio;
-      addTearDown(tester.view.reset);
-
-      await pumpTermsAndConditions(
-        tester: tester,
-        termsAndConditionsText:
-            'By selecting agree and continue. I agree to Construculator ',
-        termsAndServicesLink: 'terms & services',
-        privacyPolicyLink: 'privacy policy',
-        andAcknowledge: 'and acknowledge ',
-        theme: createTestThemeDark(),
-      );
-
-      await expectLater(
-        find.byType(Scaffold),
-        matchesGoldenFile(
-          'goldens/terms_and_conditions/${size.width}x${size.height}/terms_and_conditions_agreement_dark.png',
+          'goldens/terms_and_conditions/${size.width}x${size.height}/terms_and_conditions_agreement$suffix.png',
         ),
       );
     });


### PR DESCRIPTION
### 1. PR SUMMARY
Migrates the 7 screenshot tests in `test/features/auth/screenshots/` off the old manual dual-theme pattern (nullable `ThemeData? theme` pump param with `?? createTestTheme()`, hand-written `- Light`/`- Dark` `group()` wrappers) onto the `screenshotThemeGroups` helper (CA-847). Pump helpers now take a non-nullable `required ThemeData theme`. All golden filenames already followed the target naming convention (no suffix for light, `_dark` for dark), so no golden renames were needed — only code restructuring.

Second PR in the CA-914 migration series (2/9), stacked on 1/9. CA-968 (bump `ripplearc_linter` to pull in the `forbid_manual_screenshot_theme` rule this migration satisfies) is stacked on top of the full series, after PR 9/9.

### 2. REVIEW SUMMARY TABLE
No issues found.

## Test plan
- [x] `fvm flutter test test/features/auth/screenshots/` — all 28 tests pass
- [x] `fvm dart run custom_lint` — clean (pre-existing unrelated issue in `fake_router.dart` confirmed present on `main`)
- [ ] Reviewer: visually confirm goldens render correctly for both themes