### PR TITLE
CA-914 (3/9): migrate dashboard screenshot tests to screenshotThemeGroups

### DIFF
--- a/test/features/dashboard/screenshots/estimation_card_screenshot_test.dart
+++ b/test/features/dashboard/screenshots/estimation_card_screenshot_test.dart
@@ -19,11 +19,11 @@ void main() {
     required WidgetTester tester,
     required CostEstimate estimation,
     required VoidCallback onTap,
-    ThemeData? theme,
+    required ThemeData theme,
   }) async {
     await tester.pumpWidget(
       MaterialApp(
-        theme: theme ?? createTestTheme(),
+        theme: theme,
         locale: const Locale('en'),
         localizationsDelegates: AppLocalizations.localizationsDelegates,
         supportedLocales: AppLocalizations.supportedLocales,
@@ -40,7 +40,7 @@ void main() {
     await tester.pumpAndSettle();
   }
 
-  group('EstimationCard Screenshot Tests - Light', () {
+  screenshotThemeGroups('EstimationCard Screenshot Tests', (theme, suffix) {
     testWidgets('renders base estimation card correctly', (tester) async {
       tester.view.physicalSize = size;
       tester.view.devicePixelRatio = ratio;
@@ -56,12 +56,13 @@ void main() {
         tester: tester,
         estimation: estimation,
         onTap: () {},
+        theme: theme,
       );
 
       await expectLater(
         find.byType(EstimationCard),
         matchesGoldenFile(
-          'goldens/estimation_card/${size.width}x${size.height}/estimation_card_base.png',
+          'goldens/estimation_card/${size.width}x${size.height}/estimation_card_base$suffix.png',
         ),
       );
     });
@@ -81,66 +82,13 @@ void main() {
         tester: tester,
         estimation: estimation,
         onTap: () {},
+        theme: theme,
       );
 
       await expectLater(
         find.byType(EstimationCard),
         matchesGoldenFile(
-          'goldens/estimation_card/${size.width}x${size.height}/estimation_card_long_name.png',
-        ),
-      );
-    });
-  });
-
-  group('EstimationCard Screenshot Tests - Dark', () {
-    testWidgets('renders base estimation card correctly', (tester) async {
-      tester.view.physicalSize = size;
-      tester.view.devicePixelRatio = ratio;
-      addTearDown(tester.view.reset);
-
-      final estimation = CostEstimate.defaultEstimate(
-        estimateName: 'Base Estimate',
-        updatedAt: DateTime(2024, 1, 1, 8, 30),
-        createdAt: DateTime(2024, 1, 1, 8, 30),
-      );
-
-      await pumpEstimationCard(
-        tester: tester,
-        estimation: estimation,
-        onTap: () {},
-        theme: createTestThemeDark(),
-      );
-
-      await expectLater(
-        find.byType(EstimationCard),
-        matchesGoldenFile(
-          'goldens/estimation_card/${size.width}x${size.height}/estimation_card_base_dark.png',
-        ),
-      );
-    });
-
-    testWidgets('renders estimation card with long name correctly', (tester) async {
-      tester.view.physicalSize = size;
-      tester.view.devicePixelRatio = ratio;
-      addTearDown(tester.view.reset);
-
-      final estimation = CostEstimate.defaultEstimate(
-        estimateName: 'Complete Home Renovation and Extension Project',
-        updatedAt: DateTime(2024, 3, 10, 16, 45),
-        createdAt: DateTime(2024, 3, 10, 16, 45),
-      );
-
-      await pumpEstimationCard(
-        tester: tester,
-        estimation: estimation,
-        onTap: () {},
-        theme: createTestThemeDark(),
-      );
-
-      await expectLater(
-        find.byType(EstimationCard),
-        matchesGoldenFile(
-          'goldens/estimation_card/${size.width}x${size.height}/estimation_card_long_name_dark.png',
+          'goldens/estimation_card/${size.width}x${size.height}/estimation_card_long_name$suffix.png',
         ),
       );
     });

--- a/test/features/dashboard/screenshots/favorite_calculation_card_screenshot_test.dart
+++ b/test/features/dashboard/screenshots/favorite_calculation_card_screenshot_test.dart
@@ -17,8 +17,8 @@ void main() {
   Future<void> pumpCalculationCard({
     required WidgetTester tester,
     required FavoriteCalculation calculation,
+    required ThemeData theme,
     Size size = const Size(390, 200),
-    ThemeData? theme,
   }) async {
     tester.view.physicalSize = size;
     tester.view.devicePixelRatio = ratio;
@@ -26,7 +26,7 @@ void main() {
 
     await tester.pumpWidget(
       MaterialApp(
-        theme: theme ?? createTestTheme(),
+        theme: theme,
         locale: const Locale('en'),
         localizationsDelegates: AppLocalizations.localizationsDelegates,
         supportedLocales: AppLocalizations.supportedLocales,
@@ -43,7 +43,10 @@ void main() {
     await tester.pumpAndSettle();
   }
 
-  group('FavoriteCalculationCard Screenshot Tests - Light', () {
+  screenshotThemeGroups('FavoriteCalculationCard Screenshot Tests', (
+    theme,
+    suffix,
+  ) {
     testWidgets('renders base calculation card correctly', (tester) async {
       const baseSize = Size(390, 200);
       final calculation = FavoriteCalculation(
@@ -52,12 +55,16 @@ void main() {
         tags: const ['Flooring', 'Area', 'Tagname'],
       );
 
-      await pumpCalculationCard(tester: tester, calculation: calculation);
+      await pumpCalculationCard(
+        tester: tester,
+        calculation: calculation,
+        theme: theme,
+      );
 
       await expectLater(
         find.byType(FavoriteCalculationCard),
         matchesGoldenFile(
-          'goldens/favorite_calculation_card/${baseSize.width.toInt()}x${baseSize.height.toInt()}/favorite_calculation_card_base.png',
+          'goldens/favorite_calculation_card/${baseSize.width.toInt()}x${baseSize.height.toInt()}/favorite_calculation_card_base$suffix.png',
         ),
       );
     });
@@ -84,12 +91,13 @@ void main() {
         tester: tester,
         calculation: calculation,
         size: size,
+        theme: theme,
       );
 
       await expectLater(
         find.byType(FavoriteCalculationCard),
         matchesGoldenFile(
-          'goldens/favorite_calculation_card/${size.width.toInt()}x${size.height.toInt()}/favorite_calculation_card_at_max.png',
+          'goldens/favorite_calculation_card/${size.width.toInt()}x${size.height.toInt()}/favorite_calculation_card_at_max$suffix.png',
         ),
       );
     });
@@ -117,12 +125,13 @@ void main() {
         tester: tester,
         calculation: calculation,
         size: size,
+        theme: theme,
       );
 
       await expectLater(
         find.byType(FavoriteCalculationCard),
         matchesGoldenFile(
-          'goldens/favorite_calculation_card/${size.width.toInt()}x${size.height.toInt()}/favorite_calculation_card_overflow_plus1.png',
+          'goldens/favorite_calculation_card/${size.width.toInt()}x${size.height.toInt()}/favorite_calculation_card_overflow_plus1$suffix.png',
         ),
       );
     });
@@ -154,141 +163,13 @@ void main() {
         tester: tester,
         calculation: calculation,
         size: size,
+        theme: theme,
       );
 
       await expectLater(
         find.byType(FavoriteCalculationCard),
         matchesGoldenFile(
-          'goldens/favorite_calculation_card/${size.width.toInt()}x${size.height.toInt()}/favorite_calculation_card_overflow.png',
-        ),
-      );
-    });
-  });
-
-  group('FavoriteCalculationCard Screenshot Tests - Dark', () {
-    testWidgets('renders base calculation card correctly', (tester) async {
-      const baseSize = Size(390, 200);
-      final calculation = FavoriteCalculation(
-        id: 'calc-1',
-        date: DateTime(2025, 4, 22, 14, 30),
-        tags: const ['Flooring', 'Area', 'Tagname'],
-      );
-
-      await pumpCalculationCard(
-        tester: tester,
-        calculation: calculation,
-        theme: createTestThemeDark(),
-      );
-
-      await expectLater(
-        find.byType(FavoriteCalculationCard),
-        matchesGoldenFile(
-          'goldens/favorite_calculation_card/${baseSize.width.toInt()}x${baseSize.height.toInt()}/favorite_calculation_card_base_dark.png',
-        ),
-      );
-    });
-
-    testWidgets('renders no overflow chip when tags equal maximum', (
-      tester,
-    ) async {
-      const size = Size(390, 200);
-      final calculation = FavoriteCalculation(
-        id: 'calc-2',
-        date: DateTime(2025, 4, 22, 14, 30),
-        tags: const [
-          'Flooring',
-          'Area',
-          'Tagname',
-          'Roofing',
-          'Walls',
-          'Ceiling',
-          'Paint',
-        ],
-      );
-
-      await pumpCalculationCard(
-        tester: tester,
-        calculation: calculation,
-        size: size,
-        theme: createTestThemeDark(),
-      );
-
-      await expectLater(
-        find.byType(FavoriteCalculationCard),
-        matchesGoldenFile(
-          'goldens/favorite_calculation_card/${size.width.toInt()}x${size.height.toInt()}/favorite_calculation_card_at_max_dark.png',
-        ),
-      );
-    });
-
-    testWidgets('renders overflow chip with count 1 when one tag exceeds maximum', (
-      tester,
-    ) async {
-      const size = Size(390, 200);
-      final calculation = FavoriteCalculation(
-        id: 'calc-3',
-        date: DateTime(2025, 4, 22, 14, 30),
-        tags: const [
-          'Flooring',
-          'Area',
-          'Tagname',
-          'Roofing',
-          'Walls',
-          'Ceiling',
-          'Paint',
-          'Extra',
-        ],
-      );
-
-      await pumpCalculationCard(
-        tester: tester,
-        calculation: calculation,
-        size: size,
-        theme: createTestThemeDark(),
-      );
-
-      await expectLater(
-        find.byType(FavoriteCalculationCard),
-        matchesGoldenFile(
-          'goldens/favorite_calculation_card/${size.width.toInt()}x${size.height.toInt()}/favorite_calculation_card_overflow_plus1_dark.png',
-        ),
-      );
-    });
-
-    testWidgets('renders overflow chip when tags exceed maximum', (
-      tester,
-    ) async {
-      const size = Size(390, 200);
-      final calculation = FavoriteCalculation(
-        id: 'calc-4',
-        date: DateTime(2025, 4, 22, 14, 30),
-        tags: const [
-          'Flooring',
-          'Area',
-          'Tagname',
-          'Roofing',
-          'Walls',
-          'Ceiling',
-          'Paint',
-          'Doors',
-          'Windows',
-          'Insulation',
-          'Fixtures',
-          'Plumbing',
-        ],
-      );
-
-      await pumpCalculationCard(
-        tester: tester,
-        calculation: calculation,
-        size: size,
-        theme: createTestThemeDark(),
-      );
-
-      await expectLater(
-        find.byType(FavoriteCalculationCard),
-        matchesGoldenFile(
-          'goldens/favorite_calculation_card/${size.width.toInt()}x${size.height.toInt()}/favorite_calculation_card_overflow_dark.png',
+          'goldens/favorite_calculation_card/${size.width.toInt()}x${size.height.toInt()}/favorite_calculation_card_overflow$suffix.png',
         ),
       );
     });

--- a/test/features/dashboard/screenshots/favorite_estimation_card_screenshot_test.dart
+++ b/test/features/dashboard/screenshots/favorite_estimation_card_screenshot_test.dart
@@ -18,7 +18,7 @@ void main() {
   Future<void> pumpEstimationCard({
     required WidgetTester tester,
     required FavoriteEstimation estimation,
-    ThemeData? theme,
+    required ThemeData theme,
   }) async {
     tester.view.physicalSize = size;
     tester.view.devicePixelRatio = ratio;
@@ -26,7 +26,7 @@ void main() {
 
     await tester.pumpWidget(
       MaterialApp(
-        theme: theme ?? createTestTheme(),
+        theme: theme,
         locale: const Locale('en'),
         localizationsDelegates: AppLocalizations.localizationsDelegates,
         supportedLocales: AppLocalizations.supportedLocales,
@@ -43,47 +43,10 @@ void main() {
     await tester.pumpAndSettle();
   }
 
-  group('FavoriteEstimationCard Screenshot Tests - Light', () {
-    testWidgets('renders base estimation card correctly', (tester) async {
-      final estimation = FavoriteEstimation(
-        id: 'est-1',
-        title: '2nd Wall cost',
-        date: DateTime(2025, 5, 3, 14, 30),
-        totalCost: 12343.88,
-      );
-
-      await pumpEstimationCard(tester: tester, estimation: estimation);
-
-      await expectLater(
-        find.byType(FavoriteEstimationCard),
-        matchesGoldenFile(
-          'goldens/favorite_estimation_card/${size.width.toInt()}x${size.height.toInt()}/favorite_estimation_card_base.png',
-        ),
-      );
-    });
-
-    testWidgets('renders estimation card with long title correctly', (
-      tester,
-    ) async {
-      final estimation = FavoriteEstimation(
-        id: 'est-2',
-        title: 'Complete Home Renovation and Extension Project Phase Two',
-        date: DateTime(2025, 4, 22, 14, 30),
-        totalCost: 10000.88,
-      );
-
-      await pumpEstimationCard(tester: tester, estimation: estimation);
-
-      await expectLater(
-        find.byType(FavoriteEstimationCard),
-        matchesGoldenFile(
-          'goldens/favorite_estimation_card/${size.width.toInt()}x${size.height.toInt()}/favorite_estimation_card_long_title.png',
-        ),
-      );
-    });
-  });
-
-  group('FavoriteEstimationCard Screenshot Tests - Dark', () {
+  screenshotThemeGroups('FavoriteEstimationCard Screenshot Tests', (
+    theme,
+    suffix,
+  ) {
     testWidgets('renders base estimation card correctly', (tester) async {
       final estimation = FavoriteEstimation(
         id: 'est-1',
@@ -95,13 +58,13 @@ void main() {
       await pumpEstimationCard(
         tester: tester,
         estimation: estimation,
-        theme: createTestThemeDark(),
+        theme: theme,
       );
 
       await expectLater(
         find.byType(FavoriteEstimationCard),
         matchesGoldenFile(
-          'goldens/favorite_estimation_card/${size.width.toInt()}x${size.height.toInt()}/favorite_estimation_card_base_dark.png',
+          'goldens/favorite_estimation_card/${size.width.toInt()}x${size.height.toInt()}/favorite_estimation_card_base$suffix.png',
         ),
       );
     });
@@ -119,13 +82,13 @@ void main() {
       await pumpEstimationCard(
         tester: tester,
         estimation: estimation,
-        theme: createTestThemeDark(),
+        theme: theme,
       );
 
       await expectLater(
         find.byType(FavoriteEstimationCard),
         matchesGoldenFile(
-          'goldens/favorite_estimation_card/${size.width.toInt()}x${size.height.toInt()}/favorite_estimation_card_long_title_dark.png',
+          'goldens/favorite_estimation_card/${size.width.toInt()}x${size.height.toInt()}/favorite_estimation_card_long_title$suffix.png',
         ),
       );
     });

--- a/test/features/dashboard/screenshots/favorites_section_screenshot_test.dart
+++ b/test/features/dashboard/screenshots/favorites_section_screenshot_test.dart
@@ -20,9 +20,9 @@ void main() {
 
   Future<void> pumpFavoritesSection({
     required WidgetTester tester,
+    required ThemeData theme,
     List<FavoriteCalculation> calculations = const [],
     List<FavoriteEstimation> estimations = const [],
-    ThemeData? theme,
   }) async {
     tester.view.physicalSize = size;
     tester.view.devicePixelRatio = ratio;
@@ -30,7 +30,7 @@ void main() {
 
     await tester.pumpWidget(
       MaterialApp(
-        theme: theme ?? createTestTheme(),
+        theme: theme,
         locale: const Locale('en'),
         localizationsDelegates: AppLocalizations.localizationsDelegates,
         supportedLocales: AppLocalizations.supportedLocales,
@@ -57,8 +57,8 @@ void main() {
 
   Future<void> pumpBottomSheet({
     required WidgetTester tester,
+    required ThemeData theme,
     FavouriteFilterType selectedFilter = FavouriteFilterType.all,
-    ThemeData? theme,
   }) async {
     tester.view.physicalSize = size;
     tester.view.devicePixelRatio = ratio;
@@ -66,7 +66,7 @@ void main() {
 
     await tester.pumpWidget(
       MaterialApp(
-        theme: theme ?? createTestTheme(),
+        theme: theme,
         locale: const Locale('en'),
         localizationsDelegates: AppLocalizations.localizationsDelegates,
         supportedLocales: AppLocalizations.supportedLocales,
@@ -84,13 +84,14 @@ void main() {
     await tester.pumpAndSettle();
   }
 
-  group('FavoritesSection Screenshot Tests - Light', () {
+  screenshotThemeGroups('FavoritesSection Screenshot Tests', (theme, suffix) {
     testWidgets('renders loaded section with calculations and estimations', (
       tester,
     ) async {
       final date = DateTime(2025, 4, 22, 14, 30);
       await pumpFavoritesSection(
         tester: tester,
+        theme: theme,
         calculations: [
           FavoriteCalculation(
             id: 'c1',
@@ -122,31 +123,34 @@ void main() {
       await expectLater(
         find.byType(Scaffold),
         matchesGoldenFile(
-          'goldens/favorites_section/${size.width.toInt()}x${size.height.toInt()}/favorites_section_loaded.png',
+          'goldens/favorites_section/${size.width.toInt()}x${size.height.toInt()}/favorites_section_loaded$suffix.png',
         ),
       );
     });
 
     testWidgets('renders empty state correctly', (tester) async {
-      await pumpFavoritesSection(tester: tester);
+      await pumpFavoritesSection(tester: tester, theme: theme);
 
       await expectLater(
         find.byType(Scaffold),
         matchesGoldenFile(
-          'goldens/favorites_section/${size.width.toInt()}x${size.height.toInt()}/favorites_section_empty.png',
+          'goldens/favorites_section/${size.width.toInt()}x${size.height.toInt()}/favorites_section_empty$suffix.png',
         ),
       );
     });
   });
 
-  group('FavouriteSortBottomSheet Screenshot Tests - Light', () {
+  screenshotThemeGroups('FavouriteSortBottomSheet Screenshot Tests', (
+    theme,
+    suffix,
+  ) {
     testWidgets('renders sort sheet with All selected', (tester) async {
-      await pumpBottomSheet(tester: tester);
+      await pumpBottomSheet(tester: tester, theme: theme);
 
       await expectLater(
         find.byType(Scaffold),
         matchesGoldenFile(
-          'goldens/favorites_section/${size.width.toInt()}x${size.height.toInt()}/favourite_sort_sheet_all.png',
+          'goldens/favorites_section/${size.width.toInt()}x${size.height.toInt()}/favourite_sort_sheet_all$suffix.png',
         ),
       );
     });
@@ -156,13 +160,14 @@ void main() {
     ) async {
       await pumpBottomSheet(
         tester: tester,
+        theme: theme,
         selectedFilter: FavouriteFilterType.costEstimations,
       );
 
       await expectLater(
         find.byType(Scaffold),
         matchesGoldenFile(
-          'goldens/favorites_section/${size.width.toInt()}x${size.height.toInt()}/favourite_sort_sheet_cost_estimations.png',
+          'goldens/favorites_section/${size.width.toInt()}x${size.height.toInt()}/favourite_sort_sheet_cost_estimations$suffix.png',
         ),
       );
     });
@@ -172,119 +177,14 @@ void main() {
     ) async {
       await pumpBottomSheet(
         tester: tester,
+        theme: theme,
         selectedFilter: FavouriteFilterType.calculations,
       );
 
       await expectLater(
         find.byType(Scaffold),
         matchesGoldenFile(
-          'goldens/favorites_section/${size.width.toInt()}x${size.height.toInt()}/favourite_sort_sheet_calculations.png',
-        ),
-      );
-    });
-  });
-
-  group('FavoritesSection Screenshot Tests - Dark', () {
-    testWidgets('renders loaded section with calculations and estimations', (
-      tester,
-    ) async {
-      final date = DateTime(2025, 4, 22, 14, 30);
-      await pumpFavoritesSection(
-        tester: tester,
-        calculations: [
-          FavoriteCalculation(
-            id: 'c1',
-            date: date,
-            tags: const ['Flooring', 'Area', 'Tagname', 'Tagname'],
-          ),
-          FavoriteCalculation(
-            id: 'c2',
-            date: DateTime(2025, 4, 22, 14, 30),
-            tags: const ['Tagname', 'Tagname', 'Tagname'],
-          ),
-        ],
-        estimations: [
-          FavoriteEstimation(
-            id: 'e1',
-            title: '2nd Wall cost',
-            date: DateTime(2025, 5, 3, 14, 30),
-            totalCost: 12343.88,
-          ),
-          FavoriteEstimation(
-            id: 'e2',
-            title: 'Wall cost',
-            date: date,
-            totalCost: 10000.88,
-          ),
-        ],
-        theme: createTestThemeDark(),
-      );
-
-      await expectLater(
-        find.byType(Scaffold),
-        matchesGoldenFile(
-          'goldens/favorites_section/${size.width.toInt()}x${size.height.toInt()}/favorites_section_loaded_dark.png',
-        ),
-      );
-    });
-
-    testWidgets('renders empty state correctly', (tester) async {
-      await pumpFavoritesSection(
-        tester: tester,
-        theme: createTestThemeDark(),
-      );
-
-      await expectLater(
-        find.byType(Scaffold),
-        matchesGoldenFile(
-          'goldens/favorites_section/${size.width.toInt()}x${size.height.toInt()}/favorites_section_empty_dark.png',
-        ),
-      );
-    });
-  });
-
-  group('FavouriteSortBottomSheet Screenshot Tests - Dark', () {
-    testWidgets('renders sort sheet with All selected', (tester) async {
-      await pumpBottomSheet(tester: tester, theme: createTestThemeDark());
-
-      await expectLater(
-        find.byType(Scaffold),
-        matchesGoldenFile(
-          'goldens/favorites_section/${size.width.toInt()}x${size.height.toInt()}/favourite_sort_sheet_all_dark.png',
-        ),
-      );
-    });
-
-    testWidgets('renders sort sheet with Cost estimations selected', (
-      tester,
-    ) async {
-      await pumpBottomSheet(
-        tester: tester,
-        selectedFilter: FavouriteFilterType.costEstimations,
-        theme: createTestThemeDark(),
-      );
-
-      await expectLater(
-        find.byType(Scaffold),
-        matchesGoldenFile(
-          'goldens/favorites_section/${size.width.toInt()}x${size.height.toInt()}/favourite_sort_sheet_cost_estimations_dark.png',
-        ),
-      );
-    });
-
-    testWidgets('renders sort sheet with Calculations selected', (
-      tester,
-    ) async {
-      await pumpBottomSheet(
-        tester: tester,
-        selectedFilter: FavouriteFilterType.calculations,
-        theme: createTestThemeDark(),
-      );
-
-      await expectLater(
-        find.byType(Scaffold),
-        matchesGoldenFile(
-          'goldens/favorites_section/${size.width.toInt()}x${size.height.toInt()}/favourite_sort_sheet_calculations_dark.png',
+          'goldens/favorites_section/${size.width.toInt()}x${size.height.toInt()}/favourite_sort_sheet_calculations$suffix.png',
         ),
       );
     });

--- a/test/features/dashboard/screenshots/highlighted_project_item_screenshot_test.dart
+++ b/test/features/dashboard/screenshots/highlighted_project_item_screenshot_test.dart
@@ -33,11 +33,11 @@ void main() {
   Future<void> pumpHighlightedProjectItem({
     required WidgetTester tester,
     required Project project,
-    ThemeData? theme,
+    required ThemeData theme,
   }) async {
     await tester.pumpWidget(
       MaterialApp(
-        theme: theme ?? createTestTheme(),
+        theme: theme,
         locale: const Locale('en'),
         localizationsDelegates: AppLocalizations.localizationsDelegates,
         supportedLocales: AppLocalizations.supportedLocales,
@@ -58,46 +58,10 @@ void main() {
     await tester.pumpAndSettle();
   }
 
-  group('HighlightedProjectItem Screenshot Tests - Light', () {
-    testWidgets('renders highlighted project item correctly', (tester) async {
-      tester.view.physicalSize = size;
-      tester.view.devicePixelRatio = ratio;
-      addTearDown(tester.view.reset);
-
-      await pumpHighlightedProjectItem(tester: tester, project: buildProject());
-
-      await expectLater(
-        find.byType(HighlightedProjectItem),
-        matchesGoldenFile(
-          'goldens/highlighted_project_item/${size.width}x${size.height}/highlighted_project_item_base.png',
-        ),
-      );
-    });
-
-    testWidgets('renders highlighted project item with long name correctly', (
-      tester,
-    ) async {
-      tester.view.physicalSize = size;
-      tester.view.devicePixelRatio = ratio;
-      addTearDown(tester.view.reset);
-
-      await pumpHighlightedProjectItem(
-        tester: tester,
-        project: buildProject(
-          projectName: 'Complete Home Renovation and Extension Project Phase 2',
-        ),
-      );
-
-      await expectLater(
-        find.byType(HighlightedProjectItem),
-        matchesGoldenFile(
-          'goldens/highlighted_project_item/${size.width}x${size.height}/highlighted_project_item_long_name.png',
-        ),
-      );
-    });
-  });
-
-  group('HighlightedProjectItem Screenshot Tests - Dark', () {
+  screenshotThemeGroups('HighlightedProjectItem Screenshot Tests', (
+    theme,
+    suffix,
+  ) {
     testWidgets('renders highlighted project item correctly', (tester) async {
       tester.view.physicalSize = size;
       tester.view.devicePixelRatio = ratio;
@@ -106,13 +70,13 @@ void main() {
       await pumpHighlightedProjectItem(
         tester: tester,
         project: buildProject(),
-        theme: createTestThemeDark(),
+        theme: theme,
       );
 
       await expectLater(
         find.byType(HighlightedProjectItem),
         matchesGoldenFile(
-          'goldens/highlighted_project_item/${size.width}x${size.height}/highlighted_project_item_base_dark.png',
+          'goldens/highlighted_project_item/${size.width}x${size.height}/highlighted_project_item_base$suffix.png',
         ),
       );
     });
@@ -129,13 +93,13 @@ void main() {
         project: buildProject(
           projectName: 'Complete Home Renovation and Extension Project Phase 2',
         ),
-        theme: createTestThemeDark(),
+        theme: theme,
       );
 
       await expectLater(
         find.byType(HighlightedProjectItem),
         matchesGoldenFile(
-          'goldens/highlighted_project_item/${size.width}x${size.height}/highlighted_project_item_long_name_dark.png',
+          'goldens/highlighted_project_item/${size.width}x${size.height}/highlighted_project_item_long_name$suffix.png',
         ),
       );
     });

--- a/test/features/dashboard/screenshots/project_list_item_screenshot_test.dart
+++ b/test/features/dashboard/screenshots/project_list_item_screenshot_test.dart
@@ -33,12 +33,12 @@ void main() {
   Future<void> pumpProjectListItem({
     required WidgetTester tester,
     required Project project,
+    required ThemeData theme,
     bool isSelected = false,
-    ThemeData? theme,
   }) async {
     await tester.pumpWidget(
       MaterialApp(
-        theme: theme ?? createTestTheme(),
+        theme: theme,
         locale: const Locale('en'),
         localizationsDelegates: AppLocalizations.localizationsDelegates,
         supportedLocales: AppLocalizations.supportedLocales,
@@ -60,18 +60,22 @@ void main() {
     await tester.pumpAndSettle();
   }
 
-  group('ProjectListItem Screenshot Tests - Light', () {
+  screenshotThemeGroups('ProjectListItem Screenshot Tests', (theme, suffix) {
     testWidgets('renders base project list item correctly', (tester) async {
       tester.view.physicalSize = size;
       tester.view.devicePixelRatio = ratio;
       addTearDown(tester.view.reset);
 
-      await pumpProjectListItem(tester: tester, project: buildProject());
+      await pumpProjectListItem(
+        tester: tester,
+        project: buildProject(),
+        theme: theme,
+      );
 
       await expectLater(
         find.byType(ProjectListItem),
         matchesGoldenFile(
-          'goldens/project_list_item/${size.width}x${size.height}/project_list_item_base.png',
+          'goldens/project_list_item/${size.width}x${size.height}/project_list_item_base$suffix.png',
         ),
       );
     });
@@ -85,12 +89,13 @@ void main() {
         tester: tester,
         project: buildProject(),
         isSelected: true,
+        theme: theme,
       );
 
       await expectLater(
         find.byType(ProjectListItem),
         matchesGoldenFile(
-          'goldens/project_list_item/${size.width}x${size.height}/project_list_item_selected.png',
+          'goldens/project_list_item/${size.width}x${size.height}/project_list_item_selected$suffix.png',
         ),
       );
     });
@@ -107,76 +112,13 @@ void main() {
         project: buildProject(
           projectName: 'Complete Home Renovation and Extension Project Phase 2',
         ),
+        theme: theme,
       );
 
       await expectLater(
         find.byType(ProjectListItem),
         matchesGoldenFile(
-          'goldens/project_list_item/${size.width}x${size.height}/project_list_item_long_name.png',
-        ),
-      );
-    });
-  });
-
-  group('ProjectListItem Screenshot Tests - Dark', () {
-    testWidgets('renders base project list item correctly', (tester) async {
-      tester.view.physicalSize = size;
-      tester.view.devicePixelRatio = ratio;
-      addTearDown(tester.view.reset);
-
-      await pumpProjectListItem(
-        tester: tester,
-        project: buildProject(),
-        theme: createTestThemeDark(),
-      );
-
-      await expectLater(
-        find.byType(ProjectListItem),
-        matchesGoldenFile(
-          'goldens/project_list_item/${size.width}x${size.height}/project_list_item_base_dark.png',
-        ),
-      );
-    });
-
-    testWidgets('renders selected project list item correctly', (tester) async {
-      tester.view.physicalSize = size;
-      tester.view.devicePixelRatio = ratio;
-      addTearDown(tester.view.reset);
-
-      await pumpProjectListItem(
-        tester: tester,
-        project: buildProject(),
-        isSelected: true,
-        theme: createTestThemeDark(),
-      );
-
-      await expectLater(
-        find.byType(ProjectListItem),
-        matchesGoldenFile(
-          'goldens/project_list_item/${size.width}x${size.height}/project_list_item_selected_dark.png',
-        ),
-      );
-    });
-
-    testWidgets('renders project list item with long name correctly', (
-      tester,
-    ) async {
-      tester.view.physicalSize = size;
-      tester.view.devicePixelRatio = ratio;
-      addTearDown(tester.view.reset);
-
-      await pumpProjectListItem(
-        tester: tester,
-        project: buildProject(
-          projectName: 'Complete Home Renovation and Extension Project Phase 2',
-        ),
-        theme: createTestThemeDark(),
-      );
-
-      await expectLater(
-        find.byType(ProjectListItem),
-        matchesGoldenFile(
-          'goldens/project_list_item/${size.width}x${size.height}/project_list_item_long_name_dark.png',
+          'goldens/project_list_item/${size.width}x${size.height}/project_list_item_long_name$suffix.png',
         ),
       );
     });

--- a/test/features/dashboard/screenshots/project_search_page_screenshot_test.dart
+++ b/test/features/dashboard/screenshots/project_search_page_screenshot_test.dart
@@ -79,11 +79,11 @@ void main() {
 
   Future<void> pumpProjectSearchPage({
     required WidgetTester tester,
-    ThemeData? theme,
+    required ThemeData theme,
   }) async {
     await tester.pumpWidget(
       MaterialApp(
-        theme: theme ?? createTestTheme(),
+        theme: theme,
         locale: const Locale('en'),
         localizationsDelegates: AppLocalizations.localizationsDelegates,
         supportedLocales: AppLocalizations.supportedLocales,
@@ -98,18 +98,21 @@ void main() {
     await tester.awaitImages();
   }
 
-  group('ProjectSearchPage Screenshot Tests - Light', () {
+  screenshotThemeGroups('ProjectSearchPage Screenshot Tests', (
+    theme,
+    suffix,
+  ) {
     testWidgets('renders default state correctly', (tester) async {
       tester.view.physicalSize = size;
       tester.view.devicePixelRatio = ratio;
       addTearDown(tester.view.reset);
 
-      await pumpProjectSearchPage(tester: tester);
+      await pumpProjectSearchPage(tester: tester, theme: theme);
 
       await expectLater(
         find.byType(ProjectSearchPage),
         matchesGoldenFile(
-          'goldens/$testName/${size.width}x${size.height}/${testName}_default.png',
+          'goldens/$testName/${size.width}x${size.height}/${testName}_default$suffix.png',
         ),
       );
     });
@@ -121,7 +124,7 @@ void main() {
       tester.view.devicePixelRatio = ratio;
       addTearDown(tester.view.reset);
 
-      await pumpProjectSearchPage(tester: tester);
+      await pumpProjectSearchPage(tester: tester, theme: theme);
 
       final textFieldFinder = find.descendant(
         of: find.byType(ProjectSearchPage),
@@ -134,7 +137,7 @@ void main() {
       await expectLater(
         find.byType(ProjectSearchPage),
         matchesGoldenFile(
-          'goldens/$testName/${size.width}x${size.height}/${testName}_with_search_text.png',
+          'goldens/$testName/${size.width}x${size.height}/${testName}_with_search_text$suffix.png',
         ),
       );
     });
@@ -157,12 +160,12 @@ void main() {
         },
       ]);
 
-      await pumpProjectSearchPage(tester: tester);
+      await pumpProjectSearchPage(tester: tester, theme: theme);
 
       await expectLater(
         find.byType(ProjectSearchPage),
         matchesGoldenFile(
-          'goldens/$testName/${size.width}x${size.height}/${testName}_with_recent_searches.png',
+          'goldens/$testName/${size.width}x${size.height}/${testName}_with_recent_searches$suffix.png',
         ),
       );
     });
@@ -177,7 +180,7 @@ void main() {
         ['Carpentry', 'Carparking cost', 'Plumbing'],
       );
 
-      await pumpProjectSearchPage(tester: tester);
+      await pumpProjectSearchPage(tester: tester, theme: theme);
 
       final searchField = find.byType(TextFormField);
       await tester.enterText(searchField, 'Car');
@@ -188,11 +191,16 @@ void main() {
       await expectLater(
         find.byType(ProjectSearchPage),
         matchesGoldenFile(
-          'goldens/$testName/${size.width}x${size.height}/${testName}_with_suggestions.png',
+          'goldens/$testName/${size.width}x${size.height}/${testName}_with_suggestions$suffix.png',
         ),
       );
     });
+  });
 
+  // The following scenarios only ever had a light golden; screenshotThemeGroups
+  // always produces both light and dark, so they stay outside it rather than
+  // gaining new dark goldens as a side effect of this migration.
+  group('ProjectSearchPage Screenshot Tests - Light Only', () {
     testWidgets('renders the chip row with an active tag filter correctly', (
       tester,
     ) async {
@@ -207,7 +215,7 @@ void main() {
         },
       ]);
 
-      await pumpProjectSearchPage(tester: tester);
+      await pumpProjectSearchPage(tester: tester, theme: createTestTheme());
 
       // Drive the real flow: open the Tags sheet, select a tag, apply — so the
       // golden captures the active-pill chip row users will actually see.
@@ -240,7 +248,7 @@ void main() {
       tester.view.devicePixelRatio = ratio;
       addTearDown(tester.view.reset);
 
-      await pumpProjectSearchPage(tester: tester);
+      await pumpProjectSearchPage(tester: tester, theme: createTestTheme());
 
       // The date sheet derives its presets from the wall clock and
       // CoreDateFilterChip exposes no `today` override, so drive the bloc
@@ -308,7 +316,7 @@ void main() {
         'members': <Map<String, dynamic>>[],
       });
 
-      await pumpProjectSearchPage(tester: tester);
+      await pumpProjectSearchPage(tester: tester, theme: createTestTheme());
 
       final textFieldFinder = find.descendant(
         of: find.byType(ProjectSearchPage),
@@ -324,103 +332,6 @@ void main() {
         find.byType(ProjectSearchPage),
         matchesGoldenFile(
           'goldens/$testName/${size.width}x${size.height}/${testName}_with_search_results.png',
-        ),
-      );
-    });
-  });
-
-  group('ProjectSearchPage Screenshot Tests - Dark', () {
-    testWidgets('renders default state correctly', (tester) async {
-      tester.view.physicalSize = size;
-      tester.view.devicePixelRatio = ratio;
-      addTearDown(tester.view.reset);
-
-      await pumpProjectSearchPage(tester: tester, theme: createTestThemeDark());
-
-      await expectLater(
-        find.byType(ProjectSearchPage),
-        matchesGoldenFile(
-          'goldens/$testName/${size.width}x${size.height}/${testName}_default_dark.png',
-        ),
-      );
-    });
-
-    testWidgets(
-      'renders with search text and clear button visible correctly',
-      (tester) async {
-        tester.view.physicalSize = size;
-        tester.view.devicePixelRatio = ratio;
-        addTearDown(tester.view.reset);
-
-        await pumpProjectSearchPage(tester: tester, theme: createTestThemeDark());
-
-        final textFieldFinder = find.descendant(
-          of: find.byType(ProjectSearchPage),
-          matching: find.byType(TextFormField),
-        );
-        await tester.enterText(textFieldFinder, 'wall');
-        await tester.pumpAndSettle();
-        expect(find.text('wall'), findsOneWidget);
-
-        await expectLater(
-          find.byType(ProjectSearchPage),
-          matchesGoldenFile(
-            'goldens/$testName/${size.width}x${size.height}/${testName}_with_search_text_dark.png',
-          ),
-        );
-      },
-    );
-
-    testWidgets('renders with recent searches correctly', (tester) async {
-      tester.view.physicalSize = size;
-      tester.view.devicePixelRatio = ratio;
-      addTearDown(tester.view.reset);
-
-      fakeSupabase.addTableData(DatabaseConstants.projectSearchHistoryTable, [
-        {
-          DatabaseConstants.userIdColumn: _testUserId,
-          DatabaseConstants.searchTermColumn: 'foundation',
-          DatabaseConstants.updatedAtColumn: '2024-06-01T00:00:00.000Z',
-        },
-        {
-          DatabaseConstants.userIdColumn: _testUserId,
-          DatabaseConstants.searchTermColumn: 'wall',
-          DatabaseConstants.updatedAtColumn: '2024-05-01T00:00:00.000Z',
-        },
-      ]);
-
-      await pumpProjectSearchPage(tester: tester, theme: createTestThemeDark());
-
-      await expectLater(
-        find.byType(ProjectSearchPage),
-        matchesGoldenFile(
-          'goldens/$testName/${size.width}x${size.height}/${testName}_with_recent_searches_dark.png',
-        ),
-      );
-    });
-
-    testWidgets('renders with suggestions correctly', (tester) async {
-      tester.view.physicalSize = size;
-      tester.view.devicePixelRatio = ratio;
-      addTearDown(tester.view.reset);
-
-      fakeSupabase.setRpcResponse(
-        DatabaseConstants.projectSearchSuggestionsRpcFunction,
-        ['Carpentry', 'Carparking cost', 'Plumbing'],
-      );
-
-      await pumpProjectSearchPage(tester: tester, theme: createTestThemeDark());
-
-      final searchField = find.byType(TextFormField);
-      await tester.enterText(searchField, 'Car');
-      await tester.pump(const Duration(milliseconds: 400));
-      await tester.pumpAndSettle();
-      await tester.awaitImages();
-
-      await expectLater(
-        find.byType(ProjectSearchPage),
-        matchesGoldenFile(
-          'goldens/$testName/${size.width}x${size.height}/${testName}_with_suggestions_dark.png',
         ),
       );
     });

--- a/test/features/dashboard/screenshots/projects_bottom_sheet_screenshot_test.dart
+++ b/test/features/dashboard/screenshots/projects_bottom_sheet_screenshot_test.dart
@@ -38,7 +38,10 @@ void main() {
     harness.tearDown();
   });
 
-  group('ProjectsBottomSheet Screenshot Tests - Light', () {
+  screenshotThemeGroups('ProjectsBottomSheet Screenshot Tests', (
+    theme,
+    suffix,
+  ) {
     testWidgets('renders loaded project list', (tester) async {
       tester.view.physicalSize = size;
       tester.view.devicePixelRatio = ratio;
@@ -54,12 +57,13 @@ void main() {
       await harness.pumpSheet(
         tester,
         extraPump: const Duration(milliseconds: 100),
+        theme: theme,
       );
 
       await expectLater(
         find.byType(ProjectsBottomSheet),
         matchesGoldenFile(
-          'goldens/projects_bottom_sheet/${size.width}x${size.height}/projects_bottom_sheet_loaded.png',
+          'goldens/projects_bottom_sheet/${size.width}x${size.height}/projects_bottom_sheet_loaded$suffix.png',
         ),
       );
     });
@@ -74,60 +78,13 @@ void main() {
       await harness.pumpSheet(
         tester,
         extraPump: const Duration(milliseconds: 100),
+        theme: theme,
       );
 
       await expectLater(
         find.byType(ProjectsBottomSheet),
         matchesGoldenFile(
-          'goldens/projects_bottom_sheet/${size.width}x${size.height}/projects_bottom_sheet_empty.png',
-        ),
-      );
-    });
-  });
-
-  group('ProjectsBottomSheet Screenshot Tests - Dark', () {
-    testWidgets('renders loaded project list', (tester) async {
-      tester.view.physicalSize = size;
-      tester.view.devicePixelRatio = ratio;
-      addTearDown(tester.view.reset);
-
-      harness.fakeRepository.setAccessibleProjects([
-        buildProject(id: 'project-1', projectName: 'My project'),
-        buildProject(id: 'project-2', projectName: 'Material of building'),
-        buildProject(id: 'project-3', projectName: 'MD bungalow'),
-      ]);
-
-      await harness.pumpSheet(
-        tester,
-        extraPump: const Duration(milliseconds: 100),
-        theme: createTestThemeDark(),
-      );
-
-      await expectLater(
-        find.byType(ProjectsBottomSheet),
-        matchesGoldenFile(
-          'goldens/projects_bottom_sheet/${size.width}x${size.height}/projects_bottom_sheet_loaded_dark.png',
-        ),
-      );
-    });
-
-    testWidgets('renders empty state', (tester) async {
-      tester.view.physicalSize = size;
-      tester.view.devicePixelRatio = ratio;
-      addTearDown(tester.view.reset);
-
-      harness.fakeRepository.setAccessibleProjects([]);
-
-      await harness.pumpSheet(
-        tester,
-        extraPump: const Duration(milliseconds: 100),
-        theme: createTestThemeDark(),
-      );
-
-      await expectLater(
-        find.byType(ProjectsBottomSheet),
-        matchesGoldenFile(
-          'goldens/projects_bottom_sheet/${size.width}x${size.height}/projects_bottom_sheet_empty_dark.png',
+          'goldens/projects_bottom_sheet/${size.width}x${size.height}/projects_bottom_sheet_empty$suffix.png',
         ),
       );
     });


### PR DESCRIPTION
### 1. PR SUMMARY
Migrates the 8 screenshot tests in `test/features/dashboard/screenshots/` off the old manual dual-theme pattern onto the `screenshotThemeGroups` helper (CA-847).

Two files needed special handling:
- `favorites_section_screenshot_test.dart` covers two widgets under test (`FavoritesSection`, `FavouriteSortBottomSheet`), so it uses two separate `screenshotThemeGroups` calls, one per widget.
- `project_search_page_screenshot_test.dart` has 3 scenarios (active tag filter, active date filter, search results) that only ever had a light golden — these stay outside the helper so the migration doesn't invent new dark goldens as a side effect. The 4 scenarios with existing light+dark coverage were migrated normally.

Third PR in the CA-914 migration series (3/9), stacked on 2/9. CA-968 (bump `ripplearc_linter` to pull in the `forbid_manual_screenshot_theme` rule this migration satisfies) is stacked on top of the full series, after PR 9/9.

### 2. REVIEW SUMMARY TABLE
No issues found.

## Test plan
- [x] `fvm flutter test test/features/dashboard/screenshots/` — all 51 tests pass
- [x] `fvm dart run custom_lint` — clean (pre-existing unrelated issue in `fake_router.dart` confirmed present on `main`)
- [ ] Reviewer: visually confirm goldens render correctly for both themes