### PR TITLE
CA-914 (4/9): migrate estimations (part A) screenshot tests to screenshotThemeGroups

### DIFF
--- a/test/features/estimations/screenshots/cost_estimation_details_tab_view_screenshot_test.dart
+++ b/test/features/estimations/screenshots/cost_estimation_details_tab_view_screenshot_test.dart
@@ -14,12 +14,12 @@ void main() {
 
   Future<void> pumpTabView({
     required WidgetTester tester,
+    required ThemeData theme,
     int selectedTab = 0,
-    ThemeData? theme,
   }) async {
     await tester.pumpWidget(
       MaterialApp(
-        theme: theme ?? createTestTheme(),
+        theme: theme,
         locale: const Locale('en'),
         localizationsDelegates: AppLocalizations.localizationsDelegates,
         supportedLocales: AppLocalizations.supportedLocales,
@@ -49,17 +49,20 @@ void main() {
     await loadAppFontsAll();
   });
 
-  group('CostEstimationDetailsTabView Screenshot Tests - Light', () {
+  screenshotThemeGroups('CostEstimationDetailsTabView Screenshot Tests', (
+    theme,
+    suffix,
+  ) {
     testWidgets('renders materials tab correctly', (tester) async {
       tester.view.physicalSize = size;
       tester.view.devicePixelRatio = 1.0;
       addTearDown(tester.view.reset);
-      await pumpTabView(tester: tester, selectedTab: 0);
+      await pumpTabView(tester: tester, selectedTab: 0, theme: theme);
 
       await expectLater(
         find.byType(Scaffold),
         matchesGoldenFile(
-          'goldens/cost_estimation_details_tab_view/${size.width}x${size.height}/materials_tab.png',
+          'goldens/cost_estimation_details_tab_view/${size.width}x${size.height}/materials_tab$suffix.png',
         ),
       );
     });
@@ -68,12 +71,12 @@ void main() {
       tester.view.physicalSize = size;
       tester.view.devicePixelRatio = 1.0;
       addTearDown(tester.view.reset);
-      await pumpTabView(tester: tester, selectedTab: 1);
+      await pumpTabView(tester: tester, selectedTab: 1, theme: theme);
 
       await expectLater(
         find.byType(Scaffold),
         matchesGoldenFile(
-          'goldens/cost_estimation_details_tab_view/${size.width}x${size.height}/labours_tab.png',
+          'goldens/cost_estimation_details_tab_view/${size.width}x${size.height}/labours_tab$suffix.png',
         ),
       );
     });
@@ -82,56 +85,12 @@ void main() {
       tester.view.physicalSize = size;
       tester.view.devicePixelRatio = 1.0;
       addTearDown(tester.view.reset);
-      await pumpTabView(tester: tester, selectedTab: 2);
+      await pumpTabView(tester: tester, selectedTab: 2, theme: theme);
 
       await expectLater(
         find.byType(Scaffold),
         matchesGoldenFile(
-          'goldens/cost_estimation_details_tab_view/${size.width}x${size.height}/equipments_tab.png',
-        ),
-      );
-    });
-  });
-
-  group('CostEstimationDetailsTabView Screenshot Tests - Dark', () {
-    testWidgets('renders materials tab correctly', (tester) async {
-      tester.view.physicalSize = size;
-      tester.view.devicePixelRatio = 1.0;
-      addTearDown(tester.view.reset);
-      await pumpTabView(tester: tester, selectedTab: 0, theme: createTestThemeDark());
-
-      await expectLater(
-        find.byType(Scaffold),
-        matchesGoldenFile(
-          'goldens/cost_estimation_details_tab_view/${size.width}x${size.height}/materials_tab_dark.png',
-        ),
-      );
-    });
-
-    testWidgets('renders labours tab correctly', (tester) async {
-      tester.view.physicalSize = size;
-      tester.view.devicePixelRatio = 1.0;
-      addTearDown(tester.view.reset);
-      await pumpTabView(tester: tester, selectedTab: 1, theme: createTestThemeDark());
-
-      await expectLater(
-        find.byType(Scaffold),
-        matchesGoldenFile(
-          'goldens/cost_estimation_details_tab_view/${size.width}x${size.height}/labours_tab_dark.png',
-        ),
-      );
-    });
-
-    testWidgets('renders equipments tab correctly', (tester) async {
-      tester.view.physicalSize = size;
-      tester.view.devicePixelRatio = 1.0;
-      addTearDown(tester.view.reset);
-      await pumpTabView(tester: tester, selectedTab: 2, theme: createTestThemeDark());
-
-      await expectLater(
-        find.byType(Scaffold),
-        matchesGoldenFile(
-          'goldens/cost_estimation_details_tab_view/${size.width}x${size.height}/equipments_tab_dark.png',
+          'goldens/cost_estimation_details_tab_view/${size.width}x${size.height}/equipments_tab$suffix.png',
         ),
       );
     });

--- a/test/features/estimations/screenshots/cost_estimation_empty_page_screenshot_test.dart
+++ b/test/features/estimations/screenshots/cost_estimation_empty_page_screenshot_test.dart
@@ -12,12 +12,12 @@ void main() {
 
   Future<void> pumpCostEstimationEmptyPage({
     required WidgetTester tester,
+    required ThemeData theme,
     String? message,
-    ThemeData? theme,
   }) async {
     await tester.pumpWidget(
       MaterialApp(
-        theme: theme ?? createTestTheme(),
+        theme: theme,
         home: Builder(
           builder: (ctx) => Scaffold(
             backgroundColor: ctx.colorTheme.pageBackground,
@@ -37,7 +37,10 @@ void main() {
     await loadAppFontsAll();
   });
 
-  group('CostEstimationEmptyPage Screenshot Tests - Light', () {
+  screenshotThemeGroups('CostEstimationEmptyPage Screenshot Tests', (
+    theme,
+    suffix,
+  ) {
     testWidgets('renders with custom message correctly', (tester) async {
       tester.view.physicalSize = size;
       tester.view.devicePixelRatio = ratio;
@@ -45,12 +48,13 @@ void main() {
       await pumpCostEstimationEmptyPage(
         tester: tester,
         message: 'No data available. Please add some content to get started.',
+        theme: theme,
       );
 
       await expectLater(
         find.byType(Scaffold),
         matchesGoldenFile(
-          'goldens/cost_estimation_empty_widget/${size.width}x${size.height}/cost_estimation_empty_widget_custom_message.png',
+          'goldens/cost_estimation_empty_widget/${size.width}x${size.height}/cost_estimation_empty_widget_custom_message$suffix.png',
         ),
       );
     });
@@ -63,51 +67,13 @@ void main() {
         tester: tester,
         message:
             'This is a very long message that should wrap to multiple lines and demonstrate how the widget handles text overflow and proper spacing between elements.',
+        theme: theme,
       );
 
       await expectLater(
         find.byType(Scaffold),
         matchesGoldenFile(
-          'goldens/cost_estimation_empty_widget/${size.width}x${size.height}/cost_estimation_empty_widget_long_message.png',
-        ),
-      );
-    });
-  });
-
-  group('CostEstimationEmptyPage Screenshot Tests - Dark', () {
-    testWidgets('renders with custom message correctly', (tester) async {
-      tester.view.physicalSize = size;
-      tester.view.devicePixelRatio = ratio;
-      addTearDown(tester.view.reset);
-      await pumpCostEstimationEmptyPage(
-        tester: tester,
-        message: 'No data available. Please add some content to get started.',
-        theme: createTestThemeDark(),
-      );
-
-      await expectLater(
-        find.byType(Scaffold),
-        matchesGoldenFile(
-          'goldens/cost_estimation_empty_widget/${size.width}x${size.height}/cost_estimation_empty_widget_custom_message_dark.png',
-        ),
-      );
-    });
-
-    testWidgets('renders with long message correctly', (tester) async {
-      tester.view.physicalSize = size;
-      tester.view.devicePixelRatio = ratio;
-      addTearDown(tester.view.reset);
-      await pumpCostEstimationEmptyPage(
-        tester: tester,
-        message:
-            'This is a very long message that should wrap to multiple lines and demonstrate how the widget handles text overflow and proper spacing between elements.',
-        theme: createTestThemeDark(),
-      );
-
-      await expectLater(
-        find.byType(Scaffold),
-        matchesGoldenFile(
-          'goldens/cost_estimation_empty_widget/${size.width}x${size.height}/cost_estimation_empty_widget_long_message_dark.png',
+          'goldens/cost_estimation_empty_widget/${size.width}x${size.height}/cost_estimation_empty_widget_long_message$suffix.png',
         ),
       );
     });

--- a/test/features/estimations/screenshots/cost_estimation_log_tile_screenshot_test.dart
+++ b/test/features/estimations/screenshots/cost_estimation_log_tile_screenshot_test.dart
@@ -21,11 +21,11 @@ void main() {
   Future<void> pumpLogTile({
     required WidgetTester tester,
     required CostEstimationLog log,
-    ThemeData? theme,
+    required ThemeData theme,
   }) async {
     await tester.pumpWidget(
       MaterialApp(
-        theme: theme ?? createTestTheme(),
+        theme: theme,
         locale: const Locale('en'),
         localizationsDelegates: AppLocalizations.localizationsDelegates,
         supportedLocales: AppLocalizations.supportedLocales,
@@ -72,7 +72,10 @@ void main() {
     );
   }
 
-  group('CostEstimationLogTile Screenshot Tests - Light', () {
+  screenshotThemeGroups('CostEstimationLogTile Screenshot Tests', (
+    theme,
+    suffix,
+  ) {
     testWidgets('renders estimation created activity correctly', (
       tester,
     ) async {
@@ -87,12 +90,12 @@ void main() {
         loggedAt: DateTime(2025, 4, 22, 12, 3),
       );
 
-      await pumpLogTile(tester: tester, log: log);
+      await pumpLogTile(tester: tester, log: log, theme: theme);
 
       await expectLater(
         find.byType(CostEstimationLogTile),
         matchesGoldenFile(
-          'goldens/cost_estimation_log_tile/${size.width}x${size.height}/log_tile_created.png',
+          'goldens/cost_estimation_log_tile/${size.width}x${size.height}/log_tile_created$suffix.png',
         ),
       );
     });
@@ -112,12 +115,12 @@ void main() {
         activityDetails: {'fileName': 'materials.xlsx'},
       );
 
-      await pumpLogTile(tester: tester, log: log);
+      await pumpLogTile(tester: tester, log: log, theme: theme);
 
       await expectLater(
         find.byType(CostEstimationLogTile),
         matchesGoldenFile(
-          'goldens/cost_estimation_log_tile/${size.width}x${size.height}/log_tile_file_uploaded.png',
+          'goldens/cost_estimation_log_tile/${size.width}x${size.height}/log_tile_file_uploaded$suffix.png',
         ),
       );
     });
@@ -140,12 +143,12 @@ void main() {
         },
       );
 
-      await pumpLogTile(tester: tester, log: log);
+      await pumpLogTile(tester: tester, log: log, theme: theme);
 
       await expectLater(
         find.byType(CostEstimationLogTile),
         matchesGoldenFile(
-          'goldens/cost_estimation_log_tile/390.0x120.0/log_tile_renamed.png',
+          'goldens/cost_estimation_log_tile/390.0x120.0/log_tile_renamed$suffix.png',
         ),
       );
     });
@@ -162,12 +165,12 @@ void main() {
         loggedAt: DateTime(2025, 5, 1, 14, 20),
       );
 
-      await pumpLogTile(tester: tester, log: log);
+      await pumpLogTile(tester: tester, log: log, theme: theme);
 
       await expectLater(
         find.byType(CostEstimationLogTile),
         matchesGoldenFile(
-          'goldens/cost_estimation_log_tile/${size.width}x${size.height}/log_tile_locked.png',
+          'goldens/cost_estimation_log_tile/${size.width}x${size.height}/log_tile_locked$suffix.png',
         ),
       );
     });
@@ -190,12 +193,12 @@ void main() {
         },
       );
 
-      await pumpLogTile(tester: tester, log: log);
+      await pumpLogTile(tester: tester, log: log, theme: theme);
 
       await expectLater(
         find.byType(CostEstimationLogTile),
         matchesGoldenFile(
-          'goldens/cost_estimation_log_tile/390.0x120.0/log_tile_item_added.png',
+          'goldens/cost_estimation_log_tile/390.0x120.0/log_tile_item_added$suffix.png',
         ),
       );
     });
@@ -218,12 +221,12 @@ void main() {
         },
       );
 
-      await pumpLogTile(tester: tester, log: log);
+      await pumpLogTile(tester: tester, log: log, theme: theme);
 
       await expectLater(
         find.byType(CostEstimationLogTile),
         matchesGoldenFile(
-          'goldens/cost_estimation_log_tile/390.0x120.0/log_tile_task_assigned.png',
+          'goldens/cost_estimation_log_tile/390.0x120.0/log_tile_task_assigned$suffix.png',
         ),
       );
     });
@@ -243,12 +246,12 @@ void main() {
         activityDetails: {'format': 'PDF'},
       );
 
-      await pumpLogTile(tester: tester, log: log);
+      await pumpLogTile(tester: tester, log: log, theme: theme);
 
       await expectLater(
         find.byType(CostEstimationLogTile),
         matchesGoldenFile(
-          'goldens/cost_estimation_log_tile/390.0x120.0/log_tile_exported.png',
+          'goldens/cost_estimation_log_tile/390.0x120.0/log_tile_exported$suffix.png',
         ),
       );
     });
@@ -268,12 +271,12 @@ void main() {
         loggedAt: DateTime(2025, 8, 18, 13, 30),
       );
 
-      await pumpLogTile(tester: tester, log: log);
+      await pumpLogTile(tester: tester, log: log, theme: theme);
 
       await expectLater(
         find.byType(CostEstimationLogTile),
         matchesGoldenFile(
-          'goldens/cost_estimation_log_tile/${size.width}x${size.height}/log_tile_long_name.png',
+          'goldens/cost_estimation_log_tile/${size.width}x${size.height}/log_tile_long_name$suffix.png',
         ),
       );
     });
@@ -291,12 +294,12 @@ void main() {
         activityDetails: {'fileName': 'blueprint_v2.pdf'},
       );
 
-      await pumpLogTile(tester: tester, log: log);
+      await pumpLogTile(tester: tester, log: log, theme: theme);
 
       await expectLater(
         find.byType(CostEstimationLogTile),
         matchesGoldenFile(
-          'goldens/cost_estimation_log_tile/${size.width}x${size.height}/log_tile_attachment_added.png',
+          'goldens/cost_estimation_log_tile/${size.width}x${size.height}/log_tile_attachment_added$suffix.png',
         ),
       );
     });
@@ -317,12 +320,12 @@ void main() {
         },
       );
 
-      await pumpLogTile(tester: tester, log: log);
+      await pumpLogTile(tester: tester, log: log, theme: theme);
 
       await expectLater(
         find.byType(CostEstimationLogTile),
         matchesGoldenFile(
-          'goldens/cost_estimation_log_tile/390.0x120.0/log_tile_item_removed.png',
+          'goldens/cost_estimation_log_tile/390.0x120.0/log_tile_item_removed$suffix.png',
         ),
       );
     });
@@ -346,297 +349,12 @@ void main() {
         },
       );
 
-      await pumpLogTile(tester: tester, log: log);
+      await pumpLogTile(tester: tester, log: log, theme: theme);
 
       await expectLater(
         find.byType(CostEstimationLogTile),
         matchesGoldenFile(
-          'goldens/cost_estimation_log_tile/390.0x140.0/log_tile_item_edited.png',
-        ),
-      );
-    });
-  });
-
-  group('CostEstimationLogTile Screenshot Tests - Dark', () {
-    testWidgets('renders estimation created activity correctly', (
-      tester,
-    ) async {
-      tester.view.physicalSize = size;
-      tester.view.devicePixelRatio = ratio;
-      addTearDown(tester.view.reset);
-
-      final user = createTestUser(firstName: 'Mahesh', lastName: 'Kumar');
-      final log = createTestLog(
-        activity: CostEstimationActivityType.costEstimationCreated,
-        user: user,
-        loggedAt: DateTime(2025, 4, 22, 12, 3),
-      );
-
-      await pumpLogTile(tester: tester, log: log, theme: createTestThemeDark());
-
-      await expectLater(
-        find.byType(CostEstimationLogTile),
-        matchesGoldenFile(
-          'goldens/cost_estimation_log_tile/${size.width}x${size.height}/log_tile_created_dark.png',
-        ),
-      );
-    });
-
-    testWidgets('renders cost file uploaded activity correctly', (
-      tester,
-    ) async {
-      tester.view.physicalSize = size;
-      tester.view.devicePixelRatio = ratio;
-      addTearDown(tester.view.reset);
-
-      final user = createTestUser(firstName: 'Mahesh', lastName: 'Kumar');
-      final log = createTestLog(
-        activity: CostEstimationActivityType.costFileUploaded,
-        user: user,
-        loggedAt: DateTime(2025, 4, 22, 12, 3),
-        activityDetails: {'fileName': 'materials.xlsx'},
-      );
-
-      await pumpLogTile(tester: tester, log: log, theme: createTestThemeDark());
-
-      await expectLater(
-        find.byType(CostEstimationLogTile),
-        matchesGoldenFile(
-          'goldens/cost_estimation_log_tile/${size.width}x${size.height}/log_tile_file_uploaded_dark.png',
-        ),
-      );
-    });
-
-    testWidgets('renders renamed activity with details correctly', (
-      tester,
-    ) async {
-      tester.view.physicalSize = const Size(390.0, 120.0);
-      tester.view.devicePixelRatio = ratio;
-      addTearDown(tester.view.reset);
-
-      final user = createTestUser(firstName: 'John', lastName: 'Smith');
-      final log = createTestLog(
-        activity: CostEstimationActivityType.costEstimationRenamed,
-        user: user,
-        loggedAt: DateTime(2025, 3, 15, 10, 30),
-        activityDetails: {
-          'oldName': 'Old Project',
-          'newName': 'Renovated Building',
-        },
-      );
-
-      await pumpLogTile(tester: tester, log: log, theme: createTestThemeDark());
-
-      await expectLater(
-        find.byType(CostEstimationLogTile),
-        matchesGoldenFile(
-          'goldens/cost_estimation_log_tile/390.0x120.0/log_tile_renamed_dark.png',
-        ),
-      );
-    });
-
-    testWidgets('renders locked activity correctly', (tester) async {
-      tester.view.physicalSize = size;
-      tester.view.devicePixelRatio = ratio;
-      addTearDown(tester.view.reset);
-
-      final user = createTestUser(firstName: 'Alice', lastName: 'Johnson');
-      final log = createTestLog(
-        activity: CostEstimationActivityType.costEstimationLocked,
-        user: user,
-        loggedAt: DateTime(2025, 5, 1, 14, 20),
-      );
-
-      await pumpLogTile(tester: tester, log: log, theme: createTestThemeDark());
-
-      await expectLater(
-        find.byType(CostEstimationLogTile),
-        matchesGoldenFile(
-          'goldens/cost_estimation_log_tile/${size.width}x${size.height}/log_tile_locked_dark.png',
-        ),
-      );
-    });
-
-    testWidgets('renders cost item added activity with details correctly', (
-      tester,
-    ) async {
-      tester.view.physicalSize = const Size(390.0, 120.0);
-      tester.view.devicePixelRatio = ratio;
-      addTearDown(tester.view.reset);
-
-      final user = createTestUser(firstName: 'Bob', lastName: 'Williams');
-      final log = createTestLog(
-        activity: CostEstimationActivityType.costItemAdded,
-        user: user,
-        loggedAt: DateTime(2025, 2, 10, 9, 15),
-        activityDetails: {
-          'itemName': 'Concrete Foundation',
-          'itemType': 'Material',
-        },
-      );
-
-      await pumpLogTile(tester: tester, log: log, theme: createTestThemeDark());
-
-      await expectLater(
-        find.byType(CostEstimationLogTile),
-        matchesGoldenFile(
-          'goldens/cost_estimation_log_tile/390.0x120.0/log_tile_item_added_dark.png',
-        ),
-      );
-    });
-
-    testWidgets('renders task assigned activity with details correctly', (
-      tester,
-    ) async {
-      tester.view.physicalSize = const Size(390.0, 120.0);
-      tester.view.devicePixelRatio = ratio;
-      addTearDown(tester.view.reset);
-
-      final user = createTestUser(firstName: 'Sarah', lastName: 'Davis');
-      final log = createTestLog(
-        activity: CostEstimationActivityType.taskAssigned,
-        user: user,
-        loggedAt: DateTime(2025, 6, 5, 11, 45),
-        activityDetails: {
-          'taskName': 'Review Budget',
-          'assigneeName': 'Mike Thompson',
-        },
-      );
-
-      await pumpLogTile(tester: tester, log: log, theme: createTestThemeDark());
-
-      await expectLater(
-        find.byType(CostEstimationLogTile),
-        matchesGoldenFile(
-          'goldens/cost_estimation_log_tile/390.0x120.0/log_tile_task_assigned_dark.png',
-        ),
-      );
-    });
-
-    testWidgets('renders exported activity with format correctly', (
-      tester,
-    ) async {
-      tester.view.physicalSize = const Size(390.0, 120.0);
-      tester.view.devicePixelRatio = ratio;
-      addTearDown(tester.view.reset);
-
-      final user = createTestUser(firstName: 'Emma', lastName: 'Brown');
-      final log = createTestLog(
-        activity: CostEstimationActivityType.costEstimationExported,
-        user: user,
-        loggedAt: DateTime(2025, 7, 12, 16, 0),
-        activityDetails: {'format': 'PDF'},
-      );
-
-      await pumpLogTile(tester: tester, log: log, theme: createTestThemeDark());
-
-      await expectLater(
-        find.byType(CostEstimationLogTile),
-        matchesGoldenFile(
-          'goldens/cost_estimation_log_tile/390.0x120.0/log_tile_exported_dark.png',
-        ),
-      );
-    });
-
-    testWidgets('renders user with long name correctly', (tester) async {
-      tester.view.physicalSize = size;
-      tester.view.devicePixelRatio = ratio;
-      addTearDown(tester.view.reset);
-
-      final user = createTestUser(
-        firstName: 'Christopher',
-        lastName: 'Montgomery-Wellington',
-      );
-      final log = createTestLog(
-        activity: CostEstimationActivityType.costEstimationUnlocked,
-        user: user,
-        loggedAt: DateTime(2025, 8, 18, 13, 30),
-      );
-
-      await pumpLogTile(tester: tester, log: log, theme: createTestThemeDark());
-
-      await expectLater(
-        find.byType(CostEstimationLogTile),
-        matchesGoldenFile(
-          'goldens/cost_estimation_log_tile/${size.width}x${size.height}/log_tile_long_name_dark.png',
-        ),
-      );
-    });
-
-    testWidgets('renders attachment added activity correctly', (tester) async {
-      tester.view.physicalSize = size;
-      tester.view.devicePixelRatio = ratio;
-      addTearDown(tester.view.reset);
-
-      final user = createTestUser(firstName: 'David', lastName: 'Miller');
-      final log = createTestLog(
-        activity: CostEstimationActivityType.attachmentAdded,
-        user: user,
-        loggedAt: DateTime(2025, 9, 25, 15, 10),
-        activityDetails: {'fileName': 'blueprint_v2.pdf'},
-      );
-
-      await pumpLogTile(tester: tester, log: log, theme: createTestThemeDark());
-
-      await expectLater(
-        find.byType(CostEstimationLogTile),
-        matchesGoldenFile(
-          'goldens/cost_estimation_log_tile/${size.width}x${size.height}/log_tile_attachment_added_dark.png',
-        ),
-      );
-    });
-
-    testWidgets('renders cost item removed activity correctly', (tester) async {
-      tester.view.physicalSize = const Size(390.0, 120.0);
-      tester.view.devicePixelRatio = ratio;
-      addTearDown(tester.view.reset);
-
-      final user = createTestUser(firstName: 'Lisa', lastName: 'Anderson');
-      final log = createTestLog(
-        activity: CostEstimationActivityType.costItemRemoved,
-        user: user,
-        loggedAt: DateTime(2025, 10, 30, 10, 5),
-        activityDetails: {
-          'itemName': 'Temporary Scaffolding',
-          'itemType': 'Equipment',
-        },
-      );
-
-      await pumpLogTile(tester: tester, log: log, theme: createTestThemeDark());
-
-      await expectLater(
-        find.byType(CostEstimationLogTile),
-        matchesGoldenFile(
-          'goldens/cost_estimation_log_tile/390.0x120.0/log_tile_item_removed_dark.png',
-        ),
-      );
-    });
-
-    testWidgets('renders cost item edited activity correctly', (tester) async {
-      tester.view.physicalSize = const Size(390.0, 140.0);
-      tester.view.devicePixelRatio = ratio;
-      addTearDown(tester.view.reset);
-
-      final user = createTestUser(firstName: 'Mike', lastName: 'Wilson');
-      final log = createTestLog(
-        activity: CostEstimationActivityType.costItemEdited,
-        user: user,
-        loggedAt: DateTime(2025, 11, 15, 14, 25),
-        activityDetails: {
-          'itemName': 'Steel Beams',
-          'editedFields': {
-            'quantity': {'oldValue': 10, 'newValue': 15},
-            'unit_price': {'oldValue': 150.0, 'newValue': 175.0},
-          },
-        },
-      );
-
-      await pumpLogTile(tester: tester, log: log, theme: createTestThemeDark());
-
-      await expectLater(
-        find.byType(CostEstimationLogTile),
-        matchesGoldenFile(
-          'goldens/cost_estimation_log_tile/390.0x140.0/log_tile_item_edited_dark.png',
+          'goldens/cost_estimation_log_tile/390.0x140.0/log_tile_item_edited$suffix.png',
         ),
       );
     });

--- a/test/features/estimations/screenshots/cost_estimation_logs_list_screenshot_test.dart
+++ b/test/features/estimations/screenshots/cost_estimation_logs_list_screenshot_test.dart
@@ -56,13 +56,16 @@ void main() {
     fakeSupabase.addTableData(DatabaseConstants.costEstimationLogsTable, rows);
   }
 
-  Future<void> pumpLogsList(WidgetTester tester, {ThemeData? theme}) async {
+  Future<void> pumpLogsList(
+    WidgetTester tester, {
+    required ThemeData theme,
+  }) async {
     final bloc = Modular.get<CostEstimationLogBloc>();
     addTearDown(bloc.close);
 
     await tester.pumpWidget(
       MaterialApp(
-        theme: theme ?? createTestTheme(),
+        theme: theme,
         locale: const Locale('en'),
         localizationsDelegates: AppLocalizations.localizationsDelegates,
         supportedLocales: AppLocalizations.supportedLocales,
@@ -82,19 +85,22 @@ void main() {
     );
   }
 
-  group('CostEstimationLogsList Screenshot Tests - Light', () {
+  screenshotThemeGroups('CostEstimationLogsList Screenshot Tests', (
+    theme,
+    suffix,
+  ) {
     testWidgets('empty state', (tester) async {
       tester.view.physicalSize = size;
       tester.view.devicePixelRatio = ratio;
       addTearDown(tester.view.reset);
 
-      await pumpLogsList(tester);
+      await pumpLogsList(tester, theme: theme);
       await tester.pumpAndSettle();
 
       await expectLater(
         find.byType(Scaffold),
         matchesGoldenFile(
-          'goldens/cost_estimation_logs_list/${size.width}x${size.height}/logs_list_empty.png',
+          'goldens/cost_estimation_logs_list/${size.width}x${size.height}/logs_list_empty$suffix.png',
         ),
       );
     });
@@ -121,13 +127,13 @@ void main() {
         ),
       ]);
 
-      await pumpLogsList(tester);
+      await pumpLogsList(tester, theme: theme);
       await tester.pumpAndSettle();
 
       await expectLater(
         find.byType(Scaffold),
         matchesGoldenFile(
-          'goldens/cost_estimation_logs_list/${size.width}x${size.height}/logs_list_loaded.png',
+          'goldens/cost_estimation_logs_list/${size.width}x${size.height}/logs_list_loaded$suffix.png',
         ),
       );
     });
@@ -145,7 +151,7 @@ void main() {
         ),
       );
 
-      await pumpLogsList(tester);
+      await pumpLogsList(tester, theme: theme);
       await tester.pumpAndSettle();
 
       fakeSupabase.shouldThrowOnSelectPaginated = true;
@@ -167,98 +173,7 @@ void main() {
       await expectLater(
         find.byType(Scaffold),
         matchesGoldenFile(
-          'goldens/cost_estimation_logs_list/${size.width}x${size.height}/logs_list_load_more_error.png',
-        ),
-      );
-    });
-  });
-
-  group('CostEstimationLogsList Screenshot Tests - Dark', () {
-    testWidgets('empty state', (tester) async {
-      tester.view.physicalSize = size;
-      tester.view.devicePixelRatio = ratio;
-      addTearDown(tester.view.reset);
-
-      await pumpLogsList(tester, theme: createTestThemeDark());
-      await tester.pumpAndSettle();
-
-      await expectLater(
-        find.byType(Scaffold),
-        matchesGoldenFile(
-          'goldens/cost_estimation_logs_list/${size.width}x${size.height}/logs_list_empty_dark.png',
-        ),
-      );
-    });
-
-    testWidgets('loaded state', (tester) async {
-      tester.view.physicalSize = size;
-      tester.view.devicePixelRatio = ratio;
-      addTearDown(tester.view.reset);
-
-      seedLogs([
-        LogTestDataFactory.createLogData(
-          id: 'log-1',
-          estimateId: estimateId,
-          activity: 'costEstimationCreated',
-          firstName: 'Liam',
-        ),
-        LogTestDataFactory.createLogData(
-          id: 'log-2',
-          estimateId: estimateId,
-          activity: 'costFileUploaded',
-          activityDetails: {'fileName': 'materials.xlsx'},
-          firstName: 'Ava',
-          loggedAt: '2025-03-01T10:00:00.000Z',
-        ),
-      ]);
-
-      await pumpLogsList(tester, theme: createTestThemeDark());
-      await tester.pumpAndSettle();
-
-      await expectLater(
-        find.byType(Scaffold),
-        matchesGoldenFile(
-          'goldens/cost_estimation_logs_list/${size.width}x${size.height}/logs_list_loaded_dark.png',
-        ),
-      );
-    });
-
-    testWidgets('load-more error with retry', (tester) async {
-      tester.view.physicalSize = size;
-      tester.view.devicePixelRatio = ratio;
-      addTearDown(tester.view.reset);
-
-      final pageSize = CostEstimationLogRepositoryImpl.defaultPageSize;
-      seedLogs(
-        LogTestDataFactory.createLogDataList(
-          count: pageSize + 1,
-          estimateId: estimateId,
-        ),
-      );
-
-      await pumpLogsList(tester, theme: createTestThemeDark());
-      await tester.pumpAndSettle();
-
-      fakeSupabase.shouldThrowOnSelectPaginated = true;
-      fakeSupabase.selectPaginatedExceptionType = SupabaseExceptionType.timeout;
-
-      await tester.drag(
-        find.byType(CustomScrollView).first,
-        const Offset(0, -1800),
-      );
-      await tester.pumpAndSettle();
-
-      await tester.scrollUntilVisible(
-        find.text('Retry'),
-        300,
-        scrollable: find.byType(Scrollable).first,
-      );
-      await tester.pumpAndSettle();
-
-      await expectLater(
-        find.byType(Scaffold),
-        matchesGoldenFile(
-          'goldens/cost_estimation_logs_list/${size.width}x${size.height}/logs_list_load_more_error_dark.png',
+          'goldens/cost_estimation_logs_list/${size.width}x${size.height}/logs_list_load_more_error$suffix.png',
         ),
       );
     });

--- a/test/features/estimations/screenshots/cost_estimation_tile_screenshot_test.dart
+++ b/test/features/estimations/screenshots/cost_estimation_tile_screenshot_test.dart
@@ -31,12 +31,12 @@ void main() {
     required WidgetTester tester,
     required CostEstimate estimation,
     required VoidCallback onTap,
+    required ThemeData theme,
     VoidCallback? onMenuTap,
-    ThemeData? theme,
   }) async {
     await tester.pumpWidget(
       MaterialApp(
-        theme: theme ?? createTestTheme(),
+        theme: theme,
         locale: const Locale('en'),
         localizationsDelegates: AppLocalizations.localizationsDelegates,
         supportedLocales: AppLocalizations.supportedLocales,
@@ -65,7 +65,10 @@ void main() {
     );
   }
 
-  group('CostEstimationTile Screenshot Tests - Light', () {
+  screenshotThemeGroups('CostEstimationTile Screenshot Tests', (
+    theme,
+    suffix,
+  ) {
     testWidgets('renders base cost estimation tile correctly', (tester) async {
       tester.view.physicalSize = size;
       tester.view.devicePixelRatio = ratio;
@@ -82,12 +85,13 @@ void main() {
         estimation: estimation,
         onTap: () {},
         onMenuTap: () {},
+        theme: theme,
       );
 
       await expectLater(
         find.byType(CostEstimationTile),
         matchesGoldenFile(
-          'goldens/cost_estimation_tile/${size.width}x${size.height}/cost_estimation_tile_base.png',
+          'goldens/cost_estimation_tile/${size.width}x${size.height}/cost_estimation_tile_base$suffix.png',
         ),
       );
     });
@@ -110,70 +114,13 @@ void main() {
         estimation: estimation,
         onTap: () {},
         onMenuTap: () {},
+        theme: theme,
       );
 
       await expectLater(
         find.byType(CostEstimationTile),
         matchesGoldenFile(
-          'goldens/cost_estimation_tile/${size.width}x${size.height}/cost_estimation_tile_long_name.png',
-        ),
-      );
-    });
-  });
-
-  group('CostEstimationTile Screenshot Tests - Dark', () {
-    testWidgets('renders base cost estimation tile correctly', (tester) async {
-      tester.view.physicalSize = size;
-      tester.view.devicePixelRatio = ratio;
-      addTearDown(tester.view.reset);
-
-      final estimation = createTestEstimation(
-        estimateName: 'Base Estimate',
-        totalCost: 50000.0,
-        createdAt: DateTime(2024, 1, 1, 8, 30),
-      );
-
-      await pumpCostEstimationTile(
-        tester: tester,
-        estimation: estimation,
-        onTap: () {},
-        onMenuTap: () {},
-        theme: createTestThemeDark(),
-      );
-
-      await expectLater(
-        find.byType(CostEstimationTile),
-        matchesGoldenFile(
-          'goldens/cost_estimation_tile/${size.width}x${size.height}/cost_estimation_tile_base_dark.png',
-        ),
-      );
-    });
-
-    testWidgets('renders cost estimation tile with long name correctly', (
-      tester,
-    ) async {
-      tester.view.physicalSize = size;
-      tester.view.devicePixelRatio = ratio;
-      addTearDown(tester.view.reset);
-
-      final estimation = createTestEstimation(
-        estimateName: 'Complete Home Renovation and Extension Project',
-        totalCost: 125000.75,
-        createdAt: DateTime(2024, 3, 10, 16, 45),
-      );
-
-      await pumpCostEstimationTile(
-        tester: tester,
-        estimation: estimation,
-        onTap: () {},
-        onMenuTap: () {},
-        theme: createTestThemeDark(),
-      );
-
-      await expectLater(
-        find.byType(CostEstimationTile),
-        matchesGoldenFile(
-          'goldens/cost_estimation_tile/${size.width}x${size.height}/cost_estimation_tile_long_name_dark.png',
+          'goldens/cost_estimation_tile/${size.width}x${size.height}/cost_estimation_tile_long_name$suffix.png',
         ),
       );
     });

--- a/test/features/estimations/screenshots/cost_item_form_screen_screenshot_test.dart
+++ b/test/features/estimations/screenshots/cost_item_form_screen_screenshot_test.dart
@@ -42,12 +42,12 @@ void main() {
   Future<void> pumpScreen({
     required WidgetTester tester,
     required CostItemType type,
+    required ThemeData theme,
     bool fromCostFile = false,
-    ThemeData? theme,
   }) async {
     await tester.pumpWidget(
       MaterialApp(
-        theme: theme ?? createTestTheme(),
+        theme: theme,
         locale: const Locale('en'),
         localizationsDelegates: AppLocalizations.localizationsDelegates,
         supportedLocales: AppLocalizations.supportedLocales,
@@ -79,17 +79,20 @@ void main() {
     }
   }
 
-  group('CostItemFormScreen Screenshot Tests - Light', () {
+  screenshotThemeGroups('CostItemFormScreen Screenshot Tests', (
+    theme,
+    suffix,
+  ) {
     testWidgets('renders labour cost screen in manually mode', (tester) async {
       tester.view.physicalSize = size;
       tester.view.devicePixelRatio = 1.0;
       addTearDown(tester.view.reset);
-      await pumpScreen(tester: tester, type: CostItemType.labor);
+      await pumpScreen(tester: tester, type: CostItemType.labor, theme: theme);
 
       await expectLater(
         find.byType(CostItemFormScreen),
         matchesGoldenFile(
-          'goldens/cost_item_form_screen/${size.width}x${size.height}/labour_manually.png',
+          'goldens/cost_item_form_screen/${size.width}x${size.height}/labour_manually$suffix.png',
         ),
       );
     });
@@ -100,12 +103,16 @@ void main() {
       tester.view.physicalSize = size;
       tester.view.devicePixelRatio = 1.0;
       addTearDown(tester.view.reset);
-      await pumpScreen(tester: tester, type: CostItemType.material);
+      await pumpScreen(
+        tester: tester,
+        type: CostItemType.material,
+        theme: theme,
+      );
 
       await expectLater(
         find.byType(CostItemFormScreen),
         matchesGoldenFile(
-          'goldens/cost_item_form_screen/${size.width}x${size.height}/material_manually.png',
+          'goldens/cost_item_form_screen/${size.width}x${size.height}/material_manually$suffix.png',
         ),
       );
     });
@@ -120,99 +127,13 @@ void main() {
         tester: tester,
         type: CostItemType.material,
         fromCostFile: true,
+        theme: theme,
       );
 
       await expectLater(
         find.byType(CostItemFormScreen),
         matchesGoldenFile(
-          'goldens/cost_item_form_screen/${size.width}x${size.height}/material_from_cost_file.png',
-        ),
-      );
-    });
-
-    testWidgets('renders material cost screen with item type error', (
-      tester,
-    ) async {
-      tester.view.physicalSize = size;
-      tester.view.devicePixelRatio = 1.0;
-      addTearDown(tester.view.reset);
-      await pumpScreen(tester: tester, type: CostItemType.material);
-      await tester.enterText(
-        find.byKey(const Key('material_type_field')),
-        'x',
-      );
-      await tester.pumpAndSettle();
-      await tester.enterText(
-        find.byKey(const Key('material_type_field')),
-        '',
-      );
-      await tester.pumpAndSettle();
-
-      await expectLater(
-        find.byType(CostItemFormScreen),
-        matchesGoldenFile(
-          'goldens/cost_item_form_screen/${size.width}x${size.height}/material_manually_error.png',
-        ),
-      );
-    });
-  });
-
-  group('CostItemFormScreen Screenshot Tests - Dark', () {
-    testWidgets('renders labour cost screen in manually mode', (tester) async {
-      tester.view.physicalSize = size;
-      tester.view.devicePixelRatio = 1.0;
-      addTearDown(tester.view.reset);
-      await pumpScreen(
-        tester: tester,
-        type: CostItemType.labor,
-        theme: createTestThemeDark(),
-      );
-
-      await expectLater(
-        find.byType(CostItemFormScreen),
-        matchesGoldenFile(
-          'goldens/cost_item_form_screen/${size.width}x${size.height}/labour_manually_dark.png',
-        ),
-      );
-    });
-
-    testWidgets('renders material cost screen in manually mode', (
-      tester,
-    ) async {
-      tester.view.physicalSize = size;
-      tester.view.devicePixelRatio = 1.0;
-      addTearDown(tester.view.reset);
-      await pumpScreen(
-        tester: tester,
-        type: CostItemType.material,
-        theme: createTestThemeDark(),
-      );
-
-      await expectLater(
-        find.byType(CostItemFormScreen),
-        matchesGoldenFile(
-          'goldens/cost_item_form_screen/${size.width}x${size.height}/material_manually_dark.png',
-        ),
-      );
-    });
-
-    testWidgets('renders material cost screen in from cost file mode', (
-      tester,
-    ) async {
-      tester.view.physicalSize = size;
-      tester.view.devicePixelRatio = 1.0;
-      addTearDown(tester.view.reset);
-      await pumpScreen(
-        tester: tester,
-        type: CostItemType.material,
-        fromCostFile: true,
-        theme: createTestThemeDark(),
-      );
-
-      await expectLater(
-        find.byType(CostItemFormScreen),
-        matchesGoldenFile(
-          'goldens/cost_item_form_screen/${size.width}x${size.height}/material_from_cost_file_dark.png',
+          'goldens/cost_item_form_screen/${size.width}x${size.height}/material_from_cost_file$suffix.png',
         ),
       );
     });
@@ -226,7 +147,7 @@ void main() {
       await pumpScreen(
         tester: tester,
         type: CostItemType.material,
-        theme: createTestThemeDark(),
+        theme: theme,
       );
       await tester.enterText(
         find.byKey(const Key('material_type_field')),
@@ -242,7 +163,7 @@ void main() {
       await expectLater(
         find.byType(CostItemFormScreen),
         matchesGoldenFile(
-          'goldens/cost_item_form_screen/${size.width}x${size.height}/material_manually_error_dark.png',
+          'goldens/cost_item_form_screen/${size.width}x${size.height}/material_manually_error$suffix.png',
         ),
       );
     });

--- a/test/features/estimations/screenshots/cost_item_mode_toggle_screenshot_test.dart
+++ b/test/features/estimations/screenshots/cost_item_mode_toggle_screenshot_test.dart
@@ -18,11 +18,11 @@ void main() {
   Future<void> pumpToggle(
     WidgetTester tester, {
     required bool fromCostFile,
-    ThemeData? theme,
+    required ThemeData theme,
   }) async {
     await tester.pumpWidget(
       MaterialApp(
-        theme: theme ?? createTestTheme(),
+        theme: theme,
         locale: const Locale('en'),
         localizationsDelegates: AppLocalizations.localizationsDelegates,
         supportedLocales: AppLocalizations.supportedLocales,
@@ -41,18 +41,21 @@ void main() {
     await tester.pumpAndSettle();
   }
 
-  group('CostItemModeToggle Screenshot Tests - Light', () {
+  screenshotThemeGroups('CostItemModeToggle Screenshot Tests', (
+    theme,
+    suffix,
+  ) {
     testWidgets('manually active state', (tester) async {
       tester.view.physicalSize = size;
       tester.view.devicePixelRatio = ratio;
       addTearDown(tester.view.reset);
 
-      await pumpToggle(tester, fromCostFile: false);
+      await pumpToggle(tester, fromCostFile: false, theme: theme);
 
       await expectLater(
         find.byType(CostItemModeToggle),
         matchesGoldenFile(
-          'goldens/cost_item_mode_toggle/${size.width}x${size.height}/cost_item_mode_toggle_manually_active.png',
+          'goldens/cost_item_mode_toggle/${size.width}x${size.height}/cost_item_mode_toggle_manually_active$suffix.png',
         ),
       );
     });
@@ -62,44 +65,12 @@ void main() {
       tester.view.devicePixelRatio = ratio;
       addTearDown(tester.view.reset);
 
-      await pumpToggle(tester, fromCostFile: true);
+      await pumpToggle(tester, fromCostFile: true, theme: theme);
 
       await expectLater(
         find.byType(CostItemModeToggle),
         matchesGoldenFile(
-          'goldens/cost_item_mode_toggle/${size.width}x${size.height}/cost_item_mode_toggle_from_cost_file_active.png',
-        ),
-      );
-    });
-  });
-
-  group('CostItemModeToggle Screenshot Tests - Dark', () {
-    testWidgets('manually active state', (tester) async {
-      tester.view.physicalSize = size;
-      tester.view.devicePixelRatio = ratio;
-      addTearDown(tester.view.reset);
-
-      await pumpToggle(tester, fromCostFile: false, theme: createTestThemeDark());
-
-      await expectLater(
-        find.byType(CostItemModeToggle),
-        matchesGoldenFile(
-          'goldens/cost_item_mode_toggle/${size.width}x${size.height}/cost_item_mode_toggle_manually_active_dark.png',
-        ),
-      );
-    });
-
-    testWidgets('from cost file active state', (tester) async {
-      tester.view.physicalSize = size;
-      tester.view.devicePixelRatio = ratio;
-      addTearDown(tester.view.reset);
-
-      await pumpToggle(tester, fromCostFile: true, theme: createTestThemeDark());
-
-      await expectLater(
-        find.byType(CostItemModeToggle),
-        matchesGoldenFile(
-          'goldens/cost_item_mode_toggle/${size.width}x${size.height}/cost_item_mode_toggle_from_cost_file_active_dark.png',
+          'goldens/cost_item_mode_toggle/${size.width}x${size.height}/cost_item_mode_toggle_from_cost_file_active$suffix.png',
         ),
       );
     });

--- a/test/features/estimations/screenshots/delete_estimation_confirmation_sheet_screenshot_test.dart
+++ b/test/features/estimations/screenshots/delete_estimation_confirmation_sheet_screenshot_test.dart
@@ -17,13 +17,13 @@ void main() {
   Future<void> pumpConfirmationSheet({
     required WidgetTester tester,
     required String estimationName,
+    required ThemeData theme,
     int? imagesAttachedCount,
     int? documentsAttachedCount,
-    ThemeData? theme,
   }) async {
     await tester.pumpWidget(
       MaterialApp(
-        theme: theme ?? createTestTheme(),
+        theme: theme,
         locale: const Locale('en'),
         localizationsDelegates: AppLocalizations.localizationsDelegates,
         supportedLocales: AppLocalizations.supportedLocales,
@@ -41,7 +41,10 @@ void main() {
     await tester.pumpAndSettle();
   }
 
-  group('DeleteEstimationConfirmationSheet Screenshot Tests - Light', () {
+  screenshotThemeGroups('DeleteEstimationConfirmationSheet Screenshot Tests', (
+    theme,
+    suffix,
+  ) {
     testWidgets('renders with default state', (tester) async {
       tester.view.physicalSize = size;
       tester.view.devicePixelRatio = ratio;
@@ -50,12 +53,13 @@ void main() {
       await pumpConfirmationSheet(
         tester: tester,
         estimationName: '2nd wall cost',
+        theme: theme,
       );
 
       await expectLater(
         find.byType(DeleteEstimationConfirmationSheet),
         matchesGoldenFile(
-          'goldens/delete_confirmation_sheet/${size.width}x${size.height}/delete_confirmation_sheet_default.png',
+          'goldens/delete_confirmation_sheet/${size.width}x${size.height}/delete_confirmation_sheet_default$suffix.png',
         ),
       );
     });
@@ -70,12 +74,13 @@ void main() {
         estimationName: '2nd wall cost',
         imagesAttachedCount: 25,
         documentsAttachedCount: 5,
+        theme: theme,
       );
 
       await expectLater(
         find.byType(DeleteEstimationConfirmationSheet),
         matchesGoldenFile(
-          'goldens/delete_confirmation_sheet/${size.width}x${size.height}/delete_confirmation_sheet_with_attachments.png',
+          'goldens/delete_confirmation_sheet/${size.width}x${size.height}/delete_confirmation_sheet_with_attachments$suffix.png',
         ),
       );
     });
@@ -89,74 +94,13 @@ void main() {
         tester: tester,
         estimationName:
             'This is a very long estimation name that should be truncated with ellipsis to prevent layout overflow issues in the UI',
+        theme: theme,
       );
 
       await expectLater(
         find.byType(DeleteEstimationConfirmationSheet),
         matchesGoldenFile(
-          'goldens/delete_confirmation_sheet/${size.width}x${size.height}/delete_confirmation_sheet_long_name.png',
-        ),
-      );
-    });
-  });
-
-  group('DeleteEstimationConfirmationSheet Screenshot Tests - Dark', () {
-    testWidgets('renders with default state', (tester) async {
-      tester.view.physicalSize = size;
-      tester.view.devicePixelRatio = ratio;
-      addTearDown(tester.view.reset);
-
-      await pumpConfirmationSheet(
-        tester: tester,
-        estimationName: '2nd wall cost',
-        theme: createTestThemeDark(),
-      );
-
-      await expectLater(
-        find.byType(DeleteEstimationConfirmationSheet),
-        matchesGoldenFile(
-          'goldens/delete_confirmation_sheet/${size.width}x${size.height}/delete_confirmation_sheet_default_dark.png',
-        ),
-      );
-    });
-
-    testWidgets('renders with attachment counts', (tester) async {
-      tester.view.physicalSize = size;
-      tester.view.devicePixelRatio = ratio;
-      addTearDown(tester.view.reset);
-
-      await pumpConfirmationSheet(
-        tester: tester,
-        estimationName: '2nd wall cost',
-        imagesAttachedCount: 25,
-        documentsAttachedCount: 5,
-        theme: createTestThemeDark(),
-      );
-
-      await expectLater(
-        find.byType(DeleteEstimationConfirmationSheet),
-        matchesGoldenFile(
-          'goldens/delete_confirmation_sheet/${size.width}x${size.height}/delete_confirmation_sheet_with_attachments_dark.png',
-        ),
-      );
-    });
-
-    testWidgets('renders with long estimation name', (tester) async {
-      tester.view.physicalSize = size;
-      tester.view.devicePixelRatio = ratio;
-      addTearDown(tester.view.reset);
-
-      await pumpConfirmationSheet(
-        tester: tester,
-        estimationName:
-            'This is a very long estimation name that should be truncated with ellipsis to prevent layout overflow issues in the UI',
-        theme: createTestThemeDark(),
-      );
-
-      await expectLater(
-        find.byType(DeleteEstimationConfirmationSheet),
-        matchesGoldenFile(
-          'goldens/delete_confirmation_sheet/${size.width}x${size.height}/delete_confirmation_sheet_long_name_dark.png',
+          'goldens/delete_confirmation_sheet/${size.width}x${size.height}/delete_confirmation_sheet_long_name$suffix.png',
         ),
       );
     });


### PR DESCRIPTION
### 1. PR SUMMARY
Migrates 8 of the 15 `test/features/estimations/screenshots/` files off the old manual dual-theme pattern onto the `screenshotThemeGroups` helper (CA-847): `cost_estimation_details_tab_view`, `cost_estimation_empty_page`, `cost_estimation_logs_list`, `cost_estimation_log_tile`, `cost_estimation_tile`, `cost_item_form_screen`, `cost_item_mode_toggle`, `delete_estimation_confirmation_sheet`. The remaining 7 estimations files land in PR 5/9.

Fourth PR in the CA-914 migration series (4/9), stacked on 3/9. CA-968 (bump `ripplearc_linter` to pull in the `forbid_manual_screenshot_theme` rule this migration satisfies) is stacked on top of the full series, after PR 9/9.

### 2. REVIEW SUMMARY TABLE
No issues found.

## Test plan
- [x] `fvm flutter test` on the 8 changed files — all 60 tests pass
- [x] `fvm dart run custom_lint` — clean (pre-existing unrelated issue in `fake_router.dart` confirmed present on `main`)
- [ ] Reviewer: visually confirm goldens render correctly for both themes