### PR TITLE
CA-914 (7/9): migrate members+project screenshot tests to screenshotThemeGroups

### DIFF
--- a/test/features/members/screenshots/invited_members_list_screenshot_test.dart
+++ b/test/features/members/screenshots/invited_members_list_screenshot_test.dart
@@ -19,7 +19,7 @@ void main() {
   Future<void> pumpWidget(
     WidgetTester tester,
     Widget widget, {
-    ThemeData? theme,
+    required ThemeData theme,
   }) async {
     tester.view.physicalSize = size;
     tester.view.devicePixelRatio = ratio;
@@ -27,7 +27,7 @@ void main() {
 
     await tester.pumpWidget(
       MaterialApp(
-        theme: theme ?? createTestTheme(),
+        theme: theme,
         locale: const Locale('en'),
         localizationsDelegates: AppLocalizations.localizationsDelegates,
         supportedLocales: AppLocalizations.supportedLocales,
@@ -44,7 +44,10 @@ void main() {
 
   const goldenDir = 'goldens/member_invitation';
 
-  group('InvitedMembersList Screenshot Tests - Light', () {
+  screenshotThemeGroups('InvitedMembersList Screenshot Tests', (
+    theme,
+    suffix,
+  ) {
     testWidgets('renders list with two invited members', (tester) async {
       await pumpWidget(
         tester,
@@ -54,31 +57,12 @@ void main() {
             InvitedMember(email: 'bob@example.com', name: 'Bob Example'),
           ],
         ),
+        theme: theme,
       );
 
       await expectLater(
         find.byType(Scaffold),
-        matchesGoldenFile('$goldenDir/${size.width}x${size.height}/invited_members_list.png'),
-      );
-    });
-  });
-
-  group('InvitedMembersList Screenshot Tests - Dark', () {
-    testWidgets('renders list with two invited members', (tester) async {
-      await pumpWidget(
-        tester,
-        const InvitedMembersList(
-          members: [
-            InvitedMember(email: 'alice@example.com', name: 'Alice Example'),
-            InvitedMember(email: 'bob@example.com', name: 'Bob Example'),
-          ],
-        ),
-        theme: createTestThemeDark(),
-      );
-
-      await expectLater(
-        find.byType(Scaffold),
-        matchesGoldenFile('$goldenDir/${size.width}x${size.height}/invited_members_list_dark.png'),
+        matchesGoldenFile('$goldenDir/${size.width}x${size.height}/invited_members_list$suffix.png'),
       );
     });
   });

--- a/test/features/project/screenshots/project_header_app_bar_screenshot_test.dart
+++ b/test/features/project/screenshots/project_header_app_bar_screenshot_test.dart
@@ -55,10 +55,10 @@ void main() {
     required WidgetTester tester,
     required String projectId,
     required String projectName,
+    required ThemeData theme,
     VoidCallback? onProjectTap,
     VoidCallback? onSearchTap,
     VoidCallback? onNotificationTap,
-    ThemeData? theme,
   }) async {
     final project = Project(
       id: projectId,
@@ -74,7 +74,7 @@ void main() {
 
     await tester.pumpWidget(
       MaterialApp(
-        theme: theme ?? createTestTheme(),
+        theme: theme,
         locale: const Locale('en'),
         localizationsDelegates: AppLocalizations.localizationsDelegates,
         supportedLocales: AppLocalizations.supportedLocales,
@@ -94,7 +94,10 @@ void main() {
     await tester.awaitImages();
   }
 
-  group('ProjectHeaderAppBar Screenshot Tests - Light', () {
+  screenshotThemeGroups('ProjectHeaderAppBar Screenshot Tests', (
+    theme,
+    suffix,
+  ) {
     testWidgets('renders project header app bar with normal name correctly', (
       tester,
     ) async {
@@ -109,12 +112,13 @@ void main() {
         onProjectTap: () {},
         onSearchTap: () {},
         onNotificationTap: () {},
+        theme: theme,
       );
 
       await expectLater(
         find.byType(ProjectHeaderAppBar),
         matchesGoldenFile(
-          'goldens/$testName/${size.width}x${size.height}/${testName}_normal.png',
+          'goldens/$testName/${size.width}x${size.height}/${testName}_normal$suffix.png',
         ),
       );
     });
@@ -133,12 +137,13 @@ void main() {
         onProjectTap: () {},
         onSearchTap: () {},
         onNotificationTap: () {},
+        theme: theme,
       );
 
       await expectLater(
         find.byType(ProjectHeaderAppBar),
         matchesGoldenFile(
-          'goldens/$testName/${size.width}x${size.height}/${testName}_long_name.png',
+          'goldens/$testName/${size.width}x${size.height}/${testName}_long_name$suffix.png',
         ),
       );
     });
@@ -157,89 +162,13 @@ void main() {
         onProjectTap: () {},
         onSearchTap: () {},
         onNotificationTap: () {},
+        theme: theme,
       );
 
       await expectLater(
         find.byType(ProjectHeaderAppBar),
         matchesGoldenFile(
-          'goldens/$testName/${size.width}x${size.height}/${testName}_no_avatar.png',
-        ),
-      );
-    });
-  });
-
-  group('ProjectHeaderAppBar Screenshot Tests - Dark', () {
-    testWidgets('renders project header app bar with normal name correctly', (
-      tester,
-    ) async {
-      tester.view.physicalSize = size;
-      tester.view.devicePixelRatio = ratio;
-      addTearDown(tester.view.reset);
-
-      await pumpProjectHeaderAppBar(
-        tester: tester,
-        projectId: 'project-id-dark-1',
-        projectName: 'Kitchen Renovation',
-        onProjectTap: () {},
-        onSearchTap: () {},
-        onNotificationTap: () {},
-        theme: createTestThemeDark(),
-      );
-
-      await expectLater(
-        find.byType(ProjectHeaderAppBar),
-        matchesGoldenFile(
-          'goldens/$testName/${size.width}x${size.height}/${testName}_normal_dark.png',
-        ),
-      );
-    });
-
-    testWidgets('renders project header app bar with long name correctly', (
-      tester,
-    ) async {
-      tester.view.physicalSize = size;
-      tester.view.devicePixelRatio = ratio;
-      addTearDown(tester.view.reset);
-
-      await pumpProjectHeaderAppBar(
-        tester: tester,
-        projectId: 'project-id-dark-2',
-        projectName: 'Complete Home Renovation and Extension Project',
-        onProjectTap: () {},
-        onSearchTap: () {},
-        onNotificationTap: () {},
-        theme: createTestThemeDark(),
-      );
-
-      await expectLater(
-        find.byType(ProjectHeaderAppBar),
-        matchesGoldenFile(
-          'goldens/$testName/${size.width}x${size.height}/${testName}_long_name_dark.png',
-        ),
-      );
-    });
-
-    testWidgets('renders project header app bar without avatar correctly', (
-      tester,
-    ) async {
-      tester.view.physicalSize = size;
-      tester.view.devicePixelRatio = ratio;
-      addTearDown(tester.view.reset);
-
-      await pumpProjectHeaderAppBar(
-        tester: tester,
-        projectId: 'project-id-dark-3',
-        projectName: 'Bathroom Remodel',
-        onProjectTap: () {},
-        onSearchTap: () {},
-        onNotificationTap: () {},
-        theme: createTestThemeDark(),
-      );
-
-      await expectLater(
-        find.byType(ProjectHeaderAppBar),
-        matchesGoldenFile(
-          'goldens/$testName/${size.width}x${size.height}/${testName}_no_avatar_dark.png',
+          'goldens/$testName/${size.width}x${size.height}/${testName}_no_avatar$suffix.png',
         ),
       );
     });


### PR DESCRIPTION
### 1. PR SUMMARY
Migrates `invited_members_list_screenshot_test.dart` (members feature) and `project_header_app_bar_screenshot_test.dart` (project feature) off the old manual dual-theme pattern onto the `screenshotThemeGroups` helper (CA-847). Both are small, straightforward symmetric light/dark conversions.

Seventh PR in the CA-914 migration series (7/9), stacked on 6/9. CA-968 (bump `ripplearc_linter` to pull in the `forbid_manual_screenshot_theme` rule this migration satisfies) is stacked on top of the full series, after PR 9/9.

### 2. REVIEW SUMMARY TABLE
No issues found.

## Test plan
- [x] `fvm flutter test` on the 2 changed files — all 8 tests pass
- [x] `fvm dart run custom_lint` — clean (pre-existing unrelated issue in `fake_router.dart` confirmed present on `main`)
- [ ] Reviewer: visually confirm goldens render correctly for both themes