### PR TITLE
CA-XXX (PR2): add watchEstimationById to the PowerSync read data source

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -43,24 +43,25 @@ custom_lint:
 
   no_direct_instantiation:
     ignored_base_classes:
-        - 'State'
+      - "State"
     ast_type_prefixes:
-        - 'Fake'
-        - '_Fake'
-        - 'AppBootstrap'
-        - 'AppLogger'
-        - 'Map'
-        - 'CancelableOperation'
-        - 'AppLocalizationsEn'
-        - 'Breadcrumb'
-        - 'SentryFlutterOptions'
-        - 'SentryId'
-        - 'LogEvent'
-        - 'AppLogFilter'
-        - 'SentryUser'
-        - 'CrudEntry'
-        - 'PowerSyncCredentials'
-        - 'Posthog'
+      - "Fake"
+      - "_Fake"
+      - "AppBootstrap"
+      - "AppLogger"
+      - "Map"
+      - "CancelableOperation"
+      - "AppLocalizationsEn"
+      - "Breadcrumb"
+      - "SentryFlutterOptions"
+      - "SentryId"
+      - "LogEvent"
+      - "AppLogFilter"
+      - "SentryUser"
+      - "CrudEntry"
+      - "PowerSyncCredentials"
+      - "Posthog"
+      - "PowerSyncDatabase"
 
 linter:
   # The lint rules applied to this project can be customized in the

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -62,6 +62,7 @@ custom_lint:
       - "PowerSyncCredentials"
       - "Posthog"
       - "PowerSyncDatabase"
+      - "_SqliteWriteContextAdapter"
 
 linter:
   # The lint rules applied to this project can be customized in the

--- a/lib/app/app_bootstrap.dart
+++ b/lib/app/app_bootstrap.dart
@@ -3,6 +3,7 @@ import 'package:construculator/libraries/config/interfaces/config.dart';
 import 'package:construculator/libraries/config/interfaces/env_loader.dart';
 import 'package:construculator/libraries/sentry/interfaces/sentry_wrapper.dart';
 import 'package:construculator/libraries/supabase/interfaces/supabase_wrapper.dart';
+import 'package:powersync/powersync.dart';
 
 /// The application requires that certain services—such as the Supabase client—are fully
 /// initialized before the [AppModule] is loaded. This is critical for features like
@@ -95,10 +96,19 @@ class AppBootstrap {
   /// Its [initialize] method must be called with the app runner to enable error tracking.
   final SentryWrapper sentryWrapper;
 
+  /// The opened local PowerSync database.
+  ///
+  /// Opened during bootstrap because resolving its on-device path is
+  /// asynchronous and must complete before the module graph is built. It is
+  /// usable offline immediately; syncing starts once `PowerSyncManager`
+  /// connects after authentication.
+  final PowerSyncDatabase powerSyncDatabase;
+
   AppBootstrap({
     required this.envLoader,
     required this.config,
     required this.supabaseWrapper,
     required this.sentryWrapper,
+    required this.powerSyncDatabase,
   });
 }

--- a/lib/app/app_module.dart
+++ b/lib/app/app_module.dart
@@ -5,6 +5,7 @@ import 'package:construculator/features/auth/auth_module.dart';
 import 'package:construculator/features/project/project_module.dart';
 import 'package:construculator/libraries/auth/auth_library_module.dart';
 import 'package:construculator/libraries/config/config_module.dart';
+import 'package:construculator/libraries/powersync/powersync_module.dart';
 import 'package:construculator/libraries/router/router_module.dart';
 import 'package:construculator/libraries/supabase/supabase_module.dart';
 import 'package:flutter_modular/flutter_modular.dart';
@@ -20,6 +21,7 @@ class AppModule extends Module {
     SupabaseModule(appBootstrap),
     AuthLibraryModule(appBootstrap),
     ProjectModule(appBootstrap),
+    PowerSyncModule(appBootstrap),
   ];
 
   @override

--- a/lib/features/auth/testing/auth_test_module.dart
+++ b/lib/features/auth/testing/auth_test_module.dart
@@ -23,6 +23,7 @@ import 'package:construculator/libraries/auth/testing/fake_auth_notifier.dart';
 import 'package:construculator/libraries/auth/testing/fake_auth_repository.dart';
 import 'package:construculator/libraries/config/testing/fake_app_config.dart';
 import 'package:construculator/libraries/config/testing/fake_env_loader.dart';
+import 'package:construculator/libraries/powersync/testing/fake_powersync_database.dart';
 import 'package:construculator/libraries/router/testing/router_test_module.dart';
 import 'package:construculator/libraries/sentry/fake_sentry_wrapper.dart';
 import 'package:construculator/libraries/supabase/testing/fake_supabase_wrapper.dart';
@@ -41,6 +42,7 @@ class AuthTestModule extends Module {
         config: FakeAppConfig(),
         supabaseWrapper: FakeSupabaseWrapper(clock: FakeClockImpl()),
         sentryWrapper: FakeSentryWrapper(),
+        powerSyncDatabase: FakePowerSyncDatabase(),
       ),
     ),
     RouterTestModule(),

--- a/lib/l10n/generated/app_localizations.dart
+++ b/lib/l10n/generated/app_localizations.dart
@@ -61,8 +61,7 @@ import 'app_localizations_en.dart';
 /// be consistent with the languages listed in the AppLocalizations.supportedLocales
 /// property.
 abstract class AppLocalizations {
-  AppLocalizations(String locale)
-    : localeName = intl.Intl.canonicalizedLocale(locale.toString());
+  AppLocalizations(String locale) : localeName = intl.Intl.canonicalizedLocale(locale.toString());
 
   final String localeName;
 
@@ -70,8 +69,7 @@ abstract class AppLocalizations {
     return Localizations.of<AppLocalizations>(context, AppLocalizations);
   }
 
-  static const LocalizationsDelegate<AppLocalizations> delegate =
-      _AppLocalizationsDelegate();
+  static const LocalizationsDelegate<AppLocalizations> delegate = _AppLocalizationsDelegate();
 
   /// A list of this localizations delegate along with the default localizations
   /// delegates.
@@ -83,16 +81,17 @@ abstract class AppLocalizations {
   /// Additional delegates can be added by appending to this list in
   /// MaterialApp. This list does not have to be used at all if a custom list
   /// of delegates is preferred or required.
-  static const List<LocalizationsDelegate<dynamic>> localizationsDelegates =
-      <LocalizationsDelegate<dynamic>>[
-        delegate,
-        GlobalMaterialLocalizations.delegate,
-        GlobalCupertinoLocalizations.delegate,
-        GlobalWidgetsLocalizations.delegate,
-      ];
+  static const List<LocalizationsDelegate<dynamic>> localizationsDelegates = <LocalizationsDelegate<dynamic>>[
+    delegate,
+    GlobalMaterialLocalizations.delegate,
+    GlobalCupertinoLocalizations.delegate,
+    GlobalWidgetsLocalizations.delegate,
+  ];
 
   /// A list of this localizations delegate's supported locales.
-  static const List<Locale> supportedLocales = <Locale>[Locale('en')];
+  static const List<Locale> supportedLocales = <Locale>[
+    Locale('en')
+  ];
 
   /// Label for agree and continue button
   ///
@@ -2567,8 +2566,7 @@ abstract class AppLocalizations {
   String get calculatorGroupTrigonometry;
 }
 
-class _AppLocalizationsDelegate
-    extends LocalizationsDelegate<AppLocalizations> {
+class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> {
   const _AppLocalizationsDelegate();
 
   @override
@@ -2577,24 +2575,24 @@ class _AppLocalizationsDelegate
   }
 
   @override
-  bool isSupported(Locale locale) =>
-      <String>['en'].contains(locale.languageCode);
+  bool isSupported(Locale locale) => <String>['en'].contains(locale.languageCode);
 
   @override
   bool shouldReload(_AppLocalizationsDelegate old) => false;
 }
 
 AppLocalizations lookupAppLocalizations(Locale locale) {
+
+
   // Lookup logic when only language code is specified.
   switch (locale.languageCode) {
-    case 'en':
-      return AppLocalizationsEn();
+    case 'en': return AppLocalizationsEn();
   }
 
   throw FlutterError(
     'AppLocalizations.delegate failed to load unsupported locale "$locale". This is likely '
     'an issue with the localizations generation tool. Please file an issue '
     'on GitHub with a reproducible sample app and the gen-l10n configuration '
-    'that was used.',
+    'that was used.'
   );
 }

--- a/lib/l10n/generated/app_localizations.dart
+++ b/lib/l10n/generated/app_localizations.dart
@@ -61,7 +61,8 @@ import 'app_localizations_en.dart';
 /// be consistent with the languages listed in the AppLocalizations.supportedLocales
 /// property.
 abstract class AppLocalizations {
-  AppLocalizations(String locale) : localeName = intl.Intl.canonicalizedLocale(locale.toString());
+  AppLocalizations(String locale)
+    : localeName = intl.Intl.canonicalizedLocale(locale.toString());
 
   final String localeName;
 
@@ -69,7 +70,8 @@ abstract class AppLocalizations {
     return Localizations.of<AppLocalizations>(context, AppLocalizations);
   }
 
-  static const LocalizationsDelegate<AppLocalizations> delegate = _AppLocalizationsDelegate();
+  static const LocalizationsDelegate<AppLocalizations> delegate =
+      _AppLocalizationsDelegate();
 
   /// A list of this localizations delegate along with the default localizations
   /// delegates.
@@ -81,17 +83,16 @@ abstract class AppLocalizations {
   /// Additional delegates can be added by appending to this list in
   /// MaterialApp. This list does not have to be used at all if a custom list
   /// of delegates is preferred or required.
-  static const List<LocalizationsDelegate<dynamic>> localizationsDelegates = <LocalizationsDelegate<dynamic>>[
-    delegate,
-    GlobalMaterialLocalizations.delegate,
-    GlobalCupertinoLocalizations.delegate,
-    GlobalWidgetsLocalizations.delegate,
-  ];
+  static const List<LocalizationsDelegate<dynamic>> localizationsDelegates =
+      <LocalizationsDelegate<dynamic>>[
+        delegate,
+        GlobalMaterialLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+      ];
 
   /// A list of this localizations delegate's supported locales.
-  static const List<Locale> supportedLocales = <Locale>[
-    Locale('en')
-  ];
+  static const List<Locale> supportedLocales = <Locale>[Locale('en')];
 
   /// Label for agree and continue button
   ///
@@ -2566,7 +2567,8 @@ abstract class AppLocalizations {
   String get calculatorGroupTrigonometry;
 }
 
-class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> {
+class _AppLocalizationsDelegate
+    extends LocalizationsDelegate<AppLocalizations> {
   const _AppLocalizationsDelegate();
 
   @override
@@ -2575,24 +2577,24 @@ class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> 
   }
 
   @override
-  bool isSupported(Locale locale) => <String>['en'].contains(locale.languageCode);
+  bool isSupported(Locale locale) =>
+      <String>['en'].contains(locale.languageCode);
 
   @override
   bool shouldReload(_AppLocalizationsDelegate old) => false;
 }
 
 AppLocalizations lookupAppLocalizations(Locale locale) {
-
-
   // Lookup logic when only language code is specified.
   switch (locale.languageCode) {
-    case 'en': return AppLocalizationsEn();
+    case 'en':
+      return AppLocalizationsEn();
   }
 
   throw FlutterError(
     'AppLocalizations.delegate failed to load unsupported locale "$locale". This is likely '
     'an issue with the localizations generation tool. Please file an issue '
     'on GitHub with a reproducible sample app and the gen-l10n configuration '
-    'that was used.'
+    'that was used.',
   );
 }

--- a/lib/l10n/generated/app_localizations_en.dart
+++ b/lib/l10n/generated/app_localizations_en.dart
@@ -60,12 +60,10 @@ class AppLocalizationsEn extends AppLocalizations {
   String get continueWithPhone => 'Continue with Phone';
 
   @override
-  String get createAccountSubtitle =>
-      'Email you entered is not registered with us, to create your construculator account enter details below';
+  String get createAccountSubtitle => 'Email you entered is not registered with us, to create your construculator account enter details below';
 
   @override
-  String get createAccountSuccessMessage =>
-      'You have successfully registered with Construculator';
+  String get createAccountSuccessMessage => 'You have successfully registered with Construculator';
 
   @override
   String get createAccountTitle => 'Create your Account';
@@ -83,8 +81,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get duplicateErrorMessage => 'Duplicate Error';
 
   @override
-  String get emailAlreadyRegistered =>
-      'Email ID already registered with us. Please ';
+  String get emailAlreadyRegistered => 'Email ID already registered with us. Please ';
 
   @override
   String get emailDuplicateErrorMessage => 'Email exists';
@@ -102,15 +99,13 @@ class AppLocalizationsEn extends AppLocalizations {
   String get emailRequiredError => 'Email is required';
 
   @override
-  String get enterPasswordDescription =>
-      'Enter your password for this account. Your email id is';
+  String get enterPasswordDescription => 'Enter your password for this account. Your email id is';
 
   @override
   String get enterPasswordTitle => 'Enter your password';
 
   @override
-  String get enterYourEmailIdToLoginToYourAccount =>
-      'Hey, Enter your details to log in to your account';
+  String get enterYourEmailIdToLoginToYourAccount => 'Hey, Enter your details to log in to your account';
 
   @override
   String get firstNameHint => 'First name';
@@ -122,8 +117,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get firstNameRequired => 'First name is required';
 
   @override
-  String get forgotPasswordDescription =>
-      'An OTP will be sent to your registered email ID to reset your password';
+  String get forgotPasswordDescription => 'An OTP will be sent to your registered email ID to reset your password';
 
   @override
   String get forgotPasswordLink => 'Forgot password?';
@@ -183,8 +177,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get createProjectButton => 'Create a project';
 
   @override
-  String get projectCreationSuccessMessage =>
-      'You have successfully created a new project';
+  String get projectCreationSuccessMessage => 'You have successfully created a new project';
 
   @override
   String get continueToDashboardButton => 'Continue to Dashboard';
@@ -205,8 +198,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get projectDetailsRetryButton => 'Retry';
 
   @override
-  String get heyEnterYourDetailsToRegisterWithUs =>
-      'Hey, Enter your details to Register with us';
+  String get heyEnterYourDetailsToRegisterWithUs => 'Hey, Enter your details to Register with us';
 
   @override
   String get invalidCredentialsError => 'Invalid credentials';
@@ -218,8 +210,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get invalidOtpError => 'OTP must be exactly 6 digits';
 
   @override
-  String get invalidPhoneError =>
-      'Please enter a valid phone number in international format (e.g., +1234567890)';
+  String get invalidPhoneError => 'Please enter a valid phone number in international format (e.g., +1234567890)';
 
   @override
   String get invalidVerificationCode => 'Invalid verification code';
@@ -243,12 +234,10 @@ class AppLocalizationsEn extends AppLocalizations {
   String get logginLink => 'Log in';
 
   @override
-  String get loginFailedInvalidCredentials =>
-      'Login failed - invalid credentials';
+  String get loginFailedInvalidCredentials => 'Login failed - invalid credentials';
 
   @override
-  String get loginSuccessMessage =>
-      'You have successfully logged in with Construculator';
+  String get loginSuccessMessage => 'You have successfully logged in with Construculator';
 
   @override
   String get mobileNumberHint => 'Mobile Number';
@@ -272,8 +261,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get otpIncompleteError => 'Please enter the complete 6-digit OTP.';
 
   @override
-  String get otpPhoneVerificationNote =>
-      'Enter 6 digit code we just texted to your phone number';
+  String get otpPhoneVerificationNote => 'Enter 6 digit code we just texted to your phone number';
 
   @override
   String get otpRequiredError => 'OTP is required';
@@ -282,8 +270,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get otpResendSuccess => 'OTP Resent!';
 
   @override
-  String get otpVerificationNote =>
-      'Enter 6 digit code we just texted to your email ID';
+  String get otpVerificationNote => 'Enter 6 digit code we just texted to your email ID';
 
   @override
   String get passwordHint => 'Password';
@@ -292,20 +279,16 @@ class AppLocalizationsEn extends AppLocalizations {
   String get passwordLabel => 'Password*';
 
   @override
-  String get passwordMissingLowercaseError =>
-      'Password must contain at least one lowercase letter';
+  String get passwordMissingLowercaseError => 'Password must contain at least one lowercase letter';
 
   @override
-  String get passwordMissingNumberError =>
-      'Password must contain at least one number';
+  String get passwordMissingNumberError => 'Password must contain at least one number';
 
   @override
-  String get passwordMissingSpecialCharError =>
-      'Password must contain at least one special character (!@#\$&*~)';
+  String get passwordMissingSpecialCharError => 'Password must contain at least one special character (!@#\$&*~)';
 
   @override
-  String get passwordMissingUppercaseError =>
-      'Password must contain at least one uppercase letter';
+  String get passwordMissingUppercaseError => 'Password must contain at least one uppercase letter';
 
   @override
   String get passwordRequiredError => 'Password is required';
@@ -317,15 +300,13 @@ class AppLocalizationsEn extends AppLocalizations {
   String get hidePasswordLabel => 'Hide password';
 
   @override
-  String get passwordResetSuccessMessage =>
-      'Your password has been reset successfully!';
+  String get passwordResetSuccessMessage => 'Your password has been reset successfully!';
 
   @override
   String get passwordsDoNotMatchError => 'Passwords do not match';
 
   @override
-  String get passwordTooShortError =>
-      'Password must be at least 8 characters long';
+  String get passwordTooShortError => 'Password must be at least 8 characters long';
 
   @override
   String get phoneDuplicateErrorMessage => 'Phone number exists';
@@ -346,12 +327,10 @@ class AppLocalizationsEn extends AppLocalizations {
   String get registrationFailedError => 'Registration failed';
 
   @override
-  String get registrationFailedTryAgain =>
-      'Registration failed - please try again';
+  String get registrationFailedTryAgain => 'Registration failed - please try again';
 
   @override
-  String get registrationSuccessMessage =>
-      'You have successfully registered with Construculator';
+  String get registrationSuccessMessage => 'You have successfully registered with Construculator';
 
   @override
   String get requestTimedOut => 'Request timed out. Please try again.';
@@ -375,8 +354,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get rolesLoadingError => 'Error loading roles. Please try again.';
 
   @override
-  String get samePasswordErrorMessage =>
-      'Password is the same as current one, please change it.';
+  String get samePasswordErrorMessage => 'Password is the same as current one, please change it.';
 
   @override
   String get selectCountryCode => 'Select Country Code';
@@ -394,8 +372,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get serverError => 'Server error';
 
   @override
-  String get setNewPasswordDescription =>
-      'Your password must minimum of 8 characters, with upper and lowercase and a number or a symbol';
+  String get setNewPasswordDescription => 'Your password must minimum of 8 characters, with upper and lowercase and a number or a symbol';
 
   @override
   String get setNewPasswordTitle => 'Set new password';
@@ -407,8 +384,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get settingPasswordButton => 'Setting Password...';
 
   @override
-  String get termsAndConditionsText =>
-      'By selecting agree and continue. I agree to Construculator ';
+  String get termsAndConditionsText => 'By selecting agree and continue. I agree to Construculator ';
 
   @override
   String get termsAndServicesLink => 'terms & services';
@@ -417,12 +393,10 @@ class AppLocalizationsEn extends AppLocalizations {
   String get timeoutError => 'Request timeout';
 
   @override
-  String get tooManyAttempts =>
-      'Too many attempts, please try again in a minute.';
+  String get tooManyAttempts => 'Too many attempts, please try again in a minute.';
 
   @override
-  String get unexpectedErrorMessage =>
-      'An unexpected error occurred, try again or contact support.';
+  String get unexpectedErrorMessage => 'An unexpected error occurred, try again or contact support.';
 
   @override
   String get unknownError => 'Unknown error occurred';
@@ -464,8 +438,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get contributorRole => 'Contributor';
 
   @override
-  String get costEstimationEmptyMessage =>
-      'No estimation added. To add an estimation please click on add button';
+  String get costEstimationEmptyMessage => 'No estimation added. To add an estimation please click on add button';
 
   @override
   String get projectLoadError => 'Unable to load project';
@@ -508,8 +481,7 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
-  String get deleteEstimationWarningMessage =>
-      'By removing you will lose all the Material, Labour and Equipment Cost Calculation Permanently as well as the images and documents attached with that calculation also will be removed';
+  String get deleteEstimationWarningMessage => 'By removing you will lose all the Material, Labour and Equipment Cost Calculation Permanently as well as the images and documents attached with that calculation also will be removed';
 
   @override
   String imagesAttachedCount(int count) {
@@ -533,8 +505,7 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
-  String get deleteProjectWarningMessage =>
-      'By removing this project you will lose all calculations, costs, and images attached to your calculations';
+  String get deleteProjectWarningMessage => 'By removing this project you will lose all calculations, costs, and images attached to your calculations';
 
   @override
   String get deleteProjectButton => 'Delete project';
@@ -557,16 +528,13 @@ class AppLocalizationsEn extends AppLocalizations {
   String get estimationLockedSuccessTitle => 'You have locked the estimation';
 
   @override
-  String get estimationLockedSuccessDescription =>
-      'If you want to unlock it again press the same unlock button';
+  String get estimationLockedSuccessDescription => 'If you want to unlock it again press the same unlock button';
 
   @override
-  String get estimationUnlockedSuccessTitle =>
-      'You have unlocked the estimation';
+  String get estimationUnlockedSuccessTitle => 'You have unlocked the estimation';
 
   @override
-  String get estimationUnlockedSuccessDescription =>
-      'If you want to lock it again press the same lock button';
+  String get estimationUnlockedSuccessDescription => 'If you want to lock it again press the same lock button';
 
   @override
   String get addCostName => 'Add a cost name';
@@ -787,8 +755,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get noActivityLogs => 'No Activity Yet';
 
   @override
-  String get noActivityLogsDescription =>
-      'Activity logs will appear here when changes are made to this estimation.';
+  String get noActivityLogsDescription => 'Activity logs will appear here when changes are made to this estimation.';
 
   @override
   String get errorLoadingLogs => 'Unable to Load Activity';
@@ -809,8 +776,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get estimatesTab => 'Estimates';
 
   @override
-  String get permissionDenied =>
-      'You don\'t have permission to perform this action';
+  String get permissionDenied => 'You don\'t have permission to perform this action';
 
   @override
   String get materialsTab => 'Materials';
@@ -822,16 +788,13 @@ class AppLocalizationsEn extends AppLocalizations {
   String get equipmentsTab => 'Equipments';
 
   @override
-  String get noMaterialCostMessage =>
-      'No material cost added. For adding cost please click on add button';
+  String get noMaterialCostMessage => 'No material cost added. For adding cost please click on add button';
 
   @override
-  String get noLabourCostMessage =>
-      'No labour cost added. For adding cost please click on add button';
+  String get noLabourCostMessage => 'No labour cost added. For adding cost please click on add button';
 
   @override
-  String get noEquipmentCostMessage =>
-      'No equipment cost added. For adding cost please click on add button';
+  String get noEquipmentCostMessage => 'No equipment cost added. For adding cost please click on add button';
 
   @override
   String get addMaterialCostButton => 'Add material cost';
@@ -959,30 +922,25 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
-  String get globalSearchLoadErrorMessage =>
-      'Failed to load recent searches. Please try again.';
+  String get globalSearchLoadErrorMessage => 'Failed to load recent searches. Please try again.';
 
   @override
   String get searchPerformErrorMessage => 'Search failed. Please try again.';
 
   @override
-  String get searchFailureBodyMessage =>
-      'Something went wrong while searching.';
+  String get searchFailureBodyMessage => 'Something went wrong while searching.';
 
   @override
   String get searchFailureRetryLabel => 'Retry';
 
   @override
-  String get globalSearchDeleteErrorMessage =>
-      'Failed to remove recent search. Please try again.';
+  String get globalSearchDeleteErrorMessage => 'Failed to remove recent search. Please try again.';
 
   @override
-  String get globalSearchSuggestionsErrorMessage =>
-      'Could not load suggestions.';
+  String get globalSearchSuggestionsErrorMessage => 'Could not load suggestions.';
 
   @override
-  String get searchNavigationError =>
-      'Failed to open search. Please try again.';
+  String get searchNavigationError => 'Failed to open search. Please try again.';
 
   @override
   String get closeButton => 'Close';
@@ -1005,8 +963,7 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
-  String get dashboardLoadProfileError =>
-      'Failed to load profile. Please try again.';
+  String get dashboardLoadProfileError => 'Failed to load profile. Please try again.';
 
   @override
   String get projectSelectorSemanticLabel => 'Select project';
@@ -1032,12 +989,10 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
-  String get globalSearchFilterModifiedSemanticLabel =>
-      'Filter by modification date';
+  String get globalSearchFilterModifiedSemanticLabel => 'Filter by modification date';
 
   @override
-  String get projectSearchFilterModifiedSemanticLabel =>
-      'Filter by modification date';
+  String get projectSearchFilterModifiedSemanticLabel => 'Filter by modification date';
 
   @override
   String get projectSearchFilterOwner => 'Owner';
@@ -1056,8 +1011,7 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
-  String get projectSearchClearDateFilterSemanticLabel =>
-      'Clear modification date filter';
+  String get projectSearchClearDateFilterSemanticLabel => 'Clear modification date filter';
 
   @override
   String get projectSearchTagsSheetTitle => 'Tags';
@@ -1090,8 +1044,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get projectSearchOwnerSheetEmpty => 'No owners found.';
 
   @override
-  String get globalSearchClearDateFilterSemanticLabel =>
-      'Clear modification date filter';
+  String get globalSearchClearDateFilterSemanticLabel => 'Clear modification date filter';
 
   @override
   String get globalSearchTagsSheetTitle => 'Tags';
@@ -1120,8 +1073,7 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
-  String get globalSearchTypeSheetTitle =>
-      'Select Filter by cost or calculation';
+  String get globalSearchTypeSheetTitle => 'Select Filter by cost or calculation';
 
   @override
   String get globalSearchTypeCostLabel => 'Cost';
@@ -1151,8 +1103,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get projectNameRequiredError => 'Project name is required';
 
   @override
-  String get projectNameTooLongError =>
-      'Project name must be 100 characters or less';
+  String get projectNameTooLongError => 'Project name must be 100 characters or less';
 
   @override
   String get projectDescriptionLabel => 'Project description';
@@ -1161,8 +1112,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get projectDescriptionHintText => 'Project description';
 
   @override
-  String get projectDescriptionTooLongError =>
-      'Description must be 100 characters or less';
+  String get projectDescriptionTooLongError => 'Description must be 100 characters or less';
 
   @override
   String get dateRangeSheetTitle => 'Date range';
@@ -1339,12 +1289,10 @@ class AppLocalizationsEn extends AppLocalizations {
   String get equipmentNameRequiredError => 'Equipment name is required';
 
   @override
-  String get projectSettingsNavigationError =>
-      'Unable to open project settings. Please try again.';
+  String get projectSettingsNavigationError => 'Unable to open project settings. Please try again.';
 
   @override
-  String get projectSettingsPermissionError =>
-      'You don\'t have permission to view this project.';
+  String get projectSettingsPermissionError => 'You don\'t have permission to view this project.';
 
   @override
   String get calculatorOcLabel => 'O.C';

--- a/lib/l10n/generated/app_localizations_en.dart
+++ b/lib/l10n/generated/app_localizations_en.dart
@@ -60,10 +60,12 @@ class AppLocalizationsEn extends AppLocalizations {
   String get continueWithPhone => 'Continue with Phone';
 
   @override
-  String get createAccountSubtitle => 'Email you entered is not registered with us, to create your construculator account enter details below';
+  String get createAccountSubtitle =>
+      'Email you entered is not registered with us, to create your construculator account enter details below';
 
   @override
-  String get createAccountSuccessMessage => 'You have successfully registered with Construculator';
+  String get createAccountSuccessMessage =>
+      'You have successfully registered with Construculator';
 
   @override
   String get createAccountTitle => 'Create your Account';
@@ -81,7 +83,8 @@ class AppLocalizationsEn extends AppLocalizations {
   String get duplicateErrorMessage => 'Duplicate Error';
 
   @override
-  String get emailAlreadyRegistered => 'Email ID already registered with us. Please ';
+  String get emailAlreadyRegistered =>
+      'Email ID already registered with us. Please ';
 
   @override
   String get emailDuplicateErrorMessage => 'Email exists';
@@ -99,13 +102,15 @@ class AppLocalizationsEn extends AppLocalizations {
   String get emailRequiredError => 'Email is required';
 
   @override
-  String get enterPasswordDescription => 'Enter your password for this account. Your email id is';
+  String get enterPasswordDescription =>
+      'Enter your password for this account. Your email id is';
 
   @override
   String get enterPasswordTitle => 'Enter your password';
 
   @override
-  String get enterYourEmailIdToLoginToYourAccount => 'Hey, Enter your details to log in to your account';
+  String get enterYourEmailIdToLoginToYourAccount =>
+      'Hey, Enter your details to log in to your account';
 
   @override
   String get firstNameHint => 'First name';
@@ -117,7 +122,8 @@ class AppLocalizationsEn extends AppLocalizations {
   String get firstNameRequired => 'First name is required';
 
   @override
-  String get forgotPasswordDescription => 'An OTP will be sent to your registered email ID to reset your password';
+  String get forgotPasswordDescription =>
+      'An OTP will be sent to your registered email ID to reset your password';
 
   @override
   String get forgotPasswordLink => 'Forgot password?';
@@ -177,7 +183,8 @@ class AppLocalizationsEn extends AppLocalizations {
   String get createProjectButton => 'Create a project';
 
   @override
-  String get projectCreationSuccessMessage => 'You have successfully created a new project';
+  String get projectCreationSuccessMessage =>
+      'You have successfully created a new project';
 
   @override
   String get continueToDashboardButton => 'Continue to Dashboard';
@@ -198,7 +205,8 @@ class AppLocalizationsEn extends AppLocalizations {
   String get projectDetailsRetryButton => 'Retry';
 
   @override
-  String get heyEnterYourDetailsToRegisterWithUs => 'Hey, Enter your details to Register with us';
+  String get heyEnterYourDetailsToRegisterWithUs =>
+      'Hey, Enter your details to Register with us';
 
   @override
   String get invalidCredentialsError => 'Invalid credentials';
@@ -210,7 +218,8 @@ class AppLocalizationsEn extends AppLocalizations {
   String get invalidOtpError => 'OTP must be exactly 6 digits';
 
   @override
-  String get invalidPhoneError => 'Please enter a valid phone number in international format (e.g., +1234567890)';
+  String get invalidPhoneError =>
+      'Please enter a valid phone number in international format (e.g., +1234567890)';
 
   @override
   String get invalidVerificationCode => 'Invalid verification code';
@@ -234,10 +243,12 @@ class AppLocalizationsEn extends AppLocalizations {
   String get logginLink => 'Log in';
 
   @override
-  String get loginFailedInvalidCredentials => 'Login failed - invalid credentials';
+  String get loginFailedInvalidCredentials =>
+      'Login failed - invalid credentials';
 
   @override
-  String get loginSuccessMessage => 'You have successfully logged in with Construculator';
+  String get loginSuccessMessage =>
+      'You have successfully logged in with Construculator';
 
   @override
   String get mobileNumberHint => 'Mobile Number';
@@ -261,7 +272,8 @@ class AppLocalizationsEn extends AppLocalizations {
   String get otpIncompleteError => 'Please enter the complete 6-digit OTP.';
 
   @override
-  String get otpPhoneVerificationNote => 'Enter 6 digit code we just texted to your phone number';
+  String get otpPhoneVerificationNote =>
+      'Enter 6 digit code we just texted to your phone number';
 
   @override
   String get otpRequiredError => 'OTP is required';
@@ -270,7 +282,8 @@ class AppLocalizationsEn extends AppLocalizations {
   String get otpResendSuccess => 'OTP Resent!';
 
   @override
-  String get otpVerificationNote => 'Enter 6 digit code we just texted to your email ID';
+  String get otpVerificationNote =>
+      'Enter 6 digit code we just texted to your email ID';
 
   @override
   String get passwordHint => 'Password';
@@ -279,16 +292,20 @@ class AppLocalizationsEn extends AppLocalizations {
   String get passwordLabel => 'Password*';
 
   @override
-  String get passwordMissingLowercaseError => 'Password must contain at least one lowercase letter';
+  String get passwordMissingLowercaseError =>
+      'Password must contain at least one lowercase letter';
 
   @override
-  String get passwordMissingNumberError => 'Password must contain at least one number';
+  String get passwordMissingNumberError =>
+      'Password must contain at least one number';
 
   @override
-  String get passwordMissingSpecialCharError => 'Password must contain at least one special character (!@#\$&*~)';
+  String get passwordMissingSpecialCharError =>
+      'Password must contain at least one special character (!@#\$&*~)';
 
   @override
-  String get passwordMissingUppercaseError => 'Password must contain at least one uppercase letter';
+  String get passwordMissingUppercaseError =>
+      'Password must contain at least one uppercase letter';
 
   @override
   String get passwordRequiredError => 'Password is required';
@@ -300,13 +317,15 @@ class AppLocalizationsEn extends AppLocalizations {
   String get hidePasswordLabel => 'Hide password';
 
   @override
-  String get passwordResetSuccessMessage => 'Your password has been reset successfully!';
+  String get passwordResetSuccessMessage =>
+      'Your password has been reset successfully!';
 
   @override
   String get passwordsDoNotMatchError => 'Passwords do not match';
 
   @override
-  String get passwordTooShortError => 'Password must be at least 8 characters long';
+  String get passwordTooShortError =>
+      'Password must be at least 8 characters long';
 
   @override
   String get phoneDuplicateErrorMessage => 'Phone number exists';
@@ -327,10 +346,12 @@ class AppLocalizationsEn extends AppLocalizations {
   String get registrationFailedError => 'Registration failed';
 
   @override
-  String get registrationFailedTryAgain => 'Registration failed - please try again';
+  String get registrationFailedTryAgain =>
+      'Registration failed - please try again';
 
   @override
-  String get registrationSuccessMessage => 'You have successfully registered with Construculator';
+  String get registrationSuccessMessage =>
+      'You have successfully registered with Construculator';
 
   @override
   String get requestTimedOut => 'Request timed out. Please try again.';
@@ -354,7 +375,8 @@ class AppLocalizationsEn extends AppLocalizations {
   String get rolesLoadingError => 'Error loading roles. Please try again.';
 
   @override
-  String get samePasswordErrorMessage => 'Password is the same as current one, please change it.';
+  String get samePasswordErrorMessage =>
+      'Password is the same as current one, please change it.';
 
   @override
   String get selectCountryCode => 'Select Country Code';
@@ -372,7 +394,8 @@ class AppLocalizationsEn extends AppLocalizations {
   String get serverError => 'Server error';
 
   @override
-  String get setNewPasswordDescription => 'Your password must minimum of 8 characters, with upper and lowercase and a number or a symbol';
+  String get setNewPasswordDescription =>
+      'Your password must minimum of 8 characters, with upper and lowercase and a number or a symbol';
 
   @override
   String get setNewPasswordTitle => 'Set new password';
@@ -384,7 +407,8 @@ class AppLocalizationsEn extends AppLocalizations {
   String get settingPasswordButton => 'Setting Password...';
 
   @override
-  String get termsAndConditionsText => 'By selecting agree and continue. I agree to Construculator ';
+  String get termsAndConditionsText =>
+      'By selecting agree and continue. I agree to Construculator ';
 
   @override
   String get termsAndServicesLink => 'terms & services';
@@ -393,10 +417,12 @@ class AppLocalizationsEn extends AppLocalizations {
   String get timeoutError => 'Request timeout';
 
   @override
-  String get tooManyAttempts => 'Too many attempts, please try again in a minute.';
+  String get tooManyAttempts =>
+      'Too many attempts, please try again in a minute.';
 
   @override
-  String get unexpectedErrorMessage => 'An unexpected error occurred, try again or contact support.';
+  String get unexpectedErrorMessage =>
+      'An unexpected error occurred, try again or contact support.';
 
   @override
   String get unknownError => 'Unknown error occurred';
@@ -438,7 +464,8 @@ class AppLocalizationsEn extends AppLocalizations {
   String get contributorRole => 'Contributor';
 
   @override
-  String get costEstimationEmptyMessage => 'No estimation added. To add an estimation please click on add button';
+  String get costEstimationEmptyMessage =>
+      'No estimation added. To add an estimation please click on add button';
 
   @override
   String get projectLoadError => 'Unable to load project';
@@ -481,7 +508,8 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
-  String get deleteEstimationWarningMessage => 'By removing you will lose all the Material, Labour and Equipment Cost Calculation Permanently as well as the images and documents attached with that calculation also will be removed';
+  String get deleteEstimationWarningMessage =>
+      'By removing you will lose all the Material, Labour and Equipment Cost Calculation Permanently as well as the images and documents attached with that calculation also will be removed';
 
   @override
   String imagesAttachedCount(int count) {
@@ -505,7 +533,8 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
-  String get deleteProjectWarningMessage => 'By removing this project you will lose all calculations, costs, and images attached to your calculations';
+  String get deleteProjectWarningMessage =>
+      'By removing this project you will lose all calculations, costs, and images attached to your calculations';
 
   @override
   String get deleteProjectButton => 'Delete project';
@@ -528,13 +557,16 @@ class AppLocalizationsEn extends AppLocalizations {
   String get estimationLockedSuccessTitle => 'You have locked the estimation';
 
   @override
-  String get estimationLockedSuccessDescription => 'If you want to unlock it again press the same unlock button';
+  String get estimationLockedSuccessDescription =>
+      'If you want to unlock it again press the same unlock button';
 
   @override
-  String get estimationUnlockedSuccessTitle => 'You have unlocked the estimation';
+  String get estimationUnlockedSuccessTitle =>
+      'You have unlocked the estimation';
 
   @override
-  String get estimationUnlockedSuccessDescription => 'If you want to lock it again press the same lock button';
+  String get estimationUnlockedSuccessDescription =>
+      'If you want to lock it again press the same lock button';
 
   @override
   String get addCostName => 'Add a cost name';
@@ -755,7 +787,8 @@ class AppLocalizationsEn extends AppLocalizations {
   String get noActivityLogs => 'No Activity Yet';
 
   @override
-  String get noActivityLogsDescription => 'Activity logs will appear here when changes are made to this estimation.';
+  String get noActivityLogsDescription =>
+      'Activity logs will appear here when changes are made to this estimation.';
 
   @override
   String get errorLoadingLogs => 'Unable to Load Activity';
@@ -776,7 +809,8 @@ class AppLocalizationsEn extends AppLocalizations {
   String get estimatesTab => 'Estimates';
 
   @override
-  String get permissionDenied => 'You don\'t have permission to perform this action';
+  String get permissionDenied =>
+      'You don\'t have permission to perform this action';
 
   @override
   String get materialsTab => 'Materials';
@@ -788,13 +822,16 @@ class AppLocalizationsEn extends AppLocalizations {
   String get equipmentsTab => 'Equipments';
 
   @override
-  String get noMaterialCostMessage => 'No material cost added. For adding cost please click on add button';
+  String get noMaterialCostMessage =>
+      'No material cost added. For adding cost please click on add button';
 
   @override
-  String get noLabourCostMessage => 'No labour cost added. For adding cost please click on add button';
+  String get noLabourCostMessage =>
+      'No labour cost added. For adding cost please click on add button';
 
   @override
-  String get noEquipmentCostMessage => 'No equipment cost added. For adding cost please click on add button';
+  String get noEquipmentCostMessage =>
+      'No equipment cost added. For adding cost please click on add button';
 
   @override
   String get addMaterialCostButton => 'Add material cost';
@@ -922,25 +959,30 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
-  String get globalSearchLoadErrorMessage => 'Failed to load recent searches. Please try again.';
+  String get globalSearchLoadErrorMessage =>
+      'Failed to load recent searches. Please try again.';
 
   @override
   String get searchPerformErrorMessage => 'Search failed. Please try again.';
 
   @override
-  String get searchFailureBodyMessage => 'Something went wrong while searching.';
+  String get searchFailureBodyMessage =>
+      'Something went wrong while searching.';
 
   @override
   String get searchFailureRetryLabel => 'Retry';
 
   @override
-  String get globalSearchDeleteErrorMessage => 'Failed to remove recent search. Please try again.';
+  String get globalSearchDeleteErrorMessage =>
+      'Failed to remove recent search. Please try again.';
 
   @override
-  String get globalSearchSuggestionsErrorMessage => 'Could not load suggestions.';
+  String get globalSearchSuggestionsErrorMessage =>
+      'Could not load suggestions.';
 
   @override
-  String get searchNavigationError => 'Failed to open search. Please try again.';
+  String get searchNavigationError =>
+      'Failed to open search. Please try again.';
 
   @override
   String get closeButton => 'Close';
@@ -963,7 +1005,8 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
-  String get dashboardLoadProfileError => 'Failed to load profile. Please try again.';
+  String get dashboardLoadProfileError =>
+      'Failed to load profile. Please try again.';
 
   @override
   String get projectSelectorSemanticLabel => 'Select project';
@@ -989,10 +1032,12 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
-  String get globalSearchFilterModifiedSemanticLabel => 'Filter by modification date';
+  String get globalSearchFilterModifiedSemanticLabel =>
+      'Filter by modification date';
 
   @override
-  String get projectSearchFilterModifiedSemanticLabel => 'Filter by modification date';
+  String get projectSearchFilterModifiedSemanticLabel =>
+      'Filter by modification date';
 
   @override
   String get projectSearchFilterOwner => 'Owner';
@@ -1011,7 +1056,8 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
-  String get projectSearchClearDateFilterSemanticLabel => 'Clear modification date filter';
+  String get projectSearchClearDateFilterSemanticLabel =>
+      'Clear modification date filter';
 
   @override
   String get projectSearchTagsSheetTitle => 'Tags';
@@ -1044,7 +1090,8 @@ class AppLocalizationsEn extends AppLocalizations {
   String get projectSearchOwnerSheetEmpty => 'No owners found.';
 
   @override
-  String get globalSearchClearDateFilterSemanticLabel => 'Clear modification date filter';
+  String get globalSearchClearDateFilterSemanticLabel =>
+      'Clear modification date filter';
 
   @override
   String get globalSearchTagsSheetTitle => 'Tags';
@@ -1073,7 +1120,8 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
-  String get globalSearchTypeSheetTitle => 'Select Filter by cost or calculation';
+  String get globalSearchTypeSheetTitle =>
+      'Select Filter by cost or calculation';
 
   @override
   String get globalSearchTypeCostLabel => 'Cost';
@@ -1103,7 +1151,8 @@ class AppLocalizationsEn extends AppLocalizations {
   String get projectNameRequiredError => 'Project name is required';
 
   @override
-  String get projectNameTooLongError => 'Project name must be 100 characters or less';
+  String get projectNameTooLongError =>
+      'Project name must be 100 characters or less';
 
   @override
   String get projectDescriptionLabel => 'Project description';
@@ -1112,7 +1161,8 @@ class AppLocalizationsEn extends AppLocalizations {
   String get projectDescriptionHintText => 'Project description';
 
   @override
-  String get projectDescriptionTooLongError => 'Description must be 100 characters or less';
+  String get projectDescriptionTooLongError =>
+      'Description must be 100 characters or less';
 
   @override
   String get dateRangeSheetTitle => 'Date range';
@@ -1289,10 +1339,12 @@ class AppLocalizationsEn extends AppLocalizations {
   String get equipmentNameRequiredError => 'Equipment name is required';
 
   @override
-  String get projectSettingsNavigationError => 'Unable to open project settings. Please try again.';
+  String get projectSettingsNavigationError =>
+      'Unable to open project settings. Please try again.';
 
   @override
-  String get projectSettingsPermissionError => 'You don\'t have permission to view this project.';
+  String get projectSettingsPermissionError =>
+      'You don\'t have permission to view this project.';
 
   @override
   String get calculatorOcLabel => 'O.C';

--- a/lib/libraries/estimation/data/data_source/interfaces/powersync_cost_estimation_data_source.dart
+++ b/lib/libraries/estimation/data/data_source/interfaces/powersync_cost_estimation_data_source.dart
@@ -1,0 +1,39 @@
+// coverage:ignore-file
+import 'package:construculator/libraries/estimation/data/models/cost_estimate_dto.dart';
+import 'package:construculator/libraries/estimation/domain/enums/estimation_sort_option.dart';
+
+/// Reactive, PowerSync-backed read data source for cost estimations.
+///
+/// Reads go through `watch()` so the UI stays live as sync arrives. Unlike the
+/// request/response [CostEstimationDataSource], this seam owns activation of the
+/// on-demand `user_cost_estimates` sync stream. It returns DTOs (no `Either`)
+/// and always rethrows; the repository is the error boundary. Write operations
+/// (create/delete/rename/lock) are added in later PRs.
+abstract class PowerSyncCostEstimationDataSource {
+  /// Watches the cost estimates for [projectId] from local SQLite, ordered by
+  /// [sortBy] in the given [ascending] direction and optionally capped to
+  /// [limit] rows (null means no cap).
+  ///
+  /// Activates the on-demand `user_cost_estimates` sync stream on the first
+  /// subscription and releases it when that subscription is cancelled. The
+  /// returned stream re-emits on every local or synced change and is the single
+  /// source of truth — callers must not patch results by hand after a write.
+  Stream<List<CostEstimateDto>> watchEstimations({
+    required String projectId,
+    EstimationSortOption sortBy = EstimationSortOption.createdAt,
+    bool ascending = false,
+    int? limit,
+  });
+
+  /// Reads a one-shot snapshot of the cost estimates for [projectId] from local
+  /// SQLite, ordered by [sortBy] in the given [ascending] direction and
+  /// optionally capped to [limit] rows (null means no cap).
+  ///
+  /// Does not activate the sync stream; use [watchEstimations] for live reads.
+  Future<List<CostEstimateDto>> getEstimations({
+    required String projectId,
+    EstimationSortOption sortBy = EstimationSortOption.createdAt,
+    bool ascending = false,
+    int? limit,
+  });
+}

--- a/lib/libraries/estimation/data/data_source/interfaces/powersync_cost_estimation_data_source.dart
+++ b/lib/libraries/estimation/data/data_source/interfaces/powersync_cost_estimation_data_source.dart
@@ -25,6 +25,17 @@ abstract class PowerSyncCostEstimationDataSource {
     int? limit,
   });
 
+  /// Watches a single cost estimate by [id] from local SQLite, re-emitting on
+  /// every local or synced change to that row.
+  ///
+  /// Emits `null` when no row matches — either because the estimate has not yet
+  /// synced down or because it was deleted — so the UI can react to the row
+  /// appearing and disappearing. Like [watchEstimations], it activates the
+  /// on-demand `user_cost_estimates` sync stream on the first subscription and
+  /// releases it when that subscription is cancelled, and remains the single
+  /// source of truth — callers must not patch the result by hand after a write.
+  Stream<CostEstimateDto?> watchEstimationById({required String id});
+
   /// Reads a one-shot snapshot of the cost estimates for [projectId] from local
   /// SQLite, ordered by [sortBy] in the given [ascending] direction and
   /// optionally capped to [limit] rows (null means no cap).

--- a/lib/libraries/estimation/data/data_source/powersync_cost_estimation_data_source_impl.dart
+++ b/lib/libraries/estimation/data/data_source/powersync_cost_estimation_data_source_impl.dart
@@ -1,0 +1,140 @@
+import 'dart:async';
+
+import 'package:construculator/libraries/estimation/data/data_source/interfaces/powersync_cost_estimation_data_source.dart';
+import 'package:construculator/libraries/estimation/data/models/cost_estimate_dto.dart';
+import 'package:construculator/libraries/estimation/domain/enums/estimation_sort_option.dart';
+import 'package:construculator/libraries/logging/app_logger.dart';
+import 'package:construculator/libraries/powersync/interfaces/powersync_database_wrapper.dart';
+
+/// PowerSync-backed [PowerSyncCostEstimationDataSource].
+///
+/// Talks to the [PowerSyncDatabaseWrapper] seam: reads through reactive
+/// `watch()` streams over local SQLite and activates the on-demand
+/// `user_cost_estimates` sync stream lazily on the first watch subscription.
+/// Rows come back as `Map<String, dynamic>` and are mapped to DTOs via
+/// [CostEstimateDto.fromRow], which handles SQLite encodings (e.g. `is_locked`
+/// as `0`/`1`). Write operations are added in later PRs.
+class PowerSyncCostEstimationDataSourceImpl
+    implements PowerSyncCostEstimationDataSource {
+  final PowerSyncDatabaseWrapper _wrapper;
+  static final _logger = AppLogger().tag('PowerSyncCostEstimationDataSource');
+
+  // Local SQLite table backing cost estimates (see `schema.dart`).
+  static const _table = 'cost_estimates';
+
+  // On-demand sync stream gating which estimates sync down; membership and the
+  // `get_cost_estimations` permission are derived from the JWT server-side.
+  static const _syncStreamName = 'user_cost_estimates';
+
+  PowerSyncCostEstimationDataSourceImpl({
+    required PowerSyncDatabaseWrapper wrapper,
+  }) : _wrapper = wrapper;
+
+  @override
+  Stream<List<CostEstimateDto>> watchEstimations({
+    required String projectId,
+    EstimationSortOption sortBy = EstimationSortOption.createdAt,
+    bool ascending = false,
+    int? limit,
+  }) {
+    final sql = _buildSelectSql(
+      sortBy: sortBy,
+      ascending: ascending,
+      limited: limit != null,
+    );
+    final parameters = _selectParameters(projectId, limit);
+
+    // Lazy activation tied to the subscription lifecycle: the on-demand stream
+    // is only synced while someone is actually watching it, and is released on
+    // cancel. The watch() stream remains the single source of truth.
+    return Stream<List<CostEstimateDto>>.multi((controller) async {
+      SyncStreamHandle? handle;
+      StreamSubscription<List<CostEstimateDto>>? subscription;
+      var listenerCancelled = false;
+
+      Future<void> releaseHandle() async {
+        final currentHandle = handle;
+        handle = null;
+        currentHandle?.unsubscribe();
+      }
+
+      controller.onCancel = () async {
+        listenerCancelled = true;
+        await subscription?.cancel();
+        subscription = null;
+        await releaseHandle();
+      };
+
+      _logger.debug(
+        'Activating sync stream "$_syncStreamName" and watching estimates '
+        'for project: $projectId',
+      );
+
+      try {
+        handle = await _wrapper.syncStream(_syncStreamName);
+      } catch (error, stackTrace) {
+        controller.addError(error, stackTrace);
+        await controller.close();
+        return;
+      }
+
+      if (listenerCancelled || !controller.hasListener) {
+        await releaseHandle();
+        return;
+      }
+
+      subscription = _wrapper
+          .watch(sql, parameters: parameters)
+          .map((rows) => rows.map(CostEstimateDto.fromRow).toList())
+          .listen(
+            controller.add,
+            onError: controller.addError,
+            onDone: controller.close,
+          );
+
+      if (listenerCancelled || !controller.hasListener) {
+        await subscription?.cancel();
+        subscription = null;
+        await releaseHandle();
+      }
+    });
+  }
+
+  @override
+  Future<List<CostEstimateDto>> getEstimations({
+    required String projectId,
+    EstimationSortOption sortBy = EstimationSortOption.createdAt,
+    bool ascending = false,
+    int? limit,
+  }) async {
+    final sql = _buildSelectSql(
+      sortBy: sortBy,
+      ascending: ascending,
+      limited: limit != null,
+    );
+    final rows = await _wrapper.getAll(
+      sql,
+      _selectParameters(projectId, limit),
+    );
+    return rows.map(CostEstimateDto.fromRow).toList();
+  }
+
+  String _buildSelectSql({
+    required EstimationSortOption sortBy,
+    required bool ascending,
+    required bool limited,
+  }) {
+    final orderColumn = sortBy == EstimationSortOption.updatedAt
+        ? 'updated_at'
+        : 'created_at';
+    final direction = ascending ? 'ASC' : 'DESC';
+    final limitClause = limited ? ' LIMIT ?' : '';
+    return 'SELECT * FROM $_table WHERE project_id = ? '
+        'ORDER BY $orderColumn $direction$limitClause';
+  }
+
+  List<Object?> _selectParameters(String projectId, int? limit) => [
+    projectId,
+    if (limit != null) limit,
+  ];
+}

--- a/lib/libraries/estimation/data/data_source/powersync_cost_estimation_data_source_impl.dart
+++ b/lib/libraries/estimation/data/data_source/powersync_cost_estimation_data_source_impl.dart
@@ -42,14 +42,52 @@ class PowerSyncCostEstimationDataSourceImpl
       ascending: ascending,
       limited: limit != null,
     );
-    final parameters = _selectParameters(projectId, limit);
+    return _watchWithSyncStream(
+      sql: sql,
+      parameters: _selectParameters(projectId, limit),
+      mapRows: (rows) => rows.map(CostEstimateDto.fromRow).toList(),
+      logMessage:
+          'Activating sync stream "$_syncStreamName" and watching estimates '
+          'for project: $projectId',
+    );
+  }
 
-    // Lazy activation tied to the subscription lifecycle: the on-demand stream
-    // is only synced while someone is actually watching it, and is released on
-    // cancel. The watch() stream remains the single source of truth.
-    return Stream<List<CostEstimateDto>>.multi((controller) async {
+  @override
+  Stream<CostEstimateDto?> watchEstimationById({required String id}) {
+    return _watchWithSyncStream(
+      sql: 'SELECT * FROM $_table WHERE id = ? LIMIT 1',
+      parameters: [id],
+      mapRows: (rows) =>
+          rows.isEmpty ? null : CostEstimateDto.fromRow(rows.first),
+      // `watch` fires on any change to `cost_estimates`, so an unrelated
+      // estimate would otherwise rebuild this row into an identical DTO.
+      dedupe: true,
+      logMessage:
+          'Activating sync stream "$_syncStreamName" and watching estimate: $id',
+    );
+  }
+
+  // Watches [sql] as the single source of truth while keeping the on-demand
+  // `user_cost_estimates` sync stream active only for the subscription's
+  // lifetime.
+  //
+  // Lazy activation tied to the subscription lifecycle: the on-demand stream is
+  // only synced while someone is actually watching it, and is released on
+  // cancel. [mapRows] projects each raw result set into the emitted shape T (a
+  // list for the collection watch, a nullable DTO for the by-id watch).
+  //
+  // [dedupe] drops emissions equal to the previous one, for shapes T that have
+  // value equality.
+  Stream<T> _watchWithSyncStream<T>({
+    required String sql,
+    required List<Object?> parameters,
+    required T Function(List<Map<String, dynamic>> rows) mapRows,
+    required String logMessage,
+    bool dedupe = false,
+  }) {
+    return Stream<T>.multi((controller) async {
       SyncStreamHandle? handle;
-      StreamSubscription<List<CostEstimateDto>>? subscription;
+      StreamSubscription<T>? subscription;
       var listenerCancelled = false;
 
       Future<void> releaseHandle() async {
@@ -65,10 +103,7 @@ class PowerSyncCostEstimationDataSourceImpl
         await releaseHandle();
       };
 
-      _logger.debug(
-        'Activating sync stream "$_syncStreamName" and watching estimates '
-        'for project: $projectId',
-      );
+      _logger.debug(logMessage);
 
       try {
         handle = await _wrapper.syncStream(_syncStreamName);
@@ -83,14 +118,12 @@ class PowerSyncCostEstimationDataSourceImpl
         return;
       }
 
-      subscription = _wrapper
-          .watch(sql, parameters: parameters)
-          .map((rows) => rows.map(CostEstimateDto.fromRow).toList())
-          .listen(
-            controller.add,
-            onError: controller.addError,
-            onDone: controller.close,
-          );
+      final rows = _wrapper.watch(sql, parameters: parameters).map(mapRows);
+      subscription = (dedupe ? rows.distinct() : rows).listen(
+        controller.add,
+        onError: controller.addError,
+        onDone: controller.close,
+      );
 
       if (listenerCancelled || !controller.hasListener) {
         await subscription?.cancel();

--- a/lib/libraries/estimation/data/models/cost_estimate_dto.dart
+++ b/lib/libraries/estimation/data/models/cost_estimate_dto.dart
@@ -156,6 +156,23 @@ class CostEstimateDto extends Equatable {
     );
   }
 
+  /// Creates a [CostEstimateDto] from a PowerSync/SQLite result row.
+  ///
+  /// SQLite has no boolean type, so the `is_locked` column is stored and
+  /// returned as an integer (`0` = false, `1` = true). This factory normalizes
+  /// that encoding to a `bool` before delegating to [CostEstimateDto.fromJson],
+  /// which otherwise expects the Supabase representation where `is_locked` is
+  /// already a boolean. All other columns share the same encoding as the
+  /// Supabase rows (text ids/timestamps, `real`/`integer` numerics).
+  ///
+  /// Throws [TypeError] if required columns are missing or have invalid types.
+  factory CostEstimateDto.fromRow(Map<String, dynamic> row) {
+    return CostEstimateDto.fromJson({
+      ...row,
+      'is_locked': (row['is_locked'] as int? ?? 0) != 0,
+    });
+  }
+
   /// Converts this DTO to a JSON map.
   ///
   /// This method converts the DTO back to the database/API JSON format,

--- a/lib/libraries/estimation/estimation_library_module.dart
+++ b/lib/libraries/estimation/estimation_library_module.dart
@@ -1,8 +1,11 @@
 import 'package:construculator/app/app_bootstrap.dart';
 import 'package:construculator/libraries/estimation/data/data_source/interfaces/cost_estimation_data_source.dart';
+import 'package:construculator/libraries/estimation/data/data_source/interfaces/powersync_cost_estimation_data_source.dart';
+import 'package:construculator/libraries/estimation/data/data_source/powersync_cost_estimation_data_source_impl.dart';
 import 'package:construculator/libraries/estimation/data/data_source/remote_cost_estimation_data_source.dart';
 import 'package:construculator/libraries/estimation/data/repositories/cost_estimation_repository_impl.dart';
 import 'package:construculator/libraries/estimation/domain/repositories/cost_estimation_repository.dart';
+import 'package:construculator/libraries/powersync/powersync_module.dart';
 import 'package:construculator/libraries/supabase/supabase_module.dart';
 import 'package:flutter_modular/flutter_modular.dart';
 
@@ -17,12 +20,19 @@ class EstimationLibraryModule extends Module {
   EstimationLibraryModule(this.appBootstrap);
 
   @override
-  List<Module> get imports => [SupabaseModule(appBootstrap)];
+  List<Module> get imports => [
+    SupabaseModule(appBootstrap),
+    PowerSyncModule(appBootstrap),
+  ];
 
   @override
   void exportedBinds(Injector i) {
     i.addLazySingleton<CostEstimationDataSource>(
       () => RemoteCostEstimationDataSource(supabaseWrapper: i.get()),
+    );
+
+    i.addLazySingleton<PowerSyncCostEstimationDataSource>(
+      () => PowerSyncCostEstimationDataSourceImpl(wrapper: i.get()),
     );
 
     i.addLazySingleton<CostEstimationRepository>(

--- a/lib/libraries/powersync/data/open_powersync_database.dart
+++ b/lib/libraries/powersync/data/open_powersync_database.dart
@@ -1,0 +1,29 @@
+// coverage:ignore-file
+
+import 'package:construculator/libraries/powersync/models/schema.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+import 'package:powersync/powersync.dart';
+
+/// File name for the on-device PowerSync SQLite database.
+const _databaseFileName = 'construculator.db';
+
+/// Opens (and migrates) the local PowerSync database.
+///
+/// This only sets up the on-device SQLite store — it does **not** start
+/// syncing. The database is fully usable offline immediately; syncing with the
+/// backend begins later when [PowerSyncDatabase.connect] is called with an
+/// authenticated connector (see `PowerSyncManager`).
+///
+/// Opening is asynchronous because resolving the application support directory
+/// touches the platform, so this must run during app bootstrap (before the
+/// module graph is built) rather than inside a Modular `binds` callback.
+Future<PowerSyncDatabase> openPowerSyncDatabase() async {
+  final directory = await getApplicationSupportDirectory();
+  final databasePath = p.join(directory.path, _databaseFileName);
+
+  final database = PowerSyncDatabase(schema: schema, path: databasePath);
+  await database.initialize();
+
+  return database;
+}

--- a/lib/libraries/powersync/data/open_powersync_database.dart
+++ b/lib/libraries/powersync/data/open_powersync_database.dart
@@ -5,7 +5,7 @@ import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';
 import 'package:powersync/powersync.dart';
 
-/// File name for the on-device PowerSync SQLite database.
+// File name for the on-device PowerSync SQLite database.
 const _databaseFileName = 'construculator.db';
 
 /// Opens (and migrates) the local PowerSync database.

--- a/lib/libraries/powersync/data/powersync_database_wrapper_impl.dart
+++ b/lib/libraries/powersync/data/powersync_database_wrapper_impl.dart
@@ -2,6 +2,7 @@
 
 import 'package:construculator/libraries/powersync/interfaces/powersync_database_wrapper.dart';
 import 'package:powersync/powersync.dart';
+import 'package:sqlite_async/sqlite_async.dart';
 
 /// Default [PowerSyncDatabaseWrapper] that forwards to the opened
 /// [PowerSyncDatabase].
@@ -56,6 +57,13 @@ class PowerSyncDatabaseWrapperImpl implements PowerSyncDatabaseWrapper {
     await _database.execute(sql, parameters);
   }
 
+  @override
+  Future<T> writeTransaction<T>(Future<T> Function(WriteContext tx) action) {
+    return _database.writeTransaction(
+      (ctx) => action(_SqliteWriteContextAdapter(ctx)),
+    );
+  }
+
   /// Subscribes to the on-demand sync stream [name] and returns a handle that
   /// releases the subscription when unsubscribed.
   @override
@@ -65,6 +73,22 @@ class PowerSyncDatabaseWrapperImpl implements PowerSyncDatabaseWrapper {
     // and cannot be DI-managed.
     // ignore: no_direct_instantiation, reason: subscription-scoped adapter
     return _PowerSyncStreamHandle(subscription);
+  }
+}
+
+/// Adapts [SqliteWriteContext] to the project-owned [WriteContext] seam,
+/// keeping the sqlite_async type out of the data-source layer.
+class _SqliteWriteContextAdapter implements WriteContext {
+  final SqliteWriteContext _ctx;
+
+  _SqliteWriteContextAdapter(this._ctx);
+
+  @override
+  Future<void> execute(
+    String sql, [
+    List<Object?> parameters = const [],
+  ]) async {
+    await _ctx.execute(sql, parameters);
   }
 }
 

--- a/lib/libraries/powersync/data/powersync_database_wrapper_impl.dart
+++ b/lib/libraries/powersync/data/powersync_database_wrapper_impl.dart
@@ -1,0 +1,80 @@
+// coverage:ignore-file
+
+import 'package:construculator/libraries/powersync/interfaces/powersync_database_wrapper.dart';
+import 'package:powersync/powersync.dart';
+
+/// Default [PowerSyncDatabaseWrapper] that forwards to the opened
+/// [PowerSyncDatabase].
+///
+/// Each row returned by the underlying SDK is a `Row` (a `Map`-backed,
+/// unmodifiable view tied to the result set). This implementation copies every
+/// row into a plain, mutable `Map<String, dynamic>` so callers above the
+/// data-source layer never depend on sqlite types or row lifetimes.
+///
+/// Marked `coverage:ignore-file` because it only forwards to the native
+/// `PowerSyncDatabase`, which cannot be exercised without the platform SQLite
+/// extension; behaviour is verified through `FakePowerSyncDatabaseWrapper` in
+/// feature tests instead.
+class PowerSyncDatabaseWrapperImpl implements PowerSyncDatabaseWrapper {
+  final PowerSyncDatabase _database;
+
+  PowerSyncDatabaseWrapperImpl({required PowerSyncDatabase database})
+    : _database = database;
+
+  /// Runs [sql] once and returns every matching row as a plain mutable map.
+  @override
+  Future<List<Map<String, dynamic>>> getAll(
+    String sql, [
+    List<Object?> parameters = const [],
+  ]) async {
+    final result = await _database.getAll(sql, parameters);
+    return result.map((row) => Map<String, dynamic>.from(row)).toList();
+  }
+
+  /// Watches [sql] and re-emits the full result set as plain mutable maps
+  /// whenever a table it reads from changes.
+  @override
+  Stream<List<Map<String, dynamic>>> watch(
+    String sql, {
+    List<Object?> parameters = const [],
+    Duration throttle = kDefaultWatchThrottle,
+  }) {
+    return _database
+        .watch(sql, parameters: parameters, throttle: throttle)
+        .map(
+          (result) =>
+              result.map((row) => Map<String, dynamic>.from(row)).toList(),
+        );
+  }
+
+  /// Executes a write ([sql]) against the local database.
+  @override
+  Future<void> execute(
+    String sql, [
+    List<Object?> parameters = const [],
+  ]) async {
+    await _database.execute(sql, parameters);
+  }
+
+  /// Subscribes to the on-demand sync stream [name] and returns a handle that
+  /// releases the subscription when unsubscribed.
+  @override
+  Future<SyncStreamHandle> syncStream(String name) async {
+    final subscription = await _database.syncStream(name).subscribe();
+    // A per-subscription forwarding adapter has subscription-scoped lifetime
+    // and cannot be DI-managed.
+    // ignore: no_direct_instantiation, reason: subscription-scoped adapter
+    return _PowerSyncStreamHandle(subscription);
+  }
+}
+
+/// Forwards [unsubscribe] to the underlying PowerSync [SyncStreamSubscription],
+/// keeping that type out of the data-source layer.
+class _PowerSyncStreamHandle implements SyncStreamHandle {
+  final SyncStreamSubscription _subscription;
+
+  _PowerSyncStreamHandle(this._subscription);
+
+  @override
+  void unsubscribe() => _subscription.unsubscribe();
+}

--- a/lib/libraries/powersync/data/powersync_database_wrapper_impl.dart
+++ b/lib/libraries/powersync/data/powersync_database_wrapper_impl.dart
@@ -2,7 +2,6 @@
 
 import 'package:construculator/libraries/powersync/interfaces/powersync_database_wrapper.dart';
 import 'package:powersync/powersync.dart';
-import 'package:sqlite_async/sqlite_async.dart';
 
 /// Default [PowerSyncDatabaseWrapper] that forwards to the opened
 /// [PowerSyncDatabase].
@@ -60,7 +59,11 @@ class PowerSyncDatabaseWrapperImpl implements PowerSyncDatabaseWrapper {
   @override
   Future<T> writeTransaction<T>(Future<T> Function(WriteContext tx) action) {
     return _database.writeTransaction(
-      (ctx) => action(_SqliteWriteContextAdapter(ctx)),
+      // Adapts the transaction context by its `execute` closure rather than by
+      // type, so `sqlite_async` stays out of this file (and off the direct
+      // dependency list) while the write still runs inside the transaction.
+      // ignore: no_direct_instantiation, reason: transaction-scoped adapter
+      (ctx) => action(_WriteContextAdapter(ctx.execute)),
     );
   }
 
@@ -76,19 +79,24 @@ class PowerSyncDatabaseWrapperImpl implements PowerSyncDatabaseWrapper {
   }
 }
 
-/// Adapts [SqliteWriteContext] to the project-owned [WriteContext] seam,
-/// keeping the sqlite_async type out of the data-source layer.
-class _SqliteWriteContextAdapter implements WriteContext {
-  final SqliteWriteContext _ctx;
+/// Adapts the enclosing transaction context to the project-owned [WriteContext]
+/// seam by holding its `execute` closure.
+///
+/// Taking the closure rather than the context object means `sqlite_async`'s
+/// `SqliteWriteContext` is never named here, so this library needs no direct
+/// dependency on `sqlite_async` — and the type still cannot leak above the
+/// data-source layer.
+class _WriteContextAdapter implements WriteContext {
+  final Future<void> Function(String sql, [List<Object?> parameters]) _execute;
 
-  _SqliteWriteContextAdapter(this._ctx);
+  _WriteContextAdapter(this._execute);
 
   @override
   Future<void> execute(
     String sql, [
     List<Object?> parameters = const [],
   ]) async {
-    await _ctx.execute(sql, parameters);
+    await _execute(sql, parameters);
   }
 }
 

--- a/lib/libraries/powersync/interfaces/powersync_database_wrapper.dart
+++ b/lib/libraries/powersync/interfaces/powersync_database_wrapper.dart
@@ -1,0 +1,91 @@
+// coverage: ignore-file
+
+/// Default throttle for [PowerSyncDatabaseWrapper.watch]: coalesces rapid
+/// successive change events into a single emission. Matches PowerSync's own
+/// `watch` default; shared by the interface, implementation, and fake so the
+/// value lives in one place.
+const Duration kDefaultWatchThrottle = Duration(milliseconds: 30);
+
+/// Thin, project-owned seam over `PowerSyncDatabase`.
+///
+/// Features (data sources) depend on this interface rather than on
+/// `PowerSyncDatabase` directly, for the same reasons `SupabaseWrapper` sits in
+/// front of the Supabase client:
+/// - `PowerSyncDatabase` is a heavy native object (SQLite + FFI + isolate);
+///   faking it via `implements PowerSyncDatabase` + `noSuchMethod` is fragile.
+/// - The surface a feature needs is tiny; the full database API is dozens of
+///   methods plus inherited transaction APIs.
+/// - Cross-cutting concerns (logging, retry, error normalization) live in one
+///   implementation instead of being sprinkled across data sources.
+///
+/// Rows are returned as plain `List<Map<String, dynamic>>` so that no
+/// PowerSync / sqlite types leak above the data-source layer (mirroring
+/// `SupabaseWrapper`, which returns the same shape).
+///
+/// The surface intentionally starts small and grows as features require it.
+/// Deliberately omitted for now:
+/// - `writeTransaction` — would leak `sqlite_async`'s `SqliteWriteContext`,
+///   which is a transitive (not direct) dependency. Add it, with a direct
+///   dependency, when a feature needs atomic multi-statement writes.
+/// - `currentStatus` / `statusStream` — `SyncStatus` has an `@internal`
+///   constructor, so it cannot be faked cleanly. Expose a project-owned sync
+///   status value object when a sync indicator is actually built.
+abstract class PowerSyncDatabaseWrapper {
+  /// Runs [sql] once and returns all matching rows.
+  ///
+  /// [parameters] are bound positionally to `?` placeholders in [sql].
+  Future<List<Map<String, dynamic>>> getAll(
+    String sql, [
+    List<Object?> parameters = const [],
+  ]);
+
+  /// Watches [sql] and re-emits the full result set whenever any table the
+  /// query reads from changes.
+  ///
+  /// Emits immediately with the current result, then on every relevant local
+  /// or synced mutation — making the returned stream the single source of truth
+  /// for reactive UI. [parameters] are bound positionally to `?` placeholders.
+  /// [throttle] coalesces rapid successive changes into a single emission.
+  Stream<List<Map<String, dynamic>>> watch(
+    String sql, {
+    List<Object?> parameters = const [],
+    Duration throttle = kDefaultWatchThrottle,
+  });
+
+  /// Executes a write ([sql]) against the local database.
+  ///
+  /// The change is applied to local SQLite immediately (so any [watch] stream
+  /// re-emits at once) and queued for upload by the connector in the
+  /// background. [parameters] are bound positionally to `?` placeholders.
+  Future<void> execute(String sql, [List<Object?> parameters = const []]);
+
+  /// Activates the on-demand sync stream named [name] (declared in the backend
+  /// sync rules and referenced from `schema.dart`) so its rows begin
+  /// downloading into local SQLite.
+  ///
+  /// On-demand streams only sync while at least one subscription is active, so
+  /// callers must release the returned [SyncStreamHandle] (via
+  /// [SyncStreamHandle.unsubscribe]) once the stream is no longer needed —
+  /// typically when the watching subscription that activated it is cancelled.
+  ///
+  /// Membership and feature permissions are derived from the JWT server-side;
+  /// no parameters are passed from the client. Returning a project-owned
+  /// [SyncStreamHandle] (rather than PowerSync's `SyncStreamSubscription`)
+  /// keeps PowerSync types out of the data-source layer.
+  Future<SyncStreamHandle> syncStream(String name);
+}
+
+/// A project-owned handle to an activated on-demand sync stream, returned by
+/// [PowerSyncDatabaseWrapper.syncStream].
+///
+/// Kept as a small, project-owned interface so no PowerSync / sqlite types leak
+/// above the data-source layer (mirroring the row-shape rule on the wrapper).
+abstract class SyncStreamHandle {
+  /// Releases this subscription's interest in the stream.
+  ///
+  /// Once every subscription for a stream has been released, the stream stops
+  /// syncing (after any server-side time-to-live), so cancelling a watch that
+  /// activated a stream should call this to avoid syncing data nothing is
+  /// watching.
+  void unsubscribe();
+}

--- a/lib/libraries/powersync/interfaces/powersync_database_wrapper.dart
+++ b/lib/libraries/powersync/interfaces/powersync_database_wrapper.dart
@@ -1,10 +1,21 @@
-// coverage: ignore-file
+// coverage:ignore-file
 
 /// Default throttle for [PowerSyncDatabaseWrapper.watch]: coalesces rapid
 /// successive change events into a single emission. Matches PowerSync's own
 /// `watch` default; shared by the interface, implementation, and fake so the
 /// value lives in one place.
 const Duration kDefaultWatchThrottle = Duration(milliseconds: 30);
+
+/// Project-owned write context passed to [PowerSyncDatabaseWrapper.writeTransaction].
+///
+/// Keeps `sqlite_async`'s `SqliteWriteContext` out of the data-source layer —
+/// callers depend only on this narrow interface, not on the underlying SDK type.
+abstract class WriteContext {
+  /// Executes a write [sql] within the enclosing transaction.
+  ///
+  /// [parameters] are bound positionally to `?` placeholders in [sql].
+  Future<void> execute(String sql, [List<Object?> parameters = const []]);
+}
 
 /// Thin, project-owned seam over `PowerSyncDatabase`.
 ///
@@ -24,9 +35,6 @@ const Duration kDefaultWatchThrottle = Duration(milliseconds: 30);
 ///
 /// The surface intentionally starts small and grows as features require it.
 /// Deliberately omitted for now:
-/// - `writeTransaction` — would leak `sqlite_async`'s `SqliteWriteContext`,
-///   which is a transitive (not direct) dependency. Add it, with a direct
-///   dependency, when a feature needs atomic multi-statement writes.
 /// - `currentStatus` / `statusStream` — `SyncStatus` has an `@internal`
 ///   constructor, so it cannot be faked cleanly. Expose a project-owned sync
 ///   status value object when a sync indicator is actually built.
@@ -58,6 +66,15 @@ abstract class PowerSyncDatabaseWrapper {
   /// re-emits at once) and queued for upload by the connector in the
   /// background. [parameters] are bound positionally to `?` placeholders.
   Future<void> execute(String sql, [List<Object?> parameters = const []]);
+
+  /// Runs [action] inside a single write transaction.
+  ///
+  /// All writes issued through the [WriteContext] passed to [action] are
+  /// applied atomically — PowerSync's sync uploader sees them as a single unit,
+  /// so the server never observes partial state (e.g., a cost estimate without
+  /// its line items). The transaction is committed when [action] completes
+  /// normally and rolled back if it throws.
+  Future<T> writeTransaction<T>(Future<T> Function(WriteContext tx) action);
 
   /// Activates the on-demand sync stream named [name] (declared in the backend
   /// sync rules and referenced from `schema.dart`) so its rows begin

--- a/lib/libraries/powersync/interfaces/powersync_manager.dart
+++ b/lib/libraries/powersync/interfaces/powersync_manager.dart
@@ -1,3 +1,5 @@
+// coverage:ignore-file
+
 import 'package:powersync/powersync.dart';
 
 /// Owns the PowerSync sync lifecycle and ties it to authentication.

--- a/lib/libraries/powersync/interfaces/powersync_manager.dart
+++ b/lib/libraries/powersync/interfaces/powersync_manager.dart
@@ -1,0 +1,31 @@
+import 'package:powersync/powersync.dart';
+
+/// Owns the PowerSync sync lifecycle and ties it to authentication.
+///
+/// The local database is opened during app bootstrap and is usable offline at
+/// all times. Syncing with the backend, however, requires an authenticated
+/// session, so the manager [connect]s once the user signs in and
+/// [disconnectAndClear]s when they sign out.
+///
+/// Implementations subscribe to authentication changes themselves, so callers
+/// generally do not need to invoke [connect] / [disconnectAndClear] manually —
+/// they are exposed for explicit control and testing.
+abstract class PowerSyncManager {
+  /// The opened local PowerSync database.
+  ///
+  /// Use this to read and write data; PowerSync records local mutations whether
+  /// or not a sync connection is currently active.
+  PowerSyncDatabase get database;
+
+  /// Starts syncing with the backend using the configured connector.
+  ///
+  /// Safe to call when already connected — implementations guard against
+  /// establishing duplicate connections.
+  Future<void> connect();
+
+  /// Stops syncing and clears all synced data from the local database.
+  ///
+  /// Call this on sign-out so the next user does not inherit the previous
+  /// user's synced rows.
+  Future<void> disconnectAndClear();
+}

--- a/lib/libraries/powersync/powersync_manager_impl.dart
+++ b/lib/libraries/powersync/powersync_manager_impl.dart
@@ -23,8 +23,8 @@ class PowerSyncManagerImpl implements PowerSyncManager, Disposable {
 
   StreamSubscription<supabase.AuthState>? _authSubscription;
 
-  /// Whether a sync connection is currently established. Guards against
-  /// redundant [connect] calls when several auth events arrive in succession.
+  // Whether a sync connection is currently established. Guards against
+  // redundant [connect] calls when several auth events arrive in succession.
   bool _connected = false;
 
   PowerSyncManagerImpl({

--- a/lib/libraries/powersync/powersync_manager_impl.dart
+++ b/lib/libraries/powersync/powersync_manager_impl.dart
@@ -1,0 +1,110 @@
+import 'dart:async';
+
+import 'package:construculator/libraries/logging/app_logger.dart';
+import 'package:construculator/libraries/powersync/interfaces/powersync_manager.dart';
+import 'package:construculator/libraries/supabase/interfaces/supabase_wrapper.dart';
+import 'package:flutter_modular/flutter_modular.dart';
+import 'package:powersync/powersync.dart';
+import 'package:supabase_flutter/supabase_flutter.dart' as supabase;
+
+/// Default [PowerSyncManager] that drives the sync connection from Supabase
+/// authentication events.
+///
+/// On construction it subscribes to [SupabaseWrapper.onAuthStateChange] and,
+/// if a session has already been restored (e.g. on app relaunch), connects
+/// immediately. It then [connect]s on sign-in and [disconnectAndClear]s on
+/// sign-out. Token refreshes and other auth events are ignored — the connector
+/// refreshes credentials on demand, so an active connection survives them.
+class PowerSyncManagerImpl implements PowerSyncManager, Disposable {
+  final PowerSyncDatabase _database;
+  final PowerSyncBackendConnector _connector;
+  final SupabaseWrapper _supabaseWrapper;
+  final _logger = AppLogger().tag('PowerSyncManager');
+
+  StreamSubscription<supabase.AuthState>? _authSubscription;
+
+  /// Whether a sync connection is currently established. Guards against
+  /// redundant [connect] calls when several auth events arrive in succession.
+  bool _connected = false;
+
+  PowerSyncManagerImpl({
+    required PowerSyncDatabase database,
+    required PowerSyncBackendConnector connector,
+    required SupabaseWrapper supabaseWrapper,
+  }) : _database = database,
+       _connector = connector,
+       _supabaseWrapper = supabaseWrapper {
+    _initAuthListener();
+  }
+
+  @override
+  PowerSyncDatabase get database => _database;
+
+  void _initAuthListener() {
+    _authSubscription = _supabaseWrapper.onAuthStateChange.listen(
+      (state) {
+        switch (state.event) {
+          case supabase.AuthChangeEvent.signedIn:
+          case supabase.AuthChangeEvent.initialSession:
+            if (state.session != null) {
+              unawaited(connect());
+            }
+          case supabase.AuthChangeEvent.signedOut:
+            unawaited(disconnectAndClear());
+          default:
+            break;
+        }
+      },
+      onError: (error) {
+        _logger.warning('Error in auth state stream, ignoring', error);
+      },
+    );
+
+    // Handle the already-authenticated case: when the session is restored
+    // synchronously during bootstrap, the [signedIn] event may have been
+    // emitted before this subscription was attached.
+    if (_supabaseWrapper.isAuthenticated) {
+      unawaited(connect());
+    }
+  }
+
+  @override
+  Future<void> connect() async {
+    if (_connected) {
+      return;
+    }
+    _connected = true;
+    _logger.info('Starting PowerSync sync connection');
+    try {
+      await _database.connect(connector: _connector);
+    } catch (error, stackTrace) {
+      _connected = false;
+
+      _logger.warning('Failed to start PowerSync sync', error, stackTrace);
+    }
+  }
+
+  @override
+  Future<void> disconnectAndClear() async {
+    if (!_connected) {
+      return;
+    }
+    _connected = false;
+    _logger.info('Disconnecting PowerSync and clearing local synced data');
+    try {
+      await _database.disconnectAndClear();
+    } catch (error, stackTrace) {
+      _logger.error(
+        'Failed to disconnect and clear PowerSync',
+        error,
+        stackTrace,
+      );
+    }
+  }
+
+  @override
+  void dispose() {
+    _authSubscription?.cancel();
+    _authSubscription = null;
+  }
+}

--- a/lib/libraries/powersync/powersync_manager_impl.dart
+++ b/lib/libraries/powersync/powersync_manager_impl.dart
@@ -28,12 +28,10 @@ class PowerSyncManagerImpl implements PowerSyncManager, Disposable {
   bool _connected = false;
 
   PowerSyncManagerImpl({
-    required PowerSyncDatabase database,
-    required PowerSyncBackendConnector connector,
-    required SupabaseWrapper supabaseWrapper,
-  }) : _database = database,
-       _connector = connector,
-       _supabaseWrapper = supabaseWrapper {
+    required this._database,
+    required this._connector,
+    required this._supabaseWrapper,
+  }) {
     _initAuthListener();
   }
 
@@ -60,9 +58,6 @@ class PowerSyncManagerImpl implements PowerSyncManager, Disposable {
       },
     );
 
-    // Handle the already-authenticated case: when the session is restored
-    // synchronously during bootstrap, the [signedIn] event may have been
-    // emitted before this subscription was attached.
     if (_supabaseWrapper.isAuthenticated) {
       unawaited(connect());
     }
@@ -94,6 +89,7 @@ class PowerSyncManagerImpl implements PowerSyncManager, Disposable {
     try {
       await _database.disconnectAndClear();
     } catch (error, stackTrace) {
+      _connected = true;
       _logger.error(
         'Failed to disconnect and clear PowerSync',
         error,

--- a/lib/libraries/powersync/powersync_module.dart
+++ b/lib/libraries/powersync/powersync_module.dart
@@ -1,5 +1,7 @@
 import 'package:construculator/app/app_bootstrap.dart';
 import 'package:construculator/libraries/powersync/data/connectors/supabase_powersync_connector.dart';
+import 'package:construculator/libraries/powersync/data/powersync_database_wrapper_impl.dart';
+import 'package:construculator/libraries/powersync/interfaces/powersync_database_wrapper.dart';
 import 'package:construculator/libraries/powersync/interfaces/powersync_manager.dart';
 import 'package:construculator/libraries/powersync/powersync_manager_impl.dart';
 import 'package:flutter_modular/flutter_modular.dart';
@@ -26,6 +28,12 @@ class PowerSyncModule extends Module {
     );
 
     i.addLazySingleton<PowerSyncDatabase>(() => appBootstrap.powerSyncDatabase);
+
+    // The seam features depend on for reads/writes. Wraps the same opened
+    // database singleton; keeps PowerSync/sqlite types out of data sources.
+    i.addLazySingleton<PowerSyncDatabaseWrapper>(
+      () => PowerSyncDatabaseWrapperImpl(database: i()),
+    );
 
     // Eager singleton: instantiated when the module is committed at app
     // startup (see auto_injector's startSingletons), so the manager immediately

--- a/lib/libraries/powersync/powersync_module.dart
+++ b/lib/libraries/powersync/powersync_module.dart
@@ -1,9 +1,17 @@
 import 'package:construculator/app/app_bootstrap.dart';
 import 'package:construculator/libraries/powersync/data/connectors/supabase_powersync_connector.dart';
+import 'package:construculator/libraries/powersync/interfaces/powersync_manager.dart';
+import 'package:construculator/libraries/powersync/powersync_manager_impl.dart';
 import 'package:flutter_modular/flutter_modular.dart';
 import 'package:powersync/powersync.dart';
 
 /// Modular module that wires up the PowerSync backend connector.
+/// Wires the PowerSync stack: the opened local database, the Supabase-backed
+/// connector, and the [PowerSyncManager] that drives the sync lifecycle.
+///
+/// The database is opened during app bootstrap (see `openPowerSyncDatabase`)
+/// and passed in via [AppBootstrap], because opening it is asynchronous and
+/// must complete before the module graph is built.
 class PowerSyncModule extends Module {
   final AppBootstrap appBootstrap;
   PowerSyncModule(this.appBootstrap);
@@ -14,6 +22,20 @@ class PowerSyncModule extends Module {
       () => SupabasePowerSyncConnector(
         supabaseWrapper: appBootstrap.supabaseWrapper,
         envLoader: appBootstrap.envLoader,
+      ),
+    );
+
+    i.addLazySingleton<PowerSyncDatabase>(() => appBootstrap.powerSyncDatabase);
+
+    // Eager singleton: instantiated when the module is committed at app
+    // startup (see auto_injector's startSingletons), so the manager immediately
+    // subscribes to auth changes and drives connect/disconnect over the app's
+    // lifetime — without any caller needing to resolve it explicitly.
+    i.addSingleton<PowerSyncManager>(
+      () => PowerSyncManagerImpl(
+        database: appBootstrap.powerSyncDatabase,
+        connector: i(),
+        supabaseWrapper: appBootstrap.supabaseWrapper,
       ),
     );
   }

--- a/lib/libraries/powersync/powersync_module.dart
+++ b/lib/libraries/powersync/powersync_module.dart
@@ -5,9 +5,9 @@ import 'package:construculator/libraries/powersync/powersync_manager_impl.dart';
 import 'package:flutter_modular/flutter_modular.dart';
 import 'package:powersync/powersync.dart';
 
-/// Modular module that wires up the PowerSync backend connector.
-/// Wires the PowerSync stack: the opened local database, the Supabase-backed
-/// connector, and the [PowerSyncManager] that drives the sync lifecycle.
+/// Modular module that wires up the PowerSync stack: the opened local
+/// database, the Supabase-backed connector, and the [PowerSyncManager] that
+/// drives the sync lifecycle.
 ///
 /// The database is opened during app bootstrap (see `openPowerSyncDatabase`)
 /// and passed in via [AppBootstrap], because opening it is asynchronous and

--- a/lib/libraries/powersync/testing/fake_powersync_database.dart
+++ b/lib/libraries/powersync/testing/fake_powersync_database.dart
@@ -2,7 +2,13 @@
 
 import 'package:powersync/powersync.dart';
 
-/// Fake [PowerSyncDatabase] for testing.
+/// Fake [PowerSyncDatabase] for tests of [PowerSyncBackendConnector]
+/// implementations, which receive a real `PowerSyncDatabase` from the PowerSync
+/// runtime (e.g. `connector.uploadData(database)`).
+///
+/// Feature, repository, and data-source tests should use
+/// `FakePowerSyncDatabaseWrapper` instead — it fakes the narrow
+/// `PowerSyncDatabaseWrapper` seam rather than this full native API.
 ///
 /// Call [setNextTransaction] to control what [getNextCrudTransaction] returns.
 /// Each call to [getNextCrudTransaction] consumes and clears the queued

--- a/lib/libraries/powersync/testing/fake_powersync_database.dart
+++ b/lib/libraries/powersync/testing/fake_powersync_database.dart
@@ -32,6 +32,18 @@ class FakePowerSyncDatabase implements PowerSyncDatabase {
     _nextTransaction = transaction;
   }
 
+  /// Clears all recorded call counts, the captured connector, the configured
+  /// [connectError], and any queued transaction, returning the fake to its
+  /// initial state so it can be reused across tests.
+  void reset() {
+    connectCallCount = 0;
+    lastConnector = null;
+    disconnectCallCount = 0;
+    disconnectAndClearCallCount = 0;
+    connectError = null;
+    _nextTransaction = null;
+  }
+
   @override
   Future<void> connect({
     required PowerSyncBackendConnector connector,

--- a/lib/libraries/powersync/testing/fake_powersync_database.dart
+++ b/lib/libraries/powersync/testing/fake_powersync_database.dart
@@ -27,13 +27,17 @@ class FakePowerSyncDatabase implements PowerSyncDatabase {
   /// exercise connection-failure handling.
   Object? connectError;
 
+  /// When set, the next [disconnectAndClear] call throws this error, allowing
+  /// tests to exercise disconnect-failure handling.
+  Object? disconnectAndClearError;
+
   /// Queues [transaction] to be returned by the next [getNextCrudTransaction] call.
   void setNextTransaction(CrudTransaction? transaction) {
     _nextTransaction = transaction;
   }
 
   /// Clears all recorded call counts, the captured connector, the configured
-  /// [connectError], and any queued transaction, returning the fake to its
+  /// [connectError], [disconnectAndClearError], and any queued transaction, returning the fake to its
   /// initial state so it can be reused across tests.
   void reset() {
     connectCallCount = 0;
@@ -41,6 +45,7 @@ class FakePowerSyncDatabase implements PowerSyncDatabase {
     disconnectCallCount = 0;
     disconnectAndClearCallCount = 0;
     connectError = null;
+    disconnectAndClearError = null;
     _nextTransaction = null;
   }
 
@@ -67,6 +72,10 @@ class FakePowerSyncDatabase implements PowerSyncDatabase {
   @override
   Future<void> disconnectAndClear({bool clearLocal = true}) async {
     disconnectAndClearCallCount++;
+    final error = disconnectAndClearError;
+    if (error != null) {
+      throw error;
+    }
   }
 
   /// Returns the queued transaction (set via [setNextTransaction]) and clears

--- a/lib/libraries/powersync/testing/fake_powersync_database_wrapper.dart
+++ b/lib/libraries/powersync/testing/fake_powersync_database_wrapper.dart
@@ -37,6 +37,10 @@ class FakePowerSyncDatabaseWrapper implements PowerSyncDatabaseWrapper {
   /// Every [execute] call, in order.
   final List<RecordedSqlCall> executeCalls = [];
 
+  /// Every [writeTransaction] invocation, in order (call count only — writes
+  /// within the transaction appear in [executeCalls] as usual).
+  int writeTransactionCallCount = 0;
+
   /// Every [syncStream] activation, in order (by stream name).
   final List<String> syncStreamCalls = [];
 
@@ -44,12 +48,14 @@ class FakePowerSyncDatabaseWrapper implements PowerSyncDatabaseWrapper {
   /// in order — so tests can assert an activated stream is released on cancel.
   final List<String> syncStreamUnsubscribes = [];
 
-  /// When set, every [getAll] call throws this error until it is cleared
-  /// (set back to `null`) or [reset] is called.
+  /// When set, every [getAll] call throws this error on every call until
+  /// explicitly cleared (`getAllError = null`) or [reset] is called — it does
+  /// NOT self-clear after one use.
   Object? getAllError;
 
-  /// When set, every [execute] call throws this error until it is cleared
-  /// (set back to `null`) or [reset] is called.
+  /// When set, every [execute] call throws this error on every call until
+  /// explicitly cleared (`executeError = null`) or [reset] is called — it does
+  /// NOT self-clear after one use.
   Object? executeError;
 
   /// When set, every [syncStream] call throws this error until it is cleared
@@ -131,6 +137,12 @@ class FakePowerSyncDatabaseWrapper implements PowerSyncDatabaseWrapper {
   }
 
   @override
+  Future<T> writeTransaction<T>(Future<T> Function(WriteContext tx) action) {
+    writeTransactionCallCount++;
+    return action(_FakeWriteContext(this));
+  }
+
+  @override
   Future<SyncStreamHandle> syncStream(String name) async {
     syncStreamCalls.add(name);
     final error = syncStreamError;
@@ -149,6 +161,7 @@ class FakePowerSyncDatabaseWrapper implements PowerSyncDatabaseWrapper {
     getAllCalls.clear();
     watchCalls.clear();
     executeCalls.clear();
+    writeTransactionCallCount = 0;
     syncStreamCalls.clear();
     syncStreamUnsubscribes.clear();
     getAllError = null;
@@ -168,6 +181,19 @@ class FakePowerSyncDatabaseWrapper implements PowerSyncDatabaseWrapper {
     }
     _watchControllers.clear();
   }
+}
+
+/// Routes writes issued inside [FakePowerSyncDatabaseWrapper.writeTransaction]
+/// through the fake's own [execute], so they appear in [executeCalls] and
+/// respect [executeError] — no real transaction semantics needed in tests.
+class _FakeWriteContext implements WriteContext {
+  final FakePowerSyncDatabaseWrapper _fake;
+
+  _FakeWriteContext(this._fake);
+
+  @override
+  Future<void> execute(String sql, [List<Object?> parameters = const []]) =>
+      _fake.execute(sql, parameters);
 }
 
 /// A [SyncStreamHandle] whose [unsubscribe] runs the callback the fake uses to

--- a/lib/libraries/powersync/testing/fake_powersync_database_wrapper.dart
+++ b/lib/libraries/powersync/testing/fake_powersync_database_wrapper.dart
@@ -1,0 +1,182 @@
+import 'dart:async';
+
+import 'package:construculator/libraries/powersync/interfaces/powersync_database_wrapper.dart';
+
+/// A recorded call to [FakePowerSyncDatabaseWrapper.getAll],
+/// [FakePowerSyncDatabaseWrapper.watch], or
+/// [FakePowerSyncDatabaseWrapper.execute].
+typedef RecordedSqlCall = ({String sql, List<Object?> parameters});
+
+/// Behaviour-shaped fake of [PowerSyncDatabaseWrapper] for feature, repository,
+/// and data-source tests.
+///
+/// Unlike [FakePowerSyncDatabase] — which exists only for connector tests, that
+/// receive a real `PowerSyncDatabase` from the PowerSync runtime — this fake
+/// implements the narrow wrapper seam features actually use. It records calls
+/// for assertions, lets tests script [getAll] results and [watch] emissions per
+/// SQL string, and can be configured to throw.
+class FakePowerSyncDatabaseWrapper implements PowerSyncDatabaseWrapper {
+  /// Scripted [getAll] results, keyed by exact SQL string.
+  final Map<String, List<Map<String, dynamic>>> _getAllResults = {};
+
+  /// Live [watch] controllers, keyed by exact SQL string.
+  final Map<String, StreamController<List<Map<String, dynamic>>>>
+  _watchControllers = {};
+
+  /// Latest value emitted (or seeded) per watched SQL string, replayed to new
+  /// listeners so subscribing after [emitWatch] still sees the current state —
+  /// mirroring how real `watch` emits immediately on listen.
+  final Map<String, List<Map<String, dynamic>>> _watchSeed = {};
+
+  /// Every [getAll] call, in order.
+  final List<RecordedSqlCall> getAllCalls = [];
+
+  /// Every [watch] call, in order.
+  final List<RecordedSqlCall> watchCalls = [];
+
+  /// Every [execute] call, in order.
+  final List<RecordedSqlCall> executeCalls = [];
+
+  /// Every [syncStream] activation, in order (by stream name).
+  final List<String> syncStreamCalls = [];
+
+  /// Names of streams whose returned [SyncStreamHandle] has been unsubscribed,
+  /// in order — so tests can assert an activated stream is released on cancel.
+  final List<String> syncStreamUnsubscribes = [];
+
+  /// When set, every [getAll] call throws this error until it is cleared
+  /// (set back to `null`) or [reset] is called.
+  Object? getAllError;
+
+  /// When set, every [execute] call throws this error until it is cleared
+  /// (set back to `null`) or [reset] is called.
+  Object? executeError;
+
+  /// When set, every [syncStream] call throws this error until it is cleared
+  /// (set back to `null`) or [reset] is called.
+  Object? syncStreamError;
+
+  /// Scripts [rows] as the result of [getAll] for [sql].
+  void stubGetAll(String sql, List<Map<String, dynamic>> rows) {
+    _getAllResults[sql] = rows;
+  }
+
+  /// Emits [rows] to listeners of `watch(sql)` and records it as the current
+  /// value, so later listeners replay it on subscription.
+  void emitWatch(String sql, List<Map<String, dynamic>> rows) {
+    _watchSeed[sql] = rows;
+    final controller = _watchControllers[sql];
+    if (controller != null && !controller.isClosed) {
+      controller.add(rows);
+    }
+  }
+
+  /// Emits [error] to listeners of `watch(sql)`.
+  void emitWatchError(String sql, Object error) {
+    final controller = _watchControllers[sql];
+    if (controller != null && !controller.isClosed) {
+      controller.addError(error);
+    }
+  }
+
+  @override
+  Future<List<Map<String, dynamic>>> getAll(
+    String sql, [
+    List<Object?> parameters = const [],
+  ]) async {
+    getAllCalls.add((sql: sql, parameters: parameters));
+    final error = getAllError;
+    if (error != null) {
+      throw error;
+    }
+    return _getAllResults[sql] ?? const [];
+  }
+
+  @override
+  Stream<List<Map<String, dynamic>>> watch(
+    String sql, {
+    List<Object?> parameters = const [],
+    Duration throttle = kDefaultWatchThrottle,
+  }) {
+    watchCalls.add((sql: sql, parameters: parameters));
+    final controller = _watchControllers.putIfAbsent(
+      sql,
+      () => StreamController<List<Map<String, dynamic>>>.broadcast(),
+    );
+    // Replay the latest seeded value on listen, then forward live emissions.
+    return Stream.multi((listener) {
+      final seed = _watchSeed[sql];
+      if (seed != null) {
+        listener.add(seed);
+      }
+      final subscription = controller.stream.listen(
+        listener.add,
+        onError: listener.addError,
+        onDone: listener.close,
+      );
+      listener.onCancel = subscription.cancel;
+    });
+  }
+
+  @override
+  Future<void> execute(
+    String sql, [
+    List<Object?> parameters = const [],
+  ]) async {
+    executeCalls.add((sql: sql, parameters: parameters));
+    final error = executeError;
+    if (error != null) {
+      throw error;
+    }
+  }
+
+  @override
+  Future<SyncStreamHandle> syncStream(String name) async {
+    syncStreamCalls.add(name);
+    final error = syncStreamError;
+    if (error != null) {
+      throw error;
+    }
+    return _FakeSyncStreamHandle(() => syncStreamUnsubscribes.add(name));
+  }
+
+  /// Clears recorded calls, scripted results, errors, and watch seeds, and
+  /// closes any open [watch] controllers — returning the fake to its initial
+  /// state so it can be reused across tests.
+  void reset() {
+    _getAllResults.clear();
+    _watchSeed.clear();
+    getAllCalls.clear();
+    watchCalls.clear();
+    executeCalls.clear();
+    syncStreamCalls.clear();
+    syncStreamUnsubscribes.clear();
+    getAllError = null;
+    executeError = null;
+    syncStreamError = null;
+    _closeWatchControllers();
+  }
+
+  /// Closes all open [watch] controllers.
+  void dispose() {
+    _closeWatchControllers();
+  }
+
+  void _closeWatchControllers() {
+    for (final controller in _watchControllers.values) {
+      controller.close();
+    }
+    _watchControllers.clear();
+  }
+}
+
+/// A [SyncStreamHandle] whose [unsubscribe] runs the callback the fake uses to
+/// record the release, so tests can assert an activated stream is released.
+class _FakeSyncStreamHandle implements SyncStreamHandle {
+  final void Function() _onUnsubscribe;
+
+  _FakeSyncStreamHandle(this._onUnsubscribe);
+
+  @override
+  void unsubscribe() => _onUnsubscribe();
+}

--- a/lib/libraries/powersync/testing/fake_powersync_database_wrapper.dart
+++ b/lib/libraries/powersync/testing/fake_powersync_database_wrapper.dart
@@ -72,6 +72,11 @@ class FakePowerSyncDatabaseWrapper implements PowerSyncDatabaseWrapper {
   /// (set back to `null`) or [reset] is called.
   Object? syncStreamError;
 
+  /// Optional gate that delays [syncStream] completion until completed by the
+  /// test. Useful for exercising cancellation races while activation is still
+  /// in flight.
+  Completer<void>? syncStreamActivationGate;
+
   /// Scripts [rows] as the result of [getAll] for [sql].
   void stubGetAll(String sql, List<Map<String, dynamic>> rows) {
     _getAllResults[sql] = rows;
@@ -165,6 +170,7 @@ class FakePowerSyncDatabaseWrapper implements PowerSyncDatabaseWrapper {
     if (error != null) {
       throw error;
     }
+    await syncStreamActivationGate?.future;
     return _FakeSyncStreamHandle(() => syncStreamUnsubscribes.add(name));
   }
 
@@ -184,6 +190,7 @@ class FakePowerSyncDatabaseWrapper implements PowerSyncDatabaseWrapper {
     executeError = null;
     writeTransactionError = null;
     syncStreamError = null;
+    syncStreamActivationGate = null;
     _closeWatchControllers();
   }
 

--- a/lib/libraries/powersync/testing/fake_powersync_database_wrapper.dart
+++ b/lib/libraries/powersync/testing/fake_powersync_database_wrapper.dart
@@ -58,6 +58,16 @@ class FakePowerSyncDatabaseWrapper implements PowerSyncDatabaseWrapper {
   /// NOT self-clear after one use.
   Object? executeError;
 
+  /// When set, every [writeTransaction] call throws this error before [action]
+  /// is invoked, on every call until explicitly cleared
+  /// (`writeTransactionError = null`) or [reset] is called — it does NOT
+  /// self-clear after one use.
+  ///
+  /// Scoped to the transactional path only, so a test can fail the transaction
+  /// itself without also failing bare [execute] calls (which [executeError]
+  /// would).
+  Object? writeTransactionError;
+
   /// When set, every [syncStream] call throws this error until it is cleared
   /// (set back to `null`) or [reset] is called.
   Object? syncStreamError;
@@ -137,8 +147,14 @@ class FakePowerSyncDatabaseWrapper implements PowerSyncDatabaseWrapper {
   }
 
   @override
-  Future<T> writeTransaction<T>(Future<T> Function(WriteContext tx) action) {
+  Future<T> writeTransaction<T>(
+    Future<T> Function(WriteContext tx) action,
+  ) async {
     writeTransactionCallCount++;
+    final error = writeTransactionError;
+    if (error != null) {
+      throw error;
+    }
     return action(_FakeWriteContext(this));
   }
 
@@ -166,6 +182,7 @@ class FakePowerSyncDatabaseWrapper implements PowerSyncDatabaseWrapper {
     syncStreamUnsubscribes.clear();
     getAllError = null;
     executeError = null;
+    writeTransactionError = null;
     syncStreamError = null;
     _closeWatchControllers();
   }

--- a/lib/libraries/supabase/testing/fake_supabase_wrapper.dart
+++ b/lib/libraries/supabase/testing/fake_supabase_wrapper.dart
@@ -15,8 +15,11 @@ import 'package:supabase_flutter/supabase_flutter.dart' as supabase;
 /// Fake implementation of SupabaseWrapper for testing
 class FakeSupabaseWrapper implements SupabaseWrapper {
   /// Used to notify listeners of changes in the authentication state through [onAuthStateChange]
+  /// Synchronous so that emitting an auth event delivers it to listeners
+  /// before control returns to the test, making assertions deterministic
+  /// without draining the real event loop.
   final StreamController<supabase.AuthState> _authStateController =
-      StreamController<supabase.AuthState>.broadcast();
+      StreamController<supabase.AuthState>.broadcast(sync: true);
 
   /// Tracks the currently authenticated user
   FakeUser? _currentUser;

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6,6 +6,7 @@ import 'package:construculator/libraries/config/env_constants.dart';
 import 'package:construculator/libraries/config/env_loader_impl.dart';
 import 'package:construculator/libraries/logging/app_logger.dart';
 import 'package:construculator/libraries/sentry/sentry_sdk_impl.dart';
+import 'package:construculator/libraries/powersync/data/open_powersync_database.dart';
 import 'package:construculator/libraries/sentry/sentry_wrapper_impl.dart';
 import 'package:construculator/libraries/supabase/supabase_wrapper_impl.dart';
 import 'package:flutter/material.dart';
@@ -38,16 +39,13 @@ Future<AppBootstrap> _initializeApp() async {
   await config.initialize(env);
   final wrapper = SupabaseWrapperImpl(envLoader: envLoader);
   await wrapper.initialize();
-  final sentryWrapper = SentryWrapperImpl(
-    envLoader: envLoader,
-    config: config,
-    sentrySdk: SentrySdkImpl(),
-  );
+  final sentryWrapper = SentryWrapperImpl(envLoader: envLoader, config: config);
   return AppBootstrap(
     config: config,
     envLoader: envLoader,
     supabaseWrapper: wrapper,
     sentryWrapper: sentryWrapper,
+    powerSyncDatabase: powerSyncDatabase,
   );
 }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -5,8 +5,8 @@ import 'package:construculator/libraries/config/app_config_impl.dart';
 import 'package:construculator/libraries/config/env_constants.dart';
 import 'package:construculator/libraries/config/env_loader_impl.dart';
 import 'package:construculator/libraries/logging/app_logger.dart';
-import 'package:construculator/libraries/sentry/sentry_sdk_impl.dart';
 import 'package:construculator/libraries/powersync/data/open_powersync_database.dart';
+import 'package:construculator/libraries/sentry/sentry_sdk_impl.dart';
 import 'package:construculator/libraries/sentry/sentry_wrapper_impl.dart';
 import 'package:construculator/libraries/supabase/supabase_wrapper_impl.dart';
 import 'package:flutter/material.dart';
@@ -39,7 +39,12 @@ Future<AppBootstrap> _initializeApp() async {
   await config.initialize(env);
   final wrapper = SupabaseWrapperImpl(envLoader: envLoader);
   await wrapper.initialize();
-  final sentryWrapper = SentryWrapperImpl(envLoader: envLoader, config: config);
+  final sentryWrapper = SentryWrapperImpl(
+    envLoader: envLoader,
+    config: config,
+    sentrySdk: SentrySdkImpl(),
+  );
+  final powerSyncDatabase = await openPowerSyncDatabase();
   return AppBootstrap(
     config: config,
     envLoader: envLoader,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1211,7 +1211,7 @@ packages:
     source: hosted
     version: "0.4.1"
   sqlite_async:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: sqlite_async
       sha256: "9b47ba01bb600d4a0e44752237ea201408bd4dff57eb203356ef27df41c29421"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1211,7 +1211,7 @@ packages:
     source: hosted
     version: "0.4.1"
   sqlite_async:
-    dependency: "direct main"
+    dependency: transitive
     description:
       name: sqlite_async
       sha256: "9b47ba01bb600d4a0e44752237ea201408bd4dff57eb203356ef27df41c29421"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -217,6 +217,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.2"
+  code_assets:
+    dependency: transitive
+    description:
+      name: code_assets
+      sha256: bf394f466ba9205f1812a0433b392d6af280f155f56651eda7c18cc32ed493b8
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.1"
   collection:
     dependency: transitive
     description:
@@ -509,6 +517,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
+  hooks:
+    dependency: transitive
+    description:
+      name: hooks
+      sha256: "9a62a50b50b769a737bc0a8ff381f333529df3ab746b2f6b02e83760231455ba"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.2"
   hotreloader:
     dependency: transitive
     description:
@@ -741,6 +757,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.2"
+  objective_c:
+    dependency: transitive
+    description:
+      name: objective_c
+      sha256: b7fb95a6d9a4f009edd63dc5ac69f07420b23a16161c6dd8660290b59c602e8e
+      url: "https://pub.dev"
+    source: hosted
+    version: "9.5.0"
   package_config:
     dependency: transitive
     description:
@@ -774,7 +798,7 @@ packages:
     source: hosted
     version: "2.9.0"
   path:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: path
       sha256: "75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5"
@@ -789,6 +813,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
+  path_provider:
+    dependency: "direct main"
+    description:
+      name: path_provider
+      sha256: a7f4874f987173da295a61c181b8ee71dab59b332a486b391babf26a1b884825
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.6"
+  path_provider_android:
+    dependency: transitive
+    description:
+      name: path_provider_android
+      sha256: "149441ca6e4f38193b2e004c0ca6376a3d11f51fa5a77552d8bd4d2b0c0912ba"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.23"
+  path_provider_foundation:
+    dependency: transitive
+    description:
+      name: path_provider_foundation
+      sha256: "2a376b7d6392d80cd3705782d2caa734ca4727776db0b6ec36ef3f1855197699"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.6.0"
   path_provider_linux:
     dependency: transitive
     description:
@@ -941,6 +989,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.11.0"
+  record_use:
+    dependency: transitive
+    description:
+      name: record_use
+      sha256: "2551bd8eecfe95d14ae75f6021ad0248be5c27f138c2ec12fcb52b500b3ba1ed"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.6.0"
   result_dart:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -33,6 +33,8 @@ dependencies:
   sentry_flutter: 9.24.0
   powersync: 1.18.0
   posthog_flutter: 5.35.1
+  path_provider: ^2.1.5
+  path: ^1.9.0
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -33,7 +33,6 @@ dependencies:
   sentry_flutter: 9.24.0
   powersync: 1.18.0
   posthog_flutter: 5.35.1
-  sqlite_async: ^0.13.1
   path_provider: ^2.1.5
   path: ^1.9.0
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -33,6 +33,7 @@ dependencies:
   sentry_flutter: 9.24.0
   powersync: 1.18.0
   posthog_flutter: 5.35.1
+  sqlite_async: ^0.13.1
   path_provider: ^2.1.5
   path: ^1.9.0
 

--- a/skills/code-data-powersync/SKILL.md
+++ b/skills/code-data-powersync/SKILL.md
@@ -43,8 +43,9 @@ leak above the data-source layer.
 |--------|-----------|
 | `Stream<List<Map>> watch(sql, {parameters, throttle})` | **Default read.** Live result set; re-emits on every local *or* synced change. |
 | `Future<List<Map>> getAll(sql, [parameters])` | **One-shot read only** — validation lookups, export snapshots, reading a value inside a write flow. |
-| `Future<void> execute(sql, [parameters])` | **Write.** Applies to local SQLite immediately, queues for background upload. |
-| `Future<void> syncStream(name)` | **On-demand sync** — activate an on-demand stream when the feature is entered. |
+| `Future<void> execute(sql, [parameters])` | **Single-row write.** Applies to local SQLite immediately, queues for background upload. |
+| `Future<T> writeTransaction<T>((WriteContext tx) → Future<T>)` | **Atomic write.** All `tx.execute()` calls inside the callback commit together — use when inserting into two or more tables that must land as a unit (e.g. estimate + line items). |
+| `Future<SyncStreamHandle> syncStream(name)` | **On-demand sync** — activate an on-demand stream when the feature is entered. Returns a handle whose `unsubscribe()` must be called on cancel. |
 
 The seam intentionally starts small and **grows as features require it**. If you need
 surface it lacks (`writeTransaction` for atomic multi-statement writes, a project-owned
@@ -110,6 +111,17 @@ not separate instances. The divergence lives in separate Cubits, not the data la
   [`supabase_powersync_connector.dart`](../../lib/libraries/powersync/data/connectors/supabase_powersync_connector.dart).
 - **Always write IDs/timestamps explicitly** — PowerSync does not generate them on the
   local row. Generate UUIDs client-side and set `created_at`/`updated_at` yourself.
+- **Atomic multi-table writes use `writeTransaction`.** When two or more rows must land
+  together, wrap them in a single transaction:
+  ```dart
+  await _wrapper.writeTransaction((tx) async {
+    await tx.execute(insertEstimateSql, estimateParams);
+    await tx.execute(insertLineItemSql, lineItemParams);
+  });
+  ```
+  `tx` is a `WriteContext` — it exposes only `execute`, not `watch` or `getAll`. The
+  transaction commits atomically; if it throws, all writes roll back. Use bare `execute()`
+  for single-row writes; only reach for `writeTransaction` when atomicity is required.
 
 > 🛑 **Decision gate — do not guess.** When a write's *server acceptance* matters to the
 > UX (e.g. locking a cost estimate, anything where showing "saved" before the server
@@ -159,12 +171,15 @@ subscription lifecycle via `Stream.multi`:
 @override
 Stream<List<CostEstimateDto>> watchByProject(String projectId) {
   return Stream<List<CostEstimateDto>>.multi((controller) async {
-    await _wrapper.syncStream('cost_estimates');        // JWT-gated; no client params
+    final handle = await _wrapper.syncStream('cost_estimates'); // JWT-gated; no client params
     final sub = _wrapper
         .watch(_byProjectSql, parameters: [projectId])  // watch() stays single source of truth
         .map((rows) => rows.map(CostEstimateDto.fromRow).toList())
         .listen(controller.add, onError: controller.addError, onDone: controller.close);
-    controller.onCancel = sub.cancel;                   // release on cancel — no leak
+    controller.onCancel = () {
+      sub.cancel();
+      handle.unsubscribe(); // release the on-demand stream — no leak
+    };
   });
 }
 ```
@@ -223,8 +238,17 @@ from the `write-tests` skills; the PowerSync-specific moves are:
   to prove the RepositoryImpl maps to the right `Failure`.
 - **Write assertions:** after a write, assert `fake.executeCalls` contains the expected
   `(sql, parameters)` — verify the SQL and bound params, not just that a call happened.
+- **Transaction assertions:** assert `fake.writeTransactionCallCount == 1` to confirm a
+  transaction was opened. Each `tx.execute()` inside it still appears in `fake.executeCalls`
+  in order, so you can verify both the transaction boundary and the individual statements.
+  To test the error path, set `fake.executeError` — it propagates through the transaction
+  callback just as it does for bare `execute()` calls.
 - **Lazy on-demand activation:** assert `syncStream(...)` is called on first `watch`
   subscription and that the watch controller is released on cancel (no leak).
+- **syncStream error path:** set `fake.syncStreamError = SomeException()` to prove the
+  DataSource propagates a thrown handle-acquisition error to `controller.addError`.
+- **Handle release assertion:** after cancelling the subscription, assert
+  `fake.syncStreamUnsubscribes` contains the stream name — confirming no leak.
 - Use `fake.reset()` between tests and `fake.dispose()` in teardown to close controllers.
 
 ---

--- a/skills/code-data-powersync/SKILL.md
+++ b/skills/code-data-powersync/SKILL.md
@@ -1,0 +1,243 @@
+---
+name: code-data-powersync
+description: |
+  Data layer for PowerSync-synced (offline-first) tables. Write DataSources and
+  RepositoryImpls that read through reactive `watch()` streams and write via
+  optimistic local `execute()`, behind the `PowerSyncDatabaseWrapper` seam.
+
+  Use this INSTEAD of `code-data` when the feature reads/writes a table that is
+  synced via PowerSync (see `lib/libraries/powersync/models/schema.dart`).
+  Use plain `code-data` (SupabaseWrapper, request/response) for non-synced tables.
+
+  ⚠️ INVOCATION: Only when the ticket touches a PowerSync-synced table's data layer.
+
+  Trigger: "wire a powersync feature", "add a synced/offline-first data source",
+  "watch a synced table", "on-demand sync stream", mentions of watch()/execute()/
+  syncStream on a schema table.
+
+disable-model-invocation: false
+---
+
+# Code Data (PowerSync) Skill
+
+**Verb:** Write the data layer for an offline-first, PowerSync-synced table.
+
+**Input:** Plan + domain interfaces (`code-domain`) — repository interface, entities, failures.
+
+**Relationship to `code-data`:** Same Clean-Architecture layering and the same
+error-boundary rule (RULE_15: the DataSource always rethrows; the `RepositoryImpl`
+logs+maps once). What changes is the *shape*: reads are reactive `Stream`s, writes
+are optimistic local mutations. If the table is **not** in the PowerSync schema, use
+`code-data` instead.
+
+---
+
+## 0. The seam you depend on
+
+Features never touch `PowerSyncDatabase` directly. They depend on
+[`PowerSyncDatabaseWrapper`](../../lib/libraries/powersync/interfaces/powersync_database_wrapper.dart),
+which returns plain `List<Map<String, dynamic>>` rows so no sqlite/PowerSync types
+leak above the data-source layer.
+
+| Method | Use it for |
+|--------|-----------|
+| `Stream<List<Map>> watch(sql, {parameters, throttle})` | **Default read.** Live result set; re-emits on every local *or* synced change. |
+| `Future<List<Map>> getAll(sql, [parameters])` | **One-shot read only** — validation lookups, export snapshots, reading a value inside a write flow. |
+| `Future<void> execute(sql, [parameters])` | **Write.** Applies to local SQLite immediately, queues for background upload. |
+| `Future<void> syncStream(name)` | **On-demand sync** — activate an on-demand stream when the feature is entered. |
+
+The seam intentionally starts small and **grows as features require it**. If you need
+surface it lacks (`writeTransaction` for atomic multi-statement writes, a project-owned
+sync-status value object), add it to the interface, the `...WrapperImpl`, and
+`FakePowerSyncDatabaseWrapper` in one change with a test — don't reach around the seam.
+
+The wrapper, connector, manager, and DB lifecycle are **already wired** in
+[`powersync_module.dart`](../../lib/libraries/powersync/powersync_module.dart). You
+inject `PowerSyncDatabaseWrapper` into your DataSource; you do **not** open the DB,
+manage `connect()`, or touch the connector.
+
+---
+
+## 1. The two rules that drive every decision
+
+1. **Read reactively by default.** Anything rendered on screen (lists, detail views,
+   counts) reads through `watch()` so the UI stays live as sync arrives. Reach for
+   `getAll()` only when the read is genuinely one-shot.
+2. **`watch()` is the source of truth — including after a write.** After `execute()`,
+   do **not** re-fetch or optimistically patch UI state by hand. The local write makes
+   every relevant `watch()` stream re-emit at once; let the stream carry the new state.
+
+---
+
+## 2. Class shapes
+
+| Class | Naming | Returns | Notes |
+|-------|--------|---------|-------|
+| **DataSource** (interface) | `{Noun}DataSource` | reactive `Stream` / `Future` of **DTOs or raw rows** | Explicit method names. **No `Either` here.** Always rethrows. |
+| **PowerSync DataSource** (impl) | `PowerSync{Noun}DataSource` | same | Talks to `PowerSyncDatabaseWrapper`. Owns on-demand stream activation (§5). |
+| **RepositoryImpl** | `{Noun}RepositoryImpl` | `Stream<Either<Failure, T>>` (reads) / `Future<Either<Failure, void>>` (writes) | **Error boundary.** Maps stream/exec errors to `Failure`, logs once. |
+| **DTO** | `{Noun}Dto` | — | Row `Map` ↔ Entity. Mind sqlite encodings (§6). |
+
+**Read pipeline:** `wrapper.watch(sql)` → DataSource maps rows → `Stream<List<Dto>>`
+(rethrows) → RepositoryImpl `.map(toEntity)` + `.handleError(log & map to Failure)` →
+`Stream<Either<Failure, List<Entity>>>` → Cubit/Bloc **subscribes** (does not call once)
+and cancels on close.
+
+**Write pipeline:** Cubit → `repository.create(entity)` → DataSource `execute(insert)`
+(rethrows local failures) → RepositoryImpl wraps in `try/catch` → `Either`. The UI change
+arrives back through the existing `watch()` stream — never patch the list by hand.
+
+**One feature, many use cases → one shared instance.** DataSource and RepositoryImpl are
+stateless (they hold only the wrapper). Two UIs over the same table (e.g. "recent" vs
+"full list") share the same `addLazySingleton` instance and differ only by query — expose
+intention-revealing methods (`watchRecent(projectId, {limit})` vs `watchAll(projectId)`),
+not separate instances. The divergence lives in separate Cubits, not the data layer.
+
+---
+
+## 3. Writes — optimistic, local-first
+
+`execute()` writes to local SQLite immediately (so `watch()` re-emits at once) and
+**queues** the row for background upload by the connector.
+
+- **Repository write success means "persisted locally + queued for upload" — NOT
+  "accepted by the server."** The synchronous `Future<Either<Failure, void>>` can only
+  surface a *local* failure (SQLite/constraint).
+- **Server rejection is asynchronous.** The connector handles an RLS denial (Postgres
+  `42501`) by completing the CRUD transaction to unblock the queue; the local optimistic
+  row stays in SQLite. Surfacing that to the user happens later via the conflict channel
+  (`CA-660`), not via this return value. See
+  [`supabase_powersync_connector.dart`](../../lib/libraries/powersync/data/connectors/supabase_powersync_connector.dart).
+- **Always write IDs/timestamps explicitly** — PowerSync does not generate them on the
+  local row. Generate UUIDs client-side and set `created_at`/`updated_at` yourself.
+
+> 🛑 **Decision gate — do not guess.** When a write's *server acceptance* matters to the
+> UX (e.g. locking a cost estimate, anything where showing "saved" before the server
+> agrees is wrong), **stop and ask the user** how confirmation/conflict should be handled
+> before coding. The optimistic default is correct for most edits; it is not universal.
+
+---
+
+## 4. Backend config (separate repo) — invariants & checklist
+
+The PowerSync sync rules live in the **backend repo**, not here. This skill does not
+reproduce the YAML (it would drift). When you add or change a synced table, reconcile
+these invariants with the backend before the feature can work:
+
+- [ ] **Schema ↔ stream-SELECT parity.** Every column the local `schema.dart` `Table`
+      declares must be SELECTed by the corresponding `sync-streams.yaml` stream, with
+      matching names/types. **Mismatches cause silent data loss** — no error, just
+      missing/blank columns.
+- [ ] **RLS mirrors the connector.** The connector uploads via `upsert`/`update`/`delete`
+      keyed on `id`. Row-Level-Security policies must permit exactly those operations for
+      the authenticated user, or uploads fail (a `42501` denial is treated as permanent).
+- [ ] **Table is in the Postgres publication** PowerSync replicates from. A table absent
+      from the publication never syncs down.
+- [ ] **Permissions are JWT-derived, server-side.** Membership and feature permissions
+      (e.g. `get_cost_estimations`) are resolved from JWT claims in the sync rules — the
+      client passes **no** parameters for them. Confirm the claim exists in the issued JWT.
+- [ ] **On-demand streams are registered** in the sync rules so `syncStream(name)` from
+      the client activates them.
+
+---
+
+## 5. Wiring an on-demand synced table
+
+> **Names below are illustrative.** `cost_estimates` / `CostEstimate` /
+> `get_cost_estimations` are a running example — substitute your ticket's table, entity,
+> permission, and method names. The structure is identical for every synced table. A
+> *standard* (always-on) synced table is the same minus the activation step (§5.1).
+
+### 5.1 DataSource owns on-demand activation — lazily
+
+Activation is triggered on the **first `watch()` subscription** and released on cancel, so
+the stream only syncs while something is watching. Sync mechanics stay behind the seam;
+the repository and Cubit stay unaware. The non-obvious part is binding activation to the
+subscription lifecycle via `Stream.multi`:
+
+```dart
+@override
+Stream<List<CostEstimateDto>> watchByProject(String projectId) {
+  return Stream<List<CostEstimateDto>>.multi((controller) async {
+    await _wrapper.syncStream('cost_estimates');        // JWT-gated; no client params
+    final sub = _wrapper
+        .watch(_byProjectSql, parameters: [projectId])  // watch() stays single source of truth
+        .map((rows) => rows.map(CostEstimateDto.fromRow).toList())
+        .listen(controller.add, onError: controller.addError, onDone: controller.close);
+    controller.onCancel = sub.cancel;                   // release on cancel — no leak
+  });
+}
+```
+
+> ⚠️ **Footgun — emptiness is not permission.** If `get_cost_estimations` is denied
+> server-side, no rows sync and `watch()` simply emits `[]` — indistinguishable from
+> "no estimates yet" at the data layer. **Never infer permission state from an empty
+> stream.** Gate the feature on the permission upstream (auth/permissions), not on emptiness.
+
+### 5.2 RepositoryImpl — the error boundary
+
+`Either` lives here and nowhere below. Reads: `.map` DTOs → entities wrapped in `Right`;
+`.handleError` logs once (`AppLogger().tag(...)`) and maps to a domain `Failure` — convert
+`addError` into a `Left` rather than killing the stream where the UX should recover.
+Writes: `try/catch` around the DataSource call, `Right(null)` on success (= local+queued,
+**not** server-accepted, §3), `Left(Failure)` on a caught local error logged as `warning`.
+
+Reuse the same exception→Failure mapping as `code-data` (timeout/socket/Postgrest →
+warning vs error; unknown → `UnexpectedFailure`). **Reuse an existing `{Feature}Failure`
+case — never invent one inline.**
+
+### 5.3 Presentation & DI
+
+- **Cubit/Bloc:** subscribe to `repository.watchByProject(...)` on init, emit state per
+  `Either`, **cancel the subscription on `close()`**. Writes call `repository.create(...)`;
+  the UI updates via the same watch stream — do not manually patch the list.
+- **DI:** bind both as `addLazySingleton` in the feature's Modular module, injecting the
+  already-exported `PowerSyncDatabaseWrapper` into the DataSource and the DataSource into
+  the RepositoryImpl.
+
+---
+
+## 6. DTO / sqlite encoding notes
+
+Rows are `Map<String, dynamic>` from SQLite. Watch the encodings declared in
+[`schema.dart`](../../lib/libraries/powersync/models/schema.dart):
+
+- **Booleans are integers.** `is_locked`: `0` = false, `1` = true. Convert in the DTO.
+- **Timestamps are `text`.** Parse/format ISO strings yourself.
+- **Numerics:** `Column.real` → `double`, `Column.integer` → `int`. Don't assume.
+- **`id`** is added automatically by PowerSync — don't redeclare it; do set it on insert.
+
+---
+
+## 7. Testing (cross-link: `write-tests`, `write-tests-mutation`)
+
+Test the data layer against
+[`FakePowerSyncDatabaseWrapper`](../../lib/libraries/powersync/testing/fake_powersync_database_wrapper.dart)
+— never the real DB. General test structure, naming, and mutation-coverage rules come
+from the `write-tests` skills; the PowerSync-specific moves are:
+
+- **One-shot reads:** `fake.stubGetAll(sql, rows)`, then assert the mapped result.
+- **Reactive reads:** `fake.emitWatch(sql, rows)` to drive emissions; assert the Cubit/
+  repository reacts. Seeded values replay to late subscribers (mirrors real `watch`).
+- **Error mapping:** `fake.emitWatchError(sql, err)` / `fake.getAllError` / `fake.executeError`
+  to prove the RepositoryImpl maps to the right `Failure`.
+- **Write assertions:** after a write, assert `fake.executeCalls` contains the expected
+  `(sql, parameters)` — verify the SQL and bound params, not just that a call happened.
+- **Lazy on-demand activation:** assert `syncStream(...)` is called on first `watch`
+  subscription and that the watch controller is released on cancel (no leak).
+- Use `fake.reset()` between tests and `fake.dispose()` in teardown to close controllers.
+
+---
+
+## Checklist before you call it done
+
+- [ ] Reads go through `watch()` (one-shots justified for `getAll()`).
+- [ ] DataSource returns DTOs/rows and **rethrows**; no `Either` below the repository.
+- [ ] RepositoryImpl maps errors to a reused `Failure`, logs once (warning vs error).
+- [ ] Writes are optimistic; success ≠ server-accepted is documented/handled; server-
+      acceptance-critical writes were confirmed with the user (§3 gate).
+- [ ] On-demand `syncStream` activates lazily on first watch and releases on cancel.
+- [ ] No permission inferred from empty streams.
+- [ ] Backend invariants (§4) reconciled with the backend repo.
+- [ ] DTO handles sqlite encodings (bool-as-int, text timestamps).
+- [ ] Tests use `FakePowerSyncDatabaseWrapper`; reactive + error + activation paths covered.

--- a/test/app/shell/tab_module_manager_test.dart
+++ b/test/app/shell/tab_module_manager_test.dart
@@ -4,6 +4,7 @@ import 'package:construculator/app/shell/shell_module.dart';
 import 'package:construculator/app/shell/tab_module_manager.dart';
 import 'package:construculator/libraries/config/testing/fake_app_config.dart';
 import 'package:construculator/libraries/config/testing/fake_env_loader.dart';
+import 'package:construculator/libraries/powersync/testing/fake_powersync_database.dart';
 import 'package:construculator/libraries/sentry/fake_sentry_wrapper.dart';
 import 'package:construculator/libraries/supabase/testing/fake_supabase_wrapper.dart';
 import 'package:construculator/libraries/time/testing/fake_clock_impl.dart';
@@ -21,6 +22,7 @@ void main() {
           envLoader: FakeEnvLoader(),
           sentryWrapper: FakeSentryWrapper(),
           supabaseWrapper: FakeSupabaseWrapper(clock: FakeClockImpl()),
+          powerSyncDatabase: FakePowerSyncDatabase(),
         );
         Modular.init(ShellModule(appBootstrap));
         manager = Modular.get<TabModuleManager>();
@@ -63,6 +65,7 @@ void main() {
           envLoader: FakeEnvLoader(),
           sentryWrapper: FakeSentryWrapper(),
           supabaseWrapper: FakeSupabaseWrapper(clock: FakeClockImpl()),
+          powerSyncDatabase: FakePowerSyncDatabase(),
         );
         Modular.init(_TestShellModule(appBootstrap));
         customManager = Modular.get<TabModuleManager>();

--- a/test/libraries/auth/units/auth_manager_test.dart
+++ b/test/libraries/auth/units/auth_manager_test.dart
@@ -65,16 +65,10 @@ void main() {
       test(
         'should initialize with authenticated state when user exists',
         () async {
-          supabaseWrapper.setCurrentUser(
-            FakeUser(
-              email: testEmail,
-              id: 'test-id',
-              createdAt: clock.now().toIso8601String(),
-              appMetadata: {},
-            ),
-          );
           authNotifier.reset();
 
+          // Subscribe before emitting: the fake's auth stream delivers
+          // synchronously, so an event raised first would be missed.
           final initialEvent = expectLater(
             authNotifier.onAuthStateChanged,
             emits(
@@ -83,6 +77,16 @@ void main() {
               ),
             ),
           );
+
+          supabaseWrapper.setCurrentUser(
+            FakeUser(
+              email: testEmail,
+              id: 'test-id',
+              createdAt: clock.now().toIso8601String(),
+              appMetadata: {},
+            ),
+          );
+
           await initialEvent;
           expect(authNotifier.stateChangedEvents.length, 1);
           expect(

--- a/test/libraries/estimation/mutations/powersync_cost_estimation_data_source.xml
+++ b/test/libraries/estimation/mutations/powersync_cost_estimation_data_source.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mutations version="1.0">
+    <!-- POWERSYNC COST ESTIMATION DATA SOURCE MUTATION TESTING -->
+    <!-- Targets: reactive read data source (watch + snapshot) over local SQLite -->
+
+    <files>
+        <file>lib/libraries/estimation/data/data_source/powersync_cost_estimation_data_source_impl.dart</file>
+    </files>
+
+    <exclude>
+        <!-- Exclude logging statements -->
+        <regex pattern="_logger\.(debug|info|warning|error)\s*\(" dotAll="false"/>
+
+        <!-- Exclude try-catch structure -->
+        <regex pattern="try\s*{" dotAll="false"/>
+        <regex pattern="catch\s*\(" dotAll="false"/>
+
+        <!-- Exclude override annotations -->
+        <regex pattern="@override" dotAll="false"/>
+    </exclude>
+
+    <rules>
+        <!-- RULE 1: In _buildSelectSql, pick the wrong ORDER BY column for sortBy -->
+        <regex pattern="sortBy == EstimationSortOption\.updatedAt\s*\?\s*'updated_at'\s*:\s*'created_at'" dotAll="true" id="ds.sort.wrong_order_column">
+            <mutation text="sortBy == EstimationSortOption.updatedAt ? 'created_at' : 'updated_at'"/>
+        </regex>
+
+        <!-- RULE 2: In _buildSelectSql, invert the sort direction -->
+        <regex pattern="ascending \? 'ASC' : 'DESC'" dotAll="true" id="ds.sort.invert_direction">
+            <mutation text="ascending ? 'DESC' : 'ASC'"/>
+        </regex>
+
+        <!-- RULE 3: In _buildSelectSql, invert the LIMIT clause inclusion -->
+        <regex pattern="limited \? ' LIMIT \?' : ''" dotAll="true" id="ds.sort.invert_limit_clause">
+            <mutation text="limited ? '' : ' LIMIT ?'"/>
+        </regex>
+
+        <!-- RULE 4: In _selectParameters, invert the limit-binding guard -->
+        <regex pattern="if \(limit != null\) limit" dotAll="true" id="ds.params.invert_limit_guard">
+            <mutation text="if (limit == null) limit"/>
+        </regex>
+
+        <!-- RULE 5: In watchEstimations, drop the row->DTO mapping -->
+        <regex pattern="\.map\(\(rows\) =&gt; rows\.map\(CostEstimateDto\.fromRow\)\.toList\(\)\)" dotAll="true" id="ds.watch.skip_row_mapping">
+            <mutation text=".map((rows) =&gt; &lt;CostEstimateDto&gt;[])"/>
+        </regex>
+
+        <!-- RULE 6: In getEstimations, drop the row->DTO mapping -->
+        <regex pattern="return rows\.map\(CostEstimateDto\.fromRow\)\.toList\(\);" dotAll="true" id="ds.snapshot.skip_row_mapping">
+            <mutation text="return &lt;CostEstimateDto&gt;[];"/>
+        </regex>
+
+        <!-- RULE 7: In watchEstimations onCancel, fail to release the sync stream -->
+        <regex pattern="currentHandle\?\.unsubscribe\(\);" dotAll="true" id="ds.watch.skip_stream_release">
+            <mutation text="// currentHandle?.unsubscribe();"/>
+        </regex>
+
+        <!-- RULE 8: In watchEstimations, swallow the sync-stream activation error -->
+        <regex pattern="controller\.addError\(error, stackTrace\);" dotAll="true" id="ds.watch.swallow_activation_error">
+            <mutation text="// controller.addError(error, stackTrace);"/>
+        </regex>
+    </rules>
+
+    <commands>
+        <command group="powersync_cost_estimation_data_source" expected-return="0">flutter test test/libraries/estimation/units/data/data_source/powersync_cost_estimation_data_source_test.dart</command>
+    </commands>
+
+    <threshold failure="85">
+        <rating over="85" name="A"/>
+        <rating over="75" name="B"/>
+        <rating over="65" name="C"/>
+        <rating over="55" name="D"/>
+        <rating over="35" name="E"/>
+        <rating over="0" name="F"/>
+    </threshold>
+</mutations>

--- a/test/libraries/estimation/mutations/powersync_cost_estimation_data_source.xml
+++ b/test/libraries/estimation/mutations/powersync_cost_estimation_data_source.xml
@@ -41,8 +41,8 @@
         </regex>
 
         <!-- RULE 5: In watchEstimations, drop the row->DTO mapping -->
-        <regex pattern="\.map\(\(rows\) =&gt; rows\.map\(CostEstimateDto\.fromRow\)\.toList\(\)\)" dotAll="true" id="ds.watch.skip_row_mapping">
-            <mutation text=".map((rows) =&gt; &lt;CostEstimateDto&gt;[])"/>
+        <regex pattern="mapRows: \(rows\) =&gt; rows\.map\(CostEstimateDto\.fromRow\)\.toList\(\)," dotAll="true" id="ds.watch.skip_row_mapping">
+            <mutation text="mapRows: (rows) =&gt; &lt;CostEstimateDto&gt;[],"/>
         </regex>
 
         <!-- RULE 6: In getEstimations, drop the row->DTO mapping -->
@@ -58,6 +58,17 @@
         <!-- RULE 8: In watchEstimations, swallow the sync-stream activation error -->
         <regex pattern="controller\.addError\(error, stackTrace\);" dotAll="true" id="ds.watch.swallow_activation_error">
             <mutation text="// controller.addError(error, stackTrace);"/>
+        </regex>
+
+        <!-- RULE 9: In watchEstimationById, invert the empty-result guard so a
+             present row maps to null (and an absent one dereferences .first) -->
+        <regex pattern="rows\.isEmpty \? null" dotAll="true" id="ds.watchById.invert_empty_guard">
+            <mutation text="rows.isNotEmpty ? null"/>
+        </regex>
+
+        <!-- RULE 10: In watchEstimationById, drop the row->DTO mapping -->
+        <regex pattern=": CostEstimateDto\.fromRow\(rows\.first\)," dotAll="true" id="ds.watchById.skip_row_mapping">
+            <mutation text=": null,"/>
         </regex>
     </rules>
 

--- a/test/libraries/estimation/units/data/data_source/powersync_cost_estimation_data_source_test.dart
+++ b/test/libraries/estimation/units/data/data_source/powersync_cost_estimation_data_source_test.dart
@@ -191,6 +191,149 @@ void main() {
       });
     });
 
+    group('watchEstimationById', () {
+      const byIdSql = 'SELECT * FROM cost_estimates WHERE id = ? LIMIT 1';
+
+      test(
+        'activates the on-demand sync stream and maps the row to a DTO',
+        () async {
+          fakeWrapper.emitWatch(byIdSql, [sqliteRow()]);
+
+          final emission = expectLater(
+            dataSource.watchEstimationById(id: estimateIdDefault),
+            emits(
+              isA<CostEstimateDto>().having(
+                (dto) => dto.id,
+                'id',
+                estimateIdDefault,
+              ),
+            ),
+          );
+
+          await emission;
+          expect(fakeWrapper.syncStreamCalls, [syncStreamName]);
+          expect(fakeWrapper.watchCalls.single.sql, byIdSql);
+          expect(fakeWrapper.watchCalls.single.parameters, [estimateIdDefault]);
+        },
+      );
+
+      test('emits null when no row matches the id', () async {
+        fakeWrapper.emitWatch(byIdSql, const []);
+
+        await expectLater(
+          dataSource.watchEstimationById(id: estimateIdDefault),
+          emits(isNull),
+        );
+      });
+
+      test('decodes is_locked integer encoding to a bool DTO', () async {
+        fakeWrapper.emitWatch(byIdSql, [sqliteRow(locked: true)]);
+
+        await expectLater(
+          dataSource.watchEstimationById(id: estimateIdDefault),
+          emits(
+            isA<CostEstimateDto>().having(
+              (dto) => dto.isLocked,
+              'isLocked',
+              isTrue,
+            ),
+          ),
+        );
+      });
+
+      test('re-emits null when the watched row is deleted', () async {
+        fakeWrapper.emitWatch(byIdSql, [sqliteRow()]);
+
+        final emission = expectLater(
+          dataSource.watchEstimationById(id: estimateIdDefault),
+          emitsInOrder([isA<CostEstimateDto>(), isNull]),
+        );
+
+        await pumpEventQueue();
+        fakeWrapper.emitWatch(byIdSql, const []);
+
+        await emission;
+      });
+
+      test('emits the row once it syncs down after an empty result', () async {
+        fakeWrapper.emitWatch(byIdSql, const []);
+
+        final emission = expectLater(
+          dataSource.watchEstimationById(id: estimateIdDefault),
+          emitsInOrder([isNull, isA<CostEstimateDto>()]),
+        );
+
+        await pumpEventQueue();
+        fakeWrapper.emitWatch(byIdSql, [sqliteRow()]);
+
+        await emission;
+      });
+
+      test('drops emissions that rebuild an identical DTO', () async {
+        fakeWrapper.emitWatch(byIdSql, [sqliteRow()]);
+
+        final emitted = <CostEstimateDto?>[];
+        final subscription = dataSource
+            .watchEstimationById(id: estimateIdDefault)
+            .listen(emitted.add);
+        addTearDown(subscription.cancel);
+
+        await pumpEventQueue();
+        // An unrelated change to `cost_estimates` re-fires the same row.
+        fakeWrapper.emitWatch(byIdSql, [sqliteRow()]);
+        await pumpEventQueue();
+
+        expect(emitted, hasLength(1));
+
+        fakeWrapper.emitWatch(byIdSql, [sqliteRow(locked: true)]);
+        await pumpEventQueue();
+
+        expect(emitted, hasLength(2));
+        expect(emitted.last!.isLocked, isTrue);
+      });
+
+      test(
+        'releases the sync stream when the subscription is cancelled',
+        () async {
+          final subscription = dataSource
+              .watchEstimationById(id: estimateIdDefault)
+              .listen((_) {});
+          await pumpEventQueue();
+
+          expect(fakeWrapper.syncStreamCalls, [syncStreamName]);
+          expect(fakeWrapper.syncStreamUnsubscribes, isEmpty);
+
+          await subscription.cancel();
+
+          expect(fakeWrapper.syncStreamUnsubscribes, [syncStreamName]);
+        },
+      );
+
+      test('surfaces a sync-stream activation error on the stream', () async {
+        final error = Exception('activation failed');
+        fakeWrapper.syncStreamError = error;
+
+        await expectLater(
+          dataSource.watchEstimationById(id: estimateIdDefault),
+          emitsError(same(error)),
+        );
+      });
+
+      test('forwards watch errors to the stream', () async {
+        final error = Exception('watch failed');
+
+        final emission = expectLater(
+          dataSource.watchEstimationById(id: estimateIdDefault),
+          emitsError(same(error)),
+        );
+
+        await pumpEventQueue();
+        fakeWrapper.emitWatchError(byIdSql, error);
+
+        await emission;
+      });
+    });
+
     group('getEstimations', () {
       test(
         'returns mapped DTOs from a one-shot read without activating sync',

--- a/test/libraries/estimation/units/data/data_source/powersync_cost_estimation_data_source_test.dart
+++ b/test/libraries/estimation/units/data/data_source/powersync_cost_estimation_data_source_test.dart
@@ -1,0 +1,237 @@
+import 'dart:async';
+
+import 'package:construculator/app/app_bootstrap.dart';
+import 'package:construculator/libraries/estimation/data/data_source/interfaces/powersync_cost_estimation_data_source.dart';
+import 'package:construculator/libraries/estimation/data/models/cost_estimate_dto.dart';
+import 'package:construculator/libraries/estimation/domain/enums/estimation_sort_option.dart';
+import 'package:construculator/libraries/estimation/estimation_library_module.dart';
+import 'package:construculator/libraries/powersync/interfaces/powersync_database_wrapper.dart';
+import 'package:construculator/libraries/powersync/testing/fake_powersync_database_wrapper.dart';
+import 'package:flutter_modular/flutter_modular.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../../../../../utils/fake_app_bootstrap_factory.dart';
+import '../../../helpers/estimation_test_data_map_factory.dart';
+
+class _TestModule extends Module {
+  final AppBootstrap appBootstrap;
+
+  _TestModule(this.appBootstrap);
+
+  @override
+  List<Module> get imports => [EstimationLibraryModule(appBootstrap)];
+}
+
+void main() {
+  group('PowerSyncCostEstimationDataSource', () {
+    const projectId = testProjectId;
+    const syncStreamName = 'user_cost_estimates';
+    const defaultWatchSql =
+        'SELECT * FROM cost_estimates WHERE project_id = ? '
+        'ORDER BY created_at DESC';
+
+    late FakePowerSyncDatabaseWrapper fakeWrapper;
+    late PowerSyncCostEstimationDataSource dataSource;
+
+    setUpAll(() {
+      fakeWrapper = FakePowerSyncDatabaseWrapper();
+    });
+
+    setUp(() {
+      Modular.init(_TestModule(FakeAppBootstrapFactory.create()));
+      Modular.replaceInstance<PowerSyncDatabaseWrapper>(fakeWrapper);
+      dataSource = Modular.get<PowerSyncCostEstimationDataSource>();
+    });
+
+    tearDown(() {
+      Modular.destroy();
+      fakeWrapper.reset();
+    });
+
+    tearDownAll(() {
+      fakeWrapper.dispose();
+    });
+
+    /// A SQLite-shaped row, where `is_locked` is an integer (0/1) rather than
+    /// the boolean Supabase returns.
+    Map<String, dynamic> sqliteRow({
+      String id = estimateIdDefault,
+      bool locked = false,
+    }) {
+      final row = EstimationTestDataMapFactory.createFakeEstimationData(
+        id: id,
+        lockedByUserId: locked ? userIdDefault : null,
+        lockedAt: locked ? timestampDefault : null,
+      );
+      row['is_locked'] = locked ? 1 : 0;
+      return row;
+    }
+
+    group('watchEstimations', () {
+      test(
+        'activates the on-demand sync stream and maps rows to DTOs',
+        () async {
+          fakeWrapper.emitWatch(defaultWatchSql, [sqliteRow()]);
+
+          final emission = expectLater(
+            dataSource.watchEstimations(projectId: projectId),
+            emits(
+              isA<List<CostEstimateDto>>().having(
+                (dtos) => dtos.single.id,
+                'id',
+                estimateIdDefault,
+              ),
+            ),
+          );
+
+          await emission;
+          expect(fakeWrapper.syncStreamCalls, [syncStreamName]);
+          expect(fakeWrapper.watchCalls.single.sql, defaultWatchSql);
+          expect(fakeWrapper.watchCalls.single.parameters, [projectId]);
+        },
+      );
+
+      test('decodes is_locked integer encoding to a bool DTO', () async {
+        fakeWrapper.emitWatch(defaultWatchSql, [sqliteRow(locked: true)]);
+
+        await expectLater(
+          dataSource.watchEstimations(projectId: projectId),
+          emits(
+            isA<List<CostEstimateDto>>().having(
+              (dtos) => dtos.single.isLocked,
+              'isLocked',
+              isTrue,
+            ),
+          ),
+        );
+      });
+
+      test('builds sort, direction and limit into the watch query', () async {
+        final subscription = dataSource
+            .watchEstimations(
+              projectId: projectId,
+              sortBy: EstimationSortOption.updatedAt,
+              ascending: true,
+              limit: 5,
+            )
+            .listen((_) {});
+        addTearDown(subscription.cancel);
+
+        await pumpEventQueue();
+
+        expect(
+          fakeWrapper.watchCalls.single.sql,
+          'SELECT * FROM cost_estimates WHERE project_id = ? '
+          'ORDER BY updated_at ASC LIMIT ?',
+        );
+        expect(fakeWrapper.watchCalls.single.parameters, [projectId, 5]);
+      });
+
+      test(
+        'releases the sync stream when the subscription is cancelled',
+        () async {
+          final subscription = dataSource
+              .watchEstimations(projectId: projectId)
+              .listen((_) {});
+          await pumpEventQueue();
+
+          expect(fakeWrapper.syncStreamCalls, [syncStreamName]);
+          expect(fakeWrapper.syncStreamUnsubscribes, isEmpty);
+
+          await subscription.cancel();
+
+          expect(fakeWrapper.syncStreamUnsubscribes, [syncStreamName]);
+        },
+      );
+
+      test(
+        'does not start watch when cancelled while syncStream is still pending',
+        () async {
+          fakeWrapper.syncStreamActivationGate = Completer<void>();
+
+          final subscription = dataSource
+              .watchEstimations(projectId: projectId)
+              .listen((_) {});
+          await pumpEventQueue();
+
+          expect(fakeWrapper.syncStreamCalls, [syncStreamName]);
+          expect(fakeWrapper.watchCalls, isEmpty);
+
+          await subscription.cancel();
+          fakeWrapper.syncStreamActivationGate!.complete();
+          await pumpEventQueue();
+
+          expect(fakeWrapper.watchCalls, isEmpty);
+          expect(fakeWrapper.syncStreamUnsubscribes, [syncStreamName]);
+        },
+      );
+
+      test('surfaces a sync-stream activation error on the stream', () async {
+        final error = Exception('activation failed');
+        fakeWrapper.syncStreamError = error;
+
+        await expectLater(
+          dataSource.watchEstimations(projectId: projectId),
+          emitsError(same(error)),
+        );
+      });
+
+      test('forwards watch errors to the stream', () async {
+        final error = Exception('watch failed');
+
+        final emission = expectLater(
+          dataSource.watchEstimations(projectId: projectId),
+          emitsError(same(error)),
+        );
+
+        await pumpEventQueue();
+        fakeWrapper.emitWatchError(defaultWatchSql, error);
+
+        await emission;
+      });
+    });
+
+    group('getEstimations', () {
+      test(
+        'returns mapped DTOs from a one-shot read without activating sync',
+        () async {
+          fakeWrapper.stubGetAll(defaultWatchSql, [sqliteRow()]);
+
+          final result = await dataSource.getEstimations(projectId: projectId);
+
+          expect(result.single.id, estimateIdDefault);
+          expect(fakeWrapper.getAllCalls.single.sql, defaultWatchSql);
+          expect(fakeWrapper.getAllCalls.single.parameters, [projectId]);
+          expect(fakeWrapper.syncStreamCalls, isEmpty);
+        },
+      );
+
+      test('builds sort, direction and limit into the read query', () async {
+        const sortedSql =
+            'SELECT * FROM cost_estimates WHERE project_id = ? '
+            'ORDER BY updated_at ASC LIMIT ?';
+        fakeWrapper.stubGetAll(sortedSql, [sqliteRow()]);
+
+        await dataSource.getEstimations(
+          projectId: projectId,
+          sortBy: EstimationSortOption.updatedAt,
+          ascending: true,
+          limit: 5,
+        );
+
+        expect(fakeWrapper.getAllCalls.single.sql, sortedSql);
+        expect(fakeWrapper.getAllCalls.single.parameters, [projectId, 5]);
+      });
+
+      test('rethrows read errors', () async {
+        final error = Exception('read failed');
+        fakeWrapper.getAllError = error;
+
+        await expectLater(
+          dataSource.getEstimations(projectId: projectId),
+          throwsA(same(error)),
+        );
+      });
+    });
+  });
+}

--- a/test/libraries/estimation/units/data/models/cost_estimate_dto_test.dart
+++ b/test/libraries/estimation/units/data/models/cost_estimate_dto_test.dart
@@ -308,5 +308,43 @@ void main() {
 
       expect(convertedDto, equals(originalDto));
     });
+
+    group('fromRow (SQLite encoding)', () {
+      Map<String, dynamic> sqliteRow({int isLocked = 0}) {
+        return Map<String, dynamic>.from(
+          EstimationTestDataMapFactory.createFakeEstimationData(),
+        )..['is_locked'] = isLocked;
+      }
+
+      test('decodes is_locked integer 1 to a true bool', () {
+        final dto = CostEstimateDto.fromRow(sqliteRow(isLocked: 1));
+
+        expect(dto.isLocked, isTrue);
+      });
+
+      test('decodes is_locked integer 0 to a false bool', () {
+        final dto = CostEstimateDto.fromRow(sqliteRow(isLocked: 0));
+
+        expect(dto.isLocked, isFalse);
+      });
+
+      test('defaults missing is_locked to false', () {
+        final row = Map<String, dynamic>.from(
+          EstimationTestDataMapFactory.createFakeEstimationData(),
+        )..remove('is_locked');
+
+        final dto = CostEstimateDto.fromRow(row);
+
+        expect(dto.isLocked, isFalse);
+      });
+
+      test('maps the remaining columns identically to fromJson', () {
+        final row = sqliteRow(isLocked: 1);
+
+        final expected = CostEstimateDto.fromJson({...row, 'is_locked': true});
+
+        expect(CostEstimateDto.fromRow(row), equals(expected));
+      });
+    });
   });
 }

--- a/test/libraries/powersync/units/powersync_manager_test.dart
+++ b/test/libraries/powersync/units/powersync_manager_test.dart
@@ -1,0 +1,171 @@
+import 'package:construculator/app/app_bootstrap.dart';
+import 'package:construculator/libraries/powersync/interfaces/powersync_manager.dart';
+import 'package:construculator/libraries/powersync/powersync_module.dart';
+import 'package:construculator/libraries/powersync/testing/fake_powersync_database.dart';
+import 'package:construculator/libraries/supabase/testing/fake_supabase_user.dart';
+import 'package:construculator/libraries/supabase/testing/fake_supabase_wrapper.dart';
+import 'package:construculator/libraries/time/testing/fake_clock_impl.dart';
+import 'package:flutter_modular/flutter_modular.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:powersync/powersync.dart';
+
+import '../../../utils/fake_app_bootstrap_factory.dart';
+
+void main() {
+  final fakeSupabase = FakeSupabaseWrapper(clock: FakeClockImpl());
+  final fakeDatabase = FakePowerSyncDatabase();
+  final bootstrap = FakeAppBootstrapFactory.create(
+    supabaseWrapper: fakeSupabase,
+    powerSyncDatabase: fakeDatabase,
+  );
+
+  setUpAll(() => Modular.init(_AppModule(bootstrap)));
+
+  tearDownAll(() {
+    Modular.destroy();
+    fakeSupabase.dispose();
+  });
+
+  setUp(() {
+    (Modular.get<PowerSyncManager>() as Disposable).dispose();
+    Modular.dispose<PowerSyncManager>();
+    fakeSupabase.reset();
+    fakeDatabase.reset();
+  });
+
+  PowerSyncManager startManager() => Modular.get<PowerSyncManager>();
+
+  PowerSyncBackendConnector moduleConnector() =>
+      Modular.get<PowerSyncBackendConnector>();
+
+  void signIn() {
+    fakeSupabase.setCurrentUser(
+      FakeUser(
+        id: 'user-1',
+        email: 'user@example.com',
+        createdAt: '2000-01-01T00:00:00.000Z',
+      ),
+    );
+  }
+
+  /// Lets queued auth-stream events reach the manager's listener.
+  ///
+  /// The unit-test analogue of `tester.pumpAndSettle()`: there is no widget
+  /// tree to pump here, so we drain the event queue to flush pending
+  /// broadcast-stream deliveries instead. [pumpEventQueue] pumps repeatedly,
+  /// so it settles multi-hop async chains a single timer tick would miss.
+  Future<void> pumpAuthEvents() => pumpEventQueue();
+
+  group('PowerSyncManager', () {
+    test('exposes the database opened during bootstrap', () {
+      final manager = startManager();
+
+      expect(manager.database, same(fakeDatabase));
+    });
+
+    test('does not connect when no session exists at startup', () {
+      startManager();
+
+      expect(fakeDatabase.connectCallCount, 0);
+    });
+
+    test('connects immediately when already authenticated at startup', () {
+      signIn();
+
+      startManager();
+
+      expect(fakeDatabase.connectCallCount, 1);
+      expect(fakeDatabase.lastConnector, same(moduleConnector()));
+    });
+
+    test('connects when a sign-in event is emitted', () async {
+      startManager();
+
+      signIn();
+      await pumpAuthEvents();
+
+      expect(fakeDatabase.connectCallCount, 1);
+      expect(fakeDatabase.lastConnector, same(moduleConnector()));
+    });
+
+    test('disconnects and clears when a sign-out event is emitted', () async {
+      signIn();
+      startManager();
+
+      fakeSupabase.setCurrentUser(null);
+      await pumpAuthEvents();
+
+      expect(fakeDatabase.disconnectAndClearCallCount, 1);
+    });
+
+    test('does not establish duplicate connections', () async {
+      startManager();
+
+      signIn();
+      await pumpAuthEvents();
+
+      signIn();
+      await pumpAuthEvents();
+
+      expect(fakeDatabase.connectCallCount, 1);
+    });
+
+    test('reconnects after a sign-out followed by a new sign-in', () async {
+      signIn();
+      final manager = startManager();
+      expect(fakeDatabase.connectCallCount, 1);
+
+      fakeSupabase.setCurrentUser(null);
+      await pumpAuthEvents();
+      signIn();
+      await pumpAuthEvents();
+
+      expect(fakeDatabase.connectCallCount, 2);
+      expect(fakeDatabase.disconnectAndClearCallCount, 1);
+      expect(manager.database, same(fakeDatabase));
+    });
+
+    test('connect failure is swallowed and allows a later retry', () async {
+      final manager = startManager();
+      fakeDatabase.connectError = Exception('network down');
+
+      await manager.connect();
+      expect(fakeDatabase.connectCallCount, 1);
+
+      fakeDatabase.connectError = null;
+      await manager.connect();
+      expect(fakeDatabase.connectCallCount, 2);
+    });
+
+    test('disconnectAndClear is a no-op when not connected', () async {
+      final manager = startManager();
+
+      await manager.disconnectAndClear();
+
+      expect(fakeDatabase.disconnectAndClearCallCount, 0);
+    });
+
+    test('stops reacting to auth events after dispose', () async {
+      final manager = startManager();
+
+      (manager as Disposable).dispose();
+      signIn();
+      await pumpAuthEvents();
+
+      expect(fakeDatabase.connectCallCount, 0);
+    });
+  });
+}
+
+// Minimal host module that mirrors how the real `AppModule` composes
+// [PowerSyncModule], so the production module's wiring — including the eager
+// [PowerSyncManager] singleton — is exercised directly. [PowerSyncModule]
+// exposes its binds via `exportedBinds`, which are only resolvable through an
+// importing module, hence this wrapper.
+class _AppModule extends Module {
+  final AppBootstrap appBootstrap;
+  _AppModule(this.appBootstrap);
+
+  @override
+  List<Module> get imports => [PowerSyncModule(appBootstrap)];
+}

--- a/test/libraries/powersync/units/powersync_manager_test.dart
+++ b/test/libraries/powersync/units/powersync_manager_test.dart
@@ -48,14 +48,6 @@ void main() {
     );
   }
 
-  /// Lets queued auth-stream events reach the manager's listener.
-  ///
-  /// The unit-test analogue of `tester.pumpAndSettle()`: there is no widget
-  /// tree to pump here, so we drain the event queue to flush pending
-  /// broadcast-stream deliveries instead. [pumpEventQueue] pumps repeatedly,
-  /// so it settles multi-hop async chains a single timer tick would miss.
-  Future<void> pumpAuthEvents() => pumpEventQueue();
-
   group('PowerSyncManager', () {
     test('exposes the database opened during bootstrap', () {
       final manager = startManager();
@@ -82,7 +74,6 @@ void main() {
       startManager();
 
       signIn();
-      await pumpAuthEvents();
 
       expect(fakeDatabase.connectCallCount, 1);
       expect(fakeDatabase.lastConnector, same(moduleConnector()));
@@ -93,7 +84,6 @@ void main() {
       startManager();
 
       fakeSupabase.setCurrentUser(null);
-      await pumpAuthEvents();
 
       expect(fakeDatabase.disconnectAndClearCallCount, 1);
     });
@@ -102,10 +92,8 @@ void main() {
       startManager();
 
       signIn();
-      await pumpAuthEvents();
 
       signIn();
-      await pumpAuthEvents();
 
       expect(fakeDatabase.connectCallCount, 1);
     });
@@ -116,9 +104,7 @@ void main() {
       expect(fakeDatabase.connectCallCount, 1);
 
       fakeSupabase.setCurrentUser(null);
-      await pumpAuthEvents();
       signIn();
-      await pumpAuthEvents();
 
       expect(fakeDatabase.connectCallCount, 2);
       expect(fakeDatabase.disconnectAndClearCallCount, 1);
@@ -137,6 +123,22 @@ void main() {
       expect(fakeDatabase.connectCallCount, 2);
     });
 
+    test(
+      'disconnectAndClear failure keeps the manager connected for a retry',
+      () async {
+        signIn();
+        final manager = startManager();
+        fakeDatabase.disconnectAndClearError = Exception('disk error');
+
+        await manager.disconnectAndClear();
+        expect(fakeDatabase.disconnectAndClearCallCount, 1);
+
+        fakeDatabase.disconnectAndClearError = null;
+        await manager.disconnectAndClear();
+        expect(fakeDatabase.disconnectAndClearCallCount, 2);
+      },
+    );
+
     test('disconnectAndClear is a no-op when not connected', () async {
       final manager = startManager();
 
@@ -150,7 +152,6 @@ void main() {
 
       (manager as Disposable).dispose();
       signIn();
-      await pumpAuthEvents();
 
       expect(fakeDatabase.connectCallCount, 0);
     });

--- a/test/libraries/powersync/units/testing/fake_powersync_database_wrapper_test.dart
+++ b/test/libraries/powersync/units/testing/fake_powersync_database_wrapper_test.dart
@@ -1,0 +1,205 @@
+import 'package:construculator/libraries/powersync/testing/fake_powersync_database_wrapper.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('FakePowerSyncDatabaseWrapper', () {
+    late FakePowerSyncDatabaseWrapper fakeWrapper;
+
+    setUp(() {
+      fakeWrapper = FakePowerSyncDatabaseWrapper();
+    });
+
+    tearDown(() {
+      fakeWrapper.dispose();
+    });
+
+    group('getAll', () {
+      test('returns an empty list when nothing is stubbed', () async {
+        final rows = await fakeWrapper.getAll('SELECT * FROM projects');
+
+        expect(rows, isEmpty);
+      });
+
+      test('returns the stubbed rows for the matching sql', () async {
+        const sql = 'SELECT * FROM projects WHERE id = ?';
+        fakeWrapper.stubGetAll(sql, [
+          {'id': 'p1', 'project_name': 'Foundation'},
+        ]);
+
+        final rows = await fakeWrapper.getAll(sql, ['p1']);
+
+        expect(rows, hasLength(1));
+        expect(rows.single['id'], 'p1');
+      });
+
+      test('records the sql and parameters of each call', () async {
+        await fakeWrapper.getAll('SELECT 1', ['a', 2]);
+
+        expect(fakeWrapper.getAllCalls, hasLength(1));
+        expect(fakeWrapper.getAllCalls.single.sql, 'SELECT 1');
+        expect(fakeWrapper.getAllCalls.single.parameters, ['a', 2]);
+      });
+
+      test('throws the configured error and still records the call', () async {
+        final error = Exception('read failed');
+        fakeWrapper.getAllError = error;
+
+        await expectLater(
+          fakeWrapper.getAll('SELECT 1'),
+          throwsA(same(error)),
+        );
+        expect(fakeWrapper.getAllCalls, hasLength(1));
+      });
+    });
+
+    group('execute', () {
+      test('records the sql and parameters of each call', () async {
+        await fakeWrapper.execute('DELETE FROM projects WHERE id = ?', ['p1']);
+
+        expect(fakeWrapper.executeCalls, hasLength(1));
+        expect(
+          fakeWrapper.executeCalls.single.sql,
+          'DELETE FROM projects WHERE id = ?',
+        );
+        expect(fakeWrapper.executeCalls.single.parameters, ['p1']);
+      });
+
+      test('throws the configured error and still records the call', () async {
+        final error = Exception('write failed');
+        fakeWrapper.executeError = error;
+
+        await expectLater(
+          fakeWrapper.execute('DELETE FROM projects'),
+          throwsA(same(error)),
+        );
+        expect(fakeWrapper.executeCalls, hasLength(1));
+      });
+    });
+
+    group('watch', () {
+      const sql = 'SELECT * FROM projects';
+
+      test('records the sql and parameters of each call', () {
+        fakeWrapper.watch(sql, parameters: ['p1']);
+
+        expect(fakeWrapper.watchCalls, hasLength(1));
+        expect(fakeWrapper.watchCalls.single.sql, sql);
+        expect(fakeWrapper.watchCalls.single.parameters, ['p1']);
+      });
+
+      test('emits rows passed to emitWatch to active listeners', () async {
+        final emission = expectLater(
+          fakeWrapper.watch(sql),
+          emits([
+            {'id': 'p1'},
+          ]),
+        );
+
+        fakeWrapper.emitWatch(sql, [
+          {'id': 'p1'},
+        ]);
+
+        await emission;
+      });
+
+      test('replays the latest emitted value to a later listener', () {
+        fakeWrapper.emitWatch(sql, [
+          {'id': 'p1'},
+        ]);
+
+        return expectLater(
+          fakeWrapper.watch(sql),
+          emits([
+            {'id': 'p1'},
+          ]),
+        );
+      });
+
+      test('forwards errors passed to emitWatchError', () async {
+        final error = Exception('stream failed');
+
+        final emission = expectLater(
+          fakeWrapper.watch(sql),
+          emitsError(same(error)),
+        );
+
+        fakeWrapper.emitWatchError(sql, error);
+
+        await emission;
+      });
+    });
+
+    group('syncStream', () {
+      test('records each activation by stream name', () async {
+        await fakeWrapper.syncStream('user_cost_estimates');
+
+        expect(fakeWrapper.syncStreamCalls, ['user_cost_estimates']);
+      });
+
+      test('returned handle records its release on unsubscribe', () async {
+        final handle = await fakeWrapper.syncStream('user_cost_estimates');
+
+        expect(fakeWrapper.syncStreamUnsubscribes, isEmpty);
+
+        handle.unsubscribe();
+
+        expect(fakeWrapper.syncStreamUnsubscribes, ['user_cost_estimates']);
+      });
+
+      test('throws the configured error and still records the call', () async {
+        final error = Exception('activation failed');
+        fakeWrapper.syncStreamError = error;
+
+        await expectLater(
+          fakeWrapper.syncStream('user_cost_estimates'),
+          throwsA(same(error)),
+        );
+        expect(fakeWrapper.syncStreamCalls, ['user_cost_estimates']);
+      });
+    });
+
+    group('reset', () {
+      test('clears recorded calls, stubs, errors, and watch seeds', () async {
+        const sql = 'SELECT * FROM projects';
+        fakeWrapper.stubGetAll(sql, [
+          {'id': 'p1'},
+        ]);
+        fakeWrapper.emitWatch(sql, [
+          {'id': 'p1'},
+        ]);
+        await fakeWrapper.getAll(sql);
+        await fakeWrapper.execute('DELETE FROM projects');
+        final handle = await fakeWrapper.syncStream('user_cost_estimates');
+        handle.unsubscribe();
+        fakeWrapper.getAllError = Exception('x');
+        fakeWrapper.executeError = Exception('y');
+        fakeWrapper.syncStreamError = Exception('z');
+
+        fakeWrapper.reset();
+
+        expect(fakeWrapper.getAllCalls, isEmpty);
+        expect(fakeWrapper.executeCalls, isEmpty);
+        expect(fakeWrapper.watchCalls, isEmpty);
+        expect(fakeWrapper.syncStreamCalls, isEmpty);
+        expect(fakeWrapper.syncStreamUnsubscribes, isEmpty);
+        expect(fakeWrapper.getAllError, isNull);
+        expect(fakeWrapper.executeError, isNull);
+        expect(fakeWrapper.syncStreamError, isNull);
+        expect(await fakeWrapper.getAll(sql), isEmpty);
+
+        // The cleared seed must not replay: the first value a new listener sees
+        // is the post-reset emission, not the pre-reset 'p1'.
+        final emission = expectLater(
+          fakeWrapper.watch(sql),
+          emits([
+            {'id': 'p2'},
+          ]),
+        );
+        fakeWrapper.emitWatch(sql, [
+          {'id': 'p2'},
+        ]);
+        await emission;
+      });
+    });
+  });
+}

--- a/test/libraries/powersync/units/testing/fake_powersync_database_wrapper_test.dart
+++ b/test/libraries/powersync/units/testing/fake_powersync_database_wrapper_test.dart
@@ -44,10 +44,7 @@ void main() {
         final error = Exception('read failed');
         fakeWrapper.getAllError = error;
 
-        await expectLater(
-          fakeWrapper.getAll('SELECT 1'),
-          throwsA(same(error)),
-        );
+        await expectLater(fakeWrapper.getAll('SELECT 1'), throwsA(same(error)));
         expect(fakeWrapper.getAllCalls, hasLength(1));
       });
     });
@@ -158,6 +155,68 @@ void main() {
       });
     });
 
+    group('writeTransaction', () {
+      test('returns the value produced by the action', () async {
+        final result = await fakeWrapper.writeTransaction((_) async => 42);
+
+        expect(result, 42);
+      });
+
+      test(
+        'increments writeTransactionCallCount for each invocation',
+        () async {
+          await fakeWrapper.writeTransaction((_) async {});
+          await fakeWrapper.writeTransaction((_) async {});
+
+          expect(fakeWrapper.writeTransactionCallCount, 2);
+        },
+      );
+
+      test('writes inside the action appear in executeCalls', () async {
+        await fakeWrapper.writeTransaction((tx) async {
+          await tx.execute('INSERT INTO projects (id) VALUES (?)', ['p1']);
+          await tx.execute('INSERT INTO line_items (project_id) VALUES (?)', [
+            'p1',
+          ]);
+        });
+
+        expect(fakeWrapper.executeCalls, hasLength(2));
+        expect(
+          fakeWrapper.executeCalls.first.sql,
+          'INSERT INTO projects (id) VALUES (?)',
+        );
+        expect(
+          fakeWrapper.executeCalls.last.sql,
+          'INSERT INTO line_items (project_id) VALUES (?)',
+        );
+      });
+
+      test(
+        'executeError causes writes inside the transaction to throw',
+        () async {
+          final error = Exception('write failed');
+          fakeWrapper.executeError = error;
+
+          await expectLater(
+            fakeWrapper.writeTransaction(
+              (tx) =>
+                  tx.execute('INSERT INTO projects (id) VALUES (?)', ['p1']),
+            ),
+            throwsA(same(error)),
+          );
+        },
+      );
+
+      test('propagates an error thrown by the action', () async {
+        final error = Exception('action failed');
+
+        await expectLater(
+          fakeWrapper.writeTransaction<void>((_) async => throw error),
+          throwsA(same(error)),
+        );
+      });
+    });
+
     group('reset', () {
       test('clears recorded calls, stubs, errors, and watch seeds', () async {
         const sql = 'SELECT * FROM projects';
@@ -169,6 +228,7 @@ void main() {
         ]);
         await fakeWrapper.getAll(sql);
         await fakeWrapper.execute('DELETE FROM projects');
+        await fakeWrapper.writeTransaction((_) async {});
         final handle = await fakeWrapper.syncStream('user_cost_estimates');
         handle.unsubscribe();
         fakeWrapper.getAllError = Exception('x');
@@ -180,6 +240,7 @@ void main() {
         expect(fakeWrapper.getAllCalls, isEmpty);
         expect(fakeWrapper.executeCalls, isEmpty);
         expect(fakeWrapper.watchCalls, isEmpty);
+        expect(fakeWrapper.writeTransactionCallCount, 0);
         expect(fakeWrapper.syncStreamCalls, isEmpty);
         expect(fakeWrapper.syncStreamUnsubscribes, isEmpty);
         expect(fakeWrapper.getAllError, isNull);
@@ -187,8 +248,6 @@ void main() {
         expect(fakeWrapper.syncStreamError, isNull);
         expect(await fakeWrapper.getAll(sql), isEmpty);
 
-        // The cleared seed must not replay: the first value a new listener sees
-        // is the post-reset emission, not the pre-reset 'p1'.
         final emission = expectLater(
           fakeWrapper.watch(sql),
           emits([

--- a/test/libraries/powersync/units/testing/fake_powersync_database_wrapper_test.dart
+++ b/test/libraries/powersync/units/testing/fake_powersync_database_wrapper_test.dart
@@ -215,6 +215,64 @@ void main() {
           throwsA(same(error)),
         );
       });
+
+      test(
+        'throws writeTransactionError without invoking the action',
+        () async {
+          final error = Exception('transaction failed');
+          fakeWrapper.writeTransactionError = error;
+          var actionRan = false;
+
+          await expectLater(
+            fakeWrapper.writeTransaction<void>((_) async => actionRan = true),
+            throwsA(same(error)),
+          );
+          expect(actionRan, isFalse);
+          expect(fakeWrapper.writeTransactionCallCount, 1);
+        },
+      );
+
+      test('writeTransactionError does not affect bare execute', () async {
+        fakeWrapper.writeTransactionError = Exception('transaction failed');
+
+        await fakeWrapper.execute('DELETE FROM projects');
+
+        expect(fakeWrapper.executeCalls, hasLength(1));
+      });
+
+      test('executeError does not fire before the action runs', () async {
+        fakeWrapper.executeError = Exception('write failed');
+        var actionRan = false;
+
+        await expectLater(
+          fakeWrapper.writeTransaction<void>((_) async => actionRan = true),
+          completes,
+        );
+        expect(actionRan, isTrue);
+      });
+
+      test(
+        'writeTransactionError throws on every call until cleared',
+        () async {
+          fakeWrapper.writeTransactionError = Exception('transaction failed');
+
+          await expectLater(
+            fakeWrapper.writeTransaction<void>((_) async {}),
+            throwsA(isA<Exception>()),
+          );
+          await expectLater(
+            fakeWrapper.writeTransaction<void>((_) async {}),
+            throwsA(isA<Exception>()),
+          );
+
+          fakeWrapper.writeTransactionError = null;
+
+          await expectLater(
+            fakeWrapper.writeTransaction<void>((_) async {}),
+            completes,
+          );
+        },
+      );
     });
 
     group('reset', () {
@@ -233,6 +291,7 @@ void main() {
         handle.unsubscribe();
         fakeWrapper.getAllError = Exception('x');
         fakeWrapper.executeError = Exception('y');
+        fakeWrapper.writeTransactionError = Exception('w');
         fakeWrapper.syncStreamError = Exception('z');
 
         fakeWrapper.reset();
@@ -245,6 +304,7 @@ void main() {
         expect(fakeWrapper.syncStreamUnsubscribes, isEmpty);
         expect(fakeWrapper.getAllError, isNull);
         expect(fakeWrapper.executeError, isNull);
+        expect(fakeWrapper.writeTransactionError, isNull);
         expect(fakeWrapper.syncStreamError, isNull);
         expect(await fakeWrapper.getAll(sql), isEmpty);
 

--- a/test/libraries/powersync/units/testing/fake_powersync_database_wrapper_test.dart
+++ b/test/libraries/powersync/units/testing/fake_powersync_database_wrapper_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:construculator/libraries/powersync/testing/fake_powersync_database_wrapper.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -131,6 +133,23 @@ void main() {
         await fakeWrapper.syncStream('user_cost_estimates');
 
         expect(fakeWrapper.syncStreamCalls, ['user_cost_estimates']);
+      });
+
+      test('can delay activation until the gate completes', () async {
+        fakeWrapper.syncStreamActivationGate = Completer<void>();
+
+        final future = fakeWrapper.syncStream('user_cost_estimates');
+        await pumpEventQueue();
+
+        expect(fakeWrapper.syncStreamCalls, ['user_cost_estimates']);
+        expect(fakeWrapper.syncStreamUnsubscribes, isEmpty);
+
+        fakeWrapper.syncStreamActivationGate!.complete();
+        final handle = await future;
+
+        handle.unsubscribe();
+
+        expect(fakeWrapper.syncStreamUnsubscribes, ['user_cost_estimates']);
       });
 
       test('returned handle records its release on unsubscribe', () async {

--- a/test/utils/fake_app_bootstrap_factory.dart
+++ b/test/utils/fake_app_bootstrap_factory.dart
@@ -3,9 +3,11 @@ import 'package:construculator/libraries/config/interfaces/config.dart';
 import 'package:construculator/libraries/config/interfaces/env_loader.dart';
 import 'package:construculator/libraries/config/testing/fake_app_config.dart';
 import 'package:construculator/libraries/config/testing/fake_env_loader.dart';
+import 'package:construculator/libraries/powersync/testing/fake_powersync_database.dart';
 import 'package:construculator/libraries/sentry/fake_sentry_wrapper.dart';
 import 'package:construculator/libraries/supabase/testing/fake_supabase_wrapper.dart';
 import 'package:construculator/libraries/time/testing/fake_clock_impl.dart';
+import 'package:powersync/powersync.dart';
 
 /// Factory for creating test AppBootstrap instances with fake dependencies.
 ///
@@ -19,6 +21,8 @@ class FakeAppBootstrapFactory {
   ///   database state and assertions
   /// - [config]: Provide custom app configuration for the test
   /// - [envLoader]: Provide custom environment loading behavior
+  /// - [powerSyncDatabase]: Provide a specific fake database to assert against
+  ///   sync lifecycle calls
   ///
   /// When parameters are omitted, sensible test defaults are provided.
   ///
@@ -37,6 +41,7 @@ class FakeAppBootstrapFactory {
     FakeSupabaseWrapper? supabaseWrapper,
     Config? config,
     EnvLoader? envLoader,
+    PowerSyncDatabase? powerSyncDatabase,
   }) {
     return AppBootstrap(
       supabaseWrapper:
@@ -44,6 +49,7 @@ class FakeAppBootstrapFactory {
       config: config ?? FakeAppConfig(),
       envLoader: envLoader ?? FakeEnvLoader(),
       sentryWrapper: FakeSentryWrapper(),
+      powerSyncDatabase: powerSyncDatabase ?? FakePowerSyncDatabase(),
     );
   }
 }


### PR DESCRIPTION
**Base:** `feat/powersync_cost_estimate_data_source`
**Verification:** `flutter test test/libraries/estimation/units/data/data_source/powersync_cost_estimation_data_source_test.dart` → **16/16 pass**

---

## 1. PR Summary

Adds `watchEstimationById(id)` to the PowerSync read data source.

- Extracts the existing lazy sync-stream + `Stream.multi` lifecycle out of `watchEstimations` into a generic `_watchWithSyncStream<T>` helper, reused by both watches.
- Adds 6 unit tests and 2 mutation rules.
- No callers yet — data-source-only slice of the migration series.

**Size:** XS (~53 production lines). Single purpose, passes independently.

---

## 3. Review Summary

| Issue Name | Description | Status | Notes |
|------------|-------------|--------|-------|
| Re-emission on appear/disappear untested | Interface docstring promises the stream lets "the UI react to the row appearing and disappearing", but every by-id test asserts a **single** emission (`emits(...)`). No test asserts a sequence. The headline contract of the method is the one thing not covered. | | |
| No `distinct()` — event flooding (Rule 6) | PowerSync `watch()` fires on **any** change to `cost_estimates`, not only the watched row. A by-id watcher rebuilds whenever an unrelated estimate in the same table changes, emitting an identical DTO. `CostEstimateDto extends Equatable`, so `.distinct()` is safe and free. | | |
| Implementation comment inside `watchEstimationById` (Rule 7) | The 3-line comment above `sql:` restates the interface docstring, which already carries the contract. The `LIMIT 1` justification is also inaccurate. | | |

### 3.1 Re-emission on appear/disappear untested

**File:** `test/libraries/estimation/units/data/data_source/powersync_cost_estimation_data_source_test.dart`

Suggested addition:

```dart
test('re-emits null when the watched row is deleted', () async {
  fakeWrapper.emitWatch(byIdSql, [sqliteRow()]);

  final emission = expectLater(
    dataSource.watchEstimationById(id: estimateIdDefault),
    emitsInOrder([isA<CostEstimateDto>(), isNull]),
  );

  await pumpEventQueue();
  fakeWrapper.emitWatch(byIdSql, const []);

  await emission;
});

test('emits the row once it syncs down after an empty result', () async {
  fakeWrapper.emitWatch(byIdSql, const []);

  final emission = expectLater(
    dataSource.watchEstimationById(id: estimateIdDefault),
    emitsInOrder([isNull, isA<CostEstimateDto>()]),
  );

  await pumpEventQueue();
  fakeWrapper.emitWatch(byIdSql, [sqliteRow()]);

  await emission;
});
```

### 3.2 No `distinct()` — event flooding

**File:** `lib/libraries/estimation/data/data_source/powersync_cost_estimation_data_source_impl.dart`

Cheapest fix is one operator inside the shared helper, which covers both watches:

```dart
subscription = _wrapper
    .watch(sql, parameters: parameters)
    .map(mapRows)
    .distinct()
    .listen(
      controller.add,
      onError: controller.addError,
      onDone: controller.close,
    );
```

Note this also touches `watchEstimations` (preexisting behavior). `List<CostEstimateDto>` does not have value equality, so if you want the collection watch deduped too, compare with `const DeepCollectionEquality().equals` or apply `.distinct()` only in the by-id path.

### 3.3 Implementation comment

Two problems in the comment block above `sql:`:

1. It restates the interface docstring — "maps to null rather than erroring, so the UI can react to the row appearing and disappearing" is already documented on the abstract method.
2. `"LIMIT 1 lets SQLite stop scanning early"` is misleading. `id` is the primary key, so the index lookup already stops at one row; `LIMIT 1` buys nothing at runtime.

**Suggested Change:**

```dart
@override
Stream<CostEstimateDto?> watchEstimationById({required String id}) {
  return _watchWithSyncStream(
    sql: 'SELECT * FROM $_table WHERE id = ? LIMIT 1',
    parameters: [id],
    mapRows: (rows) =>
        rows.isEmpty ? null : CostEstimateDto.fromRow(rows.first),
    logMessage:
        'Activating sync stream "$_syncStreamName" and watching estimate: $id',
  );
}
```

Keep `LIMIT 1` as an intent guard if preferred — just drop the justification.
