### PR TITLE
CA-963/CA-964 (1/21): add consent types and error classification

### DIFF
--- a/lib/libraries/consent/domain/entities/consent_version_entity.dart
+++ b/lib/libraries/consent/domain/entities/consent_version_entity.dart
@@ -1,0 +1,60 @@
+import 'package:construculator/libraries/consent/domain/types/consent_types.dart';
+import 'package:equatable/equatable.dart';
+
+/// A published version of a consent document.
+///
+/// This is the server's side of the comparison the gate performs: the version
+/// the product currently requires, against the version the user last accepted.
+/// Exactly one version per [ConsentType] is published at a time.
+///
+/// [version] is a monotonically increasing integer rather than a timestamp or
+/// a semantic version string, because the only question ever asked of it is
+/// whether the accepted number is at least the published one. Comparing
+/// integers keeps that decision unambiguous and keeps it off the network.
+///
+/// The fields mirror a published row faithfully, including the two the gate
+/// never branches on, because `ConsentVersionDto` round-trips the entity back
+/// to that row. There is deliberately no `effectiveFrom`: which version is
+/// currently in force is decided by the database's `current_consent_versions`
+/// view, so the client never has a date to compare and cannot disagree with
+/// the server about what it is being asked to accept.
+class ConsentVersion extends Equatable {
+  /// Unique identifier for this published version.
+  final String id;
+
+  /// Which document this version belongs to.
+  final ConsentType consentType;
+
+  /// The published version number.
+  ///
+  /// A user is current when their accepted version is greater than or equal to
+  /// this value, and outdated when it is strictly less.
+  final int version;
+
+  /// Where the user can read the document this version refers to.
+  ///
+  /// Required rather than optional: asking someone to accept a document the
+  /// app cannot show them would not be consent, so a version is only publish-
+  /// able once there is something to read.
+  final String documentUrl;
+
+  /// When this version became the published one.
+  final DateTime publishedAt;
+
+  const ConsentVersion({
+    required this.id,
+    required this.consentType,
+    required this.version,
+    required this.documentUrl,
+    required this.publishedAt,
+  });
+
+  @override
+  List<Object?> get props => [
+    id,
+    consentType,
+    version,
+    documentUrl,
+    publishedAt,
+  ];
+}

--- a/lib/libraries/consent/domain/types/consent_error_type.dart
+++ b/lib/libraries/consent/domain/types/consent_error_type.dart
@@ -1,0 +1,25 @@
+// coverage:ignore-file
+
+/// Error type for consent operations.
+///
+/// Only the write path and genuinely unexpected conditions surface as errors.
+/// A failed *read* or a failed *version check* is not represented here — those
+/// resolve to a `ConsentStatus` instead, because "we could not check" is a
+/// state the gate has to reason about, not a failure to report.
+///
+/// - [connectionError]: network connectivity issues
+/// - [parsingError]: a consent row could not be mapped
+/// - [timeoutError]: the operation timed out
+/// - [unexpectedDatabaseError]: local or remote query failed
+/// - [permissionDenied]: the row was rejected, typically by RLS
+/// - [authenticationError]: no signed-in user to attribute the record to
+/// - [unexpectedError]: anything not covered above
+enum ConsentErrorType {
+  connectionError,
+  parsingError,
+  timeoutError,
+  unexpectedDatabaseError,
+  permissionDenied,
+  authenticationError,
+  unexpectedError,
+}

--- a/lib/libraries/consent/domain/types/consent_types.dart
+++ b/lib/libraries/consent/domain/types/consent_types.dart
@@ -1,0 +1,37 @@
+// coverage:ignore-file
+
+/// The kinds of consent the app tracks, versioned independently of each other.
+///
+/// The independence is the point: publishing a new privacy policy must be able
+/// to re-gate the app without invalidating the user's analytics opt-in, and
+/// withdrawing analytics must not sign anyone out.
+enum ConsentType {
+  /// Terms of service and privacy policy, accepted together as one unit.
+  ///
+  /// The only type that gates access to the app shell.
+  termsAndPrivacy,
+
+  /// Product analytics capture.
+  ///
+  /// Gates analytics capture only. A stale or withdrawn analytics consent
+  /// disables capture and never blocks the app — blocking a calculator over an
+  /// analytics opt-in would be disproportionate.
+  analytics,
+}
+
+/// What a single consent record states.
+///
+/// Consent is an append-only log rather than a mutable flag: withdrawing
+/// appends a [withdrawn] record instead of deleting the [accepted] one, so the
+/// trail shows that consent was given and later revoked rather than never
+/// given at all. Only the newest record for a type is therefore meaningful.
+enum ConsentAction {
+  /// The user agreed to the version named on the record.
+  accepted,
+
+  /// The user revoked a consent they had previously given.
+  ///
+  /// A newest record of this action means there is no acceptance on file,
+  /// which is the same position as a user who never accepted anything.
+  withdrawn,
+}

--- a/test/libraries/consent/units/domain/entities/consent_version_entity_test.dart
+++ b/test/libraries/consent/units/domain/entities/consent_version_entity_test.dart
@@ -1,0 +1,72 @@
+import 'package:construculator/libraries/consent/domain/entities/consent_version_entity.dart';
+import 'package:construculator/libraries/consent/domain/types/consent_types.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('ConsentVersion', () {
+    final publishedAt = DateTime.utc(2026, 8, 11);
+
+    ConsentVersion buildVersion({
+      String id = 'version-1',
+      ConsentType consentType = ConsentType.termsAndPrivacy,
+      int version = 2,
+      String documentUrl = 'https://example.com/terms/v2',
+      DateTime? published,
+    }) => ConsentVersion(
+      id: id,
+      consentType: consentType,
+      version: version,
+      documentUrl: documentUrl,
+      publishedAt: published ?? publishedAt,
+    );
+
+    test('treats versions with identical fields as equal', () {
+      expect(buildVersion(), buildVersion());
+    });
+
+    test('distinguishes published versions of the same document', () {
+      // The comparison the gate exists to make: a newer publication must not
+      // compare equal to the one the user already accepted.
+      expect(buildVersion(version: 2), isNot(buildVersion(version: 3)));
+    });
+
+    test('distinguishes the two documents at the same version number', () {
+      // Each type versions independently, so v2 of the terms and v2 of the
+      // analytics policy are unrelated publications.
+      expect(
+        buildVersion(consentType: ConsentType.termsAndPrivacy),
+        isNot(buildVersion(consentType: ConsentType.analytics)),
+      );
+    });
+
+    test('distinguishes versions pointing at different documents', () {
+      expect(
+        buildVersion(documentUrl: 'https://example.com/terms/v2'),
+        isNot(buildVersion(documentUrl: 'https://example.com/terms/v2-eu')),
+      );
+    });
+
+    test('keeps the persisted row fields in equality', () {
+      // Neither field is branched on by the gate, but both round-trip through
+      // ConsentVersionDto, so equality has to cover them for a version read
+      // back from the store to compare equal to the one written.
+      expect(buildVersion(id: 'version-1'), isNot(buildVersion(id: 'version-2')));
+      expect(
+        buildVersion(published: DateTime.utc(2026, 8, 11)),
+        isNot(buildVersion(published: DateTime.utc(2026, 8, 12))),
+      );
+    });
+
+    test('exposes every field in props', () {
+      final version = buildVersion();
+
+      expect(version.props, [
+        version.id,
+        version.consentType,
+        version.version,
+        version.documentUrl,
+        version.publishedAt,
+      ]);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
First PR in the consent stack (CA-961/CA-963/CA-964/CA-971 — server-driven versioned consent flow). Adds the foundational domain types, declaration-only.

- `ConsentType` (termsAndPrivacy, analytics) and `ConsentAction` (accepted, withdrawn)
- `ConsentErrorType` — the write-path error taxonomy
- `ConsentVersion` domain entity, with an equality/props test

## Changes since review

Addresses all nine findings from @ayanasamuel8's review.

| # | Finding | Resolution |
|---|---------|------------|
| 1 | Error classification in the domain layer | `fromWriteError` **deleted**. `ConsentErrorType` is now a pure enum with zero imports, matching `project_error_type.dart`. The classifier moves to `ConsentErrorMapper` in the data layer — see below. |
| 2 | `fromWriteError` cannot reach `permissionDenied` / `unexpectedError` | Fixed in the new mapper, which classifies `PostgrestException` via `PostgresErrorCode.fromCode`, plus `AuthException`, `TypeError` and `NetworkException`. **All seven enum values are now reachable.** |
| 3 | Classifier shipped under `coverage:ignore-file` with no test | No logic left in this file, so the pragma is correct again. The mapper carries no pragma and ships with a 15-case test. |
| 4 | Filename departs from the `*_entity.dart` convention | Renamed to `consent_version_entity.dart` (class name unchanged). |
| 5 | Module used two locations for the same kind of file | `consent_error_type.dart` moved to `domain/types/`, beside `consent_types.dart`. |
| 6 | `id` and `publishedAt` in `props` but never read | Kept deliberately, now documented: both round-trip through `ConsentVersionDto`, so a version read back from the store must compare equal to the one written. Covered by a test. |
| 7 | No `ConsentVersion` test | Added `consent_version_entity_test.dart` — equality, per-field distinction, and props completeness. |
| 8 | Dartdoc documented mechanics landing 12+ PRs later | Forward references dropped from `consent_version_entity.dart` and `consent_types.dart`. The `documentUrl` doc keeps *why the field is required* and drops what the guard does with it. Added a note that `effective_from` is omitted deliberately because the `current_consent_versions` view owns that decision. |
| 9 | Commit message called the enum values "the wire contract" | Reworded: the values *mirror* `consent_type_enum`, and the wire mapping lands with `consent_wire_values.dart`. |

### Two deliberate deviations

**The mapper is in #544, not here.** The review suggested extracting to `consent_error_mapper.dart` in this PR. It ships in **#544** instead, alongside `ConsentRecorder`, its only consumer:

- Rule 01 prefers a small base for a 20-deep stack, and it would grow this one for no reason a reader here could see.
- `ConsentFailure` is not added to `failures.dart` until #533, so `toFailure` cannot compile in this PR at all.
- It answers the review's own point that the value would otherwise sit unreachable for 12 PRs — in #544 it has a caller on the same diff.

Both blocking findings against *this* PR (1 and 3) resolve by deletion, so nothing is deferred: the domain layer is clean here, and the classification gap is closed where the classifier lives.

**`http.ClientException` is not handled.** The review suggested mapping it to `connectionError`. `http` is not a declared dependency in `pubspec.yaml` — it is only transitive via `supabase_flutter` — so importing it would add an undeclared dependency. The repo's own `NetworkException` covers that case instead.

### Still open, and not a code change

CA-963's design doc still shows Approver (Suyang) as "Not started" with two unresolved comments, one of which — whether `analytics` is independently withdrawable — determines the `ConsentType` values added here, and therefore every PR above. Worth settling before this merges.

## Stack
Part of a 20-PR stack. This is the base; all following PRs build on top. The whole stack was restacked on this commit — #533–#551 carry the two renamed import paths and are otherwise unchanged, except #544, which gains the mapper.

