### PR TITLE
CA-963/CA-964 (2/21): add the ConsentStatus decision type

### DIFF
--- a/lib/libraries/consent/domain/entities/consent_status_entity.dart
+++ b/lib/libraries/consent/domain/entities/consent_status_entity.dart
@@ -1,0 +1,156 @@
+import 'package:construculator/libraries/consent/domain/entities/consent_version_entity.dart';
+import 'package:equatable/equatable.dart';
+
+/// Outcome of comparing the published consent version against the user's
+/// accepted one.
+///
+/// Sealed so that every `switch` over a status is exhaustive: adding a case
+/// becomes a compile error at each call site rather than a silently unhandled
+/// branch. Given what these branches decide — whether a user reaches the app
+/// at all — a missed case must not be something the compiler tolerates.
+///
+/// [gatesAccess] states which of them block. The split is not simply "errors
+/// gate": it turns on whether there is a prior acceptance to fall back on. See
+/// [ConsentUnverified] and [ConsentIndeterminate].
+sealed class ConsentStatus extends Equatable {
+  const ConsentStatus();
+
+  /// Whether this outcome blocks the user from reaching the app.
+  ///
+  /// The single definition of the gating policy, for the same reason [resolve]
+  /// lives here: a second implementation that disagreed would gate users
+  /// differently depending on which path reached it. The route guard and the
+  /// tests both read this rather than restating the mapping.
+  bool get gatesAccess => switch (this) {
+    ConsentSatisfied() || ConsentUnverified() => false,
+    ConsentOutdated() || ConsentNeverGiven() || ConsentIndeterminate() => true,
+  };
+
+  /// Resolves the gate outcome for [acceptedVersion] against [published].
+  ///
+  /// [acceptedVersion] is null when there is no acceptance on file — either
+  /// none was ever given, or the newest record is a withdrawal, which leaves
+  /// the user in exactly the same position as someone who never accepted.
+  ///
+  /// Both arguments must describe the same [ConsentType]. The two documents
+  /// version independently, so comparing an analytics acceptance against a
+  /// published terms version would un-gate the app on a consent the user never
+  /// gave for that document. Callers resolve one type at a time.
+  ///
+  /// Lives on the status rather than in the repository because this *is* the
+  /// definition of what these states mean. Every caller has to agree on it,
+  /// and a second implementation that disagreed would gate users differently
+  /// depending on which path reached it.
+  ///
+  /// Note this never returns [ConsentUnverified] or [ConsentIndeterminate]:
+  /// both describe a requirement that could not be established, so there is no
+  /// [published] to compare against and the caller resolves them directly.
+  static ConsentStatus resolve({
+    required int? acceptedVersion,
+    required ConsentVersion published,
+  }) {
+    if (acceptedVersion == null) return ConsentNeverGiven(published);
+
+    return acceptedVersion >= published.version
+        ? ConsentSatisfied(acceptedVersion)
+        : ConsentOutdated(
+            acceptedVersion: acceptedVersion,
+            requiredVersion: published,
+          );
+  }
+}
+
+/// The accepted version is at least the published version. Ungated.
+class ConsentSatisfied extends ConsentStatus {
+  /// The version the user has on file.
+  ///
+  /// May be synthetic. When no version is published for a type there is no
+  /// requirement to meet, and `ConsentVerificationResolver` reports this state
+  /// carrying `0` rather than inventing a sixth state for "nothing to consent
+  /// to". Callers must not read that as a version the user actually accepted.
+  final int acceptedVersion;
+
+  const ConsentSatisfied(this.acceptedVersion);
+
+  @override
+  List<Object?> get props => [acceptedVersion];
+}
+
+/// A newer version has been published than the one the user accepted. Gated.
+///
+/// The only path that blocks a returning user, and it requires a *successfully
+/// fetched* published version strictly greater than the accepted one — never
+/// an inference drawn from a failed check.
+class ConsentOutdated extends ConsentStatus {
+  /// The superseded version the user has on file.
+  final int acceptedVersion;
+
+  /// The version they now need to accept, and the document to show them.
+  final ConsentVersion requiredVersion;
+
+  const ConsentOutdated({
+    required this.acceptedVersion,
+    required this.requiredVersion,
+  });
+
+  @override
+  List<Object?> get props => [acceptedVersion, requiredVersion];
+}
+
+/// No acceptance on record — a cold install, cleared data, or a prior
+/// withdrawal. Gated.
+class ConsentNeverGiven extends ConsentStatus {
+  /// The version to present for acceptance.
+  final ConsentVersion requiredVersion;
+
+  const ConsentNeverGiven(this.requiredVersion);
+
+  @override
+  List<Object?> get props => [requiredVersion];
+}
+
+/// The published version could not be established, but the user has a prior
+/// acceptance on record. **Ungated.**
+///
+/// A success-shaped value, not a failure — and that is the whole safety
+/// property of this design. Distinguishing "we know consent is stale" from "we
+/// could not check" is what stops a flaky network from being handled by the
+/// same branch as a genuinely outdated version.
+///
+/// Failing open is defensible here precisely because of what the acceptance
+/// guarantees: the user demonstrably agreed to [acceptedVersion] at some
+/// point, and nothing observed since contradicts it. The worst case is running
+/// under a superseded version for a few sessions until connectivity returns —
+/// proportionate, and far better than bricking the app on a site with no
+/// signal. The check simply retries on the next launch.
+class ConsentUnverified extends ConsentStatus {
+  /// The last known-good version on file, which is what is being trusted.
+  final int acceptedVersion;
+
+  const ConsentUnverified(this.acceptedVersion);
+
+  @override
+  List<Object?> get props => [acceptedVersion];
+}
+
+/// The requirement could not be established at all, and there is no prior
+/// acceptance to fall back on. **Gated**, with a retry screen.
+///
+/// The deliberate exception to the leniency of [ConsentUnverified], and the
+/// two must never be collapsed. Failing open requires something to fall back
+/// on. With no acceptance on record there is no such evidence, and the client
+/// additionally holds no version number and no document URL — so letting the
+/// user through would mean running with no consent at all, and showing a
+/// consent page would mean asking them to agree to a document the app cannot
+/// name. Blocking with a retry affordance is the only honest option.
+///
+/// Rare in practice: reaching the gate requires a signed-in session, and
+/// signing in requires the network, so consent data has almost always arrived
+/// by the time the guard runs. It occurs when connectivity drops between
+/// authentication and the first consent sync.
+class ConsentIndeterminate extends ConsentStatus {
+  const ConsentIndeterminate();
+
+  @override
+  List<Object?> get props => [];
+}

--- a/lib/libraries/errors/failures.dart
+++ b/lib/libraries/errors/failures.dart
@@ -1,4 +1,5 @@
 import 'package:construculator/libraries/auth/domain/types/auth_types.dart';
+import 'package:construculator/libraries/consent/domain/types/consent_error_type.dart';
 import 'package:construculator/libraries/estimation/domain/estimation_error_type.dart';
 import 'package:construculator/libraries/global_search/domain/search_error_type.dart';
 import 'package:construculator/libraries/project/domain/project_error_type.dart';
@@ -84,6 +85,23 @@ class ProjectFailure extends Failure {
 
   /// Creates a [ProjectFailure] with the given [errorType].
   const ProjectFailure({required this.errorType});
+
+  @override
+  List<Object?> get props => [errorType];
+}
+
+/// Failure thrown when a consent operation fails.
+///
+/// Returned only from the consent write path and from genuinely unexpected
+/// conditions. A failed consent *read* or *version check* deliberately returns
+/// a `ConsentStatus` on the right rather than this failure on the left — see
+/// `ConsentRepository` for why that asymmetry is load-bearing.
+class ConsentFailure extends Failure {
+  /// The type of consent error that occurred.
+  final ConsentErrorType errorType;
+
+  /// Creates a [ConsentFailure] with the given [errorType].
+  const ConsentFailure({required this.errorType});
 
   @override
   List<Object?> get props => [errorType];

--- a/test/libraries/consent/mutations/consent_status.xml
+++ b/test/libraries/consent/mutations/consent_status.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mutations version="1.0">
+    <!-- CONSENT STATUS MUTATION TESTING -->
+    <!-- Targets: ConsentStatus.resolve(), the single definition of what the
+         five gate outcomes mean. Critical path: this decides whether a user
+         reaches the app. -->
+
+    <files>
+        <file>lib/libraries/consent/domain/entities/consent_status_entity.dart</file>
+    </files>
+
+    <rules>
+        <!-- RULE 1: The null-acceptance branch reports the ungated state.
+             Do NOT mutate the condition itself (if (false), or == to !=): that
+             removes the null promotion of acceptedVersion, the file stops
+             compiling, and flutter test exits non-zero on the compile error
+             rather than on an assertion. The mutant is recorded as killed
+             without any test having distinguished the branch. -->
+        <regex pattern="if \(acceptedVersion == null\) return ConsentNeverGiven\(published\);" dotAll="true" id="status.resolve.never_given_returns_satisfied">
+            <mutation text="if (acceptedVersion == null) return ConsentSatisfied(0);"/>
+        </regex>
+
+        <!-- RULE 2: The null-acceptance branch reports the other gated state -->
+        <regex pattern="if \(acceptedVersion == null\) return ConsentNeverGiven\(published\);" dotAll="true" id="status.resolve.never_given_returns_outdated">
+            <mutation text="if (acceptedVersion == null) return ConsentOutdated(acceptedVersion: 0, requiredVersion: published);"/>
+        </regex>
+
+        <!-- RULE 3: Boundary mutation on the satisfied/outdated split -->
+        <regex pattern="acceptedVersion &gt;= published\.version" dotAll="true" id="status.resolve.boundary_strict">
+            <mutation text="acceptedVersion &gt; published.version"/>
+        </regex>
+
+        <!-- RULE 4: Invert the satisfied/outdated split entirely -->
+        <regex pattern="acceptedVersion &gt;= published\.version" dotAll="true" id="status.resolve.invert_comparison">
+            <mutation text="acceptedVersion &lt; published.version"/>
+        </regex>
+
+        <!-- RULE 5: Swap the satisfied branch for the outdated one -->
+        <regex pattern="\? ConsentSatisfied\(acceptedVersion\)" dotAll="true" id="status.resolve.wrong_satisfied_branch">
+            <mutation text="? ConsentOutdated(acceptedVersion: acceptedVersion, requiredVersion: published)"/>
+        </regex>
+
+        <!-- RULE 6: Satisfied carries the wrong version -->
+        <regex pattern="ConsentSatisfied\(acceptedVersion\)" dotAll="true" id="status.resolve.wrong_satisfied_version">
+            <mutation text="ConsentSatisfied(published.version)"/>
+        </regex>
+
+        <!-- RULE 7: Outdated's acceptedVersion field is wrong -->
+        <regex pattern="acceptedVersion: acceptedVersion,\n            requiredVersion: published," dotAll="true" id="status.resolve.wrong_outdated_accepted">
+            <mutation text="acceptedVersion: 0,\n            requiredVersion: published,"/>
+        </regex>
+
+        <!-- RULE 8: NeverGiven carries the wrong version -->
+        <regex pattern="return ConsentNeverGiven\(published\);" dotAll="true" id="status.resolve.wrong_never_given_version">
+            <mutation text="return ConsentNeverGiven(ConsentVersion(id: '', consentType: published.consentType, version: 0, documentUrl: '', publishedAt: published.publishedAt));"/>
+        </regex>
+    </rules>
+
+    <commands>
+        <command group="consent_status" expected-return="0">flutter test test/libraries/consent/units/domain/entities/consent_status_entity_test.dart</command>
+    </commands>
+
+    <threshold failure="85">
+        <rating over="85" name="A"/>
+        <rating over="75" name="B"/>
+        <rating over="65" name="C"/>
+        <rating over="55" name="D"/>
+        <rating over="35" name="E"/>
+        <rating over="0" name="F"/>
+    </threshold>
+</mutations>

--- a/test/libraries/consent/units/domain/entities/consent_status_entity_test.dart
+++ b/test/libraries/consent/units/domain/entities/consent_status_entity_test.dart
@@ -1,0 +1,136 @@
+import 'package:construculator/libraries/consent/domain/entities/consent_status_entity.dart';
+import 'package:construculator/libraries/consent/domain/entities/consent_version_entity.dart';
+import 'package:construculator/libraries/consent/domain/types/consent_types.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('ConsentStatus', () {
+    final publishedVersion = ConsentVersion(
+      id: 'version-2',
+      consentType: ConsentType.termsAndPrivacy,
+      version: 2,
+      documentUrl: 'https://example.com/terms/v2',
+      publishedAt: DateTime.utc(2026, 8, 11),
+    );
+
+    bool gates(ConsentStatus status) => status.gatesAccess;
+
+    test('lets a current acceptance through', () {
+      expect(gates(const ConsentSatisfied(2)), isFalse);
+    });
+
+    test('lets an unverifiable check through when an acceptance exists', () {
+      // The single leniency in the design: the user demonstrably accepted at
+      // some point and nothing observed since contradicts it.
+      expect(gates(const ConsentUnverified(2)), isFalse);
+    });
+
+    test('blocks when a newer version has been published', () {
+      expect(
+        gates(
+          ConsentOutdated(acceptedVersion: 1, requiredVersion: publishedVersion),
+        ),
+        isTrue,
+      );
+    });
+
+    test('blocks when nothing has ever been accepted', () {
+      expect(gates(ConsentNeverGiven(publishedVersion)), isTrue);
+    });
+
+    test('blocks when the requirement could not be established', () {
+      // Nothing to fall back on and no document to name, so neither letting
+      // the user through nor prompting them would be honest.
+      expect(gates(const ConsentIndeterminate()), isTrue);
+    });
+
+    test('distinguishes an unverified check from a satisfied one', () {
+      // Both are ungated, but they must stay distinguishable: only one of them
+      // means the version was actually confirmed.
+      expect(const ConsentUnverified(2), isNot(const ConsentSatisfied(2)));
+    });
+
+    test('compares unverified checks by the version being trusted', () {
+      // Same type on both sides, so Equatable actually reads props here. The
+      // fail-open state must not lose the version it is vouching for.
+      expect(const ConsentUnverified(2), const ConsentUnverified(2));
+      expect(const ConsentUnverified(1), isNot(const ConsentUnverified(2)));
+    });
+
+    test('gives the indeterminate outcome an explicit empty identity', () {
+      // It carries nothing beyond "nothing could be established", so every
+      // instance is the same outcome. Asserted on props directly because two
+      // const instances are canonicalised to the same object, so equality
+      // short-circuits on identity and never reads them.
+      expect(const ConsentIndeterminate().props, isEmpty);
+      expect(const ConsentIndeterminate(), const ConsentIndeterminate());
+    });
+
+    test('compares outdated statuses by accepted and required version', () {
+      expect(
+        ConsentOutdated(acceptedVersion: 1, requiredVersion: publishedVersion),
+        ConsentOutdated(acceptedVersion: 1, requiredVersion: publishedVersion),
+      );
+      expect(
+        ConsentOutdated(acceptedVersion: 1, requiredVersion: publishedVersion),
+        isNot(
+          ConsentOutdated(
+            acceptedVersion: 0,
+            requiredVersion: publishedVersion,
+          ),
+        ),
+      );
+    });
+
+    group('resolve', () {
+      test('is never given when there is no accepted version', () {
+        final status = ConsentStatus.resolve(
+          acceptedVersion: null,
+          published: publishedVersion,
+        );
+
+        expect(status, ConsentNeverGiven(publishedVersion));
+      });
+
+      test('is satisfied at the exact boundary where accepted equals published', () {
+        final status = ConsentStatus.resolve(
+          acceptedVersion: 2,
+          published: publishedVersion,
+        );
+
+        expect(status, const ConsentSatisfied(2));
+      });
+
+      test('is satisfied when the accepted version exceeds the published one', () {
+        final status = ConsentStatus.resolve(
+          acceptedVersion: 3,
+          published: publishedVersion,
+        );
+
+        expect(status, const ConsentSatisfied(3));
+      });
+
+      test('is outdated just below the boundary', () {
+        final status = ConsentStatus.resolve(
+          acceptedVersion: 1,
+          published: publishedVersion,
+        );
+
+        expect(
+          status,
+          ConsentOutdated(acceptedVersion: 1, requiredVersion: publishedVersion),
+        );
+      });
+
+      test('names the published version as the requirement when outdated', () {
+        final status = ConsentStatus.resolve(
+              acceptedVersion: 1,
+              published: publishedVersion,
+            )
+            as ConsentOutdated;
+
+        expect(status.requiredVersion, publishedVersion);
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Summary
Adds `ConsentStatus`, the sealed five-state entity that is the single definition of what every gate outcome means (`ConsentSatisfied`, `ConsentOutdated`, `ConsentNeverGiven`, `ConsentUnverified`, `ConsentIndeterminate`), plus `ConsentStatus.resolve()` and `ConsentStatus.gatesAccess` — the comparison and the gating policy every caller shares. Also adds `ConsentFailure` to the shared `failures.dart`.

## Changes since review

| # | Finding | Resolution |
|---|---------|------------|
| 1 | 🟠 Gating policy stated in prose, never in code | Added `gatesAccess` to the sealed base as one exhaustive switch. Both duplicates now read it: the test helper, and **`ConsentGuard.canActivate` in #550**, which loses its own copy of the mapping. |
| 2 | 🟠 `ConsentUnverified.props` untested; file at 81%, under the 95% gate | Added same-type equality assertions for `ConsentUnverified` and an explicit `props` assertion for `ConsentIndeterminate`. **Coverage is now 100% (24/24 lines), measured.** |
| 3 | 🟡 Nothing constrains both sides of `resolve()` to the same `ConsentType` | Precondition documented on `resolve()`, with why it matters: the two documents version independently, so a cross-type comparison would un-gate the app on a consent never given for that document. |
| 4 | 🟡 Mutation rules 1 and 2 killed by the compiler, not by tests | Both replaced with mutants that compile. Verified by hand — each now fails on a real assertion (`Expected: ConsentNeverGiven … Actual: ConsentSatisfied(0)`), not a compile error. |
| 5 | 🟡 Five tests assert on a helper defined in the test file | Resolved by finding 1: `gates()` is now `status.gatesAccess`, so all five exercise production code. |
| 6 | 🔵 Default `props` on the sealed base hides missing overrides | Removed. `Equatable.props` is abstract, so every future state must declare its own identity. `ConsentIndeterminate` now carries an explicit `props => []`, matching `LockStatus`/`UnlockedStatus`. |
| 7 | 🔵 #543 constructs `ConsentSatisfied(0)`, a value this contract doesn't admit | Documented on `acceptedVersion`: it may be synthetic when nothing is published, and callers must not read it as a version the user accepted. See note below. |
| 8 | 🔵 `ConsentIndeterminate` carries no `ConsentType` | Deferred — see note below. |
| 9 | 🔵 File naming | Renamed to `consent_status_entity.dart`, matching `consent_version_entity.dart` from #532. |

### Mutation score, corrected

The previous description claimed "8/8 mutants killed, 100%". As the review showed, two of those were killed by a compile error rather than by a test, so the real figure was 6/8. With rules 1 and 2 replaced by compiling mutants:

```
Total tests: 8    Undetected Mutations: 0 (0.00%)    Quality rating: A
```

8/8 now, and all eight genuinely die on assertions.

### Two deliberate deviations

**`gatesAccess` uses `switch (this)` rather than an abstract member.** The house idiom for a computed boolean on a sealed type is an abstract member overridden per subclass — `LockStatus.isLocked` is the only precedent, and `switch (this)` elsewhere in `lib/` appears only on enum extensions. I followed the review's suggested form anyway: the finding is that the policy is written in three places, and a single exhaustive switch is the only shape that keeps it in exactly one. Both are compile-safe when a state is added.

**`ConsentIndeterminate` does not carry a `ConsentType` yet.** The point is right, but it is constructed at 11 sites across 6 PRs (#543, #545, #547, #549, #550, #551), all currently `const ConsentIndeterminate()`. Its motivation is CA-964 §7's analytics path, which is not implemented anywhere in this stack — nothing today resolves both types, so nothing can currently be confused. Filed as a follow-up for whoever wires PostHog, rather than changing five other PRs for a case that cannot yet occur.

Similarly on finding 7: documenting the synthetic `0` keeps the fix inside this PR. Making `acceptedVersion` nullable or adding a `ConsentNotRequired` state both change the sealed hierarchy and break every exhaustive switch downstream.

### Verification

- `flutter analyze` — clean, project-wide, on this branch and at the stack tip
- `flutter test test/libraries/consent/units/domain/entities/consent_status_entity_test.dart --coverage` — 14 tests, **100% line coverage** on `consent_status_entity.dart`
- `dart run mutation_test … --no-builtin` — 8/8, rating A
- Tip: 213 tests green across consent, router and auth blocs

## Stack
2/20. Base: `consent-types-and-errors`. **#550's diff also changed** in this pass — `ConsentGuard` now reads `gatesAccess` instead of restating the mapping, which is the other half of finding 1.

