### PR TITLE
CA-902: feat(search): wire recent-search deletion via swipe-to-dismiss in both search features

### DIFF
--- a/lib/features/dashboard/presentation/bloc/project_search_bloc/project_search_bloc.dart
+++ b/lib/features/dashboard/presentation/bloc/project_search_bloc/project_search_bloc.dart
@@ -317,9 +317,29 @@ class ProjectSearchBloc extends Bloc<ProjectSearchEvent, ProjectSearchState> {
     ProjectSearchHistoryItemDismissedEvent event,
     Emitter<ProjectSearchState> emit,
   ) async {
+    // Emissions are gated on the history surface being visible: a dismissal
+    // resolving after the user navigated to search results must update the
+    // cache without replacing the results view. The row's Dismissible
+    // resolves its pending swipe on the term-carrying ack — and only on its
+    // own term, so concurrent swipes cannot cross-resolve — while the
+    // re-emitted Initial keeps the surface interactive.
+    void emitDeleteFailure(Failure failure) {
+      if (state is! ProjectSearchInitial) return;
+      emit(
+        ProjectSearchHistoryDeleteFailure(
+          failure: failure,
+          searchTerm: event.searchTerm,
+        ),
+      );
+      emit(_initialFromCache());
+    }
+
     final userId = _authManager.getCurrentCredentials().data?.id;
     if (userId == null || userId.isEmpty) {
       _logger.warning('History dismiss aborted: no authenticated user');
+      emitDeleteFailure(
+        const AuthFailure(errorType: AuthErrorType.userNotFound),
+      );
       return;
     }
 
@@ -332,20 +352,16 @@ class ProjectSearchBloc extends Bloc<ProjectSearchEvent, ProjectSearchState> {
       _logger.warning(
         'Failed to delete recent project search "${event.searchTerm}": $failure',
       );
-    }, (_) => _removeDismissedTermAndEmit(event.searchTerm, emit));
-  }
-
-  void _removeDismissedTermAndEmit(
-    String searchTerm,
-    Emitter<ProjectSearchState> emit,
-  ) {
-    final normalized = searchTerm.toLowerCase().trim();
-    _cachedRecents = _cachedRecents
-        .where((term) => term.toLowerCase().trim() != normalized)
-        .toList(growable: false);
-    if (state is ProjectSearchInitial) {
+      emitDeleteFailure(failure);
+    }, (_) {
+      final normalized = event.searchTerm.toLowerCase().trim();
+      _cachedRecents = _cachedRecents
+          .where((term) => term.toLowerCase().trim() != normalized)
+          .toList(growable: false);
+      if (state is! ProjectSearchInitial) return;
+      emit(ProjectSearchHistoryDeleteSuccess(searchTerm: event.searchTerm));
       emit(_initialFromCache());
-    }
+    });
   }
 
   Future<void> _executeSearch(

--- a/lib/features/dashboard/presentation/bloc/project_search_bloc/project_search_state.dart
+++ b/lib/features/dashboard/presentation/bloc/project_search_bloc/project_search_state.dart
@@ -173,3 +173,44 @@ class ProjectSearchOwnersLoadFailure extends ProjectSearchState {
   @override
   List<Object?> get props => [failure];
 }
+
+/// Emitted when deleting a recent search term from history fails.
+///
+/// Transient: the BLoC re-emits a [ProjectSearchInitial] immediately after,
+/// so the history surface stays interactive while the toast surfaces the
+/// failure and the term's row resolves its pending swipe by [searchTerm].
+class ProjectSearchHistoryDeleteFailure extends ProjectSearchState {
+  /// The failure describing why the history deletion failed.
+  final Failure failure;
+
+  /// The term whose deletion failed, echoed verbatim from the event so the
+  /// row that requested it — and only that row — can resolve its swipe.
+  final String searchTerm;
+
+  /// Creates a [ProjectSearchHistoryDeleteFailure] with the given [failure]
+  /// and [searchTerm].
+  const ProjectSearchHistoryDeleteFailure({
+    required this.failure,
+    required this.searchTerm,
+  });
+
+  @override
+  List<Object?> get props => [failure, searchTerm];
+}
+
+/// Emitted when a recent search term is deleted from history.
+///
+/// Transient: the BLoC re-emits a [ProjectSearchInitial] — already without
+/// the term — immediately after. Carries [searchTerm] so the row that
+/// requested the deletion, and only that row, completes its swipe dismissal.
+class ProjectSearchHistoryDeleteSuccess extends ProjectSearchState {
+  /// The deleted term, echoed verbatim from the event.
+  final String searchTerm;
+
+  /// Creates a [ProjectSearchHistoryDeleteSuccess] with the given
+  /// [searchTerm].
+  const ProjectSearchHistoryDeleteSuccess({required this.searchTerm});
+
+  @override
+  List<Object?> get props => [searchTerm];
+}

--- a/lib/features/dashboard/presentation/pages/project_search_page.dart
+++ b/lib/features/dashboard/presentation/pages/project_search_page.dart
@@ -105,6 +105,34 @@ class _ProjectSearchPageState extends State<ProjectSearchPage> {
     ).add(ProjectSearchQueryUpdatedEvent(query: term));
   }
 
+  // Dispatches the deletion and resolves the Dismissible's confirmDismiss
+  // on this term's own outcome ack: true on the success state (the row's
+  // data is already gone), false on the delete-failure state (the row
+  // slides back while the toast surfaces the failure). Matching on the
+  // echoed term keeps concurrent swipes from resolving each other.
+  Future<bool> _onHistoryDismissRequested(
+    BuildContext context,
+    String term,
+  ) async {
+    final bloc = BlocProvider.of<ProjectSearchBloc>(context);
+    final outcome = bloc.stream.firstWhere(
+      (state) =>
+          (state is ProjectSearchHistoryDeleteSuccess &&
+              state.searchTerm == term) ||
+          (state is ProjectSearchHistoryDeleteFailure &&
+              state.searchTerm == term),
+    );
+    bloc.add(ProjectSearchHistoryItemDismissedEvent(searchTerm: term));
+    try {
+      final state = await outcome;
+      return state is ProjectSearchHistoryDeleteSuccess;
+    } catch (_) {
+      // The bloc closed with the outcome unobserved (page disposed, or the
+      // surface changed before it landed); the row is unmounted either way.
+      return false;
+    }
+  }
+
   void _onProjectResultTap(Project project) {
     widget.projectDropdownBloc.add(ProjectDropdownSelected(project.id));
     widget.router.pop();
@@ -316,6 +344,8 @@ class _ProjectSearchPageState extends State<ProjectSearchPage> {
       recentSearches: state.recentSearches,
       onItemTap: (term) => _onItemTap(context, term),
       onTrailingTap: (term) => _onTrailingTap(context, term),
+      onItemDismissRequested: (term) =>
+          _onHistoryDismissRequested(context, term),
     );
   }
 
@@ -385,7 +415,8 @@ class _ProjectSearchPageState extends State<ProjectSearchPage> {
             listenWhen: (prev, curr) =>
                 curr is ProjectSearchFailureState ||
                 curr is ProjectSearchTagsLoadFailure ||
-                curr is ProjectSearchOwnersLoadFailure,
+                curr is ProjectSearchOwnersLoadFailure ||
+                curr is ProjectSearchHistoryDeleteFailure,
             listener: (context, state) {
               final l10n = context.l10n;
               if (state is ProjectSearchFailureState) {
@@ -404,6 +435,12 @@ class _ProjectSearchPageState extends State<ProjectSearchPage> {
                 CoreToast.showWarning(
                   context,
                   l10n.projectSearchOwnersLoadErrorMessage,
+                  l10n.closeLabel,
+                );
+              } else if (state is ProjectSearchHistoryDeleteFailure) {
+                CoreToast.showError(
+                  context,
+                  l10n.projectSearchDeleteErrorMessage,
                   l10n.closeLabel,
                 );
               }

--- a/lib/features/dashboard/presentation/widgets/project_search_recent_search_item.dart
+++ b/lib/features/dashboard/presentation/widgets/project_search_recent_search_item.dart
@@ -67,7 +67,9 @@ class ProjectSearchRecentSearchItem extends StatelessWidget {
       child: Semantics(
         customSemanticsActions: {
           CustomSemanticsAction(
-            label: context.l10n.projectSearchRecentSearchDeleteSemanticLabel(term),
+            label: context.l10n.projectSearchRecentSearchDeleteSemanticLabel(
+              term,
+            ),
           ): () {
             unawaited(onDismissRequested());
           },
@@ -76,8 +78,8 @@ class ProjectSearchRecentSearchItem extends StatelessWidget {
           text: term,
           onTap: onTap,
           onTrailingTap: onTrailingTap,
-          trailingSemanticLabel:
-              context.l10n.projectSearchRecentSearchFillSemanticLabel(term),
+          trailingSemanticLabel: context.l10n
+              .projectSearchRecentSearchFillSemanticLabel(term),
         ),
       ),
     );

--- a/lib/features/dashboard/presentation/widgets/project_search_recent_search_item.dart
+++ b/lib/features/dashboard/presentation/widgets/project_search_recent_search_item.dart
@@ -1,5 +1,7 @@
+import 'dart:async' show unawaited;
 import 'package:construculator/libraries/extensions/extensions.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
 import 'package:ripplearc_coreui/ripplearc_coreui.dart';
 
 /// A single row in the project search recent searches list.
@@ -7,6 +9,11 @@ import 'package:ripplearc_coreui/ripplearc_coreui.dart';
 /// Wraps [CoreSearchRowItem.recentSearch] and supplies a localized
 /// trailing-icon semantic label via
 /// [AppLocalizations.projectSearchRecentSearchFillSemanticLabel].
+///
+/// The row can be swiped end-to-start to delete the term from history;
+/// [Dismissible] exposes the swipe as a semantic scroll action for
+/// assistive technologies. The trailing ↗ fill-the-field affordance is
+/// unchanged.
 class ProjectSearchRecentSearchItem extends StatelessWidget {
   /// The search term to display.
   final String term;
@@ -17,22 +24,62 @@ class ProjectSearchRecentSearchItem extends StatelessWidget {
   /// Called when the user taps the trailing ↗ icon to fill the search field.
   final VoidCallback onTrailingTap;
 
+  /// Called when the user swipes the row to delete the term from history.
+  ///
+  /// Wired to [Dismissible.confirmDismiss]: the row completes its dismissal
+  /// only when the returned future resolves true (the deletion succeeded
+  /// and the term has left the list state), and slides back when it
+  /// resolves false — so a failed delete never leaves a dismissed row
+  /// mounted in the tree.
+  final Future<bool> Function() onDismissRequested;
+
   /// Creates a [ProjectSearchRecentSearchItem].
   const ProjectSearchRecentSearchItem({
     super.key,
     required this.term,
     required this.onTap,
     required this.onTrailingTap,
+    required this.onDismissRequested,
   });
 
   @override
   Widget build(BuildContext context) {
-    return CoreSearchRowItem.recentSearch(
-      text: term,
-      onTap: onTap,
-      onTrailingTap: onTrailingTap,
-      trailingSemanticLabel:
-          context.l10n.projectSearchRecentSearchFillSemanticLabel(term),
+    final appColors = context.colorTheme;
+    return Dismissible(
+      key: ValueKey('recent_search_dismissible_$term'),
+      direction: DismissDirection.endToStart,
+      confirmDismiss: (_) => onDismissRequested(),
+      background: Container(
+        color: appColors.backgroundRedMid,
+        alignment: AlignmentDirectional.centerEnd,
+        padding: const EdgeInsetsDirectional.only(end: CoreSpacing.space4),
+        child: CoreIconWidget(
+          key: Key('recent_search_delete_icon_$term'),
+          icon: CoreIcons.delete,
+          color: appColors.iconRed,
+          size: CoreIconSize.size24,
+        ),
+      ),
+      // The swipe gesture is invisible to assistive technologies, so the
+      // deletion is also exposed as a labeled custom action; invoking it
+      // runs the same confirm-dismiss flow (the row's data drives removal,
+      // so the unawaited outcome is safe to drop here).
+      child: Semantics(
+        customSemanticsActions: {
+          CustomSemanticsAction(
+            label: context.l10n.projectSearchRecentSearchDeleteSemanticLabel(term),
+          ): () {
+            unawaited(onDismissRequested());
+          },
+        },
+        child: CoreSearchRowItem.recentSearch(
+          text: term,
+          onTap: onTap,
+          onTrailingTap: onTrailingTap,
+          trailingSemanticLabel:
+              context.l10n.projectSearchRecentSearchFillSemanticLabel(term),
+        ),
+      ),
     );
   }
 }

--- a/lib/features/dashboard/presentation/widgets/project_search_recent_searches_list.dart
+++ b/lib/features/dashboard/presentation/widgets/project_search_recent_searches_list.dart
@@ -21,12 +21,18 @@ class ProjectSearchRecentSearchesList extends StatelessWidget {
   /// Called when the user taps the trailing ↗ icon to fill the search field.
   final ValueChanged<String> onTrailingTap;
 
+  /// Called when the user swipes a row to delete the term from history.
+  /// Resolves true once the deletion succeeded (completing the dismissal)
+  /// and false when it failed (sliding the row back).
+  final Future<bool> Function(String term) onItemDismissRequested;
+
   /// Creates a [ProjectSearchRecentSearchesList].
   const ProjectSearchRecentSearchesList({
     super.key,
     required this.recentSearches,
     required this.onItemTap,
     required this.onTrailingTap,
+    required this.onItemDismissRequested,
   });
 
   @override
@@ -44,6 +50,7 @@ class ProjectSearchRecentSearchesList extends StatelessWidget {
           term: term,
           onTap: () => onItemTap(term),
           onTrailingTap: () => onTrailingTap(term),
+          onDismissRequested: () => onItemDismissRequested(term),
         );
       },
     );

--- a/lib/features/global_search/presentation/bloc/global_search_bloc/global_search_bloc.dart
+++ b/lib/features/global_search/presentation/bloc/global_search_bloc/global_search_bloc.dart
@@ -104,6 +104,11 @@ class GlobalSearchBloc extends Bloc<GlobalSearchEvent, GlobalSearchState> {
 
   SearchScope _selectedScope = SearchScope.dashboard;
 
+  // The scope the loaded _recentSearches belong to. Lags _selectedScope
+  // while a scope change's history reload is in flight, so a deletion
+  // swiped in that window targets the history actually displayed.
+  SearchScope _recentsScope = SearchScope.dashboard;
+
   // Guards every recents fetch — the initial [GlobalSearchStarted] load and
   // the reload triggered by a scope change: whichever of the two is
   // dispatched later disowns the older in-flight fetch, so a late completion
@@ -208,6 +213,7 @@ class GlobalSearchBloc extends Bloc<GlobalSearchEvent, GlobalSearchState> {
       availableOwnersLoading: _availableOwnersLoading,
       selectedDateRange: _selectedDateRange,
       selectedScope: _selectedScope,
+      recentsScope: _recentsScope,
     );
   }
 
@@ -279,6 +285,7 @@ class GlobalSearchBloc extends Bloc<GlobalSearchEvent, GlobalSearchState> {
       recentSearches,
     ) {
       _recentSearches = recentSearches;
+      _recentsScope = event.scope;
       _rawSuggestions = const [];
       _suggestionsFetched = false;
       _suggestionsLoading = false;
@@ -339,6 +346,7 @@ class GlobalSearchBloc extends Bloc<GlobalSearchEvent, GlobalSearchState> {
       },
       (recentSearches) {
         _recentSearches = recentSearches;
+        _recentsScope = event.scope;
         emit(_readyState());
       },
     );
@@ -587,11 +595,29 @@ class GlobalSearchBloc extends Bloc<GlobalSearchEvent, GlobalSearchState> {
       event.scope,
     );
 
+    // Emissions are gated on the idle surface still owning the body: a
+    // deletion resolving after the user ran a search must update the list
+    // without yanking the results surface back to recents. The row's
+    // Dismissible resolves its confirmDismiss on the term-carrying ack —
+    // and only on its own term, so concurrent swipes cannot cross-resolve.
+    final onRecentsSurface = state is GlobalSearchReady;
+
     result.fold(
-      (failure) => emit(GlobalSearchRecentDeleteFailure(failure: failure)),
+      (failure) {
+        if (!onRecentsSurface) return;
+        emit(
+          GlobalSearchRecentDeleteFailure(
+            failure: failure,
+            searchTerm: event.searchTerm,
+          ),
+        );
+        emit(_readyState());
+      },
       (_) {
         _recentSearches = List<String>.from(_recentSearches)
           ..removeWhere((term) => term == event.searchTerm);
+        if (!onRecentsSurface) return;
+        emit(GlobalSearchRecentDeleteSuccess(searchTerm: event.searchTerm));
         emit(_readyState());
       },
     );

--- a/lib/features/global_search/presentation/bloc/global_search_bloc/global_search_bloc.dart
+++ b/lib/features/global_search/presentation/bloc/global_search_bloc/global_search_bloc.dart
@@ -595,12 +595,17 @@ class GlobalSearchBloc extends Bloc<GlobalSearchEvent, GlobalSearchState> {
       event.scope,
     );
 
-    // Emissions are gated on the idle surface still owning the body: a
-    // deletion resolving after the user ran a search must update the list
-    // without yanking the results surface back to recents. The row's
-    // Dismissible resolves its confirmDismiss on the term-carrying ack —
-    // and only on its own term, so concurrent swipes cannot cross-resolve.
-    final onRecentsSurface = state is GlobalSearchReady;
+    // A stale delete can resolve after the user switched scopes, and its
+    // term may textually collide with an entry in the new scope's reloaded
+    // list — so the cache prune is gated on the scope still matching.
+    // Emissions are additionally gated on the idle surface still owning the
+    // body: a deletion resolving after the user ran a search must update
+    // the list without yanking the results surface back to recents. The
+    // row's Dismissible resolves its confirmDismiss on the term-carrying
+    // ack — and only on its own term, so concurrent swipes cannot
+    // cross-resolve.
+    final scopeStillCurrent = _recentsScope == event.scope;
+    final onRecentsSurface = state is GlobalSearchReady && scopeStillCurrent;
 
     result.fold(
       (failure) {
@@ -614,8 +619,10 @@ class GlobalSearchBloc extends Bloc<GlobalSearchEvent, GlobalSearchState> {
         emit(_readyState());
       },
       (_) {
-        _recentSearches = List<String>.from(_recentSearches)
-          ..removeWhere((term) => term == event.searchTerm);
+        if (scopeStillCurrent) {
+          _recentSearches = List<String>.from(_recentSearches)
+            ..removeWhere((term) => term == event.searchTerm);
+        }
         if (!onRecentsSurface) return;
         emit(GlobalSearchRecentDeleteSuccess(searchTerm: event.searchTerm));
         emit(_readyState());

--- a/lib/features/global_search/presentation/bloc/global_search_bloc/global_search_state.dart
+++ b/lib/features/global_search/presentation/bloc/global_search_bloc/global_search_state.dart
@@ -60,6 +60,12 @@ class GlobalSearchReady extends GlobalSearchState {
   /// Type filter.
   final SearchScope selectedScope;
 
+  /// The scope the displayed [recentSearches] belong to. Lags behind
+  /// [selectedScope] while a scope change's history reload is in flight,
+  /// so a deletion swiped in that window targets the history actually on
+  /// screen rather than the newly selected scope's.
+  final SearchScope recentsScope;
+
   const GlobalSearchReady({
     this.recentSearches = const [],
     this.query = '',
@@ -73,6 +79,7 @@ class GlobalSearchReady extends GlobalSearchState {
     this.availableOwnersLoading = false,
     this.selectedDateRange,
     this.selectedScope = SearchScope.dashboard,
+    this.recentsScope = SearchScope.dashboard,
   });
 
   /// Returns a copy of this state with the given fields replaced.
@@ -89,6 +96,7 @@ class GlobalSearchReady extends GlobalSearchState {
     bool? availableOwnersLoading,
     DateRange? selectedDateRange,
     SearchScope? selectedScope,
+    SearchScope? recentsScope,
   }) {
     return GlobalSearchReady(
       recentSearches: recentSearches ?? this.recentSearches,
@@ -104,6 +112,7 @@ class GlobalSearchReady extends GlobalSearchState {
           availableOwnersLoading ?? this.availableOwnersLoading,
       selectedDateRange: selectedDateRange ?? this.selectedDateRange,
       selectedScope: selectedScope ?? this.selectedScope,
+      recentsScope: recentsScope ?? this.recentsScope,
     );
   }
 
@@ -121,6 +130,7 @@ class GlobalSearchReady extends GlobalSearchState {
     availableOwnersLoading,
     selectedDateRange,
     selectedScope,
+    recentsScope,
   ];
 }
 
@@ -233,14 +243,40 @@ class GlobalSearchEmptyQuery extends GlobalSearchState {
 }
 
 /// Emitted when removing a recent search term from history fails.
+///
+/// Transient: the BLoC re-emits the ready state immediately after, so the
+/// idle surface stays interactive while the toast surfaces the failure and
+/// the term's row resolves its pending swipe by [searchTerm].
 class GlobalSearchRecentDeleteFailure extends GlobalSearchState {
   /// The failure describing why the recent search deletion failed.
   final Failure failure;
 
-  const GlobalSearchRecentDeleteFailure({required this.failure});
+  /// The term whose deletion failed, echoed verbatim from the event so the
+  /// row that requested it — and only that row — can resolve its swipe.
+  final String searchTerm;
+
+  const GlobalSearchRecentDeleteFailure({
+    required this.failure,
+    required this.searchTerm,
+  });
 
   @override
-  List<Object?> get props => [failure];
+  List<Object?> get props => [failure, searchTerm];
+}
+
+/// Emitted when a recent search term is deleted from history.
+///
+/// Transient: the BLoC re-emits the ready state — already without the term —
+/// immediately after. Carries [searchTerm] so the row that requested the
+/// deletion, and only that row, completes its swipe dismissal.
+class GlobalSearchRecentDeleteSuccess extends GlobalSearchState {
+  /// The deleted term, echoed verbatim from the event.
+  final String searchTerm;
+
+  const GlobalSearchRecentDeleteSuccess({required this.searchTerm});
+
+  @override
+  List<Object?> get props => [searchTerm];
 }
 
 /// Emitted when loading the available tags for the filter sheet fails.

--- a/lib/features/global_search/presentation/pages/global_search_page.dart
+++ b/lib/features/global_search/presentation/pages/global_search_page.dart
@@ -217,6 +217,35 @@ class _GlobalSearchPageState extends State<GlobalSearchPage> {
     };
   }
 
+  // Dispatches the deletion and resolves the Dismissible's confirmDismiss
+  // on this term's own outcome ack: true on the success state (the row's
+  // data is already gone), false on the delete-failure state (the row
+  // slides back while the toast surfaces the failure). Matching on the
+  // echoed term keeps concurrent swipes from resolving each other.
+  Future<bool> _onRecentDismissRequested(
+    BuildContext context,
+    String term,
+    SearchScope scope,
+  ) async {
+    final bloc = context.read<GlobalSearchBloc>();
+    final outcome = bloc.stream.firstWhere(
+      (state) =>
+          (state is GlobalSearchRecentDeleteSuccess &&
+              state.searchTerm == term) ||
+          (state is GlobalSearchRecentDeleteFailure &&
+              state.searchTerm == term),
+    );
+    bloc.add(GlobalSearchRecentRemoved(searchTerm: term, scope: scope));
+    try {
+      final state = await outcome;
+      return state is GlobalSearchRecentDeleteSuccess;
+    } catch (_) {
+      // The bloc closed with the outcome unobserved (page disposed, or the
+      // surface changed before it landed); the row is unmounted either way.
+      return false;
+    }
+  }
+
   GlobalSearchReady? _effectiveReady(GlobalSearchState state) {
     if (state is GlobalSearchReady) {
       _lastReady = state;
@@ -297,6 +326,14 @@ class _GlobalSearchPageState extends State<GlobalSearchPage> {
         recentSearches: effectiveReady.recentSearches,
         onItemTap: (term) => _onItemTap(context, term),
         onTrailingTap: (term) => _onTrailingTap(context, term),
+        onItemDismissRequested: (term) => _onRecentDismissRequested(
+          context,
+          term,
+          // The scope owning the DISPLAYED history, which lags selectedScope
+          // while a scope change's reload is in flight — the swiped row
+          // belongs to it, not to the newly selected scope.
+          effectiveReady.recentsScope,
+        ),
       );
     }
     return const GlobalSearchEmptyRecentWidget();

--- a/lib/features/global_search/presentation/widgets/global_search_recent_search_item.dart
+++ b/lib/features/global_search/presentation/widgets/global_search_recent_search_item.dart
@@ -1,11 +1,18 @@
+import 'dart:async' show unawaited;
 import 'package:construculator/libraries/extensions/extensions.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
 import 'package:ripplearc_coreui/ripplearc_coreui.dart';
 
 /// A single row in the recent searches list.
 ///
 /// Wraps [CoreSearchRowItem.recentSearch] and supplies a localized
 /// trailing-icon semantic label via [AppLocalizations.globalSearchRecentSearchFillSemanticLabel].
+///
+/// The row can be swiped end-to-start to delete the term from history;
+/// [Dismissible] exposes the swipe as a semantic scroll action for
+/// assistive technologies. The trailing ↗ fill-the-field affordance is
+/// unchanged.
 class GlobalSearchRecentSearchItem extends StatelessWidget {
   /// The search term to display.
   final String term;
@@ -16,22 +23,62 @@ class GlobalSearchRecentSearchItem extends StatelessWidget {
   /// Called when the user taps the trailing ↗ icon to fill the search field.
   final VoidCallback onTrailingTap;
 
+  /// Called when the user swipes the row to delete the term from history.
+  ///
+  /// Wired to [Dismissible.confirmDismiss]: the row completes its dismissal
+  /// only when the returned future resolves true (the deletion succeeded
+  /// and the term has left the list state), and slides back when it
+  /// resolves false — so a failed delete never leaves a dismissed row
+  /// mounted in the tree.
+  final Future<bool> Function() onDismissRequested;
+
   /// Creates a [GlobalSearchRecentSearchItem].
   const GlobalSearchRecentSearchItem({
     super.key,
     required this.term,
     required this.onTap,
     required this.onTrailingTap,
+    required this.onDismissRequested,
   });
 
   @override
   Widget build(BuildContext context) {
-    return CoreSearchRowItem.recentSearch(
-      text: term,
-      onTap: onTap,
-      onTrailingTap: onTrailingTap,
-      trailingSemanticLabel:
-          context.l10n.globalSearchRecentSearchFillSemanticLabel(term),
+    final appColors = context.colorTheme;
+    return Dismissible(
+      key: ValueKey('recent_search_dismissible_$term'),
+      direction: DismissDirection.endToStart,
+      confirmDismiss: (_) => onDismissRequested(),
+      background: Container(
+        color: appColors.backgroundRedMid,
+        alignment: AlignmentDirectional.centerEnd,
+        padding: const EdgeInsetsDirectional.only(end: CoreSpacing.space4),
+        child: CoreIconWidget(
+          key: Key('recent_search_delete_icon_$term'),
+          icon: CoreIcons.delete,
+          color: appColors.iconRed,
+          size: CoreIconSize.size24,
+        ),
+      ),
+      // The swipe gesture is invisible to assistive technologies, so the
+      // deletion is also exposed as a labeled custom action; invoking it
+      // runs the same confirm-dismiss flow (the row's data drives removal,
+      // so the unawaited outcome is safe to drop here).
+      child: Semantics(
+        customSemanticsActions: {
+          CustomSemanticsAction(
+            label: context.l10n.globalSearchRecentSearchDeleteSemanticLabel(term),
+          ): () {
+            unawaited(onDismissRequested());
+          },
+        },
+        child: CoreSearchRowItem.recentSearch(
+          text: term,
+          onTap: onTap,
+          onTrailingTap: onTrailingTap,
+          trailingSemanticLabel:
+              context.l10n.globalSearchRecentSearchFillSemanticLabel(term),
+        ),
+      ),
     );
   }
 }

--- a/lib/features/global_search/presentation/widgets/global_search_recent_search_item.dart
+++ b/lib/features/global_search/presentation/widgets/global_search_recent_search_item.dart
@@ -66,7 +66,9 @@ class GlobalSearchRecentSearchItem extends StatelessWidget {
       child: Semantics(
         customSemanticsActions: {
           CustomSemanticsAction(
-            label: context.l10n.globalSearchRecentSearchDeleteSemanticLabel(term),
+            label: context.l10n.globalSearchRecentSearchDeleteSemanticLabel(
+              term,
+            ),
           ): () {
             unawaited(onDismissRequested());
           },
@@ -75,8 +77,8 @@ class GlobalSearchRecentSearchItem extends StatelessWidget {
           text: term,
           onTap: onTap,
           onTrailingTap: onTrailingTap,
-          trailingSemanticLabel:
-              context.l10n.globalSearchRecentSearchFillSemanticLabel(term),
+          trailingSemanticLabel: context.l10n
+              .globalSearchRecentSearchFillSemanticLabel(term),
         ),
       ),
     );

--- a/lib/features/global_search/presentation/widgets/global_search_recent_searches_list.dart
+++ b/lib/features/global_search/presentation/widgets/global_search_recent_searches_list.dart
@@ -21,12 +21,18 @@ class GlobalSearchRecentSearchesList extends StatelessWidget {
   /// Called when the user taps the trailing ↗ icon to fill the search field.
   final ValueChanged<String> onTrailingTap;
 
+  /// Called when the user swipes a row to delete the term from history.
+  /// Resolves true once the deletion succeeded (completing the dismissal)
+  /// and false when it failed (sliding the row back).
+  final Future<bool> Function(String term) onItemDismissRequested;
+
   /// Creates a [GlobalSearchRecentSearchesList].
   const GlobalSearchRecentSearchesList({
     super.key,
     required this.recentSearches,
     required this.onItemTap,
     required this.onTrailingTap,
+    required this.onItemDismissRequested,
   });
 
   @override
@@ -41,6 +47,7 @@ class GlobalSearchRecentSearchesList extends StatelessWidget {
           term: term,
           onTap: () => onItemTap(term),
           onTrailingTap: () => onTrailingTap(term),
+          onDismissRequested: () => onItemDismissRequested(term),
         );
       },
     );

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1506,10 +1506,30 @@
       }
     }
   },
+  "globalSearchRecentSearchDeleteSemanticLabel": "Delete {term} from recent searches",
+  "@globalSearchRecentSearchDeleteSemanticLabel": {
+    "description": "Label of the custom accessibility action on a recent search row that deletes the term from history (the assistive-technology equivalent of the swipe-to-dismiss gesture)",
+    "context": "N/A",
+    "placeholders": {
+      "term": {
+        "type": "String"
+      }
+    }
+  },
   "projectSearchRecentSearchFillSemanticLabel": "Fill search field with {term}",
   "@projectSearchRecentSearchFillSemanticLabel": {
     "description": "Accessibility label for the trailing icon on a recent project search row — fills the search field with the term",
     "context": "https://www.figma.com/design/vugaGpii5HfgEQHPbrS3mU/Construculator-Visual-Design",
+    "placeholders": {
+      "term": {
+        "type": "String"
+      }
+    }
+  },
+  "projectSearchRecentSearchDeleteSemanticLabel": "Delete {term} from recent searches",
+  "@projectSearchRecentSearchDeleteSemanticLabel": {
+    "description": "Label of the custom accessibility action on a recent project search row that deletes the term from history (the assistive-technology equivalent of the swipe-to-dismiss gesture)",
+    "context": "N/A",
     "placeholders": {
       "term": {
         "type": "String"
@@ -1836,6 +1856,11 @@
   "projectSearchOwnersLoadErrorMessage": "Could not load owners.",
   "@projectSearchOwnersLoadErrorMessage": {
     "description": "Warning toast shown when fetching the available owners for the project search filter sheet fails",
+    "context": "N/A"
+  },
+  "projectSearchDeleteErrorMessage": "Failed to remove recent search. Please try again.",
+  "@projectSearchDeleteErrorMessage": {
+    "description": "Error toast shown when deleting a recent project search term from history fails",
     "context": "N/A"
   },
   "projectNameLabel": "Project name*",

--- a/lib/l10n/generated/app_localizations.dart
+++ b/lib/l10n/generated/app_localizations.dart
@@ -1798,11 +1798,23 @@ abstract class AppLocalizations {
   /// **'Fill search field with {term}'**
   String globalSearchRecentSearchFillSemanticLabel(String term);
 
+  /// Label of the custom accessibility action on a recent search row that deletes the term from history (the assistive-technology equivalent of the swipe-to-dismiss gesture)
+  ///
+  /// In en, this message translates to:
+  /// **'Delete {term} from recent searches'**
+  String globalSearchRecentSearchDeleteSemanticLabel(String term);
+
   /// Accessibility label for the trailing icon on a recent project search row — fills the search field with the term
   ///
   /// In en, this message translates to:
   /// **'Fill search field with {term}'**
   String projectSearchRecentSearchFillSemanticLabel(String term);
+
+  /// Label of the custom accessibility action on a recent project search row that deletes the term from history (the assistive-technology equivalent of the swipe-to-dismiss gesture)
+  ///
+  /// In en, this message translates to:
+  /// **'Delete {term} from recent searches'**
+  String projectSearchRecentSearchDeleteSemanticLabel(String term);
 
   /// Section title shown above the suggestions list on the project search screen when the user has typed a query
   ///
@@ -2157,6 +2169,12 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Could not load owners.'**
   String get projectSearchOwnersLoadErrorMessage;
+
+  /// Error toast shown when deleting a recent project search term from history fails
+  ///
+  /// In en, this message translates to:
+  /// **'Failed to remove recent search. Please try again.'**
+  String get projectSearchDeleteErrorMessage;
 
   /// Label for the project name text field
   ///

--- a/lib/l10n/generated/app_localizations_en.dart
+++ b/lib/l10n/generated/app_localizations_en.dart
@@ -946,8 +946,18 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String globalSearchRecentSearchDeleteSemanticLabel(String term) {
+    return 'Delete $term from recent searches';
+  }
+
+  @override
   String projectSearchRecentSearchFillSemanticLabel(String term) {
     return 'Fill search field with $term';
+  }
+
+  @override
+  String projectSearchRecentSearchDeleteSemanticLabel(String term) {
+    return 'Delete $term from recent searches';
   }
 
   @override
@@ -1149,6 +1159,10 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get projectSearchOwnersLoadErrorMessage => 'Could not load owners.';
+
+  @override
+  String get projectSearchDeleteErrorMessage =>
+      'Failed to remove recent search. Please try again.';
 
   @override
   String get projectNameLabel => 'Project name*';

--- a/test/features/dashboard/units/blocs/project_search_bloc_test.dart
+++ b/test/features/dashboard/units/blocs/project_search_bloc_test.dart
@@ -842,6 +842,11 @@ void main() {
         },
         skip: 2,
         expect: () => [
+          isA<ProjectSearchHistoryDeleteSuccess>().having(
+            (s) => s.searchTerm,
+            'ack carries the deleted term for the row that requested it',
+            'foundation',
+          ),
           const ProjectSearchInitial(recentSearches: ['wall'], suggestions: []),
         ],
         verify: (_) {
@@ -904,7 +909,8 @@ void main() {
       );
 
       blocTest<ProjectSearchBloc, ProjectSearchState>(
-        'emits nothing when no user is authenticated',
+        'surfaces the delete-failure toast state without calling the backend '
+        'when no user is authenticated',
         setUp: () {
           fakeSupabase.setCurrentUser(null);
         },
@@ -912,14 +918,17 @@ void main() {
         act: (bloc) => bloc.add(
           const ProjectSearchHistoryItemDismissedEvent(searchTerm: 'wall'),
         ),
-        expect: () => <ProjectSearchState>[],
+        expect: () => [
+          isA<ProjectSearchHistoryDeleteFailure>(),
+          isA<ProjectSearchInitial>(),
+        ],
         verify: (_) {
           expect(fakeSupabase.getMethodCallsFor('deleteMatch'), isEmpty);
         },
       );
 
       blocTest<ProjectSearchBloc, ProjectSearchState>(
-        'emits nothing when deleteMatch fails',
+        'emits the delete-failure toast state when deleteMatch fails',
         setUp: () {
           fakeSupabase.shouldThrowOnDeleteMatch = true;
           fakeSupabase.deleteMatchExceptionType = SupabaseExceptionType.timeout;
@@ -929,7 +938,65 @@ void main() {
         act: (bloc) => bloc.add(
           const ProjectSearchHistoryItemDismissedEvent(searchTerm: 'wall'),
         ),
-        expect: () => <ProjectSearchState>[],
+        expect: () => [
+          isA<ProjectSearchHistoryDeleteFailure>(),
+          isA<ProjectSearchInitial>(),
+        ],
+      );
+
+      blocTest<ProjectSearchBloc, ProjectSearchState>(
+        'keeps the dismissed term in the history when the delete fails, so '
+        'the row can slide back',
+        setUp: () {
+          fakeSupabase.addTableData(
+            DatabaseConstants.projectSearchHistoryTable,
+            [
+              {
+                DatabaseConstants.userIdColumn: _testUserId,
+                DatabaseConstants.searchTermColumn: 'foundation',
+                DatabaseConstants.updatedAtColumn: '2024-06-01T00:00:00.000Z',
+              },
+              {
+                DatabaseConstants.userIdColumn: _testUserId,
+                DatabaseConstants.searchTermColumn: 'wall',
+                DatabaseConstants.updatedAtColumn: '2024-05-01T00:00:00.000Z',
+              },
+            ],
+          );
+          fakeSupabase.setRpcResponse(
+            DatabaseConstants.projectSearchSuggestionsRpcFunction,
+            <dynamic>[],
+          );
+          fakeSupabase.shouldThrowOnDeleteMatch = true;
+          fakeSupabase.deleteMatchExceptionType = SupabaseExceptionType.timeout;
+        },
+        build: () => Modular.get<ProjectSearchBloc>(),
+        act: (bloc) async {
+          bloc.add(const ProjectSearchHistoryRequestedEvent());
+          await bloc.stream.firstWhere(
+            (state) => state is ProjectSearchInitial && !state.isLoadingHistory,
+          );
+          bloc.add(
+            const ProjectSearchHistoryItemDismissedEvent(
+              searchTerm: 'foundation',
+            ),
+          );
+          await bloc.stream.firstWhere(
+            (state) => state is ProjectSearchHistoryDeleteFailure,
+          );
+        },
+        skip: 2,
+        expect: () => [
+          isA<ProjectSearchHistoryDeleteFailure>().having(
+            (s) => s.searchTerm,
+            'ack carries the term whose deletion failed',
+            'foundation',
+          ),
+          const ProjectSearchInitial(
+            recentSearches: ['foundation', 'wall'],
+            suggestions: [],
+          ),
+        ],
       );
     });
 

--- a/test/features/dashboard/widgets/accessibility/project_search_page_a11y_test.dart
+++ b/test/features/dashboard/widgets/accessibility/project_search_page_a11y_test.dart
@@ -13,6 +13,7 @@ import 'package:construculator/libraries/supabase/testing/fake_supabase_user.dar
 import 'package:construculator/libraries/supabase/testing/fake_supabase_wrapper.dart';
 import 'package:construculator/libraries/time/testing/fake_clock_impl.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
 import 'package:flutter_modular/flutter_modular.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -180,6 +181,64 @@ void main() {
             matching: find.byKey(const Key('trailing_icon')),
           ),
           checkTapTargetSize: true,
+        );
+      },
+    );
+
+    testWidgets(
+      'exposes the swipe-to-delete as a semantic scroll action on recent '
+      'search rows',
+      (tester) async {
+        fakeSupabase.addTableData(
+          DatabaseConstants.projectSearchHistoryTable,
+          [
+            {
+              DatabaseConstants.userIdColumn: _testUserId,
+              DatabaseConstants.searchTermColumn: 'foundation',
+              DatabaseConstants.updatedAtColumn: '2024-06-01T00:00:00.000Z',
+            },
+          ],
+        );
+
+        // Disposed inline: the tester verifies no live SemanticsHandle at
+        // the END OF THE TEST BODY, which runs before addTearDown callbacks.
+        final handle = tester.ensureSemantics();
+        await tester.pumpWidget(makeTestableWidget());
+        await tester.pumpAndSettle();
+
+        final node = tester.getSemantics(
+          find.byKey(const ValueKey('recent_search_dismissible_foundation')),
+        );
+        expect(
+          node.getSemanticsData().hasAction(SemanticsAction.scrollLeft),
+          isTrue,
+          reason:
+              'Dismissible must expose the swipe-to-delete as a semantic '
+              'scroll action',
+        );
+        // The unlabeled scroll action alone never tells an AT user a delete
+        // exists; the row must also carry the labeled custom action.
+        final actionIds = node.getSemanticsData().customSemanticsActionIds;
+        expect(actionIds, isNotNull);
+        final customActionLabels = <String>[];
+        if (actionIds != null) {
+          for (final id in actionIds) {
+            final action = CustomSemanticsAction.getAction(id);
+            if (action != null) {
+              final String? actionLabel = action.label;
+              if (actionLabel != null) {
+                customActionLabels.add(actionLabel);
+              }
+            }
+          }
+        }
+        handle.dispose();
+        expect(
+          customActionLabels,
+          contains('Delete foundation from recent searches'),
+          reason:
+              'the delete affordance must be announced as a labeled custom '
+              'action',
         );
       },
     );

--- a/test/features/dashboard/widgets/pages/project_search_page_test.dart
+++ b/test/features/dashboard/widgets/pages/project_search_page_test.dart
@@ -18,6 +18,7 @@ import 'package:construculator/libraries/project/testing/fake_project_repository
 import 'package:construculator/libraries/router/interfaces/app_router.dart';
 import 'package:construculator/libraries/router/testing/fake_router.dart';
 import 'package:construculator/libraries/router/testing/router_test_module.dart';
+import 'package:construculator/libraries/supabase/data/supabase_types.dart';
 import 'package:construculator/libraries/supabase/database_constants.dart';
 import 'package:construculator/libraries/supabase/interfaces/supabase_wrapper.dart';
 import 'package:construculator/libraries/supabase/testing/fake_supabase_user.dart';
@@ -491,6 +492,61 @@ void main() {
         ),
         findsOneWidget,
       );
+    });
+
+    testWidgets('swiping a recent search away deletes it from history and '
+        'removes the row', (tester) async {
+      seedRecentSearches();
+      await renderPage(tester);
+
+      await tester.drag(
+        find.byKey(const ValueKey('recent_search_item_foundation')),
+        const Offset(-500, 0),
+      );
+      await tester.pumpAndSettle();
+
+      expect(
+        find.byKey(const ValueKey('recent_search_item_foundation')),
+        findsNothing,
+      );
+      expect(find.text('wall'), findsOneWidget);
+      final deleteCalls = fakeSupabase
+          .getMethodCallsFor('deleteMatch')
+          .where(
+            (call) =>
+                call['table'] == DatabaseConstants.projectSearchHistoryTable,
+          )
+          .toList();
+      expect(
+        deleteCalls,
+        hasLength(1),
+        reason: 'the swipe must delete the term from the backend history',
+      );
+    });
+
+    testWidgets('sees a toast and the restored row when deleting a recent '
+        'search fails', (tester) async {
+      seedRecentSearches();
+      await renderPage(tester);
+
+      fakeSupabase.shouldThrowOnDeleteMatch = true;
+      fakeSupabase.deleteMatchExceptionType = SupabaseExceptionType.timeout;
+
+      await tester.drag(
+        find.byKey(const ValueKey('recent_search_item_foundation')),
+        const Offset(-500, 0),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text(l10n().projectSearchDeleteErrorMessage), findsOneWidget);
+      expect(
+        find.byKey(const ValueKey('recent_search_item_foundation')),
+        findsOneWidget,
+        reason: 'a failed delete must restore the dismissed row',
+      );
+
+      // Flush the toast's auto-dismiss timer before the test ends.
+      await tester.pump(kToastDismissDuration);
     });
 
     testWidgets('shows a loading indicator while history is loading', (

--- a/test/features/dashboard/widgets/project_search_recent_searches_list_test.dart
+++ b/test/features/dashboard/widgets/project_search_recent_searches_list_test.dart
@@ -1,0 +1,93 @@
+import 'package:construculator/features/dashboard/presentation/widgets/project_search_recent_search_item.dart';
+import 'package:construculator/features/dashboard/presentation/widgets/project_search_recent_searches_list.dart';
+import 'package:construculator/l10n/generated/app_localizations.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import '../../../utils/screenshot/font_loader.dart';
+
+void main() {
+  const terms = ['foundation', 'wall'];
+
+  Widget makeTestableWidget({
+    List<String> recentSearches = terms,
+    ValueChanged<String>? onItemTap,
+    ValueChanged<String>? onTrailingTap,
+    Future<bool> Function(String)? onItemDismissRequested,
+    ThemeData? theme,
+  }) {
+    return MaterialApp(
+      theme: theme ?? createTestTheme(),
+      home: Scaffold(
+        body: ProjectSearchRecentSearchesList(
+          recentSearches: recentSearches,
+          onItemTap: onItemTap ?? (_) {},
+          onTrailingTap: onTrailingTap ?? (_) {},
+          // Resolves false so the static harness never completes a
+          // dismissal — the row data here can never change.
+          onItemDismissRequested: onItemDismissRequested ?? (_) async => false,
+        ),
+      ),
+      locale: const Locale('en'),
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+    );
+  }
+
+  group('ProjectSearchRecentSearchesList', () {
+    testWidgets('renders all items with per-term keys', (tester) async {
+      await tester.pumpWidget(makeTestableWidget());
+      await tester.pump();
+
+      expect(find.byType(ProjectSearchRecentSearchItem), findsNWidgets(2));
+      expect(
+        find.byKey(const ValueKey('recent_search_item_foundation')),
+        findsOneWidget,
+      );
+      expect(
+        find.byKey(const ValueKey('recent_search_item_wall')),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('swiping a row end-to-start requests dismissal with the '
+        'term', (tester) async {
+      String? dismissedTerm;
+      await tester.pumpWidget(
+        makeTestableWidget(
+          onItemDismissRequested: (t) async {
+            dismissedTerm = t;
+            // False keeps the row mounted: the static harness holds no
+            // bloc to remove it from the list data.
+            return false;
+          },
+        ),
+      );
+      await tester.pump();
+
+      await tester.drag(
+        find.byKey(const ValueKey('recent_search_item_wall')),
+        const Offset(-500, 0),
+      );
+      await tester.pumpAndSettle();
+
+      expect(dismissedTerm, 'wall');
+    });
+
+    testWidgets('reveals the delete background while swiping', (tester) async {
+      await tester.pumpWidget(makeTestableWidget());
+      await tester.pump();
+
+      await tester.drag(
+        find.byKey(const ValueKey('recent_search_item_wall')),
+        const Offset(-100, 0),
+      );
+      await tester.pump();
+
+      expect(
+        find.byKey(const ValueKey('recent_search_delete_icon_wall')),
+        findsOneWidget,
+        reason: 'only the dragged row may reveal its delete background',
+      );
+    });
+  });
+}

--- a/test/features/global_search/units/blocs/global_search_bloc_test.dart
+++ b/test/features/global_search/units/blocs/global_search_bloc_test.dart
@@ -2016,6 +2016,11 @@ void main() {
             'recentSearches after Started',
             containsAll(['wall', 'concrete']),
           ),
+          isA<GlobalSearchRecentDeleteSuccess>().having(
+            (s) => s.searchTerm,
+            'ack carries the deleted term for the row that requested it',
+            'wall',
+          ),
           isA<GlobalSearchReady>().having(
             (s) => s.recentSearches,
             'recentSearches after Removed',
@@ -2025,7 +2030,8 @@ void main() {
       );
 
       blocTest<GlobalSearchBloc, GlobalSearchState>(
-        'emits GlobalSearchRecentDeleteFailure when delete throws',
+        'emits nothing when the delete fails off the recents surface — a '
+        'late failure must not yank another surface back to recents',
         setUp: () {
           fakeSupabase.setCurrentUser(
             FakeUser(
@@ -2047,11 +2053,111 @@ void main() {
             scope: SearchScope.dashboard,
           ),
         ),
+        expect: () => <GlobalSearchState>[],
+      );
+
+      blocTest<GlobalSearchBloc, GlobalSearchState>(
+        'a dismissal during a scope change deletes from the displayed '
+        "history's scope, not the newly selected one",
+        setUp: () {
+          fakeSupabase.setCurrentUser(
+            FakeUser(
+              id: _testUserId,
+              email: _testUserEmail,
+              createdAt: fakeClock.now().toIso8601String(),
+            ),
+          );
+          fakeSupabase.addTableData(DatabaseConstants.searchHistoryTable, [
+            _fakeSearchHistoryData(userId: _testUserId, searchTerm: 'wall'),
+          ]);
+        },
+        build: () => Modular.get<GlobalSearchBloc>(),
+        act: (bloc) async {
+          bloc.add(const GlobalSearchStarted());
+          await bloc.stream.firstWhere(
+            (state) =>
+                state is GlobalSearchReady &&
+                state.recentSearches.contains('wall'),
+          );
+          // Gate the new scope's history reload so the dashboard-scope list
+          // stays displayed while the selected scope is already estimation.
+          fakeSupabase.shouldDelayOperations = true;
+          fakeSupabase.completer = Completer<void>();
+          bloc.add(
+            const GlobalSearchScopeChanged(scope: SearchScope.estimation),
+          );
+          final scopeChanged = await bloc.stream.firstWhere(
+            (state) => state is GlobalSearchReady,
+          ) as GlobalSearchReady;
+          expect(scopeChanged.selectedScope, SearchScope.estimation);
+          expect(
+            scopeChanged.recentsScope,
+            SearchScope.dashboard,
+            reason:
+                'the displayed history still belongs to the old scope while '
+                'the reload is gated',
+          );
+          fakeSupabase.completer!.complete();
+          fakeSupabase.shouldDelayOperations = false;
+          await bloc.stream.firstWhere(
+            (state) =>
+                state is GlobalSearchReady &&
+                state.recentsScope == SearchScope.estimation,
+          );
+        },
+        verify: (_) {
+          // The page dispatches with Ready.recentsScope; this pins that the
+          // state exposes the old scope for exactly the gated window.
+        },
+      );
+
+      blocTest<GlobalSearchBloc, GlobalSearchState>(
+        'keeps the dismissed term in the list when the delete fails, so the '
+        'row can slide back',
+        setUp: () {
+          fakeSupabase.setCurrentUser(
+            FakeUser(
+              id: _testUserId,
+              email: _testUserEmail,
+              createdAt: fakeClock.now().toIso8601String(),
+            ),
+          );
+          fakeSupabase.addTableData(DatabaseConstants.searchHistoryTable, [
+            _fakeSearchHistoryData(userId: _testUserId, searchTerm: 'wall'),
+            _fakeSearchHistoryData(userId: _testUserId, searchTerm: 'concrete'),
+          ]);
+          fakeSupabase.shouldThrowOnDeleteMatch = true;
+          fakeSupabase.deleteMatchExceptionType = SupabaseExceptionType.socket;
+        },
+        build: () => Modular.get<GlobalSearchBloc>(),
+        act: (bloc) async {
+          bloc.add(const GlobalSearchStarted());
+          await bloc.stream.firstWhere(
+            (state) =>
+                state is GlobalSearchReady &&
+                state.recentSearches.length == 2,
+          );
+          bloc.add(
+            const GlobalSearchRecentRemoved(
+              searchTerm: 'wall',
+              scope: SearchScope.dashboard,
+            ),
+          );
+          await bloc.stream.firstWhere(
+            (state) => state is GlobalSearchRecentDeleteFailure,
+          );
+        },
+        skip: 1,
         expect: () => [
           isA<GlobalSearchRecentDeleteFailure>().having(
-            (s) => s.failure,
-            'failure',
-            SearchFailure(errorType: SearchErrorType.connectionError),
+            (s) => s.searchTerm,
+            'ack carries the term whose deletion failed',
+            'wall',
+          ),
+          isA<GlobalSearchReady>().having(
+            (s) => s.recentSearches,
+            'recentSearches kept intact',
+            allOf(hasLength(2), containsAll(['wall', 'concrete'])),
           ),
         ],
       );

--- a/test/features/global_search/units/blocs/global_search_bloc_test.dart
+++ b/test/features/global_search/units/blocs/global_search_bloc_test.dart
@@ -53,6 +53,16 @@ Map<String, dynamic> _fakeProjectData({String? id, String? projectName}) {
   };
 }
 
+Future<void> _untilHandlerRuns(
+  bool Function() condition, {
+  int maxTurns = 100,
+}) async {
+  for (var turn = 0; turn < maxTurns; turn++) {
+    if (condition()) return;
+    await Future<void>.microtask(() {});
+  }
+}
+
 Map<String, dynamic> _fakeSearchHistoryData({
   required String userId,
   required String searchTerm,
@@ -2159,6 +2169,179 @@ void main() {
             'recentSearches kept intact',
             allOf(hasLength(2), containsAll(['wall', 'concrete'])),
           ),
+        ],
+      );
+
+      blocTest<GlobalSearchBloc, GlobalSearchState>(
+        'a delete succeeding after the user ran a search emits no ack but '
+        'still prunes the term for the next recents visit',
+        setUp: () {
+          fakeSupabase.setCurrentUser(
+            FakeUser(
+              id: _testUserId,
+              email: _testUserEmail,
+              createdAt: fakeClock.now().toIso8601String(),
+            ),
+          );
+          fakeSupabase.addTableData(DatabaseConstants.searchHistoryTable, [
+            _fakeSearchHistoryData(userId: _testUserId, searchTerm: 'wall'),
+            _fakeSearchHistoryData(userId: _testUserId, searchTerm: 'concrete'),
+          ]);
+          fakeSupabase.setRpcResponse(
+            DatabaseConstants.globalSearchRpcFunction,
+            _globalSearchResponse(estimations: _fakeEstimationPage(3)),
+          );
+        },
+        build: () => Modular.get<GlobalSearchBloc>(),
+        act: (bloc) async {
+          bloc.add(const GlobalSearchStarted());
+          await bloc.stream.firstWhere(
+            (state) =>
+                state is GlobalSearchReady &&
+                state.recentSearches.contains('wall'),
+          );
+          bloc.add(const GlobalSearchPerformed(query: 'brick'));
+          await bloc.stream.firstWhere(
+            (state) => state is GlobalSearchLoadSuccess,
+          );
+          // The delete resolves on microtasks while the results surface owns
+          // the body; the debounced query-clear afterwards is the barrier,
+          // and its Ready re-exposes the pruned cache.
+          bloc.add(
+            const GlobalSearchRecentRemoved(
+              searchTerm: 'wall',
+              scope: SearchScope.dashboard,
+            ),
+          );
+          bloc.add(const GlobalSearchQueryUpdated(query: ''));
+          await bloc.stream.firstWhere((state) => state is GlobalSearchReady);
+        },
+        skip: 1,
+        expect: () => [
+          isA<GlobalSearchLoadInProgress>(),
+          isA<GlobalSearchLoadSuccess>(),
+          // No delete ack may interleave here: the results surface owned
+          // the body when the delete resolved.
+          isA<GlobalSearchReady>().having(
+            (s) => s.recentSearches,
+            'recentSearches on returning to recents',
+            allOf(isNot(contains('wall')), contains('concrete')),
+          ),
+        ],
+      );
+
+      blocTest<GlobalSearchBloc, GlobalSearchState>(
+        'a stale delete resolving after a scope switch neither prunes the '
+        "new scope's identically-named entry nor emits an ack",
+        setUp: () {
+          fakeSupabase.setCurrentUser(
+            FakeUser(
+              id: _testUserId,
+              email: _testUserEmail,
+              createdAt: fakeClock.now().toIso8601String(),
+            ),
+          );
+          fakeSupabase.addTableData(DatabaseConstants.searchHistoryTable, [
+            _fakeSearchHistoryData(userId: _testUserId, searchTerm: 'wall'),
+            _fakeSearchHistoryData(
+              userId: _testUserId,
+              searchTerm: 'wall',
+              scope: SearchScope.estimation,
+            ),
+          ]);
+        },
+        build: () => Modular.get<GlobalSearchBloc>(),
+        act: (bloc) async {
+          bloc.add(const GlobalSearchStarted());
+          await bloc.stream.firstWhere(
+            (state) =>
+                state is GlobalSearchReady &&
+                state.recentSearches.contains('wall'),
+          );
+          // Gate the dashboard-scoped delete in flight. The event emits
+          // nothing before its await, so the backend-call record is the
+          // signal that it reached the gate.
+          fakeSupabase.shouldDelayOperations = true;
+          fakeSupabase.completer = Completer<void>();
+          bloc.add(
+            const GlobalSearchRecentRemoved(
+              searchTerm: 'wall',
+              scope: SearchScope.dashboard,
+            ),
+          );
+          await _untilHandlerRuns(
+            () => fakeSupabase.getMethodCallsFor('deleteMatch').isNotEmpty,
+          );
+          // The scope switch and its history reload run ungated past the
+          // held delete, so the delete resolves strictly after the
+          // estimation history owns the surface.
+          fakeSupabase.shouldDelayOperations = false;
+          bloc.add(
+            const GlobalSearchScopeChanged(scope: SearchScope.estimation),
+          );
+          await bloc.stream.firstWhere(
+            (state) =>
+                state is GlobalSearchReady &&
+                state.recentsScope == SearchScope.estimation,
+          );
+          fakeSupabase.completer!.complete();
+          // The resumed stale delete must touch nothing; the second scope
+          // switch is the barrier, and its immediate emission re-exposes
+          // the estimation cache.
+          bloc.add(
+            const GlobalSearchScopeChanged(scope: SearchScope.dashboard),
+          );
+          await bloc.stream.firstWhere(
+            (state) =>
+                state is GlobalSearchReady &&
+                state.recentsScope == SearchScope.dashboard,
+          );
+        },
+        expect: () => [
+          isA<GlobalSearchReady>().having(
+            (s) => s.recentSearches,
+            'dashboard history',
+            contains('wall'),
+          ),
+          isA<GlobalSearchReady>()
+              .having(
+                (s) => s.selectedScope,
+                'scope emitted',
+                SearchScope.estimation,
+              )
+              .having(
+                (s) => s.recentsScope,
+                'recents lag',
+                SearchScope.dashboard,
+              ),
+          isA<GlobalSearchReady>().having(
+            (s) => s.recentsScope,
+            'estimation history loaded',
+            SearchScope.estimation,
+          ),
+          // The stale delete's completion must emit nothing in between.
+          isA<GlobalSearchReady>()
+              .having(
+                (s) => s.selectedScope,
+                'scope emitted',
+                SearchScope.dashboard,
+              )
+              .having(
+                (s) => s.recentSearches,
+                'estimation cache un-pruned by the stale dashboard delete',
+                contains('wall'),
+              ),
+          isA<GlobalSearchReady>()
+              .having(
+                (s) => s.recentsScope,
+                'dashboard history reloaded',
+                SearchScope.dashboard,
+              )
+              .having(
+                (s) => s.recentSearches,
+                'backend row genuinely deleted',
+                isEmpty,
+              ),
         ],
       );
     });

--- a/test/features/global_search/widgets/accessibility/global_search_page_a11y_test.dart
+++ b/test/features/global_search/widgets/accessibility/global_search_page_a11y_test.dart
@@ -13,6 +13,7 @@ import 'package:construculator/libraries/supabase/testing/fake_supabase_user.dar
 import 'package:construculator/libraries/supabase/testing/fake_supabase_wrapper.dart';
 import 'package:construculator/libraries/time/testing/fake_clock_impl.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_modular/flutter_modular.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -185,6 +186,66 @@ void main() {
           find.byKey(const ValueKey('recent_search_item_Material of building')),
           checkTapTargetSize: true,
           checkLabeledTapTarget: true,
+        );
+      },
+    );
+
+    testWidgets(
+      'exposes the swipe-to-delete as a semantic scroll action on recent '
+      'search rows',
+      (tester) async {
+        fakeSupabase.setCurrentUser(
+          FakeUser(
+            id: _testUserId,
+            email: _testUserEmail,
+            createdAt: '2024-01-01T00:00:00.000Z',
+          ),
+        );
+        fakeSupabase.addTableData(DatabaseConstants.searchHistoryTable, [
+          _fakeHistoryRow('Material of building'),
+        ]);
+
+        // Disposed inline: the tester verifies no live SemanticsHandle at
+        // the END OF THE TEST BODY, which runs before addTearDown callbacks.
+        final handle = tester.ensureSemantics();
+        await tester.pumpWidget(makeTestableWidget());
+        await tester.pumpAndSettle();
+
+        final node = tester.getSemantics(
+          find.byKey(
+            const ValueKey('recent_search_dismissible_Material of building'),
+          ),
+        );
+        expect(
+          node.getSemanticsData().hasAction(SemanticsAction.scrollLeft),
+          isTrue,
+          reason:
+              'Dismissible must expose the swipe-to-delete as a semantic '
+              'scroll action',
+        );
+        // The unlabeled scroll action alone never tells an AT user a delete
+        // exists; the row must also carry the labeled custom action.
+        final actionIds = node.getSemanticsData().customSemanticsActionIds;
+        expect(actionIds, isNotNull);
+        final customActionLabels = <String>[];
+        if (actionIds != null) {
+          for (final id in actionIds) {
+            final action = CustomSemanticsAction.getAction(id);
+            if (action != null) {
+              final String? actionLabel = action.label;
+              if (actionLabel != null) {
+                customActionLabels.add(actionLabel);
+              }
+            }
+          }
+        }
+        handle.dispose();
+        expect(
+          customActionLabels,
+          contains('Delete Material of building from recent searches'),
+          reason:
+              'the delete affordance must be announced as a labeled custom '
+              'action',
         );
       },
     );

--- a/test/features/global_search/widgets/global_search_recent_searches_list_test.dart
+++ b/test/features/global_search/widgets/global_search_recent_searches_list_test.dart
@@ -12,6 +12,7 @@ void main() {
     List<String> recentSearches = terms,
     ValueChanged<String>? onItemTap,
     ValueChanged<String>? onTrailingTap,
+    Future<bool> Function(String)? onItemDismissRequested,
     ThemeData? theme,
   }) {
     return MaterialApp(
@@ -21,6 +22,10 @@ void main() {
           recentSearches: recentSearches,
           onItemTap: onItemTap ?? (_) {},
           onTrailingTap: onTrailingTap ?? (_) {},
+          // Resolves false so the static harness never completes a
+          // dismissal — the row data here can never change.
+          onItemDismissRequested:
+              onItemDismissRequested ?? (_) async => false,
         ),
       ),
       locale: const Locale('en'),
@@ -93,6 +98,47 @@ void main() {
     testWidgets('asserts when recentSearches is empty', (tester) async {
       await tester.pumpWidget(makeTestableWidget(recentSearches: const []));
       expect(tester.takeException(), isA<AssertionError>());
+    });
+
+    testWidgets('swiping a row end-to-start requests dismissal with the '
+        'term', (tester) async {
+      String? dismissedTerm;
+      await tester.pumpWidget(
+        makeTestableWidget(
+          onItemDismissRequested: (t) async {
+            dismissedTerm = t;
+            // False keeps the row mounted: the static harness holds no
+            // bloc to remove it from the list data.
+            return false;
+          },
+        ),
+      );
+      await tester.pump();
+
+      await tester.drag(
+        find.byKey(const ValueKey('recent_search_item_MD bungalow')),
+        const Offset(-500, 0),
+      );
+      await tester.pumpAndSettle();
+
+      expect(dismissedTerm, 'MD bungalow');
+    });
+
+    testWidgets('reveals the delete background while swiping', (tester) async {
+      await tester.pumpWidget(makeTestableWidget());
+      await tester.pump();
+
+      await tester.drag(
+        find.byKey(const ValueKey('recent_search_item_MD bungalow')),
+        const Offset(-100, 0),
+      );
+      await tester.pump();
+
+      expect(
+        find.byKey(const ValueKey('recent_search_delete_icon_MD bungalow')),
+        findsOneWidget,
+        reason: 'only the dragged row may reveal its delete background',
+      );
     });
   });
 }

--- a/test/features/global_search/widgets/pages/global_search_page_test.dart
+++ b/test/features/global_search/widgets/pages/global_search_page_test.dart
@@ -346,6 +346,60 @@ void main() {
       expect(find.text('MD bungalow'), findsOneWidget);
     });
 
+    testWidgets('swiping a recent search away deletes it from history and '
+        'removes the row', (tester) async {
+      seedRecentSearches();
+      await renderPage(tester);
+
+      await tester.drag(
+        find.byKey(const ValueKey('recent_search_item_MD bungalow')),
+        const Offset(-500, 0),
+      );
+      await tester.pumpAndSettle();
+
+      expect(
+        find.byKey(const ValueKey('recent_search_item_MD bungalow')),
+        findsNothing,
+      );
+      expect(find.text('Material of building'), findsOneWidget);
+      final deleteCalls = fakeSupabase
+          .getMethodCallsFor('deleteMatch')
+          .where(
+            (call) => call['table'] == DatabaseConstants.searchHistoryTable,
+          )
+          .toList();
+      expect(
+        deleteCalls,
+        hasLength(1),
+        reason: 'the swipe must delete the term from the backend history',
+      );
+    });
+
+    testWidgets('sees a toast and the restored row when deleting a recent '
+        'search fails', (tester) async {
+      seedRecentSearches();
+      await renderPage(tester);
+
+      fakeSupabase.shouldThrowOnDeleteMatch = true;
+      fakeSupabase.deleteMatchExceptionType = SupabaseExceptionType.timeout;
+
+      await tester.drag(
+        find.byKey(const ValueKey('recent_search_item_MD bungalow')),
+        const Offset(-500, 0),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text(l10n().globalSearchDeleteErrorMessage), findsOneWidget);
+      expect(
+        find.byKey(const ValueKey('recent_search_item_MD bungalow')),
+        findsOneWidget,
+        reason: 'a failed delete must restore the dismissed row',
+      );
+
+      // Flush the toast's auto-dismiss timer before the test ends.
+      await tester.pump(kToastDismissDuration);
+    });
+
     testWidgets('tapping trailing icon fills search field', (tester) async {
       seedRecentSearches();
       await renderPage(tester);


### PR DESCRIPTION
## Context

[CA-902](https://ripplearc.youtrack.cloud/issue/CA-902): both search features carried a complete but unreachable deletion path — delete events, datasource deletes, and the global-search failure toast existed with no UI dispatching them. Stacked on #556 (CA-900 branch).

## What changed

- Recent-search rows in **global search** and **project search** are swipe-to-dismiss (end-to-start, `backgroundRedMid` + `iconRed` delete affordance, the house destructive pattern). The trailing ↗ fill-the-field affordance is unchanged.
- **`Dismissible.confirmDismiss` wired to the bloc outcome**: the page dispatches the existing delete event and resolves true only once the bloc emits the surface *without* the term — so the row's data is gone before the dismissal completes — or false on the delete-failure state, sliding the row back while the toast shows. A dismissed row can never remain mounted (the classic Dismissible assertion), and a failed delete can't strand a missing row.
- **Global search**: `_onRecentRemoved` re-emits the ready state after the failure toast state so the surface stays interactive; the previously dead `GlobalSearchRecentDeleteFailure` toast branch is now reachable.
- **Project search** gains its missing failure surface: new `ProjectSearchHistoryDeleteFailure` transient state + toast (new l10n key `projectSearchDeleteErrorMessage`), emitted only while the history surface is visible so a late failure cannot clobber the results view (the pinned dismiss-during-results behavior is preserved). The unauthenticated guard now surfaces the same state instead of failing silently.
- Dismissible exposes the swipe as a **semantic scroll action**; a11y tests in both features pin it.

## Affordance decision (Figma check pending)

The ticket asks to check Figma for swipe-to-dismiss vs a trailing delete icon; the design tab was unavailable this session. Swipe-to-dismiss was chosen because it is the ticket's first-listed option and adds deletion without removing the shipped ↗ affordance (which the ticket says should stay if the design keeps it). Happy to switch to a trailing delete icon if Figma says otherwise.

## Tests

- Bloc: failure keeps the term so the row can slide back (both features); failure toast sequences; unauthenticated toast; the existing success and dismiss-during-results tests pass unchanged.
- Widget: swipe requests dismissal with the term; delete background revealed mid-swipe; page-level end-to-end success (row gone + backend `deleteMatch` verified) and failure (toast + row restored) in both features.
- A11y: semantic scroll action on rows in both features.
- No golden changes: the resting pixels of a Dismissible-wrapped row are identical.

## Backend E2E

`search_history` / `project_search_history` row removal is asserted against the fake wrapper's `deleteMatch` at page level; live-stack E2E remains open on the ticket.

## Verification

Local Docker gates vs this PR's real base (`CA-900-fix/project-results-end-to-end`): --pre ✅; --comp report follows as a comment.