### PR TITLE
CA-900 (1/3): fix(shell): register estimation and project-settings as top-level routes

### DIFF
--- a/lib/app/shell/shell_module.dart
+++ b/lib/app/shell/shell_module.dart
@@ -98,15 +98,21 @@ class ShellModule extends Module {
       guards: [AuthGuard(() => Modular.get<AuthManager>())],
       children: [
         ModuleRoute(calculatorBaseRoute, module: CalculatorModule()),
-        ModuleRoute(
-          estimationBaseRoute,
-          module: EstimationRoutesModule(appBootstrap),
-        ),
-        ModuleRoute(
-          projectSettingsBaseRoute,
-          module: ProjectSettingsRoutesModule(appBootstrap),
-        ),
       ],
+    );
+    // Estimation and project-settings destinations are full-screen pushes,
+    // so they must be top-level routes like the search pages below:
+    // AppShellPage renders no RouterOutlet, and a child route resolved
+    // under '/' has no outlet to mount into — Modular swallows the push
+    // with no transition and no error (CA-900). Their inner routes carry
+    // their own AuthGuards.
+    r.module(
+      estimationBaseRoute,
+      module: EstimationRoutesModule(appBootstrap),
+    );
+    r.module(
+      projectSettingsBaseRoute,
+      module: ProjectSettingsRoutesModule(appBootstrap),
     );
     r.child(
       projectSearchRoute,

--- a/lib/app/shell/shell_module.dart
+++ b/lib/app/shell/shell_module.dart
@@ -96,23 +96,31 @@ class ShellModule extends Module {
         ),
       ),
       guards: [AuthGuard(() => Modular.get<AuthManager>())],
-      children: [
-        ModuleRoute(calculatorBaseRoute, module: CalculatorModule()),
-      ],
     );
-    // Estimation and project-settings destinations are full-screen pushes,
-    // so they must be top-level routes like the search pages below:
-    // AppShellPage renders no RouterOutlet, and a child route resolved
-    // under '/' has no outlet to mount into — Modular swallows the push
-    // with no transition and no error (CA-900). Their inner routes carry
-    // their own AuthGuards.
+    // Estimation, project-settings, and calculator destinations are
+    // full-screen pushes, so they must be top-level routes like the search
+    // pages below: AppShellPage renders no RouterOutlet, and a child route
+    // resolved under '/' has no outlet to mount into — Modular swallows the
+    // push with no transition and no error (CA-900). The estimation and
+    // project-settings inner routes carry their own AuthGuards, so the
+    // top-level guards there are defence in depth for future inner routes;
+    // the calculator's root route has no own guard, so its top-level guard
+    // is load-bearing — it replaces the shell guard the route inherited
+    // while nested.
     r.module(
       estimationBaseRoute,
       module: EstimationRoutesModule(appBootstrap),
+      guards: [AuthGuard(() => Modular.get<AuthManager>())],
     );
     r.module(
       projectSettingsBaseRoute,
       module: ProjectSettingsRoutesModule(appBootstrap),
+      guards: [AuthGuard(() => Modular.get<AuthManager>())],
+    );
+    r.module(
+      calculatorBaseRoute,
+      module: CalculatorModule(),
+      guards: [AuthGuard(() => Modular.get<AuthManager>())],
     );
     r.child(
       projectSearchRoute,

--- a/test/app/shell/shell_routes_test.dart
+++ b/test/app/shell/shell_routes_test.dart
@@ -1,5 +1,5 @@
-import 'package:construculator/app/shell/shell_module.dart';
-import 'package:construculator/features/dashboard/dashboard_module.dart';
+import 'package:construculator/app/app_module.dart';
+import 'package:construculator/features/calculator/presentation/pages/calculator_page.dart';
 import 'package:construculator/features/estimation/presentation/pages/cost_estimation_details_page.dart';
 import 'package:construculator/features/project_settings/presentation/pages/project_creation_screen.dart';
 import 'package:construculator/l10n/generated/app_localizations.dart';
@@ -9,6 +9,7 @@ import 'package:construculator/libraries/project/interfaces/current_project_noti
 import 'package:construculator/libraries/project/presentation/project_ui_provider.dart';
 import 'package:construculator/libraries/project/testing/fake_current_project_notifier.dart';
 import 'package:construculator/libraries/project/testing/fake_project_ui_provider.dart';
+import 'package:construculator/libraries/router/routes/calculator_routes.dart';
 import 'package:construculator/libraries/router/routes/estimation_routes.dart';
 import 'package:construculator/libraries/router/routes/project_settings_routes.dart';
 import 'package:construculator/libraries/supabase/testing/fake_supabase_user.dart';
@@ -21,17 +22,29 @@ import 'package:ripplearc_coreui/ripplearc_coreui.dart';
 
 import '../../utils/fake_app_bootstrap_factory.dart';
 
-/// Regression tests for CA-900: pushes to the estimation and
-/// project-settings destinations were silently swallowed while their
-/// modules were registered as children of '/', because AppShellPage renders
-/// no RouterOutlet for them to mount into. They are top-level routes now,
-/// and these tests pin that a push actually lands on the destination page.
+/// Regression tests for CA-900: pushes to the estimation, project-settings,
+/// and calculator destinations were silently swallowed while their modules
+/// were registered as children of '/', because AppShellPage renders no
+/// RouterOutlet for them to mount into. They are top-level routes now, and
+/// these tests pin that a push actually lands on the destination page —
+/// and that each route stays unreachable when signed out.
 void main() {
-  late FakeSupabaseWrapper fakeSupabaseWrapper;
+  // One wrapper and bootstrap for the whole file, with per-test state resets
+  // in setUp: modular_core's Tracker caches every imported module's injector
+  // by runtimeType and never clears that cache on Modular.destroy, so binds
+  // from imported modules (AuthManager, SupabaseWrapper, ...) capture the
+  // FIRST test's bootstrap for the rest of the process. Creating a fresh
+  // wrapper per test would leave the injector reading the first test's
+  // instance while the test mutates its own — the signed-out tests below
+  // would silently run signed-in.
+  final fakeClock = FakeClockImpl();
+  final fakeSupabaseWrapper = FakeSupabaseWrapper(clock: fakeClock);
+  final appBootstrap = FakeAppBootstrapFactory.create(
+    supabaseWrapper: fakeSupabaseWrapper,
+  );
 
   setUp(() {
-    final fakeClock = FakeClockImpl();
-    fakeSupabaseWrapper = FakeSupabaseWrapper(clock: fakeClock);
+    fakeSupabaseWrapper.reset();
 
     // An authenticated user, so every AuthGuard on the pushed routes passes.
     fakeSupabaseWrapper.setCurrentUser(
@@ -51,15 +64,11 @@ void main() {
     );
     fakeSupabaseWrapper.addTableData('users', [fakeUser.toJson()]);
 
-    final appBootstrap = FakeAppBootstrapFactory.create(
-      supabaseWrapper: fakeSupabaseWrapper,
-    );
-
-    Modular.init(ShellModule(appBootstrap));
-    addTearDown(Modular.destroy);
-    // Pre-bind DashboardModule so AuthNotifier, AuthManager, AppRouter, and
-    // RecentEstimationsBloc are resolvable when AppShellPage is constructed.
-    Modular.bindModule(DashboardModule(appBootstrap));
+    // Root the harness at AppModule so the module graph matches production
+    // wiring exactly — path composition still resolves ShellModule at '/',
+    // no manual module pre-binding is needed, and the AuthGuard's redirect
+    // target (the /auth login route) exists for the signed-out tests below.
+    Modular.init(AppModule(appBootstrap));
 
     Modular.replaceInstance<CurrentProjectNotifier>(
       FakeCurrentProjectNotifier(),
@@ -68,6 +77,14 @@ void main() {
   });
 
   tearDown(() {
+    // Modular.routerConfig is never reset by Modular.destroy, so without
+    // this the next test re-mounts THIS test's page stack against a fresh
+    // injector and stale Modular.args. Clearing the delegate's configuration
+    // returns it to the pristine state the first test of a run sees. The
+    // setter only exists on the concrete ModularRouterDelegate, which
+    // flutter_modular does not export — hence the dynamic cast.
+    (Modular.routerConfig.routerDelegate as dynamic).currentConfiguration =
+        null;
     Modular.destroy();
   });
 
@@ -109,6 +126,53 @@ void main() {
       await pumpShellAndPush(tester, createProjectRoute);
 
       expect(find.byType(ProjectCreationScreen), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'pushNamed to the calculator route renders CalculatorPage',
+    (tester) async {
+      await pumpShellAndPush(tester, calculatorBaseRoute);
+
+      expect(find.byType(CalculatorPage), findsOneWidget);
+    },
+  );
+
+  // Signed-out variants: pin the guard coverage claim, not just rendering —
+  // removing an AuthGuard from these routes must fail the suite.
+  testWidgets(
+    'pushNamed to the estimation details route does not render '
+    'CostEstimationDetailsPage when signed out',
+    (tester) async {
+      fakeSupabaseWrapper.setCurrentUser(null);
+
+      await pumpShellAndPush(tester, '$fullEstimationDetailsRoute/est-123');
+
+      expect(find.byType(CostEstimationDetailsPage), findsNothing);
+    },
+  );
+
+  testWidgets(
+    'pushNamed to the create-project route does not render '
+    'ProjectCreationScreen when signed out',
+    (tester) async {
+      fakeSupabaseWrapper.setCurrentUser(null);
+
+      await pumpShellAndPush(tester, createProjectRoute);
+
+      expect(find.byType(ProjectCreationScreen), findsNothing);
+    },
+  );
+
+  testWidgets(
+    'pushNamed to the calculator route does not render CalculatorPage '
+    'when signed out',
+    (tester) async {
+      fakeSupabaseWrapper.setCurrentUser(null);
+
+      await pumpShellAndPush(tester, calculatorBaseRoute);
+
+      expect(find.byType(CalculatorPage), findsNothing);
     },
   );
 }

--- a/test/app/shell/shell_routes_test.dart
+++ b/test/app/shell/shell_routes_test.dart
@@ -1,0 +1,114 @@
+import 'package:construculator/app/shell/shell_module.dart';
+import 'package:construculator/features/dashboard/dashboard_module.dart';
+import 'package:construculator/features/estimation/presentation/pages/cost_estimation_details_page.dart';
+import 'package:construculator/features/project_settings/presentation/pages/project_creation_screen.dart';
+import 'package:construculator/l10n/generated/app_localizations.dart';
+import 'package:construculator/libraries/auth/data/models/auth_user.dart';
+import 'package:construculator/libraries/auth/domain/types/auth_types.dart';
+import 'package:construculator/libraries/project/interfaces/current_project_notifier.dart';
+import 'package:construculator/libraries/project/presentation/project_ui_provider.dart';
+import 'package:construculator/libraries/project/testing/fake_current_project_notifier.dart';
+import 'package:construculator/libraries/project/testing/fake_project_ui_provider.dart';
+import 'package:construculator/libraries/router/routes/estimation_routes.dart';
+import 'package:construculator/libraries/router/routes/project_settings_routes.dart';
+import 'package:construculator/libraries/supabase/testing/fake_supabase_user.dart';
+import 'package:construculator/libraries/supabase/testing/fake_supabase_wrapper.dart';
+import 'package:construculator/libraries/time/testing/fake_clock_impl.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_modular/flutter_modular.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:ripplearc_coreui/ripplearc_coreui.dart';
+
+import '../../utils/fake_app_bootstrap_factory.dart';
+
+/// Regression tests for CA-900: pushes to the estimation and
+/// project-settings destinations were silently swallowed while their
+/// modules were registered as children of '/', because AppShellPage renders
+/// no RouterOutlet for them to mount into. They are top-level routes now,
+/// and these tests pin that a push actually lands on the destination page.
+void main() {
+  late FakeSupabaseWrapper fakeSupabaseWrapper;
+
+  setUp(() {
+    final fakeClock = FakeClockImpl();
+    fakeSupabaseWrapper = FakeSupabaseWrapper(clock: fakeClock);
+
+    // An authenticated user, so every AuthGuard on the pushed routes passes.
+    fakeSupabaseWrapper.setCurrentUser(
+      FakeUser(id: 'fake-id', createdAt: fakeClock.now().toIso8601String()),
+    );
+    final fakeUser = User(
+      id: '1',
+      credentialId: 'fake-id',
+      email: 'test@example.com',
+      firstName: 'Test',
+      lastName: 'User',
+      professionalRole: 'Engineer',
+      createdAt: fakeClock.now(),
+      updatedAt: fakeClock.now(),
+      userStatus: UserProfileStatus.active,
+      userPreferences: {},
+    );
+    fakeSupabaseWrapper.addTableData('users', [fakeUser.toJson()]);
+
+    final appBootstrap = FakeAppBootstrapFactory.create(
+      supabaseWrapper: fakeSupabaseWrapper,
+    );
+
+    Modular.init(ShellModule(appBootstrap));
+    addTearDown(Modular.destroy);
+    // Pre-bind DashboardModule so AuthNotifier, AuthManager, AppRouter, and
+    // RecentEstimationsBloc are resolvable when AppShellPage is constructed.
+    Modular.bindModule(DashboardModule(appBootstrap));
+
+    Modular.replaceInstance<CurrentProjectNotifier>(
+      FakeCurrentProjectNotifier(),
+    );
+    Modular.replaceInstance<ProjectUIProvider>(FakeProjectUIProvider());
+  });
+
+  tearDown(() {
+    Modular.destroy();
+  });
+
+  Widget makeApp() {
+    return MaterialApp.router(
+      routerConfig: Modular.routerConfig,
+      theme: CoreTheme.light(),
+      locale: const Locale('en'),
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+    );
+  }
+
+  // Bounded pumps instead of pumpAndSettle: shell sections may keep
+  // loading indicators animating indefinitely against the empty fakes.
+  Future<void> pumpShellAndPush(WidgetTester tester, String route) async {
+    await tester.pumpWidget(makeApp());
+    await tester.pump(const Duration(milliseconds: 500));
+    await tester.pump(const Duration(milliseconds: 500));
+
+    Modular.to.pushNamed(route);
+    await tester.pump(const Duration(milliseconds: 500));
+    await tester.pump(const Duration(milliseconds: 500));
+  }
+
+  testWidgets(
+    'pushNamed to the estimation details route renders '
+    'CostEstimationDetailsPage',
+    (tester) async {
+      await pumpShellAndPush(tester, '$fullEstimationDetailsRoute/est-123');
+
+      expect(find.byType(CostEstimationDetailsPage), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'pushNamed to the create-project route renders ProjectCreationScreen',
+    (tester) async {
+      await pumpShellAndPush(tester, createProjectRoute);
+
+      expect(find.byType(ProjectCreationScreen), findsOneWidget);
+    },
+  );
+}


### PR DESCRIPTION
## Context

[CA-900](https://ripplearc.youtrack.cloud/issue/CA-900) (P1, absorbs CA-844/CA-905): project search results never worked end-to-end. The fix splits into three independently reviewable PRs — the combined change was 261 lines of production code across three concerns, over Rule 1's L threshold:

1. **this PR** — routing: pushes to the estimation / project-settings destinations were silently swallowed
2. #578 — project-load reliability on login
3. #556 — project rows in the search results list

Stacked on #555 (CA-903).

## What changed

`grep -rn RouterOutlet lib` is still zero hits: `AppShellPage` renders no outlet, so a route resolved as a child of `/` had nothing to mount into and Modular swallowed every push with no transition and no error.

The estimation, project-settings, and **calculator** modules become **top-level routes** — the same registration the search pages already use. All three carry an explicit top-level `AuthGuard` (R1): for estimation and project-settings this is defence in depth on top of their inner routes' own guards; for the calculator it is load-bearing, replacing the shell guard the route inherited while nested.

**R1 (review):** the calculator was originally left nested on the claim that it is reached through the tab navigator — that was wrong: its only production caller is the centre FAB's `router.pushNamed(calculatorBaseRoute)` (`app_shell_page.dart`), which hit the same swallowed-push defect. It is now promoted with its own guard, same pattern applied a third time.

## Tests

`test/app/shell/shell_routes_test.dart` pins that `pushNamed` to `/estimation/details/:id`, `/project-settings/create-project`, and `/calculator` actually render their destination pages — all three fail on the old child registration. R1 adds signed-out variants per route (removing an `AuthGuard` now fails the suite) and roots the harness at `AppModule` so the module graph matches production wiring; the harness resets the router delegate's configuration between tests because `Modular.destroy` never does.

## Verification

Local Docker gates vs this PR's real base (`CA-903-feat/load-more-footer-states`); results posted as a comment.
