### PR TITLE
CA-900 (2/3): fix(project): stop silent project-load failures on login

### DIFF
--- a/lib/app/shell/app_shell_page.dart
+++ b/lib/app/shell/app_shell_page.dart
@@ -4,6 +4,7 @@ import 'package:construculator/app/shell/widgets/tab_navigator.dart';
 import 'package:construculator/features/app_header/app_header_module.dart';
 import 'package:construculator/features/calculations/presentation/pages/calculations_page.dart';
 import 'package:construculator/features/dashboard/presentation/bloc/project_dropdown_bloc/project_dropdown_bloc.dart';
+import 'package:construculator/features/dashboard/presentation/bloc/recent_estimations_bloc/recent_estimations_bloc.dart';
 import 'package:construculator/features/dashboard/presentation/widgets/projects_bottom_sheet.dart';
 import 'package:construculator/features/estimation/estimation_module.dart';
 import 'package:construculator/libraries/extensions/extensions.dart';
@@ -102,6 +103,13 @@ class _AppShellPageState extends State<AppShellPage> {
           if (widget.currentProjectNotifier.currentProjectId != newId) {
             widget.currentProjectNotifier.setCurrentProjectId(newId);
           }
+        } else if (dropdownState is ProjectDropdownLoadFailure) {
+          // Nothing is ever going to select a project after a load failure:
+          // tell project-scoped surfaces so they exit their loading hold
+          // instead of skeletoning forever (CA-900).
+          context.read<RecentEstimationsBloc>().add(
+                const RecentEstimationsProjectLoadFailed(),
+              );
         }
       },
       child: BlocBuilder<AppShellBloc, AppShellState>(

--- a/lib/app/shell/app_shell_page.dart
+++ b/lib/app/shell/app_shell_page.dart
@@ -43,6 +43,21 @@ class _AppShellPageState extends State<AppShellPage> {
     (_) => GlobalKey<NavigatorState>(),
   );
 
+  @override
+  void initState() {
+    super.initState();
+    // Start the projects watch at shell mount (not first sheet opening) so
+    // the first project auto-selects on login; without a selection,
+    // CurrentProjectNotifier stays null and every project-scoped surface
+    // (e.g. recent estimations) never loads (CA-900). Guarded like the
+    // projects sheet: a remount must not restart a loaded watch, which
+    // would reset the user's selection to the first project.
+    final projectDropdownBloc = context.read<ProjectDropdownBloc>();
+    if (projectDropdownBloc.state is! ProjectDropdownLoadSuccess) {
+      projectDropdownBloc.add(const ProjectDropdownStarted());
+    }
+  }
+
   void _onPopInvoked(bool didPop) {
     if (didPop) return;
 

--- a/lib/app/shell/shell_module.dart
+++ b/lib/app/shell/shell_module.dart
@@ -81,6 +81,9 @@ class ShellModule extends Module {
           BlocProvider<AppShellBloc>(
             create: (_) => Modular.get<AppShellBloc>(),
           ),
+          // Started once from AppShellPage.initState (not here: this value
+          // expression re-executes on every shell rebuild, and an unguarded
+          // re-dispatch resets the user's project selection).
           BlocProvider<ProjectDropdownBloc>.value(
             value: Modular.get<ProjectDropdownBloc>(),
           ),

--- a/lib/features/dashboard/domain/usecases/watch_recent_estimations_usecase.dart
+++ b/lib/features/dashboard/domain/usecases/watch_recent_estimations_usecase.dart
@@ -4,7 +4,6 @@ import 'package:construculator/libraries/estimation/domain/entities/cost_estimat
 import 'package:construculator/libraries/estimation/domain/enums/estimation_sort_option.dart';
 import 'package:construculator/libraries/estimation/domain/estimation_error_type.dart';
 import 'package:construculator/libraries/estimation/domain/repositories/cost_estimation_repository.dart';
-import 'package:construculator/libraries/logging/app_logger.dart';
 import 'package:construculator/libraries/project/interfaces/current_project_notifier.dart';
 import 'package:equatable/equatable.dart';
 
@@ -27,7 +26,6 @@ class RecentEstimationsParams extends Equatable {
 /// Retrieves a stream from the [CostEstimationRepository] with strict
 /// limits and sort ordering specific to the Dashboard requirements.
 class WatchRecentEstimationsUseCase {
-  static final _logger = AppLogger().tag('WatchRecentEstimationsUseCase');
   final CostEstimationRepository _repository;
   final CurrentProjectNotifier _currentProjectNotifier;
 
@@ -42,12 +40,10 @@ class WatchRecentEstimationsUseCase {
     final projectId = _currentProjectNotifier.currentProjectId;
 
     if (projectId == null || projectId.isEmpty) {
-      // Warning, not error: right after login this is an expected transient
-      // (the project dropdown's auto-selection has not landed yet), so it
-      // must leave a breadcrumb without paging Sentry.
-      _logger.warning(
-        'Current project ID is null or empty, cannot watch recent estimations',
-      );
+      // Defensive only: RecentEstimationsBloc, the sole production caller,
+      // short-circuits (and logs) before invoking this use case without a
+      // selected project — so this branch does not log a duplicate
+      // breadcrumb.
       return Stream.value(
         const Left(
           EstimationFailure(errorType: EstimationErrorType.unexpectedError),

--- a/lib/features/dashboard/domain/usecases/watch_recent_estimations_usecase.dart
+++ b/lib/features/dashboard/domain/usecases/watch_recent_estimations_usecase.dart
@@ -4,6 +4,7 @@ import 'package:construculator/libraries/estimation/domain/entities/cost_estimat
 import 'package:construculator/libraries/estimation/domain/enums/estimation_sort_option.dart';
 import 'package:construculator/libraries/estimation/domain/estimation_error_type.dart';
 import 'package:construculator/libraries/estimation/domain/repositories/cost_estimation_repository.dart';
+import 'package:construculator/libraries/logging/app_logger.dart';
 import 'package:construculator/libraries/project/interfaces/current_project_notifier.dart';
 import 'package:equatable/equatable.dart';
 
@@ -26,6 +27,7 @@ class RecentEstimationsParams extends Equatable {
 /// Retrieves a stream from the [CostEstimationRepository] with strict
 /// limits and sort ordering specific to the Dashboard requirements.
 class WatchRecentEstimationsUseCase {
+  static final _logger = AppLogger().tag('WatchRecentEstimationsUseCase');
   final CostEstimationRepository _repository;
   final CurrentProjectNotifier _currentProjectNotifier;
 
@@ -40,6 +42,12 @@ class WatchRecentEstimationsUseCase {
     final projectId = _currentProjectNotifier.currentProjectId;
 
     if (projectId == null || projectId.isEmpty) {
+      // Warning, not error: right after login this is an expected transient
+      // (the project dropdown's auto-selection has not landed yet), so it
+      // must leave a breadcrumb without paging Sentry.
+      _logger.warning(
+        'Current project ID is null or empty, cannot watch recent estimations',
+      );
       return Stream.value(
         const Left(
           EstimationFailure(errorType: EstimationErrorType.unexpectedError),

--- a/lib/features/dashboard/presentation/bloc/recent_estimations_bloc/recent_estimations_bloc.dart
+++ b/lib/features/dashboard/presentation/bloc/recent_estimations_bloc/recent_estimations_bloc.dart
@@ -4,6 +4,7 @@ import 'package:construculator/features/dashboard/domain/usecases/watch_recent_e
 import 'package:construculator/libraries/either/either.dart';
 import 'package:construculator/libraries/errors/failures.dart';
 import 'package:construculator/libraries/estimation/domain/entities/cost_estimate_entity.dart';
+import 'package:construculator/libraries/logging/app_logger.dart';
 import 'package:construculator/libraries/project/interfaces/current_project_notifier.dart';
 import 'package:equatable/equatable.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -16,6 +17,7 @@ part 'recent_estimations_state.dart';
 /// [RecentEstimationsError] states for the dashboard UI.
 class RecentEstimationsBloc
     extends Bloc<RecentEstimationsEvent, RecentEstimationsState> {
+  static final _logger = AppLogger().tag('RecentEstimationsBloc');
   final WatchRecentEstimationsUseCase _watchRecentEstimationsUseCase;
   final CurrentProjectNotifier _currentProjectNotifier;
   StreamSubscription<Either<Failure, List<CostEstimate>>>? _subscription;
@@ -52,12 +54,38 @@ class RecentEstimationsBloc
 
     _subscription?.cancel();
 
-    _subscription =
-        _watchRecentEstimationsUseCase(const RecentEstimationsParams()).listen((
-          result,
-        ) {
-          add(_RecentEstimationsUpdated(result));
-        });
+    // No project selected yet (right after login, before the project
+    // dropdown's auto-selection lands): stay in loading instead of
+    // surfacing a failure banner — the project-changed listener above
+    // re-dispatches this event once a selection arrives (CA-900).
+    // Zero-project accounts never get a selection and stay here; CA-984
+    // models that state distinctly.
+    // https://ripplearc.youtrack.cloud/issue/CA-984
+    final projectId = currentProjectId;
+    if (projectId == null || projectId.isEmpty) {
+      _subscription = null;
+      return;
+    }
+
+    _subscription = _watchRecentEstimationsUseCase(
+      const RecentEstimationsParams(),
+    ).listen(
+      (result) {
+        add(_RecentEstimationsUpdated(result));
+      },
+      onError: (Object error, StackTrace stackTrace) {
+        // The use case surfaces expected failures as Left values; a raw
+        // stream error would otherwise escape to the zone handler and
+        // leave the section stuck on the loading state. Warning-level:
+        // error() belongs at the stream-owning data boundary, not in a bloc.
+        _logger.warning('Recent estimations stream errored', error, stackTrace);
+        add(
+          _RecentEstimationsUpdated(
+            Left(error is Failure ? error : UnexpectedFailure()),
+          ),
+        );
+      },
+    );
   }
 
   void _onProjectChanged(

--- a/lib/features/dashboard/presentation/bloc/recent_estimations_bloc/recent_estimations_bloc.dart
+++ b/lib/features/dashboard/presentation/bloc/recent_estimations_bloc/recent_estimations_bloc.dart
@@ -117,6 +117,11 @@ class RecentEstimationsBloc
     // instead of skeletoning forever. The project-changed subscription
     // stays alive, so a later successful load (e.g. a retry from the
     // projects sheet) still re-arms the watch.
+    // TODO(CA-1017): re-arming rides on an id CHANGE, so a transient refresh
+    // failure that recovers to the same selected project parks this section
+    // on the error banner permanently — guard on RecentEstimationsLoaded or
+    // re-arm on every dropdown LoadSuccess.
+    // https://ripplearc.youtrack.cloud/issue/CA-1017
     _logger.warning('Project load failed; leaving the loading hold');
     _subscription?.cancel();
     _subscription = null;

--- a/lib/features/dashboard/presentation/bloc/recent_estimations_bloc/recent_estimations_bloc.dart
+++ b/lib/features/dashboard/presentation/bloc/recent_estimations_bloc/recent_estimations_bloc.dart
@@ -31,6 +31,7 @@ class RecentEstimationsBloc
     required this._currentProjectNotifier,
   }) : super(const RecentEstimationsLoading()) {
     on<RecentEstimationsWatchStarted>(_onWatchStarted);
+    on<RecentEstimationsProjectLoadFailed>(_onProjectLoadFailed);
     on<_RecentEstimationsProjectChanged>(_onProjectChanged);
     on<_RecentEstimationsUpdated>(_onUpdated);
   }
@@ -63,6 +64,14 @@ class RecentEstimationsBloc
     // https://ripplearc.youtrack.cloud/issue/CA-984
     final projectId = currentProjectId;
     if (projectId == null || projectId.isEmpty) {
+      // This short-circuit was the previously unlogged silent link in the
+      // project-load chain. Warning, not error: right after login it is an
+      // expected transient, so it must leave a breadcrumb without paging
+      // Sentry.
+      _logger.warning(
+        'No current project selected; holding the loading state until a '
+        'selection arrives',
+      );
       _subscription = null;
       return;
     }
@@ -78,6 +87,10 @@ class RecentEstimationsBloc
         // stream error would otherwise escape to the zone handler and
         // leave the section stuck on the loading state. Warning-level:
         // error() belongs at the stream-owning data boundary, not in a bloc.
+        // The sources reaching this handler are terminal, so the watch stays
+        // dead until the next project change re-arms it; CA-999 adds an
+        // onDone-triggered resubscribe.
+        // https://ripplearc.youtrack.cloud/issue/CA-999
         _logger.warning('Recent estimations stream errored', error, stackTrace);
         add(
           _RecentEstimationsUpdated(
@@ -93,6 +106,21 @@ class RecentEstimationsBloc
     Emitter<RecentEstimationsState> emit,
   ) {
     add(const RecentEstimationsWatchStarted());
+  }
+
+  void _onProjectLoadFailed(
+    RecentEstimationsProjectLoadFailed event,
+    Emitter<RecentEstimationsState> emit,
+  ) {
+    // The loading hold in _onWatchStarted waits for a selection that, after
+    // a project load failure, is never going to arrive — surface an error
+    // instead of skeletoning forever. The project-changed subscription
+    // stays alive, so a later successful load (e.g. a retry from the
+    // projects sheet) still re-arms the watch.
+    _logger.warning('Project load failed; leaving the loading hold');
+    _subscription?.cancel();
+    _subscription = null;
+    emit(const RecentEstimationsError('project load failed'));
   }
 
   void _onUpdated(

--- a/lib/features/dashboard/presentation/bloc/recent_estimations_bloc/recent_estimations_event.dart
+++ b/lib/features/dashboard/presentation/bloc/recent_estimations_bloc/recent_estimations_event.dart
@@ -15,6 +15,15 @@ class RecentEstimationsWatchStarted extends RecentEstimationsEvent {
   const RecentEstimationsWatchStarted();
 }
 
+/// Signals that the project load failed, so no selection is ever going to
+/// arrive and the loading hold must resolve to an error instead of
+/// waiting forever. Dispatched by the shell when the project dropdown
+/// load reaches its failure state (CA-900).
+class RecentEstimationsProjectLoadFailed extends RecentEstimationsEvent {
+  /// Defines a constructor for the project-load-failure signal.
+  const RecentEstimationsProjectLoadFailed();
+}
+
 class _RecentEstimationsProjectChanged extends RecentEstimationsEvent {
   const _RecentEstimationsProjectChanged();
 }

--- a/lib/features/dashboard/presentation/bloc/recent_estimations_bloc/recent_estimations_event.dart
+++ b/lib/features/dashboard/presentation/bloc/recent_estimations_bloc/recent_estimations_event.dart
@@ -20,7 +20,7 @@ class RecentEstimationsWatchStarted extends RecentEstimationsEvent {
 /// waiting forever. Dispatched by the shell when the project dropdown
 /// load reaches its failure state (CA-900).
 class RecentEstimationsProjectLoadFailed extends RecentEstimationsEvent {
-  /// Defines a constructor for the project-load-failure signal.
+  /// Creates a [RecentEstimationsProjectLoadFailed] event.
   const RecentEstimationsProjectLoadFailed();
 }
 

--- a/lib/libraries/project/data/repositories/project_repository_impl.dart
+++ b/lib/libraries/project/data/repositories/project_repository_impl.dart
@@ -123,7 +123,9 @@ class ProjectRepositoryImpl implements ProjectRepository {
             // the eager fetch below (and any later refresh) still serves the
             // list — it just stops live-updating. Only the fetch path pushes
             // failures to listeners (CA-900). A terminally errored stream is
-            // not resubscribed until all listeners detach; CA-985 adds
+            // not resubscribed until all listeners detach — in practice
+            // until app restart, since the sole production listener is the
+            // app-lifetime ProjectDropdownBloc singleton; CA-985 adds
             // retry/backoff. https://ripplearc.youtrack.cloud/issue/CA-985
             final failure = ProjectErrorMapper.toFailure(error);
             _logFailure(

--- a/lib/libraries/project/data/repositories/project_repository_impl.dart
+++ b/lib/libraries/project/data/repositories/project_repository_impl.dart
@@ -119,9 +119,19 @@ class ProjectRepositoryImpl implements ProjectRepository {
         .listen(
           (_) => _refreshProjects(),
           onError: (Object error, StackTrace stackTrace) {
+            // Realtime being unavailable must not fail the projects surface:
+            // the eager fetch below (and any later refresh) still serves the
+            // list — it just stops live-updating. Only the fetch path pushes
+            // failures to listeners (CA-900). A terminally errored stream is
+            // not resubscribed until all listeners detach; CA-985 adds
+            // retry/backoff. https://ripplearc.youtrack.cloud/issue/CA-985
             final failure = ProjectErrorMapper.toFailure(error);
-            _logFailure('watching project changes', failure, stackTrace);
-            _projectsController?.addError(failure, stackTrace);
+            _logFailure(
+              'watching project changes (realtime unavailable; list degrades '
+              'to fetch-once)',
+              failure,
+              stackTrace,
+            );
           },
         );
 

--- a/lib/libraries/supabase/testing/fake_supabase_wrapper.dart
+++ b/lib/libraries/supabase/testing/fake_supabase_wrapper.dart
@@ -227,6 +227,12 @@ class FakeSupabaseWrapper implements SupabaseWrapper {
   /// Defaults to [ServerException] when null.
   SupabaseExceptionType? streamExceptionType;
 
+  /// When true, a stream error emitted via [shouldEmitStreamErrors] also
+  /// closes that table's stream, mimicking a terminal realtime subscribe
+  /// failure (e.g. RealtimeSubscribeException) after which the channel
+  /// emits nothing further.
+  bool shouldCloseStreamOnError = false;
+
   /// Controls whether [signInWithPassword] returns a user
   bool shouldReturnUser = false;
 
@@ -1112,6 +1118,9 @@ class FakeSupabaseWrapper implements SupabaseWrapper {
       } catch (e, st) {
         controller.addError(e, st);
       }
+      if (shouldCloseStreamOnError) {
+        controller.close();
+      }
       return;
     }
     controller.add(_cloneRows(_tables[table] ?? const []));
@@ -1264,6 +1273,7 @@ class FakeSupabaseWrapper implements SupabaseWrapper {
     completer = null;
     shouldEmitStreamErrors = false;
     streamExceptionType = null;
+    shouldCloseStreamOnError = false;
     shouldReturnUser = false;
     shouldThrowOnGetUserProfile = false;
     _nextId = 1;

--- a/test/app/shell/app_shell_page_test.dart
+++ b/test/app/shell/app_shell_page_test.dart
@@ -473,5 +473,30 @@ void main() {
         expect(fakeProjectNotifier.currentProjectId, 'project-b');
       },
     );
+
+    testWidgets(
+      'signals RecentEstimationsBloc when the project load fails, so the '
+      'section leaves its loading hold instead of skeletoning forever '
+      '(CA-900)',
+      (tester) async {
+        fakeProjectRepository.shouldThrowOnWatchProjects = true;
+
+        // Pin one bloc instance: the module binds a factory, so without
+        // this the instance asserted here would differ from the one the
+        // page's provider resolves.
+        final recentEstimationsBloc = Modular.get<RecentEstimationsBloc>();
+        Modular.replaceInstance<RecentEstimationsBloc>(recentEstimationsBloc);
+        final errored = recentEstimationsBloc.stream.firstWhere(
+          (s) => s is RecentEstimationsError,
+        );
+
+        await tester.pumpWidget(makeApp());
+        await tester.pump();
+        await tester.pump();
+
+        await tester.runAsync(() => errored);
+        expect(recentEstimationsBloc.state, isA<RecentEstimationsError>());
+      },
+    );
   });
 }

--- a/test/app/shell/app_shell_page_test.dart
+++ b/test/app/shell/app_shell_page_test.dart
@@ -410,12 +410,46 @@ void main() {
     tearDown(() => fakeProjectNotifier.reset());
 
     testWidgets(
+      'starts the projects watch on shell mount and auto-selects the first '
+      'project without any manual dispatch',
+      (tester) async {
+        fakeProjectRepository.setAccessibleProjects([
+          buildProject('project-a', 'Project A', DateTime(2025, 1, 2)),
+        ]);
+
+        final dropdownBloc = Modular.get<ProjectDropdownBloc>();
+        final loaded = dropdownBloc.stream.firstWhere(
+          (s) => s is ProjectDropdownLoadSuccess && s.selectedProject != null,
+        );
+
+        // No ProjectDropdownStarted is dispatched here: mounting the shell
+        // must start the watch itself (CA-900 — previously nothing did
+        // until the projects sheet was opened, so no project auto-selected
+        // on login).
+        await tester.pumpWidget(makeApp());
+        await tester.pump();
+        await tester.pump();
+
+        await tester.runAsync(() => loaded);
+        await tester.pump();
+        expect(fakeProjectNotifier.currentProjectId, 'project-a');
+      },
+    );
+
+    testWidgets(
       'updates CurrentProjectNotifier when project selection changes',
       (tester) async {
         fakeProjectRepository.setAccessibleProjects([
           buildProject('project-a', 'Project A', DateTime(2025, 1, 2)),
           buildProject('project-b', 'Project B', DateTime(2025, 1, 1)),
         ]);
+
+        // Subscribe before pumping: mounting the shell auto-dispatches
+        // ProjectDropdownStarted from initState, so a manual dispatch here
+        // would restart the already-running watch.
+        final dropdownBloc = Modular.get<ProjectDropdownBloc>();
+        final firstLoad = dropdownBloc.stream
+            .firstWhere((s) => s is ProjectDropdownLoadSuccess);
 
         await tester.pumpWidget(makeApp());
         // Two pumps: first drains AppShellInitialized, second drains the
@@ -424,11 +458,6 @@ void main() {
         await tester.pump();
         await tester.pump();
 
-        final dropdownBloc = Modular.get<ProjectDropdownBloc>();
-
-        final firstLoad = dropdownBloc.stream
-            .firstWhere((s) => s is ProjectDropdownLoadSuccess);
-        dropdownBloc.add(const ProjectDropdownStarted());
         await tester.runAsync(() => firstLoad);
         await tester.pump();
         expect(fakeProjectNotifier.currentProjectId, 'project-a');

--- a/test/features/dashboard/units/blocs/recent_estimations_bloc_test.dart
+++ b/test/features/dashboard/units/blocs/recent_estimations_bloc_test.dart
@@ -3,10 +3,14 @@ import 'package:construculator/app/app_bootstrap.dart';
 import 'package:construculator/features/dashboard/domain/usecases/watch_recent_estimations_usecase.dart';
 import 'package:construculator/features/dashboard/presentation/bloc/recent_estimations_bloc/recent_estimations_bloc.dart';
 import 'package:construculator/libraries/auth/auth_library_module.dart';
+import 'package:construculator/libraries/errors/failures.dart';
 import 'package:construculator/libraries/estimation/data/models/cost_estimate_dto.dart';
+import 'package:construculator/libraries/estimation/domain/estimation_error_type.dart';
 import 'package:construculator/libraries/estimation/estimation_library_module.dart';
+import 'package:construculator/libraries/estimation/testing/fake_cost_estimation_repository.dart';
 import 'package:construculator/libraries/project/interfaces/current_project_notifier.dart';
 import 'package:construculator/libraries/project/project_library_module.dart';
+import 'package:construculator/libraries/project/testing/fake_current_project_notifier.dart';
 import 'package:construculator/libraries/supabase/data/supabase_types.dart';
 import 'package:construculator/libraries/supabase/database_constants.dart';
 import 'package:construculator/libraries/supabase/interfaces/supabase_wrapper.dart';
@@ -139,7 +143,9 @@ void main() {
   );
 
   blocTest<RecentEstimationsBloc, RecentEstimationsState>(
-    'emits [RecentEstimationsLoading, RecentEstimationsError] when there is no current project',
+    'stays in RecentEstimationsLoading when there is no current project — '
+    'right after login no failure banner may show before the project '
+    'dropdown auto-selection lands (CA-900)',
     build: () {
       currentProjectNotifier.setCurrentProjectId(null);
       return bloc;
@@ -147,9 +153,85 @@ void main() {
     act: (bloc) => bloc.add(const RecentEstimationsWatchStarted()),
     expect: () => [
       const RecentEstimationsLoading(lastKnownEstimations: null),
+    ],
+  );
+
+  blocTest<RecentEstimationsBloc, RecentEstimationsState>(
+    'emits RecentEstimationsError when the estimations stream errors '
+    'instead of leaving the section stuck on loading',
+    build: () {
+      // Constructed directly over a repository fake whose stream errors:
+      // the module-bound repository surfaces failures as Left values, so a
+      // raw stream error is only reachable this way.
+      final fakeRepository = FakeCostEstimationRepository()
+        ..streamFactory = (() => Stream.error(Exception('stream broke')));
+      final notifier = FakeCurrentProjectNotifier(
+        initialProjectId: testProjectId,
+      );
+      return RecentEstimationsBloc(
+        watchRecentEstimationsUseCase: WatchRecentEstimationsUseCase(
+          fakeRepository,
+          notifier,
+        ),
+        currentProjectNotifier: notifier,
+      );
+    },
+    act: (bloc) => bloc.add(const RecentEstimationsWatchStarted()),
+    expect: () => [
+      const RecentEstimationsLoading(lastKnownEstimations: null),
+      isA<RecentEstimationsError>(),
+    ],
+  );
+
+  blocTest<RecentEstimationsBloc, RecentEstimationsState>(
+    'preserves the typed failure message when the stream errors with a '
+    'Failure instead of collapsing it to UnexpectedFailure',
+    build: () {
+      final fakeRepository = FakeCostEstimationRepository()
+        ..streamFactory = (() => Stream.error(
+              const EstimationFailure(
+                errorType: EstimationErrorType.timeoutError,
+              ),
+            ));
+      final notifier = FakeCurrentProjectNotifier(
+        initialProjectId: testProjectId,
+      );
+      return RecentEstimationsBloc(
+        watchRecentEstimationsUseCase: WatchRecentEstimationsUseCase(
+          fakeRepository,
+          notifier,
+        ),
+        currentProjectNotifier: notifier,
+      );
+    },
+    act: (bloc) => bloc.add(const RecentEstimationsWatchStarted()),
+    expect: () => [
+      const RecentEstimationsLoading(lastKnownEstimations: null),
       const RecentEstimationsError(
-        'EstimationFailure(EstimationErrorType.unexpectedError)',
+        'EstimationFailure(EstimationErrorType.timeoutError)',
       ),
+    ],
+  );
+
+  blocTest<RecentEstimationsBloc, RecentEstimationsState>(
+    'starts watching once a project selection arrives after a null start',
+    build: () {
+      seedEstimationTable([tEstimationMap]);
+      currentProjectNotifier.setCurrentProjectId(null);
+      return bloc;
+    },
+    act: (bloc) async {
+      bloc.add(const RecentEstimationsWatchStarted());
+      currentProjectNotifier.setCurrentProjectId(testProjectId);
+      await bloc.stream.firstWhere(
+        (state) => state is RecentEstimationsLoaded,
+      );
+    },
+    expect: () => [
+      // The re-dispatched watch start emits an equal Loading state, which
+      // the bloc deduplicates, so only the initial Loading is observed.
+      const RecentEstimationsLoading(lastKnownEstimations: null),
+      RecentEstimationsLoaded(tEstimations),
     ],
   );
 

--- a/test/features/dashboard/units/blocs/recent_estimations_bloc_test.dart
+++ b/test/features/dashboard/units/blocs/recent_estimations_bloc_test.dart
@@ -236,6 +236,46 @@ void main() {
   );
 
   blocTest<RecentEstimationsBloc, RecentEstimationsState>(
+    'emits RecentEstimationsError when the project load fails — the '
+    'loading hold must not outlive the possibility of a selection (CA-900)',
+    build: () {
+      currentProjectNotifier.setCurrentProjectId(null);
+      return bloc;
+    },
+    act: (bloc) {
+      bloc.add(const RecentEstimationsWatchStarted());
+      bloc.add(const RecentEstimationsProjectLoadFailed());
+    },
+    expect: () => [
+      const RecentEstimationsLoading(lastKnownEstimations: null),
+      const RecentEstimationsError('project load failed'),
+    ],
+  );
+
+  blocTest<RecentEstimationsBloc, RecentEstimationsState>(
+    'recovers from a project load failure once a selection eventually '
+    'arrives (e.g. a successful retry from the projects sheet)',
+    build: () {
+      seedEstimationTable([tEstimationMap]);
+      currentProjectNotifier.setCurrentProjectId(null);
+      return bloc;
+    },
+    act: (bloc) async {
+      bloc.add(const RecentEstimationsWatchStarted());
+      bloc.add(const RecentEstimationsProjectLoadFailed());
+      await bloc.stream.firstWhere((s) => s is RecentEstimationsError);
+      currentProjectNotifier.setCurrentProjectId(testProjectId);
+      await bloc.stream.firstWhere((s) => s is RecentEstimationsLoaded);
+    },
+    expect: () => [
+      const RecentEstimationsLoading(lastKnownEstimations: null),
+      const RecentEstimationsError('project load failed'),
+      const RecentEstimationsLoading(lastKnownEstimations: null),
+      RecentEstimationsLoaded(tEstimations),
+    ],
+  );
+
+  blocTest<RecentEstimationsBloc, RecentEstimationsState>(
     're-watches when the current project changes after start',
     build: () {
       seedEstimationTable([tEstimationMap]);

--- a/test/features/dashboard/widgets/recent_estimations_section_test.dart
+++ b/test/features/dashboard/widgets/recent_estimations_section_test.dart
@@ -178,7 +178,39 @@ void main() {
     await tester.pump();
     await tester.pump();
 
+    // The three skeleton placeholders must actually render — a section
+    // that drew nothing at all must not pass this test.
+    expect(
+      find.descendant(
+        of: find.byType(ListView),
+        matching: find.byType(Container),
+      ),
+      findsNWidgets(3),
+    );
+    expect(find.byType(EstimationCard), findsNothing);
     expect(find.text(l10n().recentEstimationsLoadError), findsNothing);
+  });
+
+  testWidgets(
+      'shows the load error instead of holding the placeholders once the '
+      'project load fails (CA-900)', (tester) async {
+    currentProjectNotifier.setCurrentProjectId(null);
+
+    // runAsync, like pumpSection: the bloc is created in setUp, outside the
+    // fake-async zone, so its event processing only completes on the real
+    // event loop.
+    final errored = bloc.stream.firstWhere(
+      (state) => state is RecentEstimationsError,
+    );
+    bloc.add(const RecentEstimationsWatchStarted());
+    await tester.pumpWidget(buildTestApp());
+    await tester.pump();
+
+    bloc.add(const RecentEstimationsProjectLoadFailed());
+    await tester.runAsync(() => errored);
+    await tester.pump();
+
+    expect(find.text(l10n().recentEstimationsLoadError), findsOneWidget);
   });
 
   testWidgets('renders estimation cards when data is loaded', (tester) async {

--- a/test/features/dashboard/widgets/recent_estimations_section_test.dart
+++ b/test/features/dashboard/widgets/recent_estimations_section_test.dart
@@ -8,6 +8,7 @@ import 'package:construculator/libraries/either/either.dart';
 import 'package:construculator/libraries/errors/failures.dart';
 import 'package:construculator/libraries/estimation/data/models/cost_estimate_dto.dart';
 import 'package:construculator/libraries/estimation/domain/entities/cost_estimate_entity.dart';
+import 'package:construculator/libraries/estimation/domain/estimation_error_type.dart';
 import 'package:construculator/libraries/estimation/domain/repositories/cost_estimation_repository.dart';
 import 'package:construculator/libraries/estimation/testing/fake_cost_estimation_repository.dart';
 
@@ -154,11 +155,30 @@ void main() {
   testWidgets('shows error message when estimations fail to load', (
     tester,
   ) async {
-    currentProjectNotifier.setCurrentProjectId(null);
+    // A factory (not a single stream instance) because the watch may be
+    // re-invoked when the project-changed listener fires, and a
+    // single-subscription stream cannot be listened to twice.
+    fakeRepository.streamFactory = () => Stream.value(
+          const Left(
+            EstimationFailure(errorType: EstimationErrorType.unexpectedError),
+          ),
+        );
 
     await pumpSection(tester);
 
     expect(find.text(l10n().recentEstimationsLoadError), findsOneWidget);
+  });
+
+  testWidgets('stays on the loading placeholders instead of an error while '
+      'no project is selected yet (CA-900)', (tester) async {
+    currentProjectNotifier.setCurrentProjectId(null);
+
+    bloc.add(const RecentEstimationsWatchStarted());
+    await tester.pumpWidget(buildTestApp());
+    await tester.pump();
+    await tester.pump();
+
+    expect(find.text(l10n().recentEstimationsLoadError), findsNothing);
   });
 
   testWidgets('renders estimation cards when data is loaded', (tester) async {

--- a/test/libraries/project/units/data/repositories/project_repository_test.dart
+++ b/test/libraries/project/units/data/repositories/project_repository_test.dart
@@ -287,30 +287,74 @@ void main() {
         },
       );
 
-      test('propagates error from watchProjectChanges stream', () async {
-        const userId = 'user-123';
+      test(
+        'degrades to fetch-once on a watchProjectChanges error: no stream '
+        'error reaches listeners and later refreshes still serve the list '
+        '(CA-900)',
+        () async {
+          const userId = 'user-123';
+          supabaseWrapper.addTableData(DatabaseConstants.projectsTable, [
+            _createProjectRow(
+              id: 'owned-project',
+              projectName: 'Owned',
+              creatorUserId: userId,
+              updatedAt: DateTime(2025, 1, 1),
+            ),
+          ]);
 
-        final firstEmission = Completer<void>();
-        final errorReceived = Completer<void>();
-        final subscription = repository
-            .watchProjects(userId)
-            .listen(
-              (_) {
-                if (!firstEmission.isCompleted) firstEmission.complete();
-              },
-              onError: (error, _) {
-                expect(error, isA<ProjectFailure>());
-                if (!errorReceived.isCompleted) errorReceived.complete();
-              },
-            );
-        await firstEmission.future;
+          Object? receivedError;
+          final emittedBatches = <List<Project>>[];
+          final firstEmission = Completer<void>();
+          final recoveredEmission = Completer<void>();
+          final subscription = repository.watchProjects(userId).listen(
+            (batch) {
+              emittedBatches.add(batch);
+              if (!firstEmission.isCompleted) {
+                firstEmission.complete();
+              } else if (!recoveredEmission.isCompleted) {
+                recoveredEmission.complete();
+              }
+            },
+            onError: (Object error, _) => receivedError = error,
+          );
+          await firstEmission.future;
 
-        supabaseWrapper.shouldEmitStreamErrors = true;
-        supabaseWrapper.addTableData(DatabaseConstants.projectsTable, []);
+          // Realtime delivery errors (e.g. RealtimeSubscribeException when
+          // the local publication is missing the watched tables).
+          supabaseWrapper.shouldEmitStreamErrors = true;
+          supabaseWrapper.addTableData(DatabaseConstants.projectsTable, []);
 
-        await errorReceived.future;
-        await subscription.cancel();
-      });
+          // The subscription survives the error: a later realtime event
+          // still triggers a refresh that serves the full list.
+          supabaseWrapper.shouldEmitStreamErrors = false;
+          supabaseWrapper.addTableData(DatabaseConstants.projectsTable, [
+            _createProjectRow(
+              id: 'owned-project',
+              projectName: 'Owned',
+              creatorUserId: userId,
+              updatedAt: DateTime(2025, 1, 1),
+            ),
+            _createProjectRow(
+              id: 'second-project',
+              projectName: 'Second',
+              creatorUserId: userId,
+              updatedAt: DateTime(2025, 1, 2),
+            ),
+          ]);
+          await recoveredEmission.future;
+          await subscription.cancel();
+
+          expect(
+            receivedError,
+            isNull,
+            reason:
+                'a realtime failure must degrade to fetch-once, not fail '
+                'the projects surface',
+          );
+          expect(emittedBatches.first, hasLength(1));
+          expect(emittedBatches.last, hasLength(2));
+        },
+      );
 
       test(
         'queues a follow-up refresh when changes arrive mid-refresh',

--- a/test/libraries/project/units/data/repositories/project_repository_test.dart
+++ b/test/libraries/project/units/data/repositories/project_repository_test.dart
@@ -288,9 +288,9 @@ void main() {
       );
 
       test(
-        'degrades to fetch-once on a watchProjectChanges error: no stream '
-        'error reaches listeners and later refreshes still serve the list '
-        '(CA-900)',
+        'suppresses a transient watchProjectChanges error: no stream error '
+        'reaches listeners, and because the fake keeps the stream open a '
+        'later realtime event still refreshes the list (CA-900)',
         () async {
           const userId = 'user-123';
           supabaseWrapper.addTableData(DatabaseConstants.projectsTable, [
@@ -319,13 +319,15 @@ void main() {
           );
           await firstEmission.future;
 
-          // Realtime delivery errors (e.g. RealtimeSubscribeException when
-          // the local publication is missing the watched tables).
+          // A transient realtime delivery error: the fake's broadcast
+          // stream stays open afterwards. The terminal case
+          // (RealtimeSubscribeException closing the channel) is pinned by
+          // the next test.
           supabaseWrapper.shouldEmitStreamErrors = true;
           supabaseWrapper.addTableData(DatabaseConstants.projectsTable, []);
 
-          // The subscription survives the error: a later realtime event
-          // still triggers a refresh that serves the full list.
+          // The subscription survives the transient error: a later realtime
+          // event still triggers a refresh that serves the full list.
           supabaseWrapper.shouldEmitStreamErrors = false;
           supabaseWrapper.addTableData(DatabaseConstants.projectsTable, [
             _createProjectRow(
@@ -353,6 +355,81 @@ void main() {
           );
           expect(emittedBatches.first, hasLength(1));
           expect(emittedBatches.last, hasLength(2));
+        },
+      );
+
+      test(
+        'still serves the eagerly fetched list when the realtime subscribe '
+        'fails terminally: no error reaches listeners, and the dead channel '
+        'produces no further refreshes (CA-900)',
+        () async {
+          const userId = 'user-123';
+          supabaseWrapper.addTableData(DatabaseConstants.projectsTable, [
+            _createProjectRow(
+              id: 'owned-project',
+              projectName: 'Owned',
+              creatorUserId: userId,
+              updatedAt: DateTime(2025, 1, 1),
+            ),
+          ]);
+
+          Object? receivedError;
+          final emittedBatches = <List<Project>>[];
+          final firstEmission = Completer<void>();
+          final subscription = repository.watchProjects(userId).listen(
+            (batch) {
+              emittedBatches.add(batch);
+              if (!firstEmission.isCompleted) {
+                firstEmission.complete();
+              }
+            },
+            onError: (Object error, _) => receivedError = error,
+          );
+          await firstEmission.future;
+
+          // A terminal subscribe failure (the production
+          // RealtimeSubscribeException case): the error closes the channel,
+          // which emits nothing further — see the degrade comment in
+          // project_repository_impl.dart and CA-985.
+          supabaseWrapper.shouldEmitStreamErrors = true;
+          supabaseWrapper.shouldCloseStreamOnError = true;
+          supabaseWrapper.addTableData(DatabaseConstants.projectsTable, []);
+          await pumpEventQueue();
+
+          // The dead channel never observes this change, so no refresh runs.
+          supabaseWrapper.shouldEmitStreamErrors = false;
+          supabaseWrapper.addTableData(DatabaseConstants.projectsTable, [
+            _createProjectRow(
+              id: 'owned-project',
+              projectName: 'Owned',
+              creatorUserId: userId,
+              updatedAt: DateTime(2025, 1, 1),
+            ),
+            _createProjectRow(
+              id: 'second-project',
+              projectName: 'Second',
+              creatorUserId: userId,
+              updatedAt: DateTime(2025, 1, 2),
+            ),
+          ]);
+          await pumpEventQueue();
+          await subscription.cancel();
+
+          expect(
+            receivedError,
+            isNull,
+            reason:
+                'a terminal realtime failure must degrade to fetch-once, '
+                'not fail the projects surface',
+          );
+          expect(
+            emittedBatches,
+            hasLength(1),
+            reason:
+                'the eagerly fetched list is served once; a dead channel '
+                'triggers no further refreshes',
+          );
+          expect(emittedBatches.single, hasLength(1));
         },
       );
 


### PR DESCRIPTION
## Context

[CA-900](https://ripplearc.youtrack.cloud/issue/CA-900) (P1) — part 2 of 3. Stacked on #577 (routing), which is stacked on #555 (CA-903). Part 3 is #556.

Three links in the project-load chain failed quietly, so every project-scoped surface came up empty on login with no signal in logs or UI.

## What changed

**1. Realtime failure no longer fails the projects surface.** `ProjectRepositoryImpl` pushed a realtime subscribe error (the E2E `RealtimeSubscribeException`) to every listener, killing the whole projects stream. It now logs the error and degrades the watch to fetch-once: the eager fetch and any later refresh still serve the list, it just stops live-updating. A terminally errored stream is not resubscribed until all listeners detach — retry/backoff is tracked by [CA-985](https://ripplearc.youtrack.cloud/issue/CA-985) and referenced in the code comment.

**2. The projects watch actually starts.** Nothing started `ProjectDropdownBloc` until the projects sheet was first opened, so no project auto-selected on login, `CurrentProjectNotifier` stayed null, and every project-scoped surface started failed. `AppShellPage.initState` now starts it at shell mount, guarded the same way the sheet is so a remount cannot restart a loaded watch and reset the user's selection. The `BlocProvider` in `ShellModule` carries a comment saying why the dispatch is not there (that value expression re-runs on every shell rebuild).

**3. No failure banner during the login gap.** `RecentEstimationsBloc` now stays in loading until a selection lands — the project-changed listener re-dispatches once it does. Zero-project accounts never get a selection and stay in loading; [CA-984](https://ripplearc.youtrack.cloud/issue/CA-984) models that state distinctly. It also logs the null-project short-circuit that was previously the unlogged failure, and gains the missing stream `onError` handler that let a raw stream error escape to the zone handler and strand the section on loading. Both log at warning level: `error()` belongs at the stream-owning data boundary, not in a bloc.

## Tests

- `project_repository_test` rewritten to pin the realtime-degradation path (subscribe error logs and keeps serving, later refreshes still land) instead of the old propagate-to-listeners behaviour.
- `app_shell_page_test` gains a mount-starts-the-watch test that dispatches no `ProjectDropdownStarted` itself; the existing selection test drops its manual dispatch and subscribes before pumping.
- `recent_estimations_bloc_test` covers the loading hold, the selection-arrival re-dispatch, and the new `onError` path.
- `recent_estimations_section_test` updated for the loading-instead-of-error state.

## Verification

Local Docker gates vs this PR's real base (`CA-900-fix/shell-top-level-routes`); results posted as a comment.