### PR TITLE
CA-1009: fix(auth): discard stale in-flight email-availability checks on login

### DIFF
--- a/lib/features/auth/presentation/bloc/login_with_email_bloc/login_with_email_bloc.dart
+++ b/lib/features/auth/presentation/bloc/login_with_email_bloc/login_with_email_bloc.dart
@@ -13,6 +13,14 @@ class LoginWithEmailBloc
     extends Bloc<LoginWithEmailEvent, LoginWithEmailState> {
   final CheckEmailAvailabilityUseCase _checkEmailAvailabilityUseCase;
 
+  // Monotonically increasing token for availability checks. Checks fired for
+  // successive keystrokes execute concurrently, so whichever RPC resolved
+  // last used to win the final emit — a stale response for an older input
+  // (e.g. "user@example.co" while typing "user@example.com") could overwrite
+  // the verdict for the email currently in the field. A completed check
+  // whose token is no longer current discards its result instead.
+  int _availabilityCheckGeneration = 0;
+
   LoginWithEmailBloc({
     required this._checkEmailAvailabilityUseCase,
   }) : super(LoginWithEmailInitial()) {
@@ -24,8 +32,10 @@ class LoginWithEmailBloc
     LoginEmailAvailabilityCheckRequested event,
     Emitter<LoginWithEmailState> emit,
   ) async {
+    final generation = ++_availabilityCheckGeneration;
     emit(LoginWithEmailAvailabilityLoading());
     final result = await _checkEmailAvailabilityUseCase(event.email);
+    if (generation != _availabilityCheckGeneration) return;
     result.fold(
       (failure) {
         emit(LoginWithEmailAvailabilityCheckFailure(failure: failure));

--- a/test/features/auth/units/blocs/login_with_email_bloc_test.dart
+++ b/test/features/auth/units/blocs/login_with_email_bloc_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:bloc_test/bloc_test.dart';
 import 'package:construculator/features/auth/presentation/bloc/login_with_email_bloc/login_with_email_bloc.dart';
 import 'package:construculator/features/auth/testing/auth_test_module.dart';
@@ -183,6 +185,55 @@ void main() {
         expect: () => [
           LoginWithEmailAvailabilityLoading(),
           isA<LoginWithEmailAvailabilityCheckFailure>(),
+        ],
+      );
+
+      blocTest<LoginWithEmailBloc, LoginWithEmailState>(
+        'discards a superseded availability check that resolves after a '
+        'newer check — the stale verdict is never emitted',
+        setUp: () {
+          fakeSupabase.setRpcResponse('check_email_exists', true);
+          fakeSupabase.shouldDelayOperations = true;
+          fakeSupabase.completer = Completer<void>();
+        },
+        build: () => bloc,
+        act: (bloc) async {
+          final staleCheckGate = fakeSupabase.completer!;
+          bloc.add(LoginEmailAvailabilityCheckRequested('stale@example.co'));
+          await bloc.stream.firstWhere(
+            (s) => s is LoginWithEmailAvailabilityLoading,
+          );
+          // The newer check awaits its own gate so the stale check can stay
+          // parked while the newer one runs to completion.
+          final newerCheckGate = Completer<void>();
+          fakeSupabase.completer = newerCheckGate;
+          bloc.add(LoginEmailAvailabilityCheckRequested('newer@example.com'));
+          newerCheckGate.complete();
+          await bloc.stream.firstWhere(
+            (s) =>
+                s is LoginWithEmailAvailabilityCheckSuccess &&
+                s.isEmailRegistered,
+          );
+          // The stale check resumes against a contradictory verdict, so a
+          // leaked emit would show up in the captured sequence.
+          fakeSupabase.setRpcResponse('check_email_exists', false);
+          fakeSupabase.shouldDelayOperations = false;
+          staleCheckGate.complete();
+          // Fence: the stale continuation resumes before this ungated
+          // check's RPC resolves, so awaiting the fence's verdict proves the
+          // stale check already ran its generation check and discarded.
+          bloc.add(LoginEmailAvailabilityCheckRequested('fence@example.com'));
+          await bloc.stream.firstWhere(
+            (s) =>
+                s is LoginWithEmailAvailabilityCheckSuccess &&
+                !s.isEmailRegistered,
+          );
+        },
+        expect: () => [
+          LoginWithEmailAvailabilityLoading(),
+          LoginWithEmailAvailabilityCheckSuccess(isEmailRegistered: true),
+          LoginWithEmailAvailabilityLoading(),
+          LoginWithEmailAvailabilityCheckSuccess(isEmailRegistered: false),
         ],
       );
     });


### PR DESCRIPTION
## Context

[CA-1009](https://ripplearc.youtrack.cloud/issue/CA-1009): on the login screen, every keystroke of a valid email fires a `check_email_exists` RPC and the checks run concurrently with no guard — so a response for an older input (e.g. `user@example.co` while typing `user@example.com`) can resolve last and overwrite the verdict for the email actually in the field. The user sees "Email ID not registered with us" for a registered address and a disabled Continue; the only recovery is retyping a character. Reproduced live on-device on 2026-08-26 (and on the 2026-08-19 / 2026-08-25 E2E runs). Same bug family as CA-797/CA-824, fixed there with the generation-counter pattern. Stacked on #557 per the current sprint stack.

## What changed

- `LoginWithEmailBloc._onEmailChanged` now uses the house generation guard: it captures `++_availabilityCheckGeneration` before the await and discards the result when a newer check has taken ownership — a stale verdict is never emitted, so the verdict shown always corresponds to the most recently dispatched check.
- `RegisterWithEmailBloc` intentionally unchanged: its email-check event is `debounceTime(...).asyncExpand(mapper)`, which serializes checks so the last event's verdict always lands last — the guard would be dead code there.

## Tests

- New bloc regression test: the stale check is parked on `FakeSupabaseWrapper.completer`, a newer check completes with the correct verdict, then the stale check is released against a contradictory verdict and a fenced third check pins that the stale continuation emitted nothing. Act ends on `bloc.stream.firstWhere` conditions only (no wall-clock waits).
- Mutation check: with the guard line removed, exactly this test fails (8+1); with the guard, 9/9 pass.

## Live verification

Fresh install on the emulator against the local stack: before the fix, fast-typing `seeder@example.com` deterministically showed the false "not registered" verdict; with this build the same input produces the correct verdict and an enabled Continue, and the full login completes.

## Verification

Local Docker gates vs this PR's real base (`CA-902-feat/wire-recent-search-deletion`): --pre ✅; --comp report follows as a comment. Review: `reviews/CA-1009-fix-login-email-check-race__to__CA-902-feat-wire-recent-search-deletion.md` — ✅ no issues under the applied rules (Digestible PR, Naming & Abstraction, Self-Documenting Code, UI/Business Separation, Test Double Pattern, Unit Test Behavior, Mutation Testing).
